### PR TITLE
Remove directory-level gitignore entries for gemini and codex

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -250,6 +250,18 @@ describe('CLI init lifecycle and idempotency', () => {
     expect(content).not.toContain('tools/codex/');
   });
 
+  it('does not add directory-level gitignore entries for gemini or codex', () => {
+    execFileSync('node', ['dist/cli.js', 'init', '-y', '-d', tmpDir], {
+      encoding: 'utf-8',
+    });
+
+    const content = fs.readFileSync(path.join(tmpDir, '.gitignore'), 'utf8');
+    expect(content).toContain('.claude/settings.local.json');
+    expect(content).not.toContain('.gemini/');
+    expect(content).not.toContain('.codex/');
+    expect(content).not.toContain('tools/codex/');
+  });
+
   it('creates settings.json with --agent claude --permissions repo', () => {
     execFileSync('node', ['dist/cli.js', 'init', '-a', 'claude', '--permissions', 'repo', '-y', '-d', tmpDir], {
       encoding: 'utf-8',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,8 +30,8 @@ export function copyDirSync(src: string, dest: string): void {
 
 export const agentGitignoreEntries: Record<string, string[]> = {
   claude: ['.claude/settings.local.json'],
-  gemini: ['.gemini/'],
-  codex: ['.codex/', 'tools/codex/'],
+  gemini: [],
+  codex: [],
 };
 
 /**


### PR DESCRIPTION
## Summary
- Primary outcome: Prevent `.gemini/` and `.codex/` directories from being added to `.gitignore` during CLI initialization
- Notable behaviour changes: The `init` command will no longer create gitignore entries for gemini and codex agent directories
- Follow-up work deferred: None

## Context
The gemini and codex agents should not have their configuration directories ignored by git. Only Claude's local settings file (`.claude/settings.local.json`) should be gitignored, as it contains sensitive local configuration.

## Implementation Notes
- Modified `agentGitignoreEntries` in `src/utils.ts` to return empty arrays for gemini and codex agents
- Updated test in `src/cli.test.ts` to verify that `.gemini/`, `.codex/`, and `tools/codex/` are not added to `.gitignore`
- The change is minimal and focused: only the gitignore configuration is affected

## Risks & Mitigations
- Risk: Users may accidentally commit sensitive agent configuration files | Mitigation: Documentation should clarify which files should be manually added to `.gitignore` if needed
- Risk: Existing projects with these entries in `.gitignore` will not be affected | Mitigation: This is a forward-looking change; existing repos are unaffected

## Rollback Plan
Revert the changes to `src/utils.ts` to restore the original gitignore entries:
```
gemini: ['.gemini/'],
codex: ['.codex/', 'tools/codex/'],
```

## Testing
- Added unit test `does not add directory-level gitignore entries for gemini or codex` that verifies the new behavior
- Existing test suite passes with the changes
- Build and type checking should succeed

https://claude.ai/code/session_01AVFCUp2RDMDkkUb1ug7sPy