### PR TITLE
Add gh --version and gh repo view to allowed commands

### DIFF
--- a/src/agents/claude.test.ts
+++ b/src/agents/claude.test.ts
@@ -288,6 +288,13 @@ describe('buildClaudeAllowList', () => {
     expect(list).toContain('Bash(gh issue view *)');
     expect(list).toContain('Bash(gh issue create)');
     expect(list).toContain('Bash(gh issue create *)');
+    expect(list).toContain('Bash(gh repo view)');
+    expect(list).toContain('Bash(gh repo view *)');
+  });
+
+  it('allows gh --version', () => {
+    const list = buildClaudeAllowList();
+    expect(list).toContain('Bash(gh --version)');
   });
 
   it('restricts git remote to read-only operations', () => {

--- a/src/permissions.test.ts
+++ b/src/permissions.test.ts
@@ -56,6 +56,17 @@ describe('flattenPermissions', () => {
     expect(result).toContain('git push -u origin feature/*');
   });
 
+  it('flattens gh --version as a bare command', () => {
+    const result = flattenPermissions();
+    expect(result).toContain('gh --version');
+  });
+
+  it('flattens gh repo view with bare and wildcard variants', () => {
+    const result = flattenPermissions();
+    expect(result).toContain('gh repo view');
+    expect(result).toContain('gh repo view *');
+  });
+
   it('does not produce empty strings or undefined entries', () => {
     const result = flattenPermissions();
     for (const entry of result) {

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -152,6 +152,7 @@ export const permissions: Record<string, PermissionEntry> = {
   // Entries with ["", "*"] generate both bare and wildcard permissions,
   // e.g. `gh pr list` AND `gh pr list *`.
   gh: {
+    "--version": [],
     "pr create": ["", "*"],
     "pr status": [],
     "pr view": ["", "*"],
@@ -166,6 +167,7 @@ export const permissions: Record<string, PermissionEntry> = {
     "run list": [],
     "run view": ["", "*"],
     "api": ["repos/*"],
+    "repo view": ["", "*"],
   },
 
   // --- Misc utilities ---


### PR DESCRIPTION
## Summary
- Primary outcome: Expand GitHub CLI (gh) command permissions to include `gh --version` and `gh repo view` with wildcard variants
- Notable behaviour changes: Claude agent can now execute version checks and repository view operations
- Follow-up work deferred: None

## Context
These commands are commonly needed utilities for agents working with GitHub repositories. `gh --version` allows version verification, and `gh repo view` enables reading repository metadata—both read-only operations that are safe for agent execution.

## Implementation Notes
- Added `"--version": []` to gh permissions (bare command only, no wildcard variant needed)
- Added `"repo view": ["", "*"]` to gh permissions (generates both bare and wildcard variants)
- Updated corresponding test cases in `permissions.test.ts` and `agents/claude.test.ts` to verify the new commands are properly flattened and included in the Claude allow list

## Risks & Mitigations
- Risk: None identified. Both commands are read-only operations with no side effects.
- Mitigation: N/A

## Rollback Plan
Revert changes to `src/permissions.ts` (remove the two new permission entries) and remove the corresponding test cases from `src/permissions.test.ts` and `src/agents/claude.test.ts`.

## Testing
- Added unit tests for `gh --version` bare command flattening
- Added unit tests for `gh repo view` bare and wildcard variant flattening
- Added unit test verifying `gh --version` appears in Claude allow list
- Added unit tests verifying both `gh repo view` and `gh repo view *` appear in Claude allow list
- Existing test suite validates permission flattening logic and allow list generation

https://claude.ai/code/session_01FvRnsipmzMgFz9ZCyWNhGN