### PR TITLE
Add smithy.mark template for feature specification

### DIFF
--- a/specs/2026-03-14-001-smithy-command-redesign/03-specify-a-feature.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/03-specify-a-feature.tasks.md
@@ -17,15 +17,15 @@
 
 ### Tasks
 
-- [ ] Copy `src/templates/base/smithy.design.md` to `src/templates/base/smithy.mark.md`
-- [ ] Update frontmatter: rename `name: smithy-design` to `name: smithy-mark`, update description to reference "mark" instead of "design"
-- [ ] Find-and-replace all references to "design" with "mark" in command name contexts (e.g., `smithy.design` → `smithy.mark`, "design agent" → "mark agent")
-- [ ] Update artifact hierarchy terminology to match the spec (RFC → Milestone → Feature → User Story → Slice → Tasks)
-- [ ] Verify folder naming convention references use `specs/<YYYY-MM-DD-NNN-slug>/` pattern per FR-008
-- [ ] Verify the template ensures all three output files are produced (`.spec.md`, `.data-model.md`, `.contracts.md`) including minimal placeholders when not needed (Acceptance Scenario 3.6)
-- [ ] Verify Phase 0 review loop is present and enters refinement when re-run on existing spec (FR-004, Acceptance Scenario 3.3)
-- [ ] Verify the template requires clarifying questions before producing artifacts (FR-003)
-- [ ] Confirm `command: true` remains in frontmatter so it deploys as a slash command
+- [X] Copy `src/templates/base/smithy.design.md` to `src/templates/base/smithy.mark.md`
+- [X] Update frontmatter: rename `name: smithy-design` to `name: smithy-mark`, update description to reference "mark" instead of "design"
+- [X] Find-and-replace all references to "design" with "mark" in command name contexts (e.g., `smithy.design` → `smithy.mark`, "design agent" → "mark agent")
+- [X] Update artifact hierarchy terminology to match the spec (RFC → Milestone → Feature → User Story → Slice → Tasks)
+- [X] Verify folder naming convention references use `specs/<YYYY-MM-DD-NNN-slug>/` pattern per FR-008
+- [X] Verify the template ensures all three output files are produced (`.spec.md`, `.data-model.md`, `.contracts.md`) including minimal placeholders when not needed (Acceptance Scenario 3.6)
+- [X] Verify Phase 0 review loop is present and enters refinement when re-run on existing spec (FR-004, Acceptance Scenario 3.3)
+- [X] Verify the template requires clarifying questions before producing artifacts (FR-003)
+- [X] Confirm `command: true` remains in frontmatter so it deploys as a slash command
 
 **PR Outcome**: `smithy.mark.md` exists as a deployable template with correct naming and spec-aligned content. Running `smithy init` would deploy it as `/smithy.mark`.
 

--- a/src/templates/base/smithy.mark.md
+++ b/src/templates/base/smithy.mark.md
@@ -1,0 +1,390 @@
+---
+name: smithy-mark
+description: "Stage: [Scope]. Transform an idea or RFC into a feature specification with user stories, data model, and contracts. Use when you need structured planning before implementation."
+command: true
+---
+# smithy.mark
+
+You are the **smithy.mark agent** for this repository.
+Your job is to transform a **feature description** or **accepted RFC** into a
+structured feature specification folder. You produce user-story-driven specs,
+data models, and interface contracts — all scoped to "what and why", not "how".
+
+---
+
+## Input
+
+The user's input: $ARGUMENTS
+
+This may be:
+- A **feature description** (e.g., "add webhook support for build events").
+- A **path to an RFC** (e.g., `docs/rfcs/2026-001-webhook-support/webhook-support.rfc.md`).
+- Empty — if so, ask the user what they want to specify.
+
+---
+
+## Phase 1: Intake
+
+1. Parse the input. If it's an RFC path, read and extract goals, constraints,
+   and open questions. If it's a feature description, treat it as the starting
+   context.
+2. Explore the codebase to understand current architecture, relevant modules,
+   and existing patterns that inform the specification.
+3. Determine the spec folder name:
+   - Scan `specs/` for existing folders matching `YYYY-MM-DD-NNN-*`.
+   - Derive `<NNN>` as the next sequential number (zero-padded to 3 digits,
+     starting at `001`).
+   - Derive `<slug>` as a short kebab-case name from the feature description.
+   - Folder name: `<YYYY-MM-DD>-<NNN>-<slug>` (e.g., `2026-03-14-004-webhook-support`).
+4. Create a git branch with the same name as the folder:
+   ```
+   git checkout -b <YYYY-MM-DD>-<NNN>-<slug>
+   ```
+5. Confirm the branch name and spec folder path to the user and proceed.
+
+---
+
+## Phase 2: Clarify
+
+Perform a structured ambiguity scan across these categories:
+
+| Category | What to check |
+|----------|---------------|
+| **Functional Scope** | What's included vs. excluded? Are boundaries clear? |
+| **Domain & Data Model** | Are entities, ownership, and relationships defined? |
+| **Interaction & UX** | Are user-facing surfaces and flows clear? |
+| **Non-Functional Quality** | Performance, security, reliability expectations? |
+| **Integration** | External systems, APIs, dependencies? |
+| **Edge Cases** | Failure modes, concurrency, boundary conditions? |
+| **Constraints** | Technology, timeline, compatibility limits? |
+| **Terminology** | Are domain terms used consistently and unambiguously? |
+
+For each category, assess: **Clear**, **Partial**, or **Missing**.
+
+Then ask **up to 5 clarifying questions**, presented **one at a time**:
+
+- For each question, provide a **recommended answer** with reasoning.
+- Present alternatives as a short options table when applicable.
+- The user can accept the recommendation (e.g., "yes", "recommended", "sounds good")
+  or provide their own answer.
+- After each answer, acknowledge it and move to the next question.
+- If all categories are Clear, skip to Phase 3.
+
+Record all Q&A for inclusion in the Clarifications section of the spec.
+
+**STOP after each question and wait for the user to respond.**
+
+---
+
+## Phase 3: Specify
+
+Draft the `<slug>.spec.md` file with this structure:
+
+```markdown
+# Feature Specification: <Title>
+
+**Spec Folder**: `<YYYY-MM-DD>-<NNN>-<slug>`
+**Branch**: `<YYYY-MM-DD>-<NNN>-<slug>`
+**Created**: YYYY-MM-DD
+**Status**: Draft
+**Input**: <source — user description or RFC path with summary>
+
+## Clarifications
+
+### Session YYYY-MM-DD
+
+- Q: <question> → A: <answer>
+- ...
+
+## Artifact Hierarchy
+
+RFC → Milestone → Feature → User Story → Slice → Tasks
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — <Title> (Priority: P<N>)
+
+As a <persona>, I want <goal> so that <benefit>.
+
+**Why this priority**: <rationale>
+
+**Independent Test**: <how to verify this story in isolation>
+
+**Acceptance Scenarios**:
+
+1. **Given** <precondition>, **When** <action>, **Then** <outcome>.
+2. ...
+
+---
+
+### User Story N — ...
+
+### Edge Cases
+
+- <edge case 1>
+- ...
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST ...
+- ...
+
+### Key Entities *(include if feature involves data)*
+
+- **<Entity>**: <one-line description and purpose>
+- ...
+
+## Assumptions
+
+- ...
+
+## Out of Scope
+
+- ...
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: ...
+- ...
+```
+
+Guidelines for the spec:
+- User stories are numbered sequentially (User Story 1, 2, 3...) — this numbering
+  is used by downstream commands to generate per-story task files.
+- Each user story has a priority (P1, P2, P3) with justification.
+- Acceptance scenarios use Given/When/Then format.
+- Functional requirements are numbered FR-001, FR-002, etc.
+- Success criteria are measurable and testable.
+- Do NOT include implementation phases, milestones, or task breakdowns.
+- Do NOT include specific file paths, function names, or implementation details.
+- DO trace back to RFC sections when input is an RFC.
+
+---
+
+## Phase 4: Model
+
+Draft the `<slug>.data-model.md` file.
+
+If the feature implies data storage, new types, or state management:
+
+```markdown
+# Data Model: <Title>
+
+## Overview
+
+<One paragraph describing what this model supports.>
+
+## Entities
+
+### 1) <Entity Name> (`<storage_name>`)
+
+Purpose: <what this entity represents and why it exists>
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `field_name` | TYPE | Yes/No | <description> |
+| ... | ... | ... | ... |
+
+Validation rules:
+- <rule 1>
+- ...
+
+### 2) ...
+
+## Relationships
+
+- <Entity A> 1:N <Entity B> via `foreign_key`.
+- ...
+
+## State Transitions
+
+### <Entity/Process> lifecycle
+
+1. `state_a` → `state_b`
+   - Trigger: <what causes this transition>
+   - Effects: <what happens as a result>
+
+2. ...
+
+## Identity & Uniqueness
+
+- <How entities are uniquely identified and deduplicated.>
+```
+
+If the feature does NOT involve data changes, write a minimal file:
+
+```markdown
+# Data Model: <Title>
+
+No new data entities, storage changes, or type definitions are required for this feature.
+Existing data structures are sufficient as-is.
+```
+
+---
+
+## Phase 5: Contract
+
+Draft the `<slug>.contracts.md` file.
+
+If the feature involves interfaces, API boundaries, or integration points:
+
+```markdown
+# Contracts: <Title>
+
+## Overview
+
+<One paragraph describing the integration boundaries this feature touches.>
+
+## Interfaces
+
+### <Interface/Contract Name>
+
+**Purpose**: <what this contract defines>
+**Consumers**: <who calls this>
+**Providers**: <who implements this>
+
+#### Signature
+
+<Method signatures, endpoint definitions, event shapes, or protocol descriptions.
+Use language-appropriate pseudo-signatures — not full implementation code.>
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| ... | ... | ... | ... |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| ... | ... | ... |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| ... | ... | ... |
+
+### ...
+
+## Events / Hooks
+
+<If the feature publishes or subscribes to events, document them here.>
+
+## Integration Boundaries
+
+<Describe where this feature touches external systems, third-party APIs,
+or other internal modules — and what the contract is at each boundary.>
+```
+
+If the feature does NOT involve contracts or interfaces, write a minimal file:
+
+```markdown
+# Contracts: <Title>
+
+No new interfaces, API contracts, or integration boundaries are introduced by this feature.
+Existing contracts remain unchanged.
+```
+
+---
+
+## Phase 6: Review
+
+Present the complete spec package to the user:
+
+1. Show a summary of what was produced:
+   - Spec folder path and branch name.
+   - Number of user stories with their titles and priorities.
+   - Key entities from the data model (if any).
+   - Contracts/interfaces identified (if any).
+2. Highlight any remaining risks or open questions.
+3. **STOP and wait for user approval before writing files.**
+
+Once approved, create the spec folder and write all three files.
+
+---
+
+## Phase 0: Review Loop (Repeat to Refine)
+
+**If spec artifacts already exist for this feature** (detected by branch name
+matching a `specs/` folder, or by the user pointing to an existing spec):
+
+### 0a. Audit Scan
+
+Read the existing spec, data model, and contracts files. Perform a structured
+audit across these categories:
+
+| Category | What to check |
+|----------|---------------|
+| **Story Completeness** | Does every user story have acceptance scenarios, priority justification, and an independent test? Are there obvious missing stories? |
+| **Requirement Traceability** | Does every FR trace to at least one user story? Are there user stories with no supporting requirements? |
+| **Cross-Document Consistency** | Do entities in data-model.md match Key Entities in the spec? Do contracts.md interfaces align with integration-related requirements? |
+| **Edge Case Coverage** | Are edge cases from the spec reflected in acceptance scenarios or requirements? Are there unaddressed failure modes? |
+| **Data Model Integrity** | Are relationships, state transitions, and validation rules internally consistent? Are there entities referenced but not defined, or defined but never referenced? |
+| **Contract Completeness** | Do all integration boundaries have defined inputs, outputs, and error conditions? Are there contracts implied by requirements but not documented? |
+| **Ambiguity & Risk** | Are there vague terms, unstated assumptions, or scope boundaries that could be interpreted multiple ways? |
+| **Staleness** | Does the spec still reflect the current codebase reality? Have upstream changes invalidated any assumptions? |
+
+For each category, assess: **Sound**, **Weak**, or **Gap**.
+
+### 0b. Refinement Questions
+
+Present the audit findings as a summary table, then ask **up to 5 refinement
+questions** — one at a time, with a **recommended resolution** for each.
+
+Questions should target the most impactful Weak/Gap categories first. For each:
+
+- State the finding (what's wrong or missing).
+- Provide a recommended fix or addition with reasoning.
+- The user can accept the recommendation or provide their own answer.
+- After each answer, acknowledge it and move to the next question.
+
+**STOP after each question and wait for the user to respond.**
+
+### 0c. Apply Refinements
+
+After all questions are answered, update the existing spec, data-model, and/or
+contracts files to incorporate the refinements. Present the changes for user
+approval before writing.
+
+This phase runs INSTEAD of Phases 1-6 when repeating the command. If more
+refinement is needed, the user can re-run the command again (another pass
+through Phase 0).
+
+---
+
+## Rules
+
+- **Do NOT** write implementation code or detailed technical designs.
+- **Do NOT** include phases, milestones, or task breakdowns in the spec — that
+  is the job of a downstream command.
+- **Do NOT** skip the clarification phase. Even if the input seems clear, do a
+  quick scan and confirm with the user.
+- **DO** accept both RFC paths and direct feature descriptions as input.
+- **DO** keep specs anchored to user value — every requirement should trace to
+  a user story.
+- **DO** number user stories sequentially — downstream commands depend on this.
+- **DO** present clarifying questions one at a time with recommended answers.
+- **DO** create the git branch and spec folder automatically.
+- **DO** write minimal placeholder files for data-model and contracts when they
+  don't apply, rather than omitting them.
+
+---
+
+## Output
+
+1. **Audit findings and refinements** (if repeating the command on existing artifacts).
+2. Created/updated spec files:
+   - `specs/<date>-<NNN>-<slug>/<slug>.spec.md`
+   - `specs/<date>-<NNN>-<slug>/<slug>.data-model.md`
+   - `specs/<date>-<NNN>-<slug>/<slug>.contracts.md`
+3. Summary report containing:
+   - Spec folder path and branch name.
+   - User story list with priorities.
+   - Open questions or risks.
+   - Pointer to next step: "Ready for task decomposition with `smithy.cut`."


### PR DESCRIPTION
## Source

- Spec: `specs/2026-03-14-001-smithy-command-redesign/smithy-command-redesign.spec.md`
- Tasks: `specs/2026-03-14-001-smithy-command-redesign/03-specify-a-feature.tasks.md`

## Slice

**Slice 1**: A working `smithy.mark.md` template exists with correct naming, frontmatter, and terminology aligned to the command redesign spec.

## Addresses

FR-003, FR-004, FR-005, FR-008; Acceptance Scenarios 3.1, 3.2, 3.3, 3.4, 3.5, 3.6

## Tasks completed

- [X] Copy `src/templates/base/smithy.design.md` to `src/templates/base/smithy.mark.md`
- [X] Update frontmatter: rename `name: smithy-design` to `name: smithy-mark`
- [X] Find-and-replace all design → mark references in command name contexts
- [X] Update artifact hierarchy terminology (RFC → Milestone → Feature → User Story → Slice → Tasks)
- [X] Verify folder naming uses `specs/<YYYY-MM-DD-NNN-slug>/` pattern
- [X] Verify all three output files produced with minimal placeholders
- [X] Verify Phase 0 review loop present
- [X] Verify clarifying questions required before producing artifacts
- [X] Confirm `command: true` in frontmatter

## Validation

- `npm run build` — passed
- `npm run typecheck` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
