### PR TITLE
feat: smithy base directory customization specification

### DIFF
--- a/specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.spec.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.spec.md
@@ -33,7 +33,7 @@ As a developer running `smithy init`, I want to be offered the option to create 
 **Acceptance Scenarios**:
 
 1. **Given** a repo without `.smithy/`, **When** I run `smithy init` and accept the template prompt, **Then** `.smithy/` is created with `rfc.md`, `features.md`, `spec.md`, and `tasks.md` template files.
-2. **Given** a repo without `.smithy/`, **When** I run `smithy init` and decline the template prompt, **Then** no `.smithy/` directory is created.
+2. **Given** a repo without `.smithy/`, **When** I run `smithy init` and decline the template prompt, **Then** `.smithy/` may still be created (e.g., for `local.settings.json` per the base directory customization spec), but no template files are written.
 3. **Given** a repo with an existing `.smithy/` directory, **When** I run `smithy init`, **Then** init offers to *overwrite* the existing templates (not create). If the user declines, existing templates are preserved.
 4. **Given** a repo with an existing `.smithy/` directory, **When** I accept the overwrite prompt, **Then** the 4 template files are replaced with the current defaults.
 

--- a/specs/2026-03-23-003-smithy-base-dir-customization/smithy-base-dir-customization.contracts.md
+++ b/specs/2026-03-23-003-smithy-base-dir-customization/smithy-base-dir-customization.contracts.md
@@ -8,9 +8,9 @@ This feature introduces a centralized configuration system for path resolution.
 
 ### PathResolver
 
-**Purpose**: Provides resolved absolute paths for any artifact type based on current settings.
+**Purpose**: Provides resolved absolute paths for supported artifact types (`rfc`, `spec`, `strike`) based on current settings.
 **Consumers**: All smithy skills/commands that generate files.
-**Providers**: `src/settings.ts`
+**Providers**: TBD (centralized settings/path configuration module)
 
 #### Signature
 
@@ -25,14 +25,13 @@ This feature introduces a centralized configuration system for path resolution.
 
 #### Outputs
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `path` | string | The absolute path to the directory or file. |
+`string` — The absolute path to the directory or file.
 
 ## Integration Boundaries
 
 ### `smithy init` → `.smithy/local.settings.json`
 - `init` writes the initial configuration.
+- **Note**: The orders spec (`2026-03-21-002`) states that declining template creation during `smithy init` must leave no `.smithy/` directory. When base directory customization is active, `init` will always create `.smithy/local.settings.json`. These specs must be reconciled: if the user provides a non-default base directory, `.smithy/` is created regardless of the template prompt outcome. The orders spec acceptance scenario should be updated to account for settings file creation.
 
 ### `smithy rehome` → `.smithy/local.settings.json`
 - `rehome` reads and updates the configuration.

--- a/specs/2026-03-23-003-smithy-base-dir-customization/smithy-base-dir-customization.data-model.md
+++ b/specs/2026-03-23-003-smithy-base-dir-customization/smithy-base-dir-customization.data-model.md
@@ -20,7 +20,7 @@ Purpose: Stores workspace-specific configurations that should not necessarily be
 
 Validation rules:
 - `baseDir` must be a valid relative or absolute path.
-- `paths` entries must be valid relative paths.
+- `paths` entries must be valid paths. Relative `paths` entries are resolved against `baseDir`; absolute `paths` entries are used as-is.
 
 ## Identity & Uniqueness
 

--- a/specs/2026-03-23-003-smithy-base-dir-customization/smithy-base-dir-customization.spec.md
+++ b/specs/2026-03-23-003-smithy-base-dir-customization/smithy-base-dir-customization.spec.md
@@ -31,7 +31,7 @@ As a developer running `smithy init`, I want to choose a base directory for all 
 **Acceptance Scenarios**:
 
 1. **Given** a new repository, **When** I run `smithy init`, **Then** I am prompted for a base directory (defaulting to the repo root `.`).
-2. **Given** I provide `module-foo` as the base directory, **When** `init` completes, **Then** `.smithy/local.settings.json` contains `baseDir: "module-foo"`.
+2. **Given** I provide `module-foo` as the base directory, **When** `init` completes, **Then** `.smithy/local.settings.json` contains `"baseDir": "module-foo"`.
 
 ---
 
@@ -77,7 +77,7 @@ As a developer using smithy skills (like `/smithy.strike` or `/smithy.mark`), I 
 **Acceptance Scenarios**:
 
 1. **Given** a base directory of `foo`, **When** I run a command that creates an RFC, **Then** it is placed in `foo/docs/rfcs/`.
-2. **Given** a custom RFC override of `docs/planning`, **When** I run a command that creates an RFC, **Then** it is placed in `foo/docs/planning/` (relative to base) or `docs/planning/` (if absolute).
+2. **Given** a custom RFC override of `docs/planning` (a relative path), **When** I run a command that creates an RFC, **Then** it is placed in `foo/docs/planning/`. If instead I provide an absolute path override (e.g., `/docs/planning` on POSIX or `C:\docs\planning` on Windows), **Then** the RFC is placed at that absolute path and the base directory is not prefixed.
 
 ---
 


### PR DESCRIPTION
This PR adds the specification, data model, and contracts for the Smithy base directory customization feature. It defines how users can scope artifacts to specific directories, which is especially useful for monorepo workflows.

Summary of changes:
- Spec: 4 user stories, including  prompts and a new  command.
- Data Model: Defines  for path configuration.
- Contracts: Defines a  interface for centralized path resolution.

Ready for review and task decomposition.