### PR TITLE
Clarify milestone confirmation flow in RFC template docs

### DIFF
--- a/src/templates/base/smithy.render.md
+++ b/src/templates/base/smithy.render.md
@@ -139,7 +139,7 @@ Parse the input and prepare the target:
 1. **Read the RFC file.** Parse the Milestones section to extract all milestones
    (each `### Milestone N: <Title>` heading).
 2. **Validate the target milestone.** If a milestone number was specified, confirm
-   it exists. If auto-selected, confirm the choice with the user.
+   it exists. If auto-selected, proceed with that choice (step 5 will confirm).
 3. **Derive the slug.** Create a kebab-case slug from the milestone title
    (e.g., "Core Pipeline Commands" → `core-pipeline-commands`).
 4. **Derive the filename.** `<NN>-<milestone-slug>.features.md` where `<NN>` is the


### PR DESCRIPTION
## Summary
- Primary outcome: Clarify the milestone selection confirmation behavior in the RFC template documentation
- Notable behaviour changes: Documentation only—no functional changes to the CLI
- Follow-up work deferred: None

## Context
The documentation for the milestone selection step was ambiguous about when user confirmation occurs. This change clarifies that when a milestone is auto-selected, the choice proceeds immediately without explicit confirmation at that step, with confirmation deferred to step 5 of the process.

## Implementation Notes
- Documentation-only change to `src/templates/base/smithy.render.md`
- Clarifies the flow: auto-selected milestones proceed directly, with confirmation happening later in the workflow
- No changes to CLI behavior or template generation logic

## Risks & Mitigations
- Risk: None—documentation clarification only
- Mitigation: N/A

## Rollback Plan
Revert the single line change in the markdown file if clarification is deemed incorrect.

## Testing
No testing needed—documentation clarification only.

https://claude.ai/code/session_01FgK97ffTJ2FWxJSAc8xo8K