### PR TITLE
Add task breakdown for Smithy issue templates feature

### DIFF
--- a/specs/2026-03-21-002-smithy-orders-issue-templates/01-create-smithy-issue-templates-during-init.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/01-create-smithy-issue-templates-during-init.tasks.md
@@ -21,8 +21,8 @@
 - [ ] Create `src/templates/smithy-issue-templates/features.md` with the default feature issue template content from the spec
 - [ ] Create `src/templates/smithy-issue-templates/spec.md` with the default user story issue template content from the spec
 - [ ] Create `src/templates/smithy-issue-templates/tasks.md` with the default slice issue template content from the spec
-- [ ] Add a `deploySmithyTemplates(targetDir: string)` function (in `src/utils.ts` or a new module) that creates `.smithy/` and writes all 4 files — overwrites existing files if present, preserves extra files in the directory
-- [ ] Add a `addSmithyToGitignore(targetDir: string)` function leveraging the existing `addToGitignore` pattern
+- [ ] Add a `deploySmithyTemplates(targetDir: string, options?: { overwrite?: boolean })` function (in `src/utils.ts` or a new module) that creates `.smithy/` and writes all 4 files — requires `overwrite: true` to replace existing files, preserves extra files in the directory
+- [ ] Add an `addSmithyToGitignore(targetDir: string)` function leveraging the existing `addToGitignore` pattern
 - [ ] Add unit tests: verify template files are written with correct content, overwrite replaces only the 4 known files, gitignore append works (including dedup and create-from-scratch cases)
 
 **PR Outcome**: The provisioning utility is tested and ready to be called from the init flow. No user-facing behavior change yet.
@@ -43,9 +43,9 @@
 - [ ] Add `promptCreateSmithyTemplates()` prompt in `src/interactive.ts`: "Create smithy issue templates in .smithy/? (Y/n)" — default yes
 - [ ] Add `promptOverwriteSmithyTemplates()` prompt in `src/interactive.ts`: "Overwrite existing .smithy/ templates with defaults? (y/N)" — default no
 - [ ] Add `promptCommitSmithyTemplates()` prompt in `src/interactive.ts`: "Check .smithy/ into the repo? (Y/n)" — default yes; if declined, call `addSmithyToGitignore()`
-- [ ] Wire into `src/commands/init.ts`: after target dir is resolved but before agent deployment — check if `.smithy/` exists to decide create vs overwrite prompt; `--yes` defaults to creating templates; skip commit/gitignore prompt on overwrite (per contracts spec)
+- [ ] Wire into `src/commands/init.ts`: after target dir is resolved and after agent selection and permission setup are complete (per contracts spec) — check if `.smithy/` exists to decide create vs overwrite prompt; `--yes` defaults to creating templates; skip commit/gitignore prompt on overwrite (per contracts spec)
 - [ ] Verify `src/commands/uninit.ts` does NOT touch `.smithy/` — add an explicit test that `.smithy/` survives uninit
-- [ ] Add integration tests in `src/cli.test.ts`: (a) `--yes` creates `.smithy/` with 4 files, (b) `--no-smithy-templates` skips creation, (c) double-init offers overwrite (tested via `--yes` which overwrites), (d) uninit preserves `.smithy/`
+- [ ] Add integration tests in `src/cli.test.ts`: (a) `--yes` creates `.smithy/` with 4 files, (b) `--no-smithy-templates` skips creation, (c) double-init with `--yes` preserves existing `.smithy/` (since `--yes` accepts default "no" for overwrite), (d) uninit preserves `.smithy/`
 
 **PR Outcome**: Running `smithy init` prompts for `.smithy/` templates. All 4 acceptance scenarios pass. `smithy uninit` leaves `.smithy/` untouched.
 


### PR DESCRIPTION
## Summary
- **Primary outcome**: Document the implementation plan for creating `.smithy/` issue templates during `smithy init`, split into two slices with clear dependencies and acceptance criteria.
- **Notable behaviour changes**: None yet — this is a specification document for upcoming work.
- **Follow-up work deferred**: Implementation of Slice 1 and Slice 2 tasks.

## Context
This task breakdown implements **User Story 1** from the Smithy Orders Issue Templates specification (`specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.spec.md`). It defines the work needed to:
- Ship default RFC, feature, user story, and slice issue templates
- Integrate template provisioning into the `smithy init` flow with interactive prompts
- Ensure `smithy uninit` does not remove user templates
- Meet all four acceptance scenarios (template creation, overwrite handling, gitignore management, uninit safety)

## Implementation Notes
- **Slice 1** focuses on the data layer (template files) and reusable utility functions (`deploySmithyTemplates`, `addSmithyToGitignore`), with unit test coverage.
- **Slice 2** integrates into the CLI and init flow, adding interactive prompts, CLI flags (`--smithy-templates`), and integration tests.
- **Dependency order**: Slice 1 must complete before Slice 2, as the init flow depends on the provisioning utility.
- **Key patterns**: Follows existing conventions for `--issue-templates` flag and `addToGitignore` utility.
- **Impacted modules**: `src/cli.ts`, `src/commands/init.ts`, `src/commands/uninit.ts`, `src/interactive.ts`, `src/utils.ts`, `src/templates/`.

## Risks & Mitigations
| Risk | Mitigation |
|------|-----------|
| Double-init with existing `.smithy/` could overwrite user edits | Slice 2 adds an overwrite prompt (default no) to protect user changes |
| `.smithy/` accidentally removed by `uninit` | Explicit test in Slice 2 verifies `.smithy/` survives uninit |
| Template content drift from spec | Templates sourced directly from spec; unit tests verify exact content |

## Rollback Plan
- If issues arise during Slice 1: Remove `src/templates/smithy-issue-templates/` and utility functions; no user data affected.
- If issues arise during Slice 2: Revert CLI flag and init flow changes; existing `.smithy/` directories remain untouched.

## Testing
- **Slice 1**: Unit tests verify template file content, overwrite behavior, and gitignore deduplication.
- **Slice 2**: Integration tests cover `--yes` flag, `--no-smithy-templates` flag, overwrite prompts, and uninit preservation.
- **CI**: Build, type check, and all tests must pass before merge.

## Issue
- Relates to Smithy Orders Issue Templates specification (2026-03-21-002)

https://claude.ai/code/session_01XULreFcZGtex3RcSJsDM8t