### PR TITLE
Add auto-generated release notes to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,3 +78,11 @@ jobs:
       run: |
         git push origin "HEAD:refs/heads/${{ inputs.branch }}"
         git push origin "v${{ steps.version.outputs.version }}"
+
+    - name: Create GitHub Release with auto-generated notes
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release create "v${{ steps.version.outputs.version }}" \
+          --title "v${{ steps.version.outputs.version }}" \
+          --generate-notes


### PR DESCRIPTION
Use gh release create --generate-notes to create a GitHub Release
with auto-generated notes from PRs/commits since the last release,
instead of only pushing a bare tag.

https://claude.ai/code/session_01Mu3DrqvA7EtDn85yQwpUZ3