### PR TITLE
fix: add parallel-execution awareness to smithy.cut and cross-story dependency checks to smithy.forge

### DIFF
--- a/src/templates/base/smithy.cut.md
+++ b/src/templates/base/smithy.cut.md
@@ -196,9 +196,11 @@ Recommended implementation sequence:
 
 ### Cross-Story Dependencies
 
+Direction must be either `depends on` or `depended upon by`.
+
 | Dependency | Direction | Notes |
 |------------|-----------|-------|
-| User Story <X>: <title> | depends on / depended upon by | <what this story needs from or provides to the other story> |
+| User Story <X>: <title> | depends on | <what this story needs from or provides to the other story> |
 
 _If no cross-story dependencies exist, state "None — this story is self-contained."_
 ```

--- a/src/templates/base/smithy.forge.md
+++ b/src/templates/base/smithy.forge.md
@@ -44,8 +44,10 @@ This may be:
 5. **Check cross-story dependencies.** If the tasks file includes a
    "Cross-Story Dependencies" section listing stories this slice depends on,
    check whether those stories' slices have been implemented:
-   - Look for merged PRs or completed task checkboxes (`- [X]`) in the
-     dependent stories' `.tasks.md` files.
+   - Treat the dependent stories' `.tasks.md` files as the primary source of
+     truth: look for completed task checkboxes (`- [x]`) in the relevant slices.
+     Optionally, if your environment provides repository metadata, you may also
+     look for merged PRs corresponding to those slices.
    - If dependent work is **not yet complete**, present the dependencies to the
      user and ask how to proceed: wait, stub/mock the missing functionality
      against the contracts and data model, or proceed assuming it will land
@@ -100,7 +102,7 @@ Execute each task from the slice's checklist **in order**:
 1. Read and understand the task.
 2. Apply the necessary code changes.
 3. Run tests and build validation relevant to the changes. If tests fail, fix the issue before proceeding — do not mark the task complete.
-4. Once tests pass, mark the task complete — change `- [ ]` to `- [X]` for that task and include this edit in the implementation commit. For `.tasks.md` mode, update the checkbox in the tasks file's slice checklist. For `.strike.md` mode, update the checkbox in the strike file's Single Slice checklist.
+4. Once tests pass, mark the task complete — change `- [ ]` to `- [x]` for that task and include this edit in the implementation commit. For `.tasks.md` mode, update the checkbox in the tasks file's slice checklist. For `.strike.md` mode, update the checkbox in the strike file's Single Slice checklist.
 5. If a task cannot be completed (missing information, conflicting requirements), stop and document the blocker. Do not guess.
 
 Stay within the slice's scope. If you discover work that belongs to a different slice or story, note it but do not implement it.

--- a/src/templates/base/smithy.render.md
+++ b/src/templates/base/smithy.render.md
@@ -219,9 +219,11 @@ this format:
 
 ## Cross-Milestone Dependencies
 
+Direction must be either `depends on` or `depended upon by`.
+
 | Dependency | Direction | Notes |
 |------------|-----------|-------|
-| Milestone <X>: <title> | depends on / depended upon by | <what this milestone needs from or provides to the other> |
+| Milestone <X>: <title> | depends on | <what this milestone needs from or provides to the other> |
 
 _If no cross-milestone dependencies exist, state "None — this milestone is self-contained."_
 ```


### PR DESCRIPTION
When running multiple smithy.cut instances in parallel (one per story in a
spec), agents would ask confusing clarification questions about building
dependencies from other stories. The spec artifacts already contain sufficient
information — the prompts just lacked inter-story scope boundaries.

smithy.cut changes:
- Phase 2: analyze codebase as-is, don't plan for other stories' work
- Phase 3: add Inter-Story Boundaries to ambiguity scan (almost always Clear)
- Phase 4: add Cross-Story Dependencies table to output template
- Rules: 5 new rules enforcing single-story scope and parallel awareness

smithy.forge changes:
- Intake: check cross-story dependencies and prompt user if unmet
- Implementation: code against contracts/data-model for missing cross-story work
- Edge cases: handle unmet dependencies with wait/stub/proceed options

Closes #74

https://claude.ai/code/session_01UqhnweSWWCTGb7tv1itHnY