### PR TITLE
Change force push from auto-deny to request-approval

### DIFF
--- a/src/agents/claude.test.ts
+++ b/src/agents/claude.test.ts
@@ -123,11 +123,13 @@ describe('buildClaudeDenyList', () => {
     expect(list).toContain('Bash(git branch --delete *)');
   });
 
-  it('blocks force push and hard reset', () => {
+  it('blocks hard reset but not force push (force push requires approval)', () => {
     const list = buildClaudeDenyList();
-    expect(list).toContain('Bash(git push --force *)');
-    expect(list).toContain('Bash(git push -f *)');
     expect(list).toContain('Bash(git reset --hard *)');
+    // Force push is no longer denied — it triggers a user approval prompt instead
+    expect(list).not.toContain('Bash(git push --force *)');
+    expect(list).not.toContain('Bash(git push -f *)');
+    expect(list).not.toContain('Bash(git push --force-with-lease *)');
   });
 
   it('blocks destructive checkout and stash operations', () => {

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -173,10 +173,7 @@ export const denyPermissions: string[] = [
   // Git tag deletion
   "git tag -d *",
   "git tag --delete *",
-  // Git force push & destructive reset
-  "git push --force *",
-  "git push -f *",
-  "git push --force-with-lease *",
+  // Git destructive reset
   "git reset --hard *",
   "git clean *",
   // Git symbolic-ref mutation (repointing and deletion)


### PR DESCRIPTION
Force push commands (--force, -f, --force-with-lease) are sometimes
necessary after rebases. Instead of automatically denying them, remove
them from the deny list so Claude Code prompts the user for approval.
This preserves safety while allowing legitimate use cases.

Fixes #28

https://claude.ai/code/session_0119TdoJckBxkwJEYdJ6dKVg