### PR TITLE
Add audit checklist markers to producing command templates

### DIFF
--- a/specs/2026-03-14-001-smithy-command-redesign/07-context-aware-artifact-review.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/07-context-aware-artifact-review.tasks.md
@@ -17,13 +17,13 @@
 
 ### Tasks
 
-- [ ] Define the marker convention: `<!-- audit-checklist-start -->` / `<!-- audit-checklist-end -->`
-- [ ] Add audit checklist section to `smithy.ignite.md` covering: ambiguity, milestone completeness, feasibility (AS 7.1)
-- [ ] Add audit checklist section to `smithy.render.md` (once created) covering: feature coverage, gaps, overlap (AS 7.2)
-- [ ] Add audit checklist section to `smithy.mark.md` (once created) covering: requirement traceability, acceptance coverage, data model consistency (AS 7.3)
-- [ ] Add audit checklist section to `smithy.cut.md` covering: slice scoping, testability, edge case coverage (AS 7.4) — align with existing Phase 0 categories
-- [ ] Add audit checklist section to `smithy.strike.md` covering: requirement completeness, slice scoping, validation plan coverage, data model/contracts presence (AS 7.5)
-- [ ] Ensure each checklist uses a consistent format (category table with "what to check" column) so `init` can extract uniformly
+- [x] Define the marker convention: `<!-- audit-checklist-start -->` / `<!-- audit-checklist-end -->`
+- [x] Add audit checklist section to `smithy.ignite.md` covering: ambiguity, milestone completeness, feasibility (AS 7.1)
+- [x] Add audit checklist section to `smithy.render.md` covering: feature coverage, gaps, overlap (AS 7.2)
+- [x] Add audit checklist section to `smithy.mark.md` covering: requirement traceability, acceptance coverage, data model consistency (AS 7.3)
+- [x] Add audit checklist section to `smithy.cut.md` covering: slice scoping, testability, edge case coverage (AS 7.4) — align with existing Phase 0 categories
+- [x] Add audit checklist section to `smithy.strike.md` covering: requirement completeness, slice scoping, validation plan coverage, data model/contracts presence (AS 7.5)
+- [x] Ensure each checklist uses a consistent format (category table with "what to check" column) so `init` can extract uniformly
 
 **PR Outcome**: All producing command templates contain marked audit checklists. Templates still function normally — markers are invisible to agents. No behavior change yet.
 

--- a/src/templates/base/smithy.cut.md
+++ b/src/templates/base/smithy.cut.md
@@ -232,6 +232,19 @@ where `<NN>` is the zero-padded user story number.
 - **DO** explore the codebase to ground slices in reality — don't slice in
   the abstract.
 
+<!-- audit-checklist-start -->
+## Audit Checklist (.tasks.md)
+
+| Category | What to check |
+|----------|---------------|
+| **Slice Scoping** | Is each slice PR-sized? Does each have a standalone goal that delivers a working increment — not disconnected scaffolding? |
+| **Task Completeness** | Are tasks within each slice sufficient to achieve the slice goal? Are there missing steps (tests, docs, validation)? |
+| **Testability** | Is it clear how each slice should be tested? Are integration test concerns addressed? |
+| **Edge Case Coverage** | Are boundary conditions, error paths, and failure modes covered in the tasks? |
+| **FR Traceability** | Does every slice trace to at least one FR or acceptance scenario? Are any FRs unaddressed? |
+| **Dependency Order** | Is the recommended implementation sequence logical? Would reordering reduce risk or unblock parallel work? |
+<!-- audit-checklist-end -->
+
 ---
 
 ## Output

--- a/src/templates/base/smithy.ignite.md
+++ b/src/templates/base/smithy.ignite.md
@@ -210,3 +210,15 @@ Once the user approves the draft:
 - **DO** ensure milestones are clearly delineated with distinct scope and success criteria.
 - **DO** challenge assumptions and surface risks during clarification.
 - **DO** keep the RFC concise — a good RFC is a starting point, not a final design.
+
+<!-- audit-checklist-start -->
+## Audit Checklist (.rfc.md)
+
+| Category | What to check |
+|----------|---------------|
+| **Ambiguity** | Are problem statement, goals, and constraints clearly defined? Are there vague terms that need tightening? |
+| **Milestone Completeness** | Does every milestone have a clear deliverable? Are milestones ordered logically with no gaps in coverage? |
+| **Feasibility** | Are there known technical risks, dependencies, or unknowns that could block milestones? Are constraints realistic? |
+| **Persona Clarity** | Are target personas identified? Is it clear who benefits and how? |
+| **Scope Boundaries** | Is it clear what is explicitly out of scope? Are there adjacent concerns that could cause scope creep? |
+<!-- audit-checklist-end -->

--- a/src/templates/base/smithy.mark.md
+++ b/src/templates/base/smithy.mark.md
@@ -374,6 +374,21 @@ through Phase 0).
 - **DO** write minimal placeholder files for data-model and contracts when they
   don't apply, rather than omitting them.
 
+<!-- audit-checklist-start -->
+## Audit Checklist (.spec.md)
+
+| Category | What to check |
+|----------|---------------|
+| **Story Completeness** | Does every user story have acceptance scenarios, priority justification, and an independent test? Are there obvious missing stories? |
+| **Requirement Traceability** | Does every FR trace to at least one user story? Are there user stories with no supporting requirements? |
+| **Cross-Document Consistency** | Do entities in data-model.md match Key Entities in the spec? Do contracts.md interfaces align with integration-related requirements? |
+| **Edge Case Coverage** | Are edge cases from the spec reflected in acceptance scenarios or requirements? Are there unaddressed failure modes? |
+| **Data Model Integrity** | Are relationships, state transitions, and validation rules internally consistent? Are there entities referenced but not defined, or defined but never referenced? |
+| **Contract Completeness** | Do all integration boundaries have defined inputs, outputs, and error conditions? Are there contracts implied by requirements but not documented? |
+| **Ambiguity & Risk** | Are there vague terms, unstated assumptions, or scope boundaries that could be interpreted multiple ways? |
+| **Staleness** | Does the spec still reflect the current codebase reality? Have upstream changes invalidated any assumptions? |
+<!-- audit-checklist-end -->
+
 ---
 
 ## Output

--- a/src/templates/base/smithy.render.md
+++ b/src/templates/base/smithy.render.md
@@ -239,3 +239,15 @@ Once the user approves the draft:
 - **DO** ensure each feature is a discrete unit of user-facing functionality.
 - **DO** surface overlapping concerns and ambiguous boundaries during clarification.
 - **DO** keep feature descriptions concise — a feature map is a breakdown, not a design doc.
+
+<!-- audit-checklist-start -->
+## Audit Checklist (.features.md)
+
+| Category | What to check |
+|----------|---------------|
+| **Feature Coverage** | Are all aspects of the milestone represented by at least one feature? |
+| **Gaps** | Are there milestone goals or success criteria that no feature addresses? |
+| **Overlap** | Are there features with unclear or overlapping boundaries? |
+| **Dependency Clarity** | Are inter-feature dependencies within the milestone evident, or are they hidden? |
+| **RFC Alignment** | Does the feature map align with the RFC's stated goals and success criteria for this milestone? |
+<!-- audit-checklist-end -->

--- a/src/templates/base/smithy.strike.md
+++ b/src/templates/base/smithy.strike.md
@@ -141,3 +141,16 @@ After writing the strike document, present a summary to the user:
 - **Do not skip the interactive phase.** Always explore, propose, and get approval before implementing.
 - **If scope grows too large** (more than ~5 tasks or touches many subsystems), tell the user this feature may be better suited for `smithy-ignite` and the full pipeline.
 - **Keep commits atomic.** Each commit should represent a logical, working change.
+
+<!-- audit-checklist-start -->
+## Audit Checklist (.strike.md)
+
+| Category | What to check |
+|----------|---------------|
+| **Requirement Completeness** | Are all functional requirements numbered and testable? Do they cover the full scope of the feature? |
+| **Slice Scoping** | Is the single slice PR-sized? Does it have a clear standalone goal and justification? |
+| **Validation Plan Coverage** | Does the validation plan have concrete steps that verify each requirement and success criterion? |
+| **Data Model Presence** | Is a Data Model section present? If data changes are needed, are entities and relationships defined? |
+| **Contracts Presence** | Is a Contracts section present? If interface changes are needed, are they specified? |
+| **Success Criteria** | Are success criteria numbered, testable, and aligned with the requirements? |
+<!-- audit-checklist-end -->


### PR DESCRIPTION
## Source
- Spec: `specs/2026-03-14-001-smithy-command-redesign/smithy-command-redesign.spec.md` — User Story 7
- Tasks: `specs/2026-03-14-001-smithy-command-redesign/07-context-aware-artifact-review.tasks.md`

## Slice
**Slice 1**: Add audit checklist markers to producing command templates

## Addresses
FR-012; Acceptance Scenarios 7.1, 7.2, 7.3, 7.4, 7.5

## Tasks completed
- [x] Define marker convention: `<!-- audit-checklist-start -->` / `<!-- audit-checklist-end -->`
- [x] Add audit checklist to `smithy.ignite.md` (ambiguity, milestone completeness, feasibility)
- [x] Add audit checklist to `smithy.render.md` (feature coverage, gaps, overlap, dependency clarity, RFC alignment)
- [x] Add audit checklist to `smithy.mark.md` (story completeness, requirement traceability, cross-doc consistency, edge cases, data model, contracts, ambiguity, staleness)
- [x] Add audit checklist to `smithy.cut.md` (slice scoping, testability, edge case coverage)
- [x] Add audit checklist to `smithy.strike.md` (requirement completeness, slice scoping, validation plan, data model/contracts)
- [x] Consistent format across all checklists (category table with "what to check" column)

## Validation
- `npm run build` — success
- `npm run typecheck` — success
- `npm test` — 32/32 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)