### PR TITLE
docs: restructure testing docs around 3-part conceptual model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,11 +78,11 @@ node dist/cli.js update  # Test update flow
 
 ## Testing
 
-Smithy has three conceptual parts, each tested differently:
+Smithy has three testing tiers, each tested differently:
 
-1. **CLI behavior** (Part 1) — init/uninit/update flows, option parsing, file deployment, idempotency. Covered by `npm test` (automated, CI) and interactive terminal tests (H1-H4).
-2. **Agent-skill file validation** (Part 2) — template composition, partial resolution, frontmatter, agent variants, file categorization. Covered by `npm test` (automated, CI) and agent-session tests (A1-A5).
-3. **Agent-skill execution behavior** (Part 3) — skills produce correct output when invoked by an AI agent, sub-agents are dispatched, output structure matches expectations. Covered by evals framework (`npm run eval`, local on-demand, not CI). **Status: in development.**
+1. **CLI behavior** (Tier 1) — init/uninit/update flows, option parsing, file deployment, idempotency. Covered by `npm test` (automated, CI) and interactive terminal tests (H1-H4).
+2. **Agent-skill file validation** (Tier 2) — template composition, partial resolution, frontmatter, agent variants, file categorization. Covered by `npm test` (automated, CI) and agent-session tests (A1-A5).
+3. **Agent-skill execution behavior** (Tier 3) — skills produce correct output when invoked by an AI agent, sub-agents are dispatched, output structure matches expectations. Covered by evals framework (`npm run eval`, local on-demand, not CI). **Status: in development.**
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for test file details. Agent and human test cases are in **[tests/](tests/)**: [tests/Agent.tests.md](tests/Agent.tests.md) (A-series), [tests/Manual.tests.md](tests/Manual.tests.md) (H-series).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,13 +78,13 @@ node dist/cli.js update  # Test update flow
 
 ## Testing
 
-Smithy uses a three-tier testing strategy:
+Smithy has three conceptual parts, each tested differently:
 
-1. **Automated** (`npm test`): A comprehensive suite covering init/uninit flows, template composition, permissions, and utilities. Runs in CI on every push and PR.
-2. **Agent** (Claude Code session): Manual A-series test cases (A1-A5) verifying prompt visibility, slash command invocability, permissions enforcement, stale artifact cleanup, and sub-agent output structure.
-3. **Human** (interactive terminal): Manual H-series test cases (H1-H4) for Inquirer-based prompts that cannot be driven programmatically.
+1. **CLI behavior** (Part 1) — init/uninit/update flows, option parsing, file deployment, idempotency. Covered by `npm test` (automated, CI) and interactive terminal tests (H1-H4).
+2. **Agent-skill file validation** (Part 2) — template composition, partial resolution, frontmatter, agent variants, file categorization. Covered by `npm test` (automated, CI) and agent-session tests (A1-A5).
+3. **Agent-skill execution behavior** (Part 3) — skills produce correct output when invoked by an AI agent, sub-agents are dispatched, output structure matches expectations. Covered by evals framework (`npm run eval`, local on-demand, not CI). **Status: in development.**
 
-Agent and human test cases are documented in **[tests/](tests/)** with step-by-step instructions and checkboxes. See [tests/README.md](tests/README.md) for an overview, [tests/Agent.tests.md](tests/Agent.tests.md) for agent-runnable tests (A-series), and [tests/Manual.tests.md](tests/Manual.tests.md) for interactive terminal tests (H-series).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for test file details. Agent and human test cases are in **[tests/](tests/)**: [tests/Agent.tests.md](tests/Agent.tests.md) (A-series), [tests/Manual.tests.md](tests/Manual.tests.md) (H-series).
 
 ### Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,42 +13,58 @@ Always use `npm run` scripts. Do not use `npx tsx`, `npx vitest`, or similar dir
 
 ## Testing
 
-Smithy uses a three-tier testing strategy:
+Smithy has three conceptual parts that each require different testing strategies:
 
-### 1. Automated Tests (`npm test`)
+### Part 1: CLI Behavior (init / uninit / update)
 
-Unit and integration tests covering init/uninit flows, template composition, permissions generation, and utility functions. These run in CI on every push and PR.
+Tests that the CLI parses options correctly, deploys files to the right locations, handles idempotency, and cleans up properly. **Well covered** by automated tests and manual interactive tests.
+
+**Automated** (`npm test`) — runs in CI on every push and PR:
 
 | Test file | Scope |
 |-----------|-------|
-| `src/cli.test.ts` | CLI integration (init, uninit, lifecycle, idempotency) |
+| `src/cli.test.ts` | CLI integration (init, uninit, update, lifecycle, idempotency) |
 | `src/agents/claude.test.ts` | Claude deploy/remove, permissions, allow/deny lists |
 | `src/agents/gemini.test.ts` | Gemini deploy/remove |
 | `src/agents/codex.test.ts` | Codex deploy/remove |
-| `src/templates.test.ts` | Template composition and audit checklist extraction |
 | `src/utils.test.ts` | Utility functions (gitignore, copy, remove) |
 | `src/permissions.test.ts` | Permission flattening |
 
-### 2. Agent Tests (Claude Code session)
+**Human tests** (interactive terminal) — for Inquirer-based prompts that cannot be driven programmatically. See **[tests/Manual.tests.md](tests/Manual.tests.md)** (H1-H4).
 
-Tests that require a Claude Code runtime to verify prompts load, slash commands work, and permissions are enforced. These can be run by a Claude agent or by a developer in a Claude Code session.
+### Part 2: Agent-Skill File Validation (template composition & deployment)
 
-See **[tests/Agent.tests.md](tests/Agent.tests.md)** (A1-A5).
+Tests that templates compose correctly (snippet/partial resolution, frontmatter handling, agent-variant rendering), deploy to the right directories with the right format, and match expected file counts. **Well covered** by automated tests and agent-session tests.
 
-### 3. Human Tests (Interactive terminal)
+**Automated** (`npm test`):
 
-Tests for the Inquirer-based interactive prompts that cannot be driven programmatically. These require a developer at a real terminal.
+| Test file | Scope |
+|-----------|-------|
+| `src/templates.test.ts` | Template composition, partial resolution, frontmatter, agent variants, file categorization |
 
-See **[tests/Manual.tests.md](tests/Manual.tests.md)** (H1-H4).
+**Agent tests** (Claude Code session) — verify deployed prompts are visible, slash commands are invocable, permissions are enforced, and stale artifacts are cleaned up. See **[tests/Agent.tests.md](tests/Agent.tests.md)** (A1-A5).
+
+### Part 3: Agent-Skill Execution Behavior (evals)
+
+Tests that the deployed skills actually *work* when invoked by an AI agent — slash commands trigger, output has the correct structure, sub-agents are dispatched, and results meet quality expectations. **Not yet covered** — planned via a dedicated evals framework.
+
+The evals framework (under `evals/`) will:
+- Execute skills via `claude -p` in headless mode against a reference fixture codebase
+- Validate outputs structurally (required headings, sections, tables)
+- Verify sub-agent invocation (e.g., strike dispatches plan, scout, reconcile, clarify)
+- Run locally on demand (`npm run eval`), not in CI, due to LLM cost
+
+See **[specs/2026-04-06-003-smithy-evals-framework/](specs/2026-04-06-003-smithy-evals-framework/)** for the feature specification.
 
 ## Pre-Release Checklist
 
 Before publishing a new version:
 
 1. All automated tests pass: `npm test`
-2. Agent tests (A1-A4) verified in a Claude Code session
+2. Agent tests (A1-A5) verified in a Claude Code session
 3. Human tests (H1-H4) verified in an interactive terminal
-4. Trigger the **Publish to npm** workflow with both test gate checkboxes checked
+4. Evals pass (when available): `npm run eval`
+5. Trigger the **Publish to npm** workflow with both test gate checkboxes checked
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,9 @@ Always use `npm run` scripts. Do not use `npx tsx`, `npx vitest`, or similar dir
 
 ## Testing
 
-Smithy has three conceptual parts that each require different testing strategies:
+Smithy has three testing tiers that each require different strategies:
 
-### Part 1: CLI Behavior (init / uninit / update)
+### Tier 1: CLI Behavior (init / uninit / update)
 
 Tests that the CLI parses options correctly, deploys files to the right locations, handles idempotency, and cleans up properly. **Well covered** by automated tests and manual interactive tests.
 
@@ -32,7 +32,7 @@ Tests that the CLI parses options correctly, deploys files to the right location
 
 **Human tests** (interactive terminal) — for Inquirer-based prompts that cannot be driven programmatically. See **[tests/Manual.tests.md](tests/Manual.tests.md)** (H1-H4).
 
-### Part 2: Agent-Skill File Validation (template composition & deployment)
+### Tier 2: Agent-Skill File Validation (template composition & deployment)
 
 Tests that templates compose correctly (snippet/partial resolution, frontmatter handling, agent-variant rendering), deploy to the right directories with the right format, and match expected file counts. **Well covered** by automated tests and agent-session tests.
 
@@ -44,7 +44,7 @@ Tests that templates compose correctly (snippet/partial resolution, frontmatter 
 
 **Agent tests** (Claude Code session) — verify deployed prompts are visible, slash commands are invocable, permissions are enforced, and stale artifacts are cleaned up. See **[tests/Agent.tests.md](tests/Agent.tests.md)** (A1-A5).
 
-### Part 3: Agent-Skill Execution Behavior (evals)
+### Tier 3: Agent-Skill Execution Behavior (evals)
 
 Tests that the deployed skills actually *work* when invoked by an AI agent — slash commands trigger, output has the correct structure, sub-agents are dispatched, and results meet quality expectations. **Not yet covered** — planned via a dedicated evals framework.
 

--- a/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.contracts.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.contracts.md
@@ -83,7 +83,7 @@ validateStructure(output: string, expectations: StructuralExpectations): CheckRe
 
 **Purpose**: Checks whether expected sub-agents were invoked by looking for evidence patterns in the skill output.
 **Consumers**: Orchestrator (`run-evals.ts`)
-**Providers**: `evals/lib/structural.ts` (same module as structural validator)
+**Providers**: `evals/lib/structural.ts` (co-located with StructuralValidator — both operate on output strings with regex patterns, so they share a module despite being separate logical interfaces)
 
 #### Signature
 

--- a/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.contracts.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.contracts.md
@@ -1,0 +1,180 @@
+# Contracts: Smithy Evals Framework
+
+## Overview
+
+The evals framework has three internal integration boundaries: the runner (executes skills), the structural validator (checks output format), and the orchestrator (composes runner + validator into an eval pipeline). The primary external boundary is the `claude` CLI invoked via child process.
+
+## Interfaces
+
+### Runner
+
+**Purpose**: Executes a single eval scenario by invoking `claude -p` against a copy of the reference fixture and returning the captured output.
+**Consumers**: Orchestrator (`run-evals.ts`)
+**Providers**: `evals/lib/runner.ts`
+
+#### Signature
+
+```
+runScenario(scenario: EvalScenario, fixtureDir: string): Promise<RunOutput>
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scenario` | EvalScenario | Yes | The parsed scenario definition (skill, prompt, timeout) |
+| `fixtureDir` | string | Yes | Path to the source fixture directory (will be copied to temp) |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `output` | string | Raw stdout from `claude -p` |
+| `duration_ms` | number | Wall-clock execution time |
+| `exit_code` | number | Process exit code |
+| `timed_out` | boolean | Whether the process was killed due to timeout |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| `claude` not in PATH | Thrown error | Runner validates CLI availability before spawning |
+| Process timeout | `{ timed_out: true }` | Process killed via SIGTERM, partial output returned |
+| Non-zero exit code | `{ exit_code: N }` | Output still captured; caller decides if this is an error |
+| Fixture copy fails | Thrown error | Filesystem error copying fixture to temp directory |
+
+---
+
+### StructuralValidator
+
+**Purpose**: Validates a skill output string against a set of structural expectations (headings, patterns, tables) and returns per-check results.
+**Consumers**: Orchestrator (`run-evals.ts`)
+**Providers**: `evals/lib/structural.ts`
+
+#### Signature
+
+```
+validateStructure(output: string, expectations: StructuralExpectations): CheckResult[]
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `output` | string | Yes | The raw skill output to validate |
+| `expectations` | StructuralExpectations | Yes | The structural checks from the scenario YAML |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `CheckResult[]` | array | One entry per check, each with `check_name`, `passed`, `expected`, `actual` |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Empty output string | All checks fail | Checks run against empty string; all heading/pattern checks will fail |
+| Invalid regex in expectations | Thrown error | Malformed regex in `required_patterns` or `forbidden_patterns` |
+
+---
+
+### SubAgentVerifier
+
+**Purpose**: Checks whether expected sub-agents were invoked by looking for evidence patterns in the skill output.
+**Consumers**: Orchestrator (`run-evals.ts`)
+**Providers**: `evals/lib/structural.ts` (same module as structural validator)
+
+#### Signature
+
+```
+verifySubAgents(output: string, evidence: SubAgentEvidence[]): CheckResult[]
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `output` | string | Yes | The raw skill output to check |
+| `evidence` | SubAgentEvidence[] | Yes | Agent name + pattern pairs from the scenario |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `CheckResult[]` | array | One entry per sub-agent, indicating whether evidence of invocation was found |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Empty evidence array | Empty result array | No checks to run |
+
+---
+
+### Orchestrator CLI
+
+**Purpose**: CLI entry point that loads scenarios, runs them through the runner and validator, and produces the summary report.
+**Consumers**: Developer via `npm run eval` or `node evals/run-evals.ts`
+**Providers**: `evals/run-evals.ts`
+
+#### Signature
+
+```
+run-evals [--case <name>] [--timeout <seconds>] [--fixture <path>]
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `--case` | string | No | Run only the named scenario (matches YAML `name` field) |
+| `--timeout` | number | No | Override the default per-case timeout (seconds) |
+| `--fixture` | string | No | Override the fixture directory path (defaults to `evals/fixture/`) |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| stdout | text | Summary report with per-case pass/fail status and overall result |
+| exit code | number | `0` if all cases pass, `1` if any case fails |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| No scenario files found | Exit 1 with message | No YAML files in `evals/cases/` |
+| `--case` name not found | Exit 1 with message | Named case does not match any scenario |
+| `claude` CLI not available | Exit 1 with message | Fail-fast before running any cases |
+| API key not configured | Exit 1 with message | Fail-fast before running any cases |
+| Fixture directory missing | Exit 1 with message | `evals/fixture/` does not exist |
+
+## Events / Hooks
+
+No events or hooks are published by the evals framework. It is a standalone CLI tool.
+
+## Integration Boundaries
+
+### Claude CLI (`claude -p`)
+
+The primary external dependency. The runner invokes `claude -p "<prompt>"` as a child process with the fixture's temp copy as the working directory. The contract with the CLI is:
+
+- **Input**: prompt string via `-p` flag, working directory containing `.claude/` with deployed skills
+- **Output**: skill output on stdout, exit code 0 on success
+- **Assumption**: headless mode loads `.claude/commands/`, `.claude/prompts/`, and `.claude/agents/` from cwd
+
+### Smithy CLI (`smithy init`)
+
+Used during fixture setup (either pre-baked into the committed fixture or run as part of eval setup). The contract is:
+
+- **Input**: `smithy init -a claude -y` targeting the fixture directory
+- **Output**: deployed skills in `.claude/commands/`, `.claude/prompts/`, `.claude/agents/`
+
+### Filesystem (temp directories)
+
+The runner creates a temp directory per eval case by copying the fixture. The contract is:
+
+- Temp directories are created in the OS temp directory
+- Each eval case gets a unique temp directory
+- Temp directories are cleaned up after the case completes (regardless of pass/fail)
+- The source fixture directory is verified unmodified via checksum after each case

--- a/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.data-model.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.data-model.md
@@ -1,0 +1,105 @@
+# Data Model: Smithy Evals Framework
+
+## Overview
+
+The evals framework operates on three core entities: scenario definitions (input), eval results (per-case output), and eval reports (aggregate output). All data is file-based — YAML for scenarios, JSON for baselines, and in-memory structures for results and reports during execution.
+
+## Entities
+
+### 1) EvalScenario (`evals/cases/*.yaml`)
+
+Purpose: Declares a single eval case — which skill to invoke, with what arguments, and what structural properties the output must satisfy.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | Unique identifier for the case (e.g., `strike-health-check`) |
+| `skill` | string | Yes | The skill to invoke (e.g., `/smithy.strike`, `smithy-plan`) |
+| `prompt` | string | Yes | The prompt text or `$ARGUMENTS` to pass to the skill |
+| `model` | string | No | Model override for `claude -p` (defaults to framework default) |
+| `timeout` | number | No | Per-case timeout in seconds (defaults to 120) |
+| `structural_expectations` | object | Yes | Structural checks to run against the output |
+| `structural_expectations.required_headings` | string[] | Yes | Markdown headings that must be present (e.g., `["## Plan", "### Approach"]`) |
+| `structural_expectations.required_tables` | object[] | No | Tables that must be present with expected column names |
+| `structural_expectations.forbidden_patterns` | string[] | No | Regex patterns that must NOT appear in the output (e.g., `["^---\\n"]` for frontmatter) |
+| `structural_expectations.required_patterns` | string[] | No | Regex patterns that MUST appear in the output |
+| `sub_agents` | string[] | No | Sub-agent names expected to be invoked (e.g., `["smithy-plan", "smithy-scout"]`) |
+| `sub_agent_evidence` | object[] | No | Patterns that indicate a sub-agent was invoked (e.g., `{agent: "smithy-scout", pattern: "Scout Report"}`) |
+
+Validation rules:
+- `name` must be unique across all scenario files.
+- `skill` must be a valid Smithy skill name (command or agent).
+- `structural_expectations.required_headings` must contain at least one entry.
+
+### 2) EvalResult (in-memory)
+
+Purpose: Captures the outcome of running a single eval scenario, including the raw output, per-check results, and timing information.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `scenario_name` | string | Yes | References the EvalScenario `name` |
+| `status` | enum | Yes | `pass`, `fail`, `timeout`, `error` |
+| `output` | string | Yes | Raw stdout captured from `claude -p` |
+| `duration_ms` | number | Yes | Wall-clock time for the skill invocation |
+| `structural_checks` | CheckResult[] | Yes | Per-check pass/fail results |
+| `sub_agent_checks` | CheckResult[] | No | Per-agent invocation verification results |
+| `error` | string | No | Error message if status is `error` or `timeout` |
+
+### 3) CheckResult (in-memory, nested in EvalResult)
+
+Purpose: A single structural or sub-agent check result.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `check_name` | string | Yes | Human-readable check description (e.g., `"has '## Plan' heading"`) |
+| `passed` | boolean | Yes | Whether the check passed |
+| `expected` | string | No | What was expected (e.g., the heading text) |
+| `actual` | string | No | What was found (or "not found") |
+
+### 4) EvalReport (in-memory / stdout)
+
+Purpose: Aggregate summary across all scenarios in a single eval run.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `timestamp` | string | Yes | ISO 8601 timestamp of the run |
+| `total_cases` | number | Yes | Number of scenarios executed |
+| `passed` | number | Yes | Count of scenarios with status `pass` |
+| `failed` | number | Yes | Count of scenarios with status `fail`, `timeout`, or `error` |
+| `overall_status` | enum | Yes | `pass` (all cases pass) or `fail` (any case fails) |
+| `results` | EvalResult[] | Yes | Per-case results |
+| `total_duration_ms` | number | Yes | Total wall-clock time for the entire run |
+
+## Relationships
+
+- EvalReport 1:N EvalResult — one report contains results for all scenarios in a run.
+- EvalResult 1:N CheckResult — one result contains all structural and sub-agent checks for that scenario.
+- EvalResult N:1 EvalScenario — each result references the scenario it was run against (via `scenario_name`).
+
+## State Transitions
+
+### Eval case lifecycle
+
+1. `pending` → `running`
+   - Trigger: the orchestrator selects the next scenario to execute.
+   - Effects: fixture is copied to temp dir, `claude -p` is spawned.
+
+2. `running` → `pass`
+   - Trigger: skill output is captured and all structural checks pass.
+   - Effects: result is recorded with status `pass`.
+
+3. `running` → `fail`
+   - Trigger: skill output is captured but one or more structural checks fail.
+   - Effects: result is recorded with status `fail` and failing check details.
+
+4. `running` → `timeout`
+   - Trigger: per-case timeout is exceeded.
+   - Effects: process is killed, result is recorded with status `timeout`.
+
+5. `running` → `error`
+   - Trigger: `claude -p` exits with non-zero code, or an unexpected error occurs.
+   - Effects: result is recorded with status `error` and the error message.
+
+## Identity & Uniqueness
+
+- Scenarios are uniquely identified by their `name` field, which must be unique across all YAML files in `evals/cases/`.
+- Eval results are identified by `scenario_name` + run timestamp (a scenario can only have one result per run).

--- a/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.data-model.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.data-model.md
@@ -22,8 +22,7 @@ Purpose: Declares a single eval case — which skill to invoke, with what argume
 | `structural_expectations.required_tables` | object[] | No | Tables that must be present with expected column names |
 | `structural_expectations.forbidden_patterns` | string[] | No | Regex patterns that must NOT appear in the output (e.g., `["^---\\n"]` for frontmatter) |
 | `structural_expectations.required_patterns` | string[] | No | Regex patterns that MUST appear in the output |
-| `sub_agents` | string[] | No | Sub-agent names expected to be invoked (e.g., `["smithy-plan", "smithy-scout"]`) |
-| `sub_agent_evidence` | object[] | No | Patterns that indicate a sub-agent was invoked (e.g., `{agent: "smithy-scout", pattern: "Scout Report"}`) |
+| `sub_agent_evidence` | object[] | No | Agent name + evidence pattern pairs indicating a sub-agent was invoked (e.g., `{agent: "smithy-scout", pattern: "Scout Report"}`). Each entry specifies both the agent name (for reporting) and the regex pattern to search for in the output. |
 
 Validation rules:
 - `name` must be unique across all scenario files.
@@ -37,7 +36,7 @@ Purpose: Captures the outcome of running a single eval scenario, including the r
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
 | `scenario_name` | string | Yes | References the EvalScenario `name` |
-| `status` | enum | Yes | `pass`, `fail`, `timeout`, `error` |
+| `status` | enum | Yes | `pass`, `fail`, `timeout`, `error`. Note: `pending` and `running` are orchestrator-internal states used during execution but not persisted in the final result. |
 | `output` | string | Yes | Raw stdout captured from `claude -p` |
 | `duration_ms` | number | Yes | Wall-clock time for the skill invocation |
 | `structural_checks` | CheckResult[] | Yes | Per-check pass/fail results |

--- a/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.spec.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.spec.md
@@ -1,0 +1,234 @@
+# Feature Specification: Smithy Evals Framework
+
+**Spec Folder**: `2026-04-06-003-smithy-evals-framework`
+**Branch**: `claude/smithy-evals-framework-eeV5U`
+**Created**: 2026-04-06
+**Status**: Draft
+**Input**: User description — establish Tier 3 (execution behavior) testing for Smithy agent-skills, focusing on structural validation of headless `claude -p` output against a reference fixture.
+
+## Clarifications
+
+### Session 2026-04-06
+
+- Q: Should this spec cover Tier 2 improvements (shared validation package for deployed files)? → A: No, focus on Tier 3 (execution behavior) only. Tier 2 is a separate spec.
+- Q: Which skills should the eval framework cover initially? → A: Strike + all sub-agents it dispatches (plan x3 lenses, reconcile, scout, clarify). NOT orders (needs GitHub API mocking which requires Docker). The goal is depth-over-breadth: one end-to-end command tested thoroughly.
+- Q: Include rubric grading (LLM-as-judge) in v1? → A: Defer to v2. Structural-only validation for now.
+- Q: How should eval scenarios be defined? → A: YAML files in `evals/cases/`, one per scenario.
+- Q: Which sub-agents dispatched by strike should be verified? → A: All of them (plan x3 competing lenses, reconcile, scout, clarify).
+- Q: How complex should the reference fixture be? → A: Minimal (5-6 files, Express-style API). Enough for meaningful planning but low maintenance burden.
+- Q: Docker for isolation? → A: No Docker for v1. Copy fixture to temp directory. Add Docker later if contamination is a real problem.
+
+## Artifact Hierarchy
+
+RFC → Milestone → Feature → User Story → Slice → Tasks
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1: Execute a Skill Headlessly and Capture Output (Priority: P1)
+
+As a Smithy developer, I want to execute a deployed agent-skill via `claude -p` in headless mode against a reference fixture so that I can capture the skill's output for automated validation.
+
+**Why this priority**: Nothing else works without the ability to invoke skills headlessly and capture their output. This is the foundational capability.
+
+**Independent Test**: Run `claude -p "/smithy.strike 'add a health check endpoint'"` against a fixture project with Smithy skills deployed, confirm stdout is captured to a file.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reference fixture with Smithy skills deployed via `smithy init`, **When** the eval runner invokes `claude -p` with a skill prompt, **Then** the skill's full output is captured as a string.
+2. **Given** a skill invocation that exceeds the per-case timeout (default 120s), **When** the timeout is reached, **Then** the process is killed and the case is recorded as a timeout failure.
+3. **Given** no `claude` CLI in PATH or no valid API key, **When** the eval runner starts, **Then** it fails fast with a clear error message before attempting any skill invocations.
+4. **Given** the reference fixture on disk, **When** an eval case runs, **Then** the fixture source directory is not modified (a copy in a temp directory is used instead).
+
+---
+
+### User Story 2: Validate Output Structure (Priority: P1)
+
+As a Smithy developer, I want to validate that a skill's output contains the expected headings, sections, and table structures so that I can detect structural regressions without manual review.
+
+**Why this priority**: Structural validation is the core value proposition of the evals framework — it replaces vibes-based "looks right" with automated checks.
+
+**Independent Test**: Given a known skill output string, run the structural validator with a set of expectations (required headings, section presence), confirm it returns pass/fail per check.
+
+**Acceptance Scenarios**:
+
+1. **Given** a skill output and a scenario's structural expectations (list of required headings), **When** the validator runs, **Then** it returns a pass/fail result per heading check.
+2. **Given** a skill output missing a required section (e.g., `### Risks` absent from a plan output), **When** the validator runs, **Then** the missing section is reported as a failure with the expected heading name.
+3. **Given** a skill output with all required structural elements present, **When** the validator runs, **Then** all checks pass regardless of content quality (structural checks are format-only).
+
+---
+
+### User Story 3: Verify Strike End-to-End Output (Priority: P1)
+
+As a Smithy developer, I want to run `/smithy.strike` against the reference fixture and validate that the output has the correct overall structure so that I can catch regressions in the flagship command.
+
+**Why this priority**: Strike is the most-used command and exercises the full planning pipeline. If strike works end-to-end, the core agent-skill machinery is healthy.
+
+**Independent Test**: Invoke `/smithy.strike "add a health check endpoint"` via `claude -p` against the fixture, validate the output contains expected top-level sections.
+
+**Acceptance Scenarios**:
+
+1. **Given** the reference fixture with Smithy skills deployed, **When** `/smithy.strike` is invoked with a feature description, **Then** the output contains the expected strike output sections.
+2. **Given** a strike eval case, **When** the output is captured, **Then** no YAML frontmatter (`---`) appears at the top of the output (frontmatter should be stripped for Claude).
+3. **Given** a successful strike run, **When** the structural validator checks the output, **Then** the slash command is confirmed to have triggered the skill (output is not a generic Claude response).
+
+---
+
+### User Story 4: Verify Sub-Agent Invocation (Priority: P1)
+
+As a Smithy developer, I want to verify that strike dispatches all expected sub-agents (plan x3 lenses, reconcile, scout, clarify) so that I can detect when the agent dispatch chain breaks.
+
+**Why this priority**: Sub-agent dispatch is the most fragile part of strike — prompt changes can silently break agent invocation. This is the highest-risk area for silent regressions.
+
+**Independent Test**: Run a strike eval and check the output for evidence that each sub-agent was invoked (e.g., scout report section, reconciled plan section, competing lens references).
+
+**Acceptance Scenarios**:
+
+1. **Given** a strike eval run against the fixture (with Claude variant deployed), **When** the output is analyzed, **Then** evidence of smithy-scout invocation is present (e.g., a scout report or consistency scan section).
+2. **Given** a strike eval run, **When** the output is analyzed, **Then** evidence of smithy-plan invocation is present (e.g., competing plan references or lens labels like "Simplification", "Separation of Concerns", "Robustness").
+3. **Given** a strike eval run, **When** the output is analyzed, **Then** evidence of smithy-reconcile invocation is present (e.g., a reconciled plan or merged approach section).
+4. **Given** a strike eval run, **When** the output is analyzed, **Then** evidence of smithy-clarify invocation is present (e.g., clarification questions or assumption triage).
+
+---
+
+### User Story 5: Define Eval Scenarios Declaratively (Priority: P2)
+
+As a Smithy developer, I want to define eval scenarios in YAML files so that I can add new eval cases without modifying runner code.
+
+**Why this priority**: Important for maintainability but not blocking — the framework could launch with hardcoded cases and migrate to YAML. YAML separation is a quality-of-life improvement.
+
+**Independent Test**: Create a new YAML scenario file, run the eval runner, confirm the new case is picked up and executed without code changes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a YAML file in `evals/cases/` with a skill name, prompt, and structural expectations, **When** the eval runner starts, **Then** the scenario is loaded and executed.
+2. **Given** multiple YAML scenario files, **When** the eval runner is invoked with `--case <name>`, **Then** only the specified case runs.
+3. **Given** a YAML scenario file with an invalid structure (missing required fields), **When** the eval runner loads it, **Then** a clear validation error is reported and the case is skipped.
+
+---
+
+### User Story 6: Reference Fixture Project (Priority: P2)
+
+As a Smithy developer, I want a minimal reference codebase checked into the repo so that all eval runs test against the same known project state.
+
+**Why this priority**: The fixture is required for eval runs but its exact design can be iterated on. A minimal starting fixture unblocks everything.
+
+**Independent Test**: Run `smithy init -a claude -y` against the fixture directory, confirm skills are deployed successfully.
+
+**Acceptance Scenarios**:
+
+1. **Given** the fixture project in `evals/fixture/`, **When** `smithy init -a claude -y` runs against it, **Then** skills are deployed to `.claude/commands/`, `.claude/prompts/`, and `.claude/agents/`.
+2. **Given** the fixture project, **When** a scout eval runs against it, **Then** the scout detects at least one deliberate inconsistency (e.g., stale doc comment, mismatched signature).
+3. **Given** the fixture project, **When** a plan eval runs against it, **Then** the plan references specific files and structures from the fixture (not generic advice).
+
+---
+
+### User Story 7: Eval Summary Report (Priority: P2)
+
+As a Smithy developer, I want a pass/fail summary printed to stdout after all eval cases run so that I can quickly see which cases passed and which failed.
+
+**Why this priority**: Essential for usability but the report format can be refined over time. A basic pass/fail summary is sufficient for v1.
+
+**Independent Test**: Run the eval suite, confirm stdout contains a summary with case names and pass/fail status.
+
+**Acceptance Scenarios**:
+
+1. **Given** a completed eval run with 3 cases (2 pass, 1 fail), **When** the summary is printed, **Then** each case name appears with its pass/fail status and the overall result is FAIL.
+2. **Given** a completed eval run with all cases passing, **When** the summary is printed, **Then** the overall result is PASS with the total count.
+3. **Given** a case that timed out, **When** the summary is printed, **Then** the timeout is reported as a distinct failure reason (not just "FAIL").
+
+---
+
+### User Story 8: Baseline Structural Expectations (Priority: P3)
+
+As a Smithy developer, I want to store known-good structural expectations alongside each scenario so that I can detect regressions when skill output structure changes unexpectedly.
+
+**Why this priority**: Baselines add regression detection value but the framework is useful without them (manual review of pass/fail is sufficient initially).
+
+**Independent Test**: Modify a skill template to remove a required section, re-run evals, confirm the structural check fails against the baseline expectation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a baseline file for a scenario with expected headings and section counts, **When** the eval runs and output matches the baseline, **Then** the case passes.
+2. **Given** a baseline file, **When** the eval output is missing a section that the baseline expects, **Then** the case fails with a clear diff showing what's missing.
+3. **Given** a new eval case with no baseline, **When** the eval runs, **Then** the structural checks still run (baselines are optional, not required).
+
+---
+
+### User Story 9: Cost and Time Transparency (Priority: P3)
+
+As a Smithy developer, I want to see estimated run duration before starting an eval run so that I can make informed decisions about when to run evals.
+
+**Why this priority**: Nice-to-have for developer experience. The framework is fully usable without it.
+
+**Independent Test**: Run the eval suite, confirm a duration estimate or per-case timing is displayed.
+
+**Acceptance Scenarios**:
+
+1. **Given** the eval runner is invoked, **When** execution begins, **Then** the number of cases to run is displayed.
+2. **Given** a completed eval run, **When** the summary is printed, **Then** the total elapsed time and per-case duration are included.
+
+---
+
+### Edge Cases
+
+- Eval case where `claude -p` returns an empty response (model refusal, API error).
+- Eval case where the skill produces output but in an unexpected format (e.g., raw text instead of Markdown).
+- Concurrent eval runs modifying the same temp directory (should use unique temp dirs per run).
+- Fixture directory accidentally deleted or corrupted.
+- `claude` CLI version incompatible with `-p` flag or `.claude/` file loading behavior.
+- API rate limiting during multi-case sequential execution.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST execute agent-skills via `claude -p` in headless mode and capture the full stdout output.
+- **FR-002**: The system MUST copy the reference fixture to a unique temp directory before each eval case to prevent cross-case contamination.
+- **FR-003**: The system MUST validate that `claude` is available in PATH and API credentials are configured before running any eval cases.
+- **FR-004**: The system MUST enforce a per-case timeout (configurable, default 120 seconds) and kill the process on timeout.
+- **FR-005**: The system MUST validate skill output against structural expectations defined in the scenario (required headings, section presence).
+- **FR-006**: The system MUST report per-check pass/fail results for each structural assertion.
+- **FR-007**: The system MUST support YAML-based scenario definitions with skill name, prompt text, and structural expectations.
+- **FR-008**: The system MUST support filtering which cases to run via a `--case` CLI argument.
+- **FR-009**: The system MUST print a summary report to stdout with per-case pass/fail status and overall result.
+- **FR-010**: The system MUST run via a dedicated `npm run eval` script, completely decoupled from `npm test` and `pretest`.
+- **FR-011**: The system MUST verify that the source fixture directory was not modified after each eval case (checksum validation).
+- **FR-012**: The system MUST detect whether the slash command actually triggered the deployed skill (vs. a generic Claude response).
+
+### Key Entities
+
+- **EvalScenario**: A declarative test case definition (YAML) specifying which skill to invoke, with what prompt, and what structural properties the output must have.
+- **EvalResult**: The outcome of running a single scenario — captured output, per-check pass/fail results, duration, and any errors.
+- **EvalReport**: An aggregate summary across all scenarios in a run — total pass/fail counts, per-case results, and overall status.
+- **ReferenceFixture**: A minimal, static TypeScript project checked into the repo that serves as the target for all skill invocations.
+
+## Assumptions
+
+- The `claude` CLI supports `-p` (headless/pipe mode) for non-interactive skill execution.
+- Headless mode loads `.claude/commands/`, `.claude/prompts/`, and `.claude/agents/` from the working directory (same as interactive mode).
+- Sub-agent dispatch works in headless mode (plan, scout, reconcile, clarify are invoked by the skill prompt, not by interactive user action).
+- The `ANTHROPIC_API_KEY` environment variable is sufficient for authentication in headless mode.
+- Developers running evals have the `claude` CLI installed and authenticated locally.
+- A minimal 5-6 file fixture is sufficient for strike/plan/scout to produce structurally meaningful output.
+
+## Out of Scope
+
+- **Rubric grading / LLM-as-judge** — deferred to v2 once structural evals prove valuable.
+- **Docker isolation** — deferred to v2. Temp directory copy + checksum validation is sufficient for v1.
+- **CI integration** — evals run locally on demand only.
+- **Tier 2 improvements** (shared validation package for deployed file format) — separate spec.
+- **Gemini / Codex evals** — Tier 3 focuses on Claude Code execution only for now.
+- **smithy.orders evals** — requires GitHub API mocking, which needs Docker.
+- **Multi-run statistical analysis** (median-of-N scoring, variance tracking) — deferred to v2 with rubric grading.
+- **Automatic baseline generation or updating** — baselines are created and updated manually.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The eval framework can execute at least 3 eval cases (strike, plan, scout) against the reference fixture and produce a pass/fail report.
+- **SC-002**: Structural validation detects when a required output section is missing (e.g., removing `### Risks` from a plan template causes the plan eval to fail).
+- **SC-003**: Sub-agent invocation is verified for all agents dispatched by strike (plan x3, reconcile, scout, clarify).
+- **SC-004**: The eval suite runs in under 10 minutes for all cases combined (assuming typical LLM response times).
+- **SC-005**: Evals are fully decoupled from `npm test` — running `npm test` never triggers eval cases.
+- **SC-006**: Adding a new eval case requires only creating a YAML file in `evals/cases/` — no runner code changes needed.

--- a/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.spec.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.spec.md
@@ -24,7 +24,38 @@ RFC → Milestone → Feature → User Story → Slice → Tasks
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1: Execute a Skill Headlessly and Capture Output (Priority: P1)
+### User Story 1: Validate Headless Execution Assumptions (Priority: P1)
+
+As a Smithy developer, I want to confirm that `claude -p` headless mode loads deployed `.claude/` files and supports sub-agent dispatch so that I can proceed with building the evals framework on solid ground.
+
+**Why this priority**: The entire framework depends on three unvalidated assumptions about `claude -p` behavior. If any fail, the architecture needs rethinking before any other story is implemented.
+
+**Independent Test**: Run `claude -p "/smithy.strike 'add a health check endpoint'"` in a directory with deployed Smithy skills, observe whether the skill is triggered and sub-agents are dispatched.
+
+**Acceptance Scenarios**:
+
+1. **Given** a directory with Smithy skills deployed via `smithy init -a claude -y`, **When** `claude -p "/smithy.strike 'add a health check'"` is run, **Then** the output reflects the strike skill (not a generic Claude response).
+2. **Given** a deployed smithy-plan agent, **When** strike runs in headless mode, **Then** evidence of sub-agent dispatch appears in the output (e.g., competing lens labels, scout report).
+3. **Given** headless mode does NOT load `.claude/` files, **When** the spike reveals this, **Then** a fallback approach is documented (e.g., injecting prompt content directly via `claude -p "$(cat .claude/commands/smithy.strike.md) ..."`).
+
+---
+
+### User Story 2: Reference Fixture Exists and Is Deployable (Priority: P1)
+
+As a Smithy developer, I want a minimal reference codebase checked into the repo so that all eval runs test against the same known project state.
+
+**Why this priority**: Every eval case depends on a fixture to run against. Without it, nothing can execute.
+
+**Independent Test**: Run `smithy init -a claude -y` against the fixture directory, confirm skills are deployed successfully.
+
+**Acceptance Scenarios**:
+
+1. **Given** the fixture project in `evals/fixture/`, **When** `smithy init -a claude -y` runs against it, **Then** skills are deployed to `.claude/commands/`, `.claude/prompts/`, and `.claude/agents/`.
+2. **Given** the fixture project, **When** a plan eval runs against it, **Then** the plan references specific files and structures from the fixture (not generic advice).
+
+---
+
+### User Story 3: Execute a Skill Headlessly and Capture Output (Priority: P1)
 
 As a Smithy developer, I want to execute a deployed agent-skill via `claude -p` in headless mode against a reference fixture so that I can capture the skill's output for automated validation.
 
@@ -41,7 +72,7 @@ As a Smithy developer, I want to execute a deployed agent-skill via `claude -p` 
 
 ---
 
-### User Story 2: Validate Output Structure (Priority: P1)
+### User Story 4: Validate Output Structure (Priority: P1)
 
 As a Smithy developer, I want to validate that a skill's output contains the expected headings, sections, and table structures so that I can detect structural regressions without manual review.
 
@@ -57,7 +88,7 @@ As a Smithy developer, I want to validate that a skill's output contains the exp
 
 ---
 
-### User Story 3: Verify Strike End-to-End Output (Priority: P1)
+### User Story 5: Verify Strike End-to-End Output (Priority: P1)
 
 As a Smithy developer, I want to run `/smithy.strike` against the reference fixture and validate that the output has the correct overall structure so that I can catch regressions in the flagship command.
 
@@ -69,11 +100,11 @@ As a Smithy developer, I want to run `/smithy.strike` against the reference fixt
 
 1. **Given** the reference fixture with Smithy skills deployed, **When** `/smithy.strike` is invoked with a feature description, **Then** the output contains the expected strike output sections.
 2. **Given** a strike eval case, **When** the output is captured, **Then** no YAML frontmatter (`---`) appears at the top of the output (frontmatter should be stripped for Claude).
-3. **Given** a successful strike run, **When** the structural validator checks the output, **Then** the slash command is confirmed to have triggered the skill (output is not a generic Claude response).
+3. **Given** a successful strike run, **When** the structural validator checks the output, **Then** the skill is confirmed triggered by the presence of strike-specific structural markers (e.g., `# Strike:` heading, `## Requirements`, `## Tasks` sections) AND the absence of generic refusal patterns (e.g., "I'd be happy to help", "Sure, here's").
 
 ---
 
-### User Story 4: Verify Sub-Agent Invocation (Priority: P1)
+### User Story 6: Verify Sub-Agent Invocation (Priority: P1)
 
 As a Smithy developer, I want to verify that strike dispatches all expected sub-agents (plan x3 lenses, reconcile, scout, clarify) so that I can detect when the agent dispatch chain breaks.
 
@@ -90,7 +121,7 @@ As a Smithy developer, I want to verify that strike dispatches all expected sub-
 
 ---
 
-### User Story 5: Define Eval Scenarios Declaratively (Priority: P2)
+### User Story 7: Define Eval Scenarios Declaratively (Priority: P2)
 
 As a Smithy developer, I want to define eval scenarios in YAML files so that I can add new eval cases without modifying runner code.
 
@@ -106,23 +137,22 @@ As a Smithy developer, I want to define eval scenarios in YAML files so that I c
 
 ---
 
-### User Story 6: Reference Fixture Project (Priority: P2)
+### User Story 8: Fixture Contains Deliberate Inconsistencies for Scout (Priority: P2)
 
-As a Smithy developer, I want a minimal reference codebase checked into the repo so that all eval runs test against the same known project state.
+As a Smithy developer, I want the reference fixture to contain deliberate inconsistencies so that scout evals can verify inconsistency detection, not just structural output format.
 
-**Why this priority**: The fixture is required for eval runs but its exact design can be iterated on. A minimal starting fixture unblocks everything.
+**Why this priority**: The fixture already exists (US2), but adding deliberate flaws enriches scout eval coverage. Can be added after the basic framework works.
 
-**Independent Test**: Run `smithy init -a claude -y` against the fixture directory, confirm skills are deployed successfully.
+**Independent Test**: Run a scout eval against the fixture, confirm the scout detects the planted inconsistency.
 
 **Acceptance Scenarios**:
 
-1. **Given** the fixture project in `evals/fixture/`, **When** `smithy init -a claude -y` runs against it, **Then** skills are deployed to `.claude/commands/`, `.claude/prompts/`, and `.claude/agents/`.
-2. **Given** the fixture project, **When** a scout eval runs against it, **Then** the scout detects at least one deliberate inconsistency (e.g., stale doc comment, mismatched signature).
-3. **Given** the fixture project, **When** a plan eval runs against it, **Then** the plan references specific files and structures from the fixture (not generic advice).
+1. **Given** the fixture project with a deliberate stale doc comment, **When** a scout eval runs against it, **Then** the scout detects at least one inconsistency (e.g., stale doc comment, mismatched signature).
+2. **Given** the fixture project, **When** a new deliberate inconsistency is added, **Then** the scout eval detects it without changes to the eval runner.
 
 ---
 
-### User Story 7: Eval Summary Report (Priority: P2)
+### User Story 9: Eval Summary Report (Priority: P2)
 
 As a Smithy developer, I want a pass/fail summary printed to stdout after all eval cases run so that I can quickly see which cases passed and which failed.
 
@@ -138,23 +168,25 @@ As a Smithy developer, I want a pass/fail summary printed to stdout after all ev
 
 ---
 
-### User Story 8: Baseline Structural Expectations (Priority: P3)
+### User Story 10: Baseline Structural Expectations (Priority: P3)
 
-As a Smithy developer, I want to store known-good structural expectations alongside each scenario so that I can detect regressions when skill output structure changes unexpectedly.
+As a Smithy developer, I want to store known-good output snapshots as baselines so that I can compare new eval outputs against a previous known-good run to detect regressions beyond structural checks.
 
-**Why this priority**: Baselines add regression detection value but the framework is useful without them (manual review of pass/fail is sufficient initially).
+**Why this priority**: Baselines add regression detection value but the framework is useful without them (YAML structural expectations cover format; baselines cover content drift). Can be layered on after the structural framework works.
 
-**Independent Test**: Modify a skill template to remove a required section, re-run evals, confirm the structural check fails against the baseline expectation.
+**Clarification**: Baselines are distinct from the YAML structural expectations. YAML expectations define *format rules* (e.g., "must have `## Plan` heading"). Baselines are *snapshot files* of a previous known-good output, used to detect content drift (e.g., "the approach section used to mention file X but no longer does"). Baselines are optional; structural expectations are required per scenario.
+
+**Independent Test**: Store a baseline snapshot, modify a skill template to change output content, re-run evals, confirm the baseline comparison flags the drift.
 
 **Acceptance Scenarios**:
 
-1. **Given** a baseline file for a scenario with expected headings and section counts, **When** the eval runs and output matches the baseline, **Then** the case passes.
-2. **Given** a baseline file, **When** the eval output is missing a section that the baseline expects, **Then** the case fails with a clear diff showing what's missing.
+1. **Given** a baseline snapshot file for a scenario, **When** the eval runs and output content substantially matches the baseline, **Then** the case passes the baseline comparison.
+2. **Given** a baseline snapshot, **When** the eval output has structural changes not present in the baseline, **Then** the case flags a regression with a summary of what changed.
 3. **Given** a new eval case with no baseline, **When** the eval runs, **Then** the structural checks still run (baselines are optional, not required).
 
 ---
 
-### User Story 9: Cost and Time Transparency (Priority: P3)
+### User Story 11: Cost and Time Transparency (Priority: P3)
 
 As a Smithy developer, I want to see estimated run duration before starting an eval run so that I can make informed decisions about when to run evals.
 
@@ -178,6 +210,12 @@ As a Smithy developer, I want to see estimated run duration before starting an e
 - `claude` CLI version incompatible with `-p` flag or `.claude/` file loading behavior.
 - API rate limiting during multi-case sequential execution.
 
+### Eval Strategy Note: Standalone vs. Indirect Coverage
+
+Plan and scout are tested **both** ways:
+- **Indirectly** via strike (US5, US6) — verifying they are dispatched as sub-agents and their output appears in strike's output.
+- **Standalone** via their own YAML eval scenarios — invoking them directly as sub-agents with their own structural expectations (e.g., `## Plan` with 4 sections for plan, `## Scout Report` with severity tables for scout). This validates their output structure independently of strike's orchestration.
+
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
@@ -193,7 +231,9 @@ As a Smithy developer, I want to see estimated run duration before starting an e
 - **FR-009**: The system MUST print a summary report to stdout with per-case pass/fail status and overall result.
 - **FR-010**: The system MUST run via a dedicated `npm run eval` script, completely decoupled from `npm test` and `pretest`.
 - **FR-011**: The system MUST verify that the source fixture directory was not modified after each eval case (checksum validation).
-- **FR-012**: The system MUST detect whether the slash command actually triggered the deployed skill (vs. a generic Claude response).
+- **FR-012**: The system MUST detect whether the slash command actually triggered the deployed skill by checking for skill-specific structural markers (e.g., `# Strike:` heading for strike, `## Plan` heading for plan) AND the absence of generic refusal patterns (e.g., "I'd be happy to help", "Sure, here's"). A scenario MAY define custom `required_patterns` and `forbidden_patterns` for this purpose.
+- **FR-013**: The system MUST clean up temp directories after each eval case completes, regardless of pass/fail/timeout/error status.
+- **FR-014**: Before building the full framework, a validation spike MUST confirm that `claude -p` headless mode (a) loads `.claude/commands/`, `.claude/prompts/`, and `.claude/agents/` from the working directory, (b) supports sub-agent dispatch, and (c) captures skill output on stdout. If any assumption fails, a fallback approach MUST be documented.
 
 ### Key Entities
 
@@ -226,7 +266,7 @@ As a Smithy developer, I want to see estimated run duration before starting an e
 
 ### Measurable Outcomes
 
-- **SC-001**: The eval framework can execute at least 3 eval cases (strike, plan, scout) against the reference fixture and produce a pass/fail report.
+- **SC-001**: The eval framework can execute at least 3 eval cases (strike end-to-end, plan standalone, scout standalone) against the reference fixture and produce a pass/fail report.
 - **SC-002**: Structural validation detects when a required output section is missing (e.g., removing `### Risks` from a plan template causes the plan eval to fail).
 - **SC-003**: Sub-agent invocation is verified for all agents dispatched by strike (plan x3, reconcile, scout, clarify).
 - **SC-004**: The eval suite runs in under 10 minutes for all cases combined (assuming typical LLM response times).

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,8 +1,12 @@
-# Manual Test Cases
+# Manual & Eval Test Cases
 
 Pre-release checklist for tests that cannot be fully automated. Run these before publishing a new version.
 
-Automated tests (`npm test`) cover unit and integration tests. The cases here cover agent-runtime and interactive-terminal scenarios that automated tests cannot reach.
+Smithy's testing covers three parts (see [CONTRIBUTING.md](../CONTRIBUTING.md#testing) for full details):
+- **Part 1 (CLI behavior)** and **Part 2 (file validation)** are covered by `npm test` (automated).
+- **Part 2 (agent-session)** is covered by the A-series agent tests below.
+- **Part 1 (interactive)** is covered by the H-series human tests below.
+- **Part 3 (execution behavior)** is covered by the evals framework in `evals/` (in development).
 
 ## Test Files
 
@@ -10,6 +14,7 @@ Automated tests (`npm test`) cover unit and integration tests. The cases here co
 |------|--------|-------------|
 | [Agent.tests.md](Agent.tests.md) | Claude Code agent or developer in a Claude Code session | Verifies deployed prompts, slash commands, permissions, stale cleanup, and sub-agent output structure |
 | [Manual.tests.md](Manual.tests.md) | Developer at an interactive terminal | Verifies Inquirer-based prompts that cannot be driven programmatically |
+| `evals/` (planned) | Developer running `npm run eval` locally | Executes skills via `claude -p` headless mode against a reference fixture, validates output structure |
 
 ## Setup
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,11 +2,11 @@
 
 Pre-release checklist for tests that cannot be fully automated. Run these before publishing a new version.
 
-Smithy's testing covers three parts (see [CONTRIBUTING.md](../CONTRIBUTING.md#testing) for full details):
-- **Part 1 (CLI behavior)** and **Part 2 (file validation)** are covered by `npm test` (automated).
-- **Part 2 (agent-session)** is covered by the A-series agent tests below.
-- **Part 1 (interactive)** is covered by the H-series human tests below.
-- **Part 3 (execution behavior)** is covered by the evals framework in `evals/` (in development).
+Smithy's testing covers three tiers (see [CONTRIBUTING.md](../CONTRIBUTING.md#testing) for full details):
+- **Tier 1 (CLI behavior)** and **Tier 2 (file validation)** are covered by `npm test` (automated).
+- **Tier 2 (agent-session)** is covered by the A-series agent tests below.
+- **Tier 1 (interactive)** is covered by the H-series human tests below.
+- **Tier 3 (execution behavior)** is covered by the evals framework in `evals/` (in development).
 
 ## Test Files
 


### PR DESCRIPTION
Reframe testing documentation from runner-based tiers (automated/agent/human)
to part-based tiers (CLI behavior, file validation, execution behavior) across
CLAUDE.md, CONTRIBUTING.md, and tests/README.md. Adds placeholder for the
planned Part 3 evals framework.

https://claude.ai/code/session_01NrkGLy5e5Fhwzt6wzQXD25