### PR TITLE
feat: rewrite smithy.forge as slice-based slash command

### DIFF
--- a/src/templates/base/smithy.forge.md
+++ b/src/templates/base/smithy.forge.md
@@ -55,7 +55,8 @@ Example: `001/us-03-bar/slice-2`
 
 Before creating the branch:
 - Check if the branch already exists. If it does, ask the user whether to continue on it or abort.
-- Create the branch from the main branch and check it out.
+- Create the branch from the repository's default branch and check it out.
+  Discover the default branch dynamically (e.g., `git symbolic-ref refs/remotes/origin/HEAD`) rather than assuming `main`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Rewrites `smithy.forge.md` from phase-based to slice-based workflow, consuming `.tasks.md` slices as input
- Adds `command: true` frontmatter so it deploys as `/smithy.forge` slash command
- Defines intake logic, branch naming (`<NNN>/us-<NN>-<slug>/slice-<N>`), sequential task execution, and PR creation with full spec traceability

## Source

- Spec: `specs/2026-03-14-001-smithy-command-redesign/smithy-command-redesign.spec.md` — User Story 5
- Tasks: `specs/2026-03-14-001-smithy-command-redesign/05-implement-slice-as-pr.tasks.md` — Slice 1
- Addresses: FR-001, FR-005; Acceptance Scenarios 5.1, 5.2, 5.3

## Test plan

- [ ] Run `smithy init` targeting a test repo with Claude selected
- [ ] Verify `smithy.forge.md` appears in `.claude/commands/` (due to `command: true`)
- [ ] Restart Claude Code and confirm `/smithy.forge` is available as a slash command
- [ ] Verify template handles `$ARGUMENTS` substitution with a tasks file path + slice number

🤖 Generated with [Claude Code](https://claude.com/claude-code)
