### PR TITLE
Add spec for refactoring smithy.ignite to piecewise RFC generation

### DIFF
--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.contracts.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.contracts.md
@@ -1,0 +1,178 @@
+# Contracts: Refactor Ignite Workflow
+
+## Overview
+
+This feature modifies the ignite prompt template's internal pipeline structure but does not introduce new external interfaces, APIs, or integration boundaries. The contracts between ignite and its sub-agents (smithy-clarify, smithy-plan, smithy-reconcile, smithy-refine) remain unchanged — only the invocation parameters and context passed to them are enriched.
+
+The primary contract changes are internal to the ignite template: the sub-phase pipeline protocol and the intermediate file format conventions.
+
+## Interfaces
+
+### Sub-Phase Pipeline Protocol
+
+**Purpose**: Defines how each sub-phase (3a-3f) operates within the piecewise drafting pipeline.
+**Consumers**: The ignite orchestrator (main prompt context)
+**Providers**: Each sub-phase snippet (`ignite-phase3a.md` through `ignite-phase3f.md`)
+
+#### Signature
+
+Each sub-phase follows this protocol:
+1. Read all prior `_wip/` files from disk for context
+2. Draft its assigned RFC section(s)
+3. Write output to the designated `_wip/<NN>-<section>.md` file
+4. Control returns to the orchestrator for the next sub-phase
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `rfc_folder` | Path | Yes | The RFC folder path (e.g., `docs/rfcs/2026-001-slug/`) |
+| `prior_wip_files` | File contents | Yes | Contents of all `_wip/` files with lower numeric prefixes |
+| `clarify_output` | Text | Yes | The Q&A and assumptions from Phase 2 clarification |
+| `reconciled_plan` | Text | Conditional | The reconciled approach from Phase 1.5 (required for 3d, 3e, 3f) |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `wip_file` | File | The `_wip/<NN>-<section>.md` file written to disk |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Prior `_wip/` file missing | Halt pipeline | If a required prior file is missing, the sub-phase cannot proceed. Report the gap and halt. |
+| Write failure | Halt pipeline | If the `_wip/` file cannot be written, report the error and halt. |
+
+### Sub-Phase to Section Mapping
+
+**Purpose**: Defines which RFC sections each sub-phase is responsible for drafting.
+**Consumers**: Sub-phase snippets, assemble step (3g)
+**Providers**: The ignite template specification
+
+#### Mapping Table
+
+| Sub-Phase | WIP File | RFC Sections Produced |
+|-----------|----------|----------------------|
+| 3a | `01-problem.md` | Summary, Motivation / Problem Statement |
+| 3b | `02-personas.md` | Personas |
+| 3c | `03-goals.md` | Goals, Out of Scope |
+| 3d | `04-proposal.md` | Proposal, Design Considerations |
+| 3e | `05-decisions.md` | Decisions, Open Questions |
+| 3f | `06-milestones.md` | Milestones (with Success Criteria per milestone) |
+
+### Assemble Step (3g) Contract
+
+**Purpose**: Defines how the final RFC is composed from intermediate files.
+**Consumers**: Phase 4 (Write & Review)
+**Providers**: Sub-phase 3g
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `wip_files` | File list | Yes | All 6 `_wip/` files (01 through 06) |
+| `rfc_template` | Template | Yes | The RFC Markdown template structure from the ignite prompt |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `rfc_file` | File | The final `<slug>.rfc.md` written to disk |
+| `wip_cleanup` | Side effect | The `_wip/` directory is deleted after successful write |
+
+#### Process
+
+1. Read all 6 `_wip/` files in order
+2. Map each file's content to the corresponding RFC template section(s)
+3. Concatenate into the full RFC template structure
+4. Perform coherence/harmonization pass (smooth tone, fix cross-references)
+5. Add RFC metadata header (`Created`, `Status`)
+6. Write final RFC to `<slug>.rfc.md`
+7. Delete `_wip/` directory
+
+### Clarify Log Contract
+
+**Purpose**: Defines the format and usage of `.clarify-log.md` for cross-session deduplication.
+**Consumers**: smithy-clarify sub-agent (on subsequent sessions)
+**Providers**: The ignite orchestrator (after Phase 2 completes)
+
+#### Write Format
+
+```markdown
+### Session YYYY-MM-DD
+
+**Assumptions**:
+- <assumption 1>
+- <assumption 2>
+
+**Questions & Answers**:
+- Q: <question> → A: <answer>
+- Q: <question> → A: <answer>
+```
+
+#### Read Protocol
+
+When passed to smithy-clarify as additional context:
+- Include the instruction: "Do not re-ask questions already answered in this log."
+- Pass the last 2 sessions from the log (not the full history) to limit context usage.
+
+### Updated RFC Template Schema
+
+**Purpose**: The canonical RFC template structure that all sub-phases and the assemble step must conform to.
+**Consumers**: Sub-phases 3a-3f, assemble step 3g, Phase 0 audit, `smithy.audit`
+**Providers**: The ignite template specification
+
+#### Template Structure
+
+```markdown
+# RFC: <Title>
+
+**Created**: YYYY-MM-DD  |  **Status**: Draft
+
+## Summary
+## Motivation / Problem Statement
+## Goals
+## Out of Scope
+## Personas
+## Proposal
+## Design Considerations
+## Decisions
+## Open Questions
+## Milestones
+### Milestone N: <Title>
+```
+
+New sections vs. current template:
+- `## Out of Scope` — NEW (after Goals)
+- `## Personas` — NEW (after Out of Scope)
+
+### Updated Phase 0 Audit Categories
+
+**Purpose**: The audit criteria used by smithy-refine during the Phase 0 review loop.
+**Consumers**: smithy-refine sub-agent
+**Providers**: The ignite template Phase 0 specification
+
+#### Categories
+
+| Category | What to check |
+|----------|---------------|
+| **Problem Statement** | Problem clarity, solution outline, compelling motivation |
+| **Goals** | Concrete, achievable, non-overlapping |
+| **Out of Scope Completeness** | Explicit exclusions documented, scope boundaries clear |
+| **Persona Coverage** | Personas identified with descriptions, relevant to stated goals |
+| **Milestones** | Well-defined scope, clear boundaries, success criteria |
+| **Feasibility** | Technical risks, dependency concerns, resource assumptions |
+| **Scope** | Drift from stated goals, feature creep indicators |
+| **Stakeholders** | Missing perspectives, unconsidered personas |
+
+New categories vs. current: **Out of Scope Completeness** and **Persona Coverage**.
+
+## Integration Boundaries
+
+This feature's integration boundaries are entirely within the smithy template system:
+
+- **Ignite → Sub-agents**: The invocation interface for smithy-clarify, smithy-plan, smithy-reconcile, and smithy-refine remains unchanged. Only the content of the context and criteria parameters changes.
+- **Ignite → Snippets**: New snippet files are consumed via existing Dotprompt `{{>partial-name}}` mechanism. No changes to the partial resolution system.
+- **Ignite → File System**: New file I/O patterns (`_wip/` directory, `.clarify-log.md`) use standard file read/write operations already available to the agent.
+- **Ignite → Downstream Commands**: The final RFC format adds two new sections (Personas, Out of Scope) that `smithy.render` and `smithy.mark` may reference but do not require. No breaking changes to downstream consumers.

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.contracts.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.contracts.md
@@ -46,7 +46,7 @@ The orchestrator dispatches smithy-prose with a section assignment and context. 
 | Property | Value | Notes |
 |----------|-------|-------|
 | Tools | Read, Grep, Glob | Read-only codebase access for context gathering |
-| Model | Opus | Narrative quality benefits from the strongest model |
+| Model | opus | Narrative quality benefits from the strongest model |
 | Interactive | No | Returns output to parent agent only |
 
 ---

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.contracts.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.contracts.md
@@ -2,32 +2,87 @@
 
 ## Overview
 
-This feature modifies the ignite prompt template's internal pipeline structure but does not introduce new external interfaces, APIs, or integration boundaries. The contracts between ignite and its sub-agents (smithy-clarify, smithy-plan, smithy-reconcile, smithy-refine) remain unchanged — only the invocation parameters and context passed to them are enriched.
+This feature restructures the ignite prompt into an orchestrator that dispatches sub-agents for each RFC section. It introduces a new shared `smithy-prose` sub-agent for narrative sections and reuses `smithy-plan` for structured analytical sections. The contracts between ignite and existing sub-agents (smithy-clarify, smithy-reconcile, smithy-refine) remain unchanged.
 
-The primary contract changes are internal to the ignite template: the sub-phase pipeline protocol and the intermediate file format conventions.
+The primary contract changes are: (1) the new smithy-prose sub-agent interface, (2) the sub-phase pipeline protocol and intermediate file conventions, and (3) expanded smithy-plan dispatch for per-section analytical drafting.
 
 ## Interfaces
+
+### Smithy-Prose Sub-Agent Interface (NEW)
+
+**Purpose**: Shared sub-agent for drafting narrative/persuasive sections of planning artifacts.
+**Consumers**: Ignite orchestrator (sub-phases 3a, 3b), potentially render, mark, and other commands in future.
+**Providers**: `src/templates/agent-skills/agents/smithy.prose.prompt`
+
+#### Signature
+
+The orchestrator dispatches smithy-prose with a section assignment and context. The sub-agent drafts the narrative section and returns it as text output. The orchestrator writes the output to the `_wip/` file.
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `section_assignment` | Text | Yes | Which RFC section(s) to draft (e.g., "Summary and Motivation / Problem Statement") |
+| `idea_description` | Text | Yes | The user's original idea or PRD content from intake |
+| `clarify_output` | Text | Yes | The Q&A and assumptions from Phase 2 clarification |
+| `prior_wip_files` | File paths | No | Paths to prior `_wip/` files for context (empty for 3a, populated for 3b) |
+| `tone_directives` | Text | No | Specific prose guidance (e.g., "emphasize stakeholder impact", "frame as urgency") |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `section_content` | Markdown | The drafted RFC section(s) in Markdown format |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Insufficient context | Return partial with flags | If the idea description is too vague to write a compelling narrative, return what's possible and flag the gaps for the orchestrator to address. |
+| Empty output | Halt | If no meaningful content can be produced, return an error rather than placeholder text. |
+
+#### Agent Properties
+
+| Property | Value | Notes |
+|----------|-------|-------|
+| Tools | Read, Grep, Glob | Read-only codebase access for context gathering |
+| Model | Opus | Narrative quality benefits from the strongest model |
+| Interactive | No | Returns output to parent agent only |
+
+---
 
 ### Sub-Phase Pipeline Protocol
 
 **Purpose**: Defines how each sub-phase (3a-3f) operates within the piecewise drafting pipeline.
 **Consumers**: The ignite orchestrator (main prompt context)
-**Providers**: Each sub-phase snippet (`ignite-phase3a.md` through `ignite-phase3f.md`)
+**Providers**: Sub-agents (smithy-prose for 3a/3b, smithy-plan for 3c/3d/3f, orchestrator inline for 3e)
 
 #### Signature
 
 Each sub-phase follows this protocol:
-1. Read all prior `_wip/` files from disk for context
-2. Draft its assigned RFC section(s)
-3. Write output to the designated `_wip/<NN>-<section>.md` file
-4. Control returns to the orchestrator for the next sub-phase
+1. Orchestrator gathers context: prior `_wip/` files, clarification output, reconciled plan
+2. Orchestrator dispatches the appropriate sub-agent with section assignment and context
+3. Sub-agent returns drafted section content
+4. Orchestrator writes output to the designated `_wip/<NN>-<section>.md` file
+5. Orchestrator proceeds to next sub-phase
+
+#### Sub-Agent Dispatch Map
+
+| Sub-Phase | Sub-Agent | Rationale |
+|-----------|-----------|-----------|
+| 3a (Summary, Motivation) | smithy-prose | Narrative/persuasive writing |
+| 3b (Personas) | smithy-prose | Persona descriptions are narrative |
+| 3c (Goals, Out of Scope) | smithy-plan | Structured analytical decomposition |
+| 3d (Proposal, Design Considerations) | smithy-plan | Analytical, draws on reconciled approach |
+| 3e (Decisions, Open Questions) | Orchestrator inline | Synthesis of clarification record — straightforward partitioning |
+| 3f (Milestones) | smithy-plan | Structured decomposition with success criteria |
 
 #### Inputs
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `rfc_folder` | Path | Yes | The RFC folder path (e.g., `docs/rfcs/2026-001-slug/`) |
-| `prior_wip_files` | File contents | Yes | Contents of all `_wip/` files with lower numeric prefixes |
+| `prior_wip_files` | File paths | Yes | Paths to all `_wip/` files with lower numeric prefixes |
 | `clarify_output` | Text | Yes | The Q&A and assumptions from Phase 2 clarification |
 | `reconciled_plan` | Text | Conditional | The reconciled approach from Phase 1.5 (required for 3d, 3e, 3f) |
 
@@ -35,19 +90,20 @@ Each sub-phase follows this protocol:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `wip_file` | File | The `_wip/<NN>-<section>.md` file written to disk |
+| `wip_file` | File | The `_wip/<NN>-<section>.md` file written to disk by the orchestrator |
 
 #### Error Conditions
 
 | Condition | Response | Description |
 |-----------|----------|-------------|
 | Prior `_wip/` file missing | Halt pipeline | If a required prior file is missing, the sub-phase cannot proceed. Report the gap and halt. |
+| Sub-agent returns empty/error | Halt pipeline | If the dispatched sub-agent fails to produce content, halt and report. |
 | Write failure | Halt pipeline | If the `_wip/` file cannot be written, report the error and halt. |
 
 ### Sub-Phase to Section Mapping
 
 **Purpose**: Defines which RFC sections each sub-phase is responsible for drafting.
-**Consumers**: Sub-phase snippets, assemble step (3g)
+**Consumers**: Sub-agents (smithy-prose, smithy-plan), orchestrator, assemble step (3g)
 **Providers**: The ignite template specification
 
 #### Mapping Table
@@ -172,7 +228,9 @@ New categories vs. current: **Out of Scope Completeness** and **Persona Coverage
 
 This feature's integration boundaries are entirely within the smithy template system:
 
-- **Ignite → Sub-agents**: The invocation interface for smithy-clarify, smithy-plan, smithy-reconcile, and smithy-refine remains unchanged. Only the content of the context and criteria parameters changes.
-- **Ignite → Snippets**: New snippet files are consumed via existing Dotprompt `{{>partial-name}}` mechanism. No changes to the partial resolution system.
+- **Ignite → smithy-prose (NEW)**: New sub-agent dispatched for narrative RFC sections. Deployed as `src/templates/agent-skills/agents/smithy.prose.prompt` and follows the same agent conventions as smithy-plan, smithy-clarify, etc.
+- **Ignite → smithy-plan (expanded)**: smithy-plan is now dispatched for individual structured sections (3c, 3d, 3f) in addition to its existing role in Phase 1.5 competing plans. Its interface is unchanged — only the planning context and directives differ per dispatch.
+- **Ignite → smithy-clarify, smithy-reconcile, smithy-refine**: Invocation interfaces unchanged. Only the content of context and criteria parameters changes.
 - **Ignite → File System**: New file I/O patterns (`_wip/` directory, `.clarify-log.md`) use standard file read/write operations already available to the agent.
 - **Ignite → Downstream Commands**: The final RFC format adds two new sections (Personas, Out of Scope) that `smithy.render` and `smithy.mark` may reference but do not require. No breaking changes to downstream consumers.
+- **smithy-prose → Other Commands (future)**: smithy-prose is designed as a shared agent. Other commands can dispatch it for their narrative sections without modification to smithy-prose itself.

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.contracts.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.contracts.md
@@ -32,13 +32,13 @@ The orchestrator dispatches smithy-prose with a section assignment and context. 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `section_content` | Markdown | The drafted RFC section(s) in Markdown format |
+| `section_content` | Markdown | The drafted RFC section(s) in Markdown format. If context is insufficient but some useful draft content can be produced, the output MUST still be returned in this field and MUST end with a `## Gaps / Missing Context` section that lists the specific missing facts, assumptions, or questions the orchestrator should address. |
 
 #### Error Conditions
 
 | Condition | Response | Description |
 |-----------|----------|-------------|
-| Insufficient context | Return partial with flags | If the idea description is too vague to write a compelling narrative, return what's possible and flag the gaps for the orchestrator to address. |
+| Insufficient context | Return partial in `section_content` with `## Gaps / Missing Context` | If the idea description is too vague to write a fully compelling narrative, return the best partial draft possible and append a `## Gaps / Missing Context` section so the orchestrator can detect and address the gaps consistently. |
 | Empty output | Halt | If no meaningful content can be produced, return an error rather than placeholder text. |
 
 #### Agent Properties

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.contracts.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.contracts.md
@@ -4,7 +4,7 @@
 
 This feature restructures the ignite prompt into an orchestrator that dispatches sub-agents for each RFC section. It introduces a new shared `smithy-prose` sub-agent for narrative sections and reuses `smithy-plan` for structured analytical sections. The contracts between ignite and existing sub-agents (smithy-clarify, smithy-reconcile, smithy-refine) remain unchanged.
 
-The primary contract changes are: (1) the new smithy-prose sub-agent interface, (2) the sub-phase pipeline protocol and intermediate file conventions, and (3) expanded smithy-plan dispatch for per-section analytical drafting.
+The primary contract changes are: (1) the new smithy-prose sub-agent interface, (2) the sub-phase pipeline protocol with direct RFC file writes, and (3) expanded smithy-plan dispatch for per-section analytical drafting.
 
 ## Interfaces
 
@@ -16,7 +16,7 @@ The primary contract changes are: (1) the new smithy-prose sub-agent interface, 
 
 #### Signature
 
-The orchestrator dispatches smithy-prose with a section assignment and context. The sub-agent drafts the narrative section and returns it as text output. The orchestrator writes the output to the `_wip/` file.
+The orchestrator dispatches smithy-prose with a section assignment and context. The sub-agent drafts the narrative section and returns it as text output. The orchestrator appends the output to the RFC file.
 
 #### Inputs
 
@@ -25,7 +25,7 @@ The orchestrator dispatches smithy-prose with a section assignment and context. 
 | `section_assignment` | Text | Yes | Which RFC section(s) to draft (e.g., "Summary and Motivation / Problem Statement") |
 | `idea_description` | Text | Yes | The user's original idea or PRD content from intake |
 | `clarify_output` | Text | Yes | The Q&A and assumptions from Phase 2 clarification |
-| `prior_wip_files` | File paths | No | Paths to prior `_wip/` files for context (empty for 3a, populated for 3b) |
+| `rfc_file_path` | Path | No | Path to the accumulating `<slug>.rfc.md` for context (empty for 3a, populated for 3b) |
 | `tone_directives` | Text | No | Specific prose guidance (e.g., "emphasize stakeholder impact", "frame as urgency") |
 
 #### Outputs
@@ -46,7 +46,7 @@ The orchestrator dispatches smithy-prose with a section assignment and context. 
 | Property | Value | Notes |
 |----------|-------|-------|
 | Tools | Read, Grep, Glob | Read-only codebase access for context gathering |
-| Model | opus | Narrative quality benefits from the strongest model |
+| Model | Opus | Narrative quality benefits from the strongest model |
 | Interactive | No | Returns output to parent agent only |
 
 ---
@@ -60,10 +60,10 @@ The orchestrator dispatches smithy-prose with a section assignment and context. 
 #### Signature
 
 Each sub-phase follows this protocol:
-1. Orchestrator gathers context: prior `_wip/` files, clarification output, reconciled plan
+1. Orchestrator gathers context: path to accumulating RFC file, clarification output, reconciled plan
 2. Orchestrator dispatches the appropriate sub-agent with section assignment and context
 3. Sub-agent returns drafted section content
-4. Orchestrator writes output to the designated `_wip/<NN>-<section>.md` file
+4. Orchestrator appends the returned content to `<slug>.rfc.md`
 5. Orchestrator proceeds to next sub-phase
 
 #### Sub-Agent Dispatch Map
@@ -81,8 +81,7 @@ Each sub-phase follows this protocol:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `rfc_folder` | Path | Yes | The RFC folder path (e.g., `docs/rfcs/2026-001-slug/`) |
-| `prior_wip_files` | File paths | Yes | Paths to all `_wip/` files with lower numeric prefixes |
+| `rfc_file_path` | Path | Yes | Path to the accumulating `<slug>.rfc.md` file |
 | `clarify_output` | Text | Yes | The Q&A and assumptions from Phase 2 clarification |
 | `reconciled_plan` | Text | Conditional | The reconciled approach from Phase 1.5 (required for 3d, 3e, 3f) |
 
@@ -90,62 +89,57 @@ Each sub-phase follows this protocol:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `wip_file` | File | The `_wip/<NN>-<section>.md` file written to disk by the orchestrator |
+| `section_content` | Markdown | The drafted section(s) returned by the sub-agent, appended to the RFC file by the orchestrator |
 
 #### Error Conditions
 
 | Condition | Response | Description |
 |-----------|----------|-------------|
-| Prior `_wip/` file missing | Halt pipeline | If a required prior file is missing, the sub-phase cannot proceed. Report the gap and halt. |
+| RFC file missing or unreadable | Halt pipeline | If the accumulating RFC file is missing when a sub-phase needs it for context, halt and report. |
 | Sub-agent returns empty/error | Halt pipeline | If the dispatched sub-agent fails to produce content, halt and report. |
-| Write failure | Halt pipeline | If the `_wip/` file cannot be written, report the error and halt. |
+| Write failure | Halt pipeline | If the RFC file cannot be appended to, report the error and halt. |
 
 ### Sub-Phase to Section Mapping
 
 **Purpose**: Defines which RFC sections each sub-phase is responsible for drafting.
-**Consumers**: Sub-agents (smithy-prose, smithy-plan), orchestrator, assemble step (3g)
+**Consumers**: Sub-agents (smithy-prose, smithy-plan), orchestrator, harmonize step (3g)
 **Providers**: The ignite template specification
 
 #### Mapping Table
 
-| Sub-Phase | WIP File | RFC Sections Produced |
-|-----------|----------|----------------------|
-| 3a | `01-problem.md` | Summary, Motivation / Problem Statement |
-| 3b | `02-personas.md` | Personas |
-| 3c | `03-goals.md` | Goals, Out of Scope |
-| 3d | `04-proposal.md` | Proposal, Design Considerations |
-| 3e | `05-decisions.md` | Decisions, Open Questions |
-| 3f | `06-milestones.md` | Milestones (with Success Criteria per milestone) |
+| Sub-Phase | RFC Sections Produced |
+|-----------|----------------------|
+| 3a | Summary, Motivation / Problem Statement |
+| 3b | Personas |
+| 3c | Goals, Out of Scope |
+| 3d | Proposal, Design Considerations |
+| 3e | Decisions, Open Questions |
+| 3f | Milestones (with Success Criteria per milestone) |
 
-### Assemble Step (3g) Contract
+### Harmonize Step (3g) Contract
 
-**Purpose**: Defines how the final RFC is composed from intermediate files.
+**Purpose**: Defines how the accumulated RFC is polished after all sections are written.
 **Consumers**: Phase 4 (Write & Review)
-**Providers**: Sub-phase 3g
+**Providers**: Sub-phase 3g (orchestrator inline)
 
 #### Inputs
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `wip_files` | File list | Yes | All 6 `_wip/` files (01 through 06) |
-| `rfc_template` | Template | Yes | The RFC Markdown template structure from the ignite prompt |
+| `rfc_file_path` | Path | Yes | Path to the complete `<slug>.rfc.md` with all sections |
 
 #### Outputs
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `rfc_file` | File | The final `<slug>.rfc.md` written to disk |
-| `wip_cleanup` | Side effect | The `_wip/` directory is deleted after successful write |
+| `rfc_file` | File | The harmonized `<slug>.rfc.md` rewritten in place |
 
 #### Process
 
-1. Read all 6 `_wip/` files in order
-2. Map each file's content to the corresponding RFC template section(s)
-3. Concatenate into the full RFC template structure
-4. Perform coherence/harmonization pass (smooth tone, fix cross-references)
-5. Add RFC metadata header (`Created`, `Status`)
-6. Write final RFC to `<slug>.rfc.md`
-7. Delete `_wip/` directory
+1. Read the complete `<slug>.rfc.md`
+2. Perform coherence pass (smooth tone across sections, fix cross-references)
+3. Verify all template sections are present and non-empty
+4. Rewrite the file in place
 
 ### Clarify Log Contract
 
@@ -175,8 +169,8 @@ When passed to smithy-clarify as additional context:
 
 ### Updated RFC Template Schema
 
-**Purpose**: The canonical RFC template structure that all sub-phases and the assemble step must conform to.
-**Consumers**: Sub-phases 3a-3f, assemble step 3g, Phase 0 audit, `smithy.audit`
+**Purpose**: The canonical RFC template structure that all sub-phases must conform to.
+**Consumers**: Sub-phases 3a-3f, harmonize step 3g, Phase 0 audit, `smithy.audit`
 **Providers**: The ignite template specification
 
 #### Template Structure
@@ -231,6 +225,6 @@ This feature's integration boundaries are entirely within the smithy template sy
 - **Ignite → smithy-prose (NEW)**: New sub-agent dispatched for narrative RFC sections. Deployed as `src/templates/agent-skills/agents/smithy.prose.prompt` and follows the same agent conventions as smithy-plan, smithy-clarify, etc.
 - **Ignite → smithy-plan (expanded)**: smithy-plan is now dispatched for individual structured sections (3c, 3d, 3f) in addition to its existing role in Phase 1.5 competing plans. Its interface is unchanged — only the planning context and directives differ per dispatch.
 - **Ignite → smithy-clarify, smithy-reconcile, smithy-refine**: Invocation interfaces unchanged. Only the content of context and criteria parameters changes.
-- **Ignite → File System**: New file I/O patterns (`_wip/` directory, `.clarify-log.md`) use standard file read/write operations already available to the agent.
+- **Ignite → File System**: Piecewise writes append to `<slug>.rfc.md` incrementally. `.clarify-log.md` uses standard append. All file I/O uses operations already available to the agent.
 - **Ignite → Downstream Commands**: The final RFC format adds two new sections (Personas, Out of Scope) that `smithy.render` and `smithy.mark` may reference but do not require. No breaking changes to downstream consumers.
 - **smithy-prose → Other Commands (future)**: smithy-prose is designed as a shared agent. Other commands can dispatch it for their narrative sections without modification to smithy-prose itself.

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.data-model.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.data-model.md
@@ -1,0 +1,84 @@
+# Data Model: Refactor Ignite Workflow
+
+## Overview
+
+This feature introduces intermediate file artifacts used during piecewise RFC generation. These are transient (the `_wip/` directory) or persistent (the `.clarify-log.md`) files that support the pipeline's context-passing and deduplication mechanisms.
+
+## Entities
+
+### 1) WIP Sub-Phase Output (`_wip/<NN>-<section>.md`)
+
+Purpose: Holds the intermediate output of a single sub-phase during piecewise RFC drafting. Each file contains one or more RFC sections in Markdown format. Files are consumed by subsequent sub-phases for context and by the assemble step for final RFC composition.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `filename` | String | Yes | Zero-padded prefix + kebab-case section name (e.g., `01-problem.md`, `02-personas.md`) |
+| `content` | Markdown | Yes | One or more RFC sections in Markdown format, using the RFC template's heading conventions |
+| `location` | Path | Yes | `docs/rfcs/<YYYY-NNN-slug>/_wip/` |
+
+Validation rules:
+- Filename prefix must be two-digit zero-padded (01-06).
+- Content must be non-empty Markdown.
+- Files must be numbered sequentially without gaps for the assemble step to succeed.
+
+### 2) Clarify Log (`.clarify-log.md`)
+
+Purpose: Persistent record of clarification Q&A and assumptions from each `smithy.ignite` session. Used by smithy-clarify in subsequent sessions to avoid re-asking resolved questions.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `filename` | String | Yes | Always `.clarify-log.md` |
+| `location` | Path | Yes | `docs/rfcs/<YYYY-NNN-slug>/` (co-located with the RFC) |
+| `sessions` | Markdown sections | Yes | Each session is a dated heading (`### Session YYYY-MM-DD`) followed by assumptions and Q&A |
+
+Validation rules:
+- Each session entry must include a date heading.
+- Assumptions and questions should be formatted consistently (bullet points with Q/A notation).
+- The file is append-only — new sessions are added at the end, existing sessions are never modified.
+
+## Relationships
+
+- WIP Sub-Phase Output 1:1 RFC — each `_wip/` directory belongs to exactly one RFC folder.
+- Clarify Log 1:1 RFC — each `.clarify-log.md` belongs to exactly one RFC folder.
+- WIP Sub-Phase Output is consumed-by Assemble Step — the 3g assemble step reads all `_wip/` files to produce the final RFC.
+- Clarify Log is consumed-by smithy-clarify — passed as additional context on subsequent sessions.
+
+## State Transitions
+
+### WIP Directory Lifecycle
+
+1. `nonexistent` → `in-progress`
+   - Trigger: Sub-phase 3a begins and writes `01-problem.md`
+   - Effects: `_wip/` directory is created inside the RFC folder
+
+2. `in-progress` → `in-progress` (files accumulate)
+   - Trigger: Each subsequent sub-phase (3b-3f) completes
+   - Effects: New numbered file added to `_wip/`
+
+3. `in-progress` → `deleted`
+   - Trigger: Sub-phase 3g (Assemble) successfully writes the final RFC
+   - Effects: `_wip/` directory and all contents are deleted
+
+4. `in-progress` → `partial` (interrupted)
+   - Trigger: Session interruption or crash during any sub-phase
+   - Effects: `_wip/` directory remains with files from completed sub-phases only
+
+5. `partial` → `in-progress` (resumed)
+   - Trigger: Phase 0 detects partial state and user accepts resume
+   - Effects: Pipeline continues from first missing sub-phase file
+
+### Clarify Log Lifecycle
+
+1. `nonexistent` → `created`
+   - Trigger: First clarification phase completes for an RFC
+   - Effects: `.clarify-log.md` created with initial session entry
+
+2. `created` → `appended`
+   - Trigger: Subsequent clarification sessions complete
+   - Effects: New session entry appended to existing file
+
+## Identity & Uniqueness
+
+- WIP files are uniquely identified by their numeric prefix within a `_wip/` directory. Only one file per prefix number can exist.
+- The clarify log is uniquely identified by its fixed filename (`.clarify-log.md`) within an RFC folder. Only one can exist per RFC.
+- The `_wip/` directory is uniquely identified by its parent RFC folder path. Only one `_wip/` directory can exist per RFC.

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.data-model.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.data-model.md
@@ -2,26 +2,11 @@
 
 ## Overview
 
-This feature introduces intermediate file artifacts used during piecewise RFC generation, plus a new shared sub-agent definition. The artifacts include transient files (the `_wip/` directory), persistent files (the `.clarify-log.md`), and a new agent template (`smithy-prose`).
+This feature introduces a new shared sub-agent definition (`smithy-prose`) and a persistent clarification log file (`.clarify-log.md`). The RFC file itself (`<slug>.rfc.md`) serves as the intermediate artifact during piecewise generation — each sub-phase appends its section(s) directly to the growing file.
 
 ## Entities
 
-### 1) WIP Sub-Phase Output (`_wip/<NN>-<section>.md`)
-
-Purpose: Holds the intermediate output of a single sub-phase during piecewise RFC drafting. Each file contains one or more RFC sections in Markdown format. Files are consumed by subsequent sub-phases for context and by the assemble step for final RFC composition.
-
-| Field | Type | Required | Notes |
-|-------|------|----------|-------|
-| `filename` | String | Yes | Zero-padded prefix + kebab-case section name (e.g., `01-problem.md`, `02-personas.md`) |
-| `content` | Markdown | Yes | One or more RFC sections in Markdown format, using the RFC template's heading conventions |
-| `location` | Path | Yes | `docs/rfcs/<YYYY-NNN-slug>/_wip/` |
-
-Validation rules:
-- Filename prefix must be two-digit zero-padded (01-06).
-- Content must be non-empty Markdown.
-- Files must be numbered sequentially without gaps for the assemble step to succeed.
-
-### 2) Clarify Log (`.clarify-log.md`)
+### 1) Clarify Log (`.clarify-log.md`)
 
 Purpose: Persistent record of clarification Q&A and assumptions from each `smithy.ignite` session. Used by smithy-clarify in subsequent sessions to avoid re-asking resolved questions.
 
@@ -36,7 +21,7 @@ Validation rules:
 - Assumptions and questions should be formatted consistently (bullet points with Q/A notation).
 - The file is append-only — new sessions are added at the end, existing sessions are never modified.
 
-### 3) Smithy-Prose Agent Definition (`smithy.prose.prompt`)
+### 2) Smithy-Prose Agent Definition (`smithy.prose.prompt`)
 
 Purpose: New shared sub-agent template for drafting narrative/persuasive sections of planning artifacts. Used by ignite for Summary, Motivation, and Personas sections. Designed for reuse by other commands.
 
@@ -52,38 +37,38 @@ Purpose: New shared sub-agent template for drafting narrative/persuasive section
 Validation rules:
 - Must follow the same frontmatter schema as other agent definitions (name, description, tools, model).
 - Must be non-interactive (returns output to parent agent only).
-- Must accept section assignment, idea description, clarification output, and optional prior `_wip/` file paths as input.
+- Must accept section assignment, idea description, clarification output, and optional RFC file path as input.
 
 ## Relationships
 
-- WIP Sub-Phase Output 1:1 RFC — each `_wip/` directory belongs to exactly one RFC folder.
 - Clarify Log 1:1 RFC — each `.clarify-log.md` belongs to exactly one RFC folder.
-- WIP Sub-Phase Output is consumed-by Assemble Step — the 3g assemble step reads all `_wip/` files to produce the final RFC.
 - Clarify Log is consumed-by smithy-clarify — passed as additional context on subsequent sessions.
+- RFC File is written-by orchestrator — the orchestrator appends sub-agent output to `<slug>.rfc.md` after each sub-phase.
+- RFC File is read-by sub-agents — smithy-prose and smithy-plan receive the path to the accumulating RFC file as context for subsequent sub-phases.
 
 ## State Transitions
 
-### WIP Directory Lifecycle
+### RFC File Lifecycle (during piecewise generation)
 
-1. `nonexistent` → `in-progress`
-   - Trigger: Sub-phase 3a begins and writes `01-problem.md`
-   - Effects: `_wip/` directory is created inside the RFC folder
+1. `nonexistent` → `header-only`
+   - Trigger: Phase 3 begins; orchestrator creates `<slug>.rfc.md` with RFC title and metadata header
+   - Effects: File exists with `# RFC: <Title>` and `**Created**: ... | **Status**: Draft`
 
-2. `in-progress` → `in-progress` (files accumulate)
-   - Trigger: Each subsequent sub-phase (3b-3f) completes
-   - Effects: New numbered file added to `_wip/`
+2. `header-only` → `partial` (sections accumulate)
+   - Trigger: Each sub-phase (3a-3f) completes and orchestrator appends the returned content
+   - Effects: New section(s) appended to the file
 
-3. `in-progress` → `deleted`
-   - Trigger: Sub-phase 3g (Assemble) successfully writes the final RFC
-   - Effects: `_wip/` directory and all contents are deleted
+3. `partial` → `complete`
+   - Trigger: All sub-phases 3a-3f have appended their sections
+   - Effects: File contains all RFC template sections
 
-4. `in-progress` → `partial` (interrupted)
-   - Trigger: Session interruption or crash during any sub-phase
-   - Effects: `_wip/` directory remains with files from completed sub-phases only
+4. `complete` → `harmonized`
+   - Trigger: Sub-phase 3g (Harmonize) rewrites the file in place for coherence
+   - Effects: File is the final RFC, ready for Phase 4 (Write & Review)
 
-5. `partial` → `in-progress` (resumed)
-   - Trigger: Phase 0 detects partial state and user accepts resume
-   - Effects: Pipeline continues from first missing sub-phase file
+5. `partial` → `partial` (resumed after interruption)
+   - Trigger: Phase 0 detects partial RFC (by parsing headings), user accepts resume
+   - Effects: Pipeline continues from first missing section
 
 ### Clarify Log Lifecycle
 
@@ -97,6 +82,5 @@ Validation rules:
 
 ## Identity & Uniqueness
 
-- WIP files are uniquely identified by their numeric prefix within a `_wip/` directory. Only one file per prefix number can exist.
+- The RFC file is uniquely identified by its filename (`<slug>.rfc.md`) within the RFC folder. Only one RFC file per folder.
 - The clarify log is uniquely identified by its fixed filename (`.clarify-log.md`) within an RFC folder. Only one can exist per RFC.
-- The `_wip/` directory is uniquely identified by its parent RFC folder path. Only one `_wip/` directory can exist per RFC.

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.data-model.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.data-model.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This feature introduces intermediate file artifacts used during piecewise RFC generation. These are transient (the `_wip/` directory) or persistent (the `.clarify-log.md`) files that support the pipeline's context-passing and deduplication mechanisms.
+This feature introduces intermediate file artifacts used during piecewise RFC generation, plus a new shared sub-agent definition. The artifacts include transient files (the `_wip/` directory), persistent files (the `.clarify-log.md`), and a new agent template (`smithy-prose`).
 
 ## Entities
 
@@ -35,6 +35,24 @@ Validation rules:
 - Each session entry must include a date heading.
 - Assumptions and questions should be formatted consistently (bullet points with Q/A notation).
 - The file is append-only — new sessions are added at the end, existing sessions are never modified.
+
+### 3) Smithy-Prose Agent Definition (`smithy.prose.prompt`)
+
+Purpose: New shared sub-agent template for drafting narrative/persuasive sections of planning artifacts. Used by ignite for Summary, Motivation, and Personas sections. Designed for reuse by other commands.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `filename` | String | Yes | `smithy.prose.prompt` |
+| `location` | Path | Yes | `src/templates/agent-skills/agents/` |
+| `frontmatter.name` | String | Yes | `smithy-prose` |
+| `frontmatter.tools` | Array | Yes | `[Read, Grep, Glob]` — read-only codebase access |
+| `frontmatter.model` | String | Yes | `opus` — narrative quality benefits from strongest model |
+| `body` | Markdown | Yes | Prompt instructions for narrative drafting |
+
+Validation rules:
+- Must follow the same frontmatter schema as other agent definitions (name, description, tools, model).
+- Must be non-interactive (returns output to parent agent only).
+- Must accept section assignment, idea description, clarification output, and optional prior `_wip/` file paths as input.
 
 ## Relationships
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
@@ -1,0 +1,210 @@
+# Feature Specification: Refactor Ignite Workflow
+
+**Spec Folder**: `2026-04-07-003-refactor-ignite-workflow`
+**Branch**: `claude/refactor-ignite-workflow-gDuYU`
+**Created**: 2026-04-07
+**Status**: Draft
+**Input**: GitHub Issues #49 (Personas in `smithy.ignite`) and #50 (Out of scope when building with `smithy.ignite`), plus user-described problems with one-shot RFC generation quality variance.
+
+## Clarifications
+
+### Session 2026-04-07
+
+- Q: Should the 3g assemble step just concatenate or also harmonize? → A: Concatenate + harmonize. Assemble reads all `_wip/` files, concatenates into RFC structure, then does a coherence pass to smooth tone and fix cross-references before writing the final file.
+- Q: How should Phase 0 handle partial `_wip/` state from interrupted sessions? → A: Resume from last incomplete sub-phase. Detect which `_wip/` files exist, skip completed sub-phases, resume from the first missing one. User is told which phases completed and where resumption starts.
+- Q: Should Phase 0 audit categories be updated for new Personas and Out of Scope sections? → A: Yes, update both Phase 0 inline categories and the `audit-checklist-rfc.md` snippet to add Persona Coverage and Out of Scope Completeness.
+
+## Artifact Hierarchy
+
+RFC → Milestone → Feature → User Story → Slice → Tasks
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1: Piecewise RFC Generation (Priority: P1)
+
+As a developer using `smithy.ignite`, I want the RFC to be built section by section with intermediate file writes so that each section gets dedicated attention and no section is silently skipped or underwritten.
+
+**Why this priority**: This is the core structural change that addresses the root cause of inconsistent section quality and large output variance. All other stories depend on this pipeline existing.
+
+**Independent Test**: Run `smithy.ignite` with a broad idea description. Verify that `_wip/` files are created sequentially (01-problem.md through 06-milestones.md) during drafting, and that the final assembled RFC contains all sections with substantive content.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user provides a broad idea description, **When** ignite reaches Phase 3, **Then** it drafts each RFC section as a separate sub-phase (3a through 3f), writing each to a numbered file in `docs/rfcs/<YYYY-NNN-slug>/_wip/`.
+2. **Given** sub-phase 3d (Proposal) is being drafted, **When** the agent begins writing, **Then** it reads `_wip/01-problem.md`, `_wip/02-personas.md`, and `_wip/03-goals.md` from disk before drafting, ensuring context flows forward.
+3. **Given** all sub-phases 3a-3f have completed, **When** sub-phase 3g (Assemble) runs, **Then** it reads all `_wip/` files, concatenates them into the RFC template structure, performs a coherence/harmonization pass, writes the final RFC to `<slug>.rfc.md`, and deletes the `_wip/` directory.
+4. **Given** a sub-phase is writing its section, **When** the section is written to disk, **Then** the next sub-phase can begin without requiring the prior section to remain in the context window.
+
+---
+
+### User Story 2: Mandatory Personas Section (Priority: P1)
+
+As a developer using `smithy.ignite`, I want personas identified during clarification to always appear as a dedicated section in the final RFC so that downstream commands (mark, render) can reference them for user stories and feature scoping.
+
+**Why this priority**: Directly addresses Issue #49. Personas are consistently discussed during clarification but lost in the one-shot draft because the RFC template has no section for them.
+
+**Independent Test**: Run `smithy.ignite` and verify the generated RFC contains a `## Personas` section with at least one persona described, and that this section appears between Goals and Proposal in the final document.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user runs `smithy.ignite` with any idea, **When** the RFC is generated, **Then** the final RFC contains a `## Personas` section listing identified users/stakeholders with descriptions.
+2. **Given** the Personas section is drafted in sub-phase 3b, **When** sub-phase 3b completes, **Then** the personas are written to `_wip/02-personas.md` and are available for subsequent sub-phases to reference.
+3. **Given** the Phase 2 clarification identifies personas, **When** the sub-phases draft the RFC, **Then** the personas from clarification appear in the Personas section (not lost between clarification and drafting).
+
+---
+
+### User Story 3: Mandatory Out of Scope Section (Priority: P1)
+
+As a developer using `smithy.ignite`, I want the RFC to always include an explicit Out of Scope section so that scope boundaries are clearly documented and downstream commands know what is excluded.
+
+**Why this priority**: Directly addresses Issue #50. The clarification phase asks about scope but the RFC template has no section to receive the answer, so it is consistently omitted.
+
+**Independent Test**: Run `smithy.ignite` and verify the generated RFC contains a `## Out of Scope` section, even if the content is "None identified at this time."
+
+**Acceptance Scenarios**:
+
+1. **Given** the user runs `smithy.ignite` with any idea, **When** the RFC is generated, **Then** the final RFC contains a `## Out of Scope` section after the Goals section.
+2. **Given** clarification identifies items as out of scope, **When** the RFC is drafted, **Then** those items appear in the Out of Scope section.
+3. **Given** nothing is identified as out of scope during clarification, **When** the RFC is drafted, **Then** the Out of Scope section contains a placeholder (e.g., "None identified at this time") rather than being omitted.
+
+---
+
+### User Story 4: Sub-Phase Snippet Extraction (Priority: P1)
+
+As a maintainer of the smithy template system, I want each sub-phase's instructions extracted into separate snippet files so that the ignite prompt remains maintainable and each sub-phase can be reviewed/tested independently.
+
+**Why this priority**: The ignite prompt is already 249 lines. Adding 6 sub-phase specifications inline would make it unmanageable. Snippets are the established codebase pattern and this is a prerequisite for the piecewise pipeline to be maintainable.
+
+**Independent Test**: Verify that the ignite prompt uses `{{>ignite-phase3a}}` style partial includes for each sub-phase, that the snippet files exist in `src/templates/agent-skills/snippets/`, and that Dotprompt resolves them correctly at deploy time.
+
+**Acceptance Scenarios**:
+
+1. **Given** the refactored ignite prompt, **When** it references sub-phase 3a, **Then** it includes the instruction via a Handlebars partial (e.g., `{{>ignite-phase3a}}`).
+2. **Given** snippet files exist for each sub-phase, **When** they are placed in `src/templates/agent-skills/snippets/`, **Then** they follow the naming convention `ignite-phase3a.md`, `ignite-phase3b.md`, etc.
+3. **Given** the ignite prompt is deployed via `smithy init`, **When** Dotprompt resolves partials, **Then** all sub-phase snippets are inlined into the final deployed prompt.
+
+---
+
+### User Story 5: Session Resume from Partial State (Priority: P2)
+
+As a developer whose `smithy.ignite` session was interrupted mid-pipeline, I want to resume from where I left off so that I don't lose the work already completed in earlier sub-phases.
+
+**Why this priority**: Important for robustness but not a core workflow change. The `_wip/` directory structure (from Story 1) naturally enables this; this story defines the detection and resume UX.
+
+**Independent Test**: Create a partial `_wip/` directory with files 01-03, then run `smithy.ignite` pointing to the same RFC folder. Verify it detects the partial state, reports which phases completed, and resumes from sub-phase 3d.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `_wip/` directory exists in the RFC folder with files `01-problem.md`, `02-personas.md`, and `03-goals.md`, **When** the user runs `smithy.ignite` and Phase 0 detects partial state, **Then** Phase 0 informs the user which sub-phases completed and offers to resume from sub-phase 3d.
+2. **Given** the user accepts the resume, **When** the pipeline continues, **Then** sub-phases 3a-3c are skipped and 3d begins by reading the existing `_wip/` files for context.
+3. **Given** no `_wip/` directory exists, **When** Phase 0 runs, **Then** it proceeds with the normal review loop (existing behavior unchanged).
+
+---
+
+### User Story 6: Cross-Session Question Deduplication (Priority: P2)
+
+As a developer iterating on an RFC across multiple `smithy.ignite` sessions, I want previously asked clarification questions to not be re-asked so that repeat sessions are faster and less redundant.
+
+**Why this priority**: Addresses the "repeated questions" problem but is an enhancement on top of the core pipeline, not a structural prerequisite.
+
+**Independent Test**: Run `smithy.ignite` twice on the same RFC. Verify that on the second run, smithy-clarify receives the `.clarify-log.md` from the first session and avoids re-asking the same questions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clarification phase completes, **When** the Q&A and assumptions are finalized, **Then** they are written to `docs/rfcs/<YYYY-NNN-slug>/.clarify-log.md` in the RFC folder.
+2. **Given** a `.clarify-log.md` exists from a prior session, **When** smithy-clarify is invoked in a new session, **Then** the log contents are passed as additional context with the instruction "Do not re-ask questions already answered in this log."
+3. **Given** no `.clarify-log.md` exists, **When** smithy-clarify runs, **Then** clarification proceeds normally (no dedup context).
+
+---
+
+### User Story 7: Updated Phase 0 Audit Categories (Priority: P2)
+
+As a developer reviewing an existing RFC via `smithy.ignite` Phase 0, I want the audit to check for persona coverage and out-of-scope completeness so that the review catches the same gaps that the new template sections are designed to prevent.
+
+**Why this priority**: Ensures the review loop stays aligned with the new RFC template. Without this, Phase 0 could approve an RFC that is missing the new mandatory sections.
+
+**Independent Test**: Run `smithy.ignite` on an existing RFC that lacks Personas and Out of Scope sections. Verify the Phase 0 audit flags these as gaps.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Phase 0 review loop runs on an existing RFC, **When** the audit categories are evaluated, **Then** "Persona Coverage" and "Out of Scope Completeness" are included alongside existing categories (Problem Statement, Goals, Milestones, Feasibility, Scope, Stakeholders).
+2. **Given** the `audit-checklist-rfc.md` snippet is used by `smithy.audit`, **When** it audits an RFC, **Then** it includes checks for persona coverage and out-of-scope completeness.
+3. **Given** an RFC has a Personas section but it contains only vague references, **When** the audit runs, **Then** it flags the section as Weak rather than Sound.
+
+---
+
+### User Story 8: Updated RFC Template Schema (Priority: P1)
+
+As a developer using `smithy.ignite`, I want the RFC template to include all sections that downstream commands expect so that the generated RFC is complete and parseable by `smithy.render` and `smithy.mark`.
+
+**Why this priority**: The template schema defines what sections the RFC contains. Without updating it, the piecewise pipeline would still produce an RFC missing Personas and Out of Scope even if sub-phases draft them, because the assemble step uses the template as its structure guide.
+
+**Independent Test**: Read the RFC template in the ignite prompt and verify it contains: Summary, Motivation/Problem Statement, Goals, Out of Scope, Personas, Proposal, Design Considerations, Decisions, Open Questions, Milestones.
+
+**Acceptance Scenarios**:
+
+1. **Given** the RFC template in the ignite prompt, **When** it is rendered, **Then** it includes `## Personas` between Goals and Proposal.
+2. **Given** the RFC template in the ignite prompt, **When** it is rendered, **Then** it includes `## Out of Scope` after Goals (before Personas).
+3. **Given** the Phase 3g assemble step uses the template as its structure guide, **When** it assembles the final RFC, **Then** all template sections are present in the output.
+
+---
+
+### Edge Cases
+
+- **Empty idea description**: If the user provides no input, the prompt asks for an idea before starting the pipeline. No `_wip/` directory is created until Phase 3 begins.
+- **PRD file input**: When the input is a PRD file path, intake reads and extracts the core idea. The piecewise pipeline proceeds identically — the PRD content feeds into clarification and sub-phase 3a.
+- **Very small RFC**: For trivially simple ideas, each sub-phase may produce only 1-2 sentences. This is acceptable — the pipeline structure ensures all sections exist even if minimal.
+- **`_wip/` directory already exists from a different idea**: Phase 0's resume detection should verify that the `_wip/` content is contextually related to the current idea (by reading `01-problem.md` and comparing). If unrelated, warn the user and offer to delete and restart.
+- **Session crash during 3g (assemble)**: If the assemble step crashes after writing the final RFC but before deleting `_wip/`, the next session's Phase 0 should detect both the final RFC and the `_wip/` directory and prioritize the final RFC (entering normal review mode).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST replace the monolithic Phase 3 (Draft RFC) with sequential sub-phases 3a through 3g, each producing one or more RFC sections.
+- **FR-002**: Each sub-phase (3a-3f) MUST write its output to a numbered file in a `_wip/` subdirectory within the RFC folder before the next sub-phase begins.
+- **FR-003**: Each sub-phase (3b-3f) MUST read all prior `_wip/` files from disk before drafting its section, ensuring context flows forward without relying on the context window.
+- **FR-004**: Sub-phase 3g (Assemble) MUST read all `_wip/` files, concatenate them into the RFC template structure, perform a coherence/harmonization pass, write the final RFC to `<slug>.rfc.md`, and delete the `_wip/` directory.
+- **FR-005**: The RFC template MUST include a mandatory `## Personas` section positioned between Goals and Proposal.
+- **FR-006**: The RFC template MUST include a mandatory `## Out of Scope` section positioned after Goals and before Personas.
+- **FR-007**: Sub-phase instructions MUST be extracted into snippet files in `src/templates/agent-skills/snippets/` and included via Handlebars partials.
+- **FR-008**: Phase 0 MUST detect partial `_wip/` directories and offer to resume from the first missing sub-phase.
+- **FR-009**: After each clarification phase completes, the system MUST write Q&A and assumptions to a `.clarify-log.md` file in the RFC folder.
+- **FR-010**: When a `.clarify-log.md` exists from a prior session, the system MUST pass its contents to smithy-clarify as additional context with instructions to avoid re-asking answered questions.
+- **FR-011**: Phase 0 audit categories MUST include "Persona Coverage" and "Out of Scope Completeness" alongside existing categories.
+- **FR-012**: The `audit-checklist-rfc.md` snippet MUST be updated to include persona coverage and out-of-scope completeness checks.
+- **FR-013**: The `_wip/` file naming convention MUST use zero-padded two-digit prefixes: `01-problem.md`, `02-personas.md`, `03-goals.md`, `04-proposal.md`, `05-decisions.md`, `06-milestones.md`.
+
+### Key Entities
+
+- **`_wip/` directory**: Temporary subdirectory within an RFC folder that holds intermediate sub-phase outputs during piecewise drafting. Deleted after successful assembly.
+- **`.clarify-log.md`**: Persistent file in the RFC folder that records Q&A and assumptions from each clarification session for cross-session deduplication.
+- **Sub-phase snippet**: A Markdown file in `src/templates/agent-skills/snippets/` containing the instructions for one sub-phase of the piecewise pipeline (e.g., `ignite-phase3a.md`).
+
+## Assumptions
+
+- Sub-agent prompts (smithy-clarify, smithy-plan, smithy-reconcile, smithy-refine) do not need modification — they are generic enough to handle the new invocation patterns.
+- No TypeScript code changes are required — this is purely a prompt template and snippet change.
+- The existing Dotprompt/Handlebars partial resolution system handles nested snippet includes correctly.
+- The competing plans phase (Phase 1.5) with three lenses and smithy-reconcile remains unchanged in structure, though it now benefits from richer context when sub-phases reference its output.
+- smithy-scout is NOT added to the ignite pipeline (ignite works from ideas/PRDs, not existing code).
+
+## Out of Scope
+
+- Changes to other smithy commands (mark, render, cut, forge, strike) — they consume RFCs but their templates are not modified by this feature.
+- New sub-agent definitions — no new agent files are created; all piecewise orchestration happens within the ignite template via snippets.
+- TypeScript code changes to `src/cli.ts`, `src/commands/`, or `src/agents/` — this is a prompt-only change.
+- Gemini/Codex deployment considerations — the ignite template deploys the same way; only the content changes.
+- Per-section clarification passes — the reconciled approach uses a single upfront clarify pass, not per-section runs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every RFC generated by the refactored `smithy.ignite` contains all template sections (Summary, Motivation, Goals, Out of Scope, Personas, Proposal, Design Considerations, Decisions, Open Questions, Milestones) with non-empty content.
+- **SC-002**: The Personas section in generated RFCs contains at least one named persona with a description (Issue #49 resolved).
+- **SC-003**: The Out of Scope section in generated RFCs contains explicit content — either exclusions or "None identified" (Issue #50 resolved).
+- **SC-004**: Running `smithy.ignite` on the same idea twice in separate sessions does not re-ask questions that were answered and logged in `.clarify-log.md`.
+- **SC-005**: Interrupting an `smithy.ignite` session mid-pipeline and restarting successfully resumes from the last completed sub-phase without losing prior work.
+- **SC-006**: The `audit-checklist-rfc.md` snippet includes persona coverage and out-of-scope completeness checks, and `smithy.audit` flags RFCs missing these sections.
+- **SC-007**: The ignite prompt template uses snippet partials for sub-phase instructions, keeping the main template under 150 lines (excluding snippet content).

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
@@ -44,14 +44,14 @@ As a developer using `smithy.ignite`, I want narrative/persuasive RFC sections (
 
 **Why this priority**: The problem statement is the foundation the entire RFC builds on. It's fundamentally different from structured sections (goals lists, milestone tables) — it requires compelling narrative framing. A dedicated sub-agent with prose-tuned instructions produces better results than generic inline drafting. This agent must exist before the piecewise pipeline can dispatch it.
 
-**Independent Test**: Dispatch smithy-prose with a problem description and context files. Verify it produces a well-structured Summary and Motivation/Problem Statement with compelling narrative framing, and writes the output to the designated `_wip/` file.
+**Independent Test**: Dispatch smithy-prose with a problem description and context files. Verify it returns a well-structured Summary and Motivation/Problem Statement with compelling narrative framing that the orchestrator can then write to the designated `_wip/` file.
 
 **Acceptance Scenarios**:
 
-1. **Given** a new `smithy-prose` sub-agent definition exists at `src/templates/agent-skills/agents/smithy.prose.prompt`, **When** it is dispatched by the ignite orchestrator during sub-phase 3a, **Then** it drafts the Summary and Motivation/Problem Statement sections and writes them to `_wip/01-problem.md`.
+1. **Given** a new `smithy-prose` sub-agent definition exists at `src/templates/agent-skills/agents/smithy.prose.prompt`, **When** it is dispatched by the ignite orchestrator during sub-phase 3a, **Then** it returns the drafted Summary and Motivation/Problem Statement sections to the orchestrator, which writes them to `_wip/01-problem.md`.
 2. **Given** smithy-prose receives the idea description and clarification output as context, **When** it drafts the narrative sections, **Then** the output uses persuasive framing (impact of not solving, urgency, stakeholder value) rather than dry bullet-point style.
 3. **Given** smithy-prose is designed as a shared sub-agent, **When** other commands (render, mark) need narrative sections drafted, **Then** they can dispatch smithy-prose with their own context without modification.
-4. **Given** the ignite orchestrator dispatches smithy-prose, **When** the sub-agent completes, **Then** its output is a file on disk that subsequent sub-phases can read, enabling context-scarcity handling.
+4. **Given** the ignite orchestrator dispatches smithy-prose, **When** the sub-agent returns its content, **Then** the orchestrator writes it to the `_wip/` file on disk so that subsequent sub-phases can read it, enabling context-scarcity handling.
 
 ---
 
@@ -82,10 +82,10 @@ As a developer using `smithy.ignite`, I want the RFC to be built section by sect
 
 **Acceptance Scenarios**:
 
-1. **Given** a user provides a broad idea description, **When** ignite reaches Phase 3, **Then** it dispatches sub-agents for each RFC section group (smithy-prose for narrative sections, smithy-plan for structured sections), writing each output to a numbered file in `docs/rfcs/<YYYY-NNN-slug>/_wip/`.
+1. **Given** a user provides a broad idea description, **When** ignite reaches Phase 3, **Then** the orchestrator dispatches sub-agents for each RFC section group (smithy-prose for narrative sections, smithy-plan for structured sections), receives their returned content, and writes each to a numbered file in `docs/rfcs/<YYYY-NNN-slug>/_wip/`.
 2. **Given** sub-phase 3d (Proposal) is being drafted via smithy-plan, **When** the sub-agent begins, **Then** it receives file paths to `_wip/01-problem.md`, `_wip/02-personas.md`, and `_wip/03-goals.md` as context, ensuring prior sections inform the current one.
 3. **Given** all sub-phases 3a-3f have completed, **When** sub-phase 3g (Assemble) runs, **Then** the orchestrator reads all `_wip/` files, concatenates them into the RFC template structure, performs a coherence/harmonization pass, writes the final RFC to `<slug>.rfc.md`, and deletes the `_wip/` directory.
-4. **Given** a sub-agent writes its section to disk, **When** the sub-agent returns, **Then** the next sub-phase can begin in a fresh context without requiring the prior section to remain in the orchestrator's context window.
+4. **Given** a sub-agent returns its drafted content to the orchestrator, **When** the orchestrator writes it to disk, **Then** the next sub-phase can begin in a fresh context without requiring the prior section to remain in the orchestrator's context window.
 
 ---
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
@@ -189,7 +189,7 @@ As a developer reviewing an existing RFC via `smithy.ignite` Phase 0, I want the
 - **FR-006**: The RFC template MUST include a mandatory `## Out of Scope` section positioned after Goals and before Personas.
 - **FR-007**: A new shared `smithy-prose` sub-agent MUST be created at `src/templates/agent-skills/agents/smithy.prose.prompt` for drafting narrative/persuasive RFC sections (Summary, Motivation/Problem Statement).
 - **FR-007a**: The ignite orchestrator MUST dispatch `smithy-plan` for structured analytical sections (Goals, Out of Scope, Proposal, Design Considerations, Milestones).
-- **FR-007b**: The ignite orchestrator MUST dispatch `smithy-prose` for narrative sections (Summary, Motivation/Problem Statement) and `smithy-plan` for structured sections, writing each sub-agent's output to the corresponding `_wip/` file.
+- **FR-007b**: The ignite orchestrator MUST dispatch `smithy-prose` for narrative sections (Summary, Motivation/Problem Statement, Personas) and `smithy-plan` for structured sections, writing each sub-agent's returned content to the corresponding `_wip/` file.
 - **FR-008**: Phase 0 MUST detect partial `_wip/` directories and offer to resume from the first missing sub-phase.
 - **FR-009**: After each clarification phase completes, the system MUST write Q&A and assumptions to a `.clarify-log.md` file in the RFC folder.
 - **FR-010**: When a `.clarify-log.md` exists from a prior session, the system MUST pass its contents to smithy-clarify as additional context with instructions to avoid re-asking answered questions.

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
@@ -10,11 +10,12 @@
 
 ### Session 2026-04-07
 
-- Q: Should the 3g assemble step just concatenate or also harmonize? → A: Concatenate + harmonize. Assemble reads all `_wip/` files, concatenates into RFC structure, then does a coherence pass to smooth tone and fix cross-references before writing the final file.
-- Q: How should Phase 0 handle partial `_wip/` state from interrupted sessions? → A: Resume from last incomplete sub-phase. Detect which `_wip/` files exist, skip completed sub-phases, resume from the first missing one. User is told which phases completed and where resumption starts.
+- Q: Should the 3g assemble step just concatenate or also harmonize? → A: Concatenate + harmonize. The orchestrator does a coherence pass to smooth tone and fix cross-references after all sections are written.
+- Q: How should Phase 0 handle partial RFC state from interrupted sessions? → A: Resume from last incomplete sub-phase. Parse the RFC file's headings to detect which sections exist, skip completed sub-phases, resume from the first missing one. User is told which phases completed and where resumption starts.
 - Q: Should Phase 0 audit categories be updated for new Personas and Out of Scope sections? → A: Yes, update both Phase 0 inline categories and the `audit-checklist-rfc.md` snippet to add Persona Coverage and Out of Scope Completeness.
 - Q: Should sub-phase instructions be extracted into snippets or delegated to sub-agents? → A: Delegate to sub-agents. Create a new shared `smithy-prose` sub-agent for narrative/persuasive sections (Summary, Motivation). Use `smithy-plan` for structured analytical sections (scope derivation, milestone decomposition). Drop ignite-specific snippets — they aren't shared content. The ignite orchestrator becomes primarily a dispatcher.
 - Q: Should smithy-prose be reusable across commands or ignite-only? → A: Shared across commands. Design as a general narrative-writing sub-agent that any command can dispatch for prose-heavy sections.
+- Q: Should intermediate output use a `_wip/` directory or write directly to the RFC file? → A: Write directly to the RFC file. Each sub-phase appends its section(s) to `<slug>.rfc.md`. Resume by parsing which headings exist. Harmonize pass rewrites the file in place at the end. No `_wip/` directory.
 
 ## Artifact Hierarchy
 
@@ -34,7 +35,7 @@ As a developer using `smithy.ignite`, I want the RFC template to include all sec
 
 1. **Given** the RFC template in the ignite prompt, **When** it is rendered, **Then** it includes `## Personas` between Out of Scope and Proposal.
 2. **Given** the RFC template in the ignite prompt, **When** it is rendered, **Then** it includes `## Out of Scope` after Goals (before Personas).
-3. **Given** the Phase 3g assemble step uses the template as its structure guide, **When** it assembles the final RFC, **Then** all template sections are present in the output.
+3. **Given** the sub-phases write directly to the RFC file using the template as their structure guide, **When** all sub-phases complete, **Then** all template sections are present in the output.
 
 ---
 
@@ -44,14 +45,14 @@ As a developer using `smithy.ignite`, I want narrative/persuasive RFC sections (
 
 **Why this priority**: The problem statement is the foundation the entire RFC builds on. It's fundamentally different from structured sections (goals lists, milestone tables) — it requires compelling narrative framing. A dedicated sub-agent with prose-tuned instructions produces better results than generic inline drafting. This agent must exist before the piecewise pipeline can dispatch it.
 
-**Independent Test**: Dispatch smithy-prose with a problem description and context files. Verify it returns a well-structured Summary and Motivation/Problem Statement with compelling narrative framing that the orchestrator can then write to the designated `_wip/` file.
+**Independent Test**: Dispatch smithy-prose with a problem description and context files. Verify it returns a well-structured Summary and Motivation/Problem Statement with compelling narrative framing that the orchestrator can then append to the RFC file.
 
 **Acceptance Scenarios**:
 
-1. **Given** a new `smithy-prose` sub-agent definition exists at `src/templates/agent-skills/agents/smithy.prose.prompt`, **When** it is dispatched by the ignite orchestrator during sub-phase 3a, **Then** it returns the drafted Summary and Motivation/Problem Statement sections to the orchestrator, which writes them to `_wip/01-problem.md`.
+1. **Given** a new `smithy-prose` sub-agent definition exists at `src/templates/agent-skills/agents/smithy.prose.prompt`, **When** it is dispatched by the ignite orchestrator during sub-phase 3a, **Then** it returns the drafted Summary and Motivation/Problem Statement sections to the orchestrator, which appends them to `<slug>.rfc.md`.
 2. **Given** smithy-prose receives the idea description and clarification output as context, **When** it drafts the narrative sections, **Then** the output uses persuasive framing (impact of not solving, urgency, stakeholder value) rather than dry bullet-point style.
 3. **Given** smithy-prose is designed as a shared sub-agent, **When** other commands (render, mark) need narrative sections drafted, **Then** they can dispatch smithy-prose with their own context without modification.
-4. **Given** the ignite orchestrator dispatches smithy-prose, **When** the sub-agent returns its content, **Then** the orchestrator writes it to the `_wip/` file on disk so that subsequent sub-phases can read it, enabling context-scarcity handling.
+4. **Given** the ignite orchestrator dispatches smithy-prose, **When** the sub-agent returns its content, **Then** the orchestrator appends it to the RFC file on disk so that subsequent sub-phases can read the accumulating file for context.
 
 ---
 
@@ -61,14 +62,14 @@ As a developer using `smithy.ignite`, I want structured analytical RFC sections 
 
 **Why this priority**: Structured sections like Goals, Proposal, and Milestones require analytical decomposition — the same kind of work smithy-plan already does well. Reusing smithy-plan for these sections leverages an existing, proven sub-agent rather than relying on the orchestrator to draft inline. This dispatch pattern must be defined before the pipeline can use it.
 
-**Independent Test**: During sub-phase 3c (Goals + Out of Scope), verify that smithy-plan is dispatched with the clarification output and prior `_wip/` files as context, and that it produces a structured Goals list and Out of Scope section written to `_wip/03-goals.md`.
+**Independent Test**: During sub-phase 3c (Goals + Out of Scope), verify that smithy-plan is dispatched with the clarification output and the accumulating RFC file as context, and that it returns a structured Goals list and Out of Scope section.
 
 **Acceptance Scenarios**:
 
-1. **Given** sub-phase 3c (Goals + Out of Scope) begins, **When** the orchestrator dispatches smithy-plan, **Then** smithy-plan receives the clarification output, `_wip/01-problem.md`, and `_wip/02-personas.md` as context and produces structured Goals and Out of Scope sections.
-2. **Given** sub-phase 3d (Proposal + Design Considerations) begins, **When** the orchestrator dispatches smithy-plan, **Then** smithy-plan receives the reconciled approach from Phase 1.5 plus all prior `_wip/` files and produces the Proposal and Design Considerations sections.
-3. **Given** sub-phase 3f (Milestones) begins, **When** the orchestrator dispatches smithy-plan, **Then** smithy-plan produces milestone decomposition with success criteria, informed by the accumulated `_wip/` context.
-4. **Given** smithy-plan is dispatched for a structured section, **When** it completes, **Then** its output is written to the designated `_wip/` file by the orchestrator.
+1. **Given** sub-phase 3c (Goals + Out of Scope) begins, **When** the orchestrator dispatches smithy-plan, **Then** smithy-plan receives the clarification output and the path to the accumulating `<slug>.rfc.md` (containing Summary, Motivation, Personas) as context and produces structured Goals and Out of Scope sections.
+2. **Given** sub-phase 3d (Proposal + Design Considerations) begins, **When** the orchestrator dispatches smithy-plan, **Then** smithy-plan receives the reconciled approach from Phase 1.5 plus the accumulating RFC file and produces the Proposal and Design Considerations sections.
+3. **Given** sub-phase 3f (Milestones) begins, **When** the orchestrator dispatches smithy-plan, **Then** smithy-plan produces milestone decomposition with success criteria, informed by the accumulated RFC content.
+4. **Given** smithy-plan is dispatched for a structured section, **When** it completes, **Then** its returned content is appended to the RFC file by the orchestrator.
 
 ---
 
@@ -78,14 +79,14 @@ As a developer using `smithy.ignite`, I want the RFC to be built section by sect
 
 **Why this priority**: This is the core orchestration that wires together the template (Story 1), smithy-prose (Story 2), and smithy-plan (Story 3) into a working pipeline. It addresses the root cause of inconsistent section quality and large output variance.
 
-**Independent Test**: Run `smithy.ignite` with a broad idea description. Verify that `_wip/` files are created sequentially (01-problem.md through 06-milestones.md) during drafting, and that the final assembled RFC contains all sections with substantive content.
+**Independent Test**: Run `smithy.ignite` with a broad idea description. Verify that `<slug>.rfc.md` grows incrementally as each sub-phase appends its section(s), and that the final RFC contains all sections with substantive content.
 
 **Acceptance Scenarios**:
 
-1. **Given** a user provides a broad idea description, **When** ignite reaches Phase 3, **Then** the orchestrator dispatches sub-agents for each RFC section group (smithy-prose for narrative sections, smithy-plan for structured sections), receives their returned content, and writes each to a numbered file in `docs/rfcs/<YYYY-NNN-slug>/_wip/`.
-2. **Given** sub-phase 3d (Proposal) is being drafted via smithy-plan, **When** the sub-agent begins, **Then** it receives file paths to `_wip/01-problem.md`, `_wip/02-personas.md`, and `_wip/03-goals.md` as context, ensuring prior sections inform the current one.
-3. **Given** all sub-phases 3a-3f have completed, **When** sub-phase 3g (Assemble) runs, **Then** the orchestrator reads all `_wip/` files, concatenates them into the RFC template structure, performs a coherence/harmonization pass, writes the final RFC to `<slug>.rfc.md`, and deletes the `_wip/` directory.
-4. **Given** a sub-agent returns its drafted content to the orchestrator, **When** the orchestrator writes it to disk, **Then** the next sub-phase can begin in a fresh context without requiring the prior section to remain in the orchestrator's context window.
+1. **Given** a user provides a broad idea description, **When** ignite reaches Phase 3, **Then** the orchestrator creates `<slug>.rfc.md` with the RFC header, then dispatches sub-agents for each section group (smithy-prose for narrative sections, smithy-plan for structured sections), appending each sub-agent's returned content to the RFC file.
+2. **Given** sub-phase 3d (Proposal) is being drafted via smithy-plan, **When** the sub-agent begins, **Then** it receives the path to the accumulating `<slug>.rfc.md` (containing Summary, Motivation, Personas, Goals, Out of Scope) as context, ensuring prior sections inform the current one.
+3. **Given** all sub-phases 3a-3f have completed, **When** the harmonization pass (3g) runs, **Then** the orchestrator reads the full RFC file, performs a coherence pass to smooth tone and fix cross-references, and rewrites the file in place.
+4. **Given** a sub-agent returns its drafted content to the orchestrator, **When** the orchestrator appends it to the RFC file, **Then** the next sub-phase can begin in a fresh context by reading the file from disk rather than relying on the context window.
 
 ---
 
@@ -100,7 +101,7 @@ As a developer using `smithy.ignite`, I want personas identified during clarific
 **Acceptance Scenarios**:
 
 1. **Given** the user runs `smithy.ignite` with any idea, **When** the RFC is generated, **Then** the final RFC contains a `## Personas` section listing identified users/stakeholders with descriptions.
-2. **Given** the Personas section is drafted in sub-phase 3b, **When** sub-phase 3b completes, **Then** the personas are written to `_wip/02-personas.md` and are available for subsequent sub-phases to reference.
+2. **Given** the Personas section is drafted in sub-phase 3b, **When** sub-phase 3b completes, **Then** the personas are appended to `<slug>.rfc.md` and are available for subsequent sub-phases to reference by reading the file.
 3. **Given** the Phase 2 clarification identifies personas, **When** the sub-phases draft the RFC, **Then** the personas from clarification appear in the Personas section (not lost between clarification and drafting).
 
 ---
@@ -125,15 +126,15 @@ As a developer using `smithy.ignite`, I want the RFC to always include an explic
 
 As a developer whose `smithy.ignite` session was interrupted mid-pipeline, I want to resume from where I left off so that I don't lose the work already completed in earlier sub-phases.
 
-**Why this priority**: Important for robustness but not a core workflow change. The `_wip/` directory structure (from Story 1) naturally enables this; this story defines the detection and resume UX.
+**Why this priority**: Important for robustness but not a core workflow change. The direct-write approach (from Story 4) naturally leaves a partial RFC on disk; this story defines the detection and resume UX.
 
-**Independent Test**: Create a partial `_wip/` directory with files 01-03, then run `smithy.ignite` pointing to the same RFC folder. Verify it detects the partial state, reports which phases completed, and resumes from sub-phase 3d.
+**Independent Test**: Create a partial RFC file containing Summary, Motivation, and Personas sections but no Goals or later sections. Run `smithy.ignite` pointing to the same RFC folder. Verify it detects the partial state, reports which sections are present, and resumes from sub-phase 3c.
 
 **Acceptance Scenarios**:
 
-1. **Given** a `_wip/` directory exists in the RFC folder with files `01-problem.md`, `02-personas.md`, and `03-goals.md`, **When** the user runs `smithy.ignite` and Phase 0 detects partial state, **Then** Phase 0 informs the user which sub-phases completed and offers to resume from sub-phase 3d.
-2. **Given** the user accepts the resume, **When** the pipeline continues, **Then** sub-phases 3a-3c are skipped and 3d begins by reading the existing `_wip/` files for context.
-3. **Given** no `_wip/` directory exists, **When** Phase 0 runs, **Then** it proceeds with the normal review loop (existing behavior unchanged).
+1. **Given** an RFC file exists with sections through Personas but no Goals or later sections, **When** the user runs `smithy.ignite` and Phase 0 detects the partial RFC, **Then** Phase 0 informs the user which sections are present and offers to resume from the first missing section (Goals).
+2. **Given** the user accepts the resume, **When** the pipeline continues, **Then** completed sub-phases are skipped and the next sub-phase begins by reading the existing RFC file for context.
+3. **Given** no RFC file exists, **When** Phase 0 runs, **Then** it proceeds to Phase 1 (Intake) as normal.
 
 ---
 
@@ -171,35 +172,32 @@ As a developer reviewing an existing RFC via `smithy.ignite` Phase 0, I want the
 
 ### Edge Cases
 
-- **Empty idea description**: If the user provides no input, the prompt asks for an idea before starting the pipeline. No `_wip/` directory is created until Phase 3 begins.
+- **Empty idea description**: If the user provides no input, the prompt asks for an idea before starting the pipeline. No RFC file is created until Phase 3 begins.
 - **PRD file input**: When the input is a PRD file path, intake reads and extracts the core idea. The piecewise pipeline proceeds identically — the PRD content feeds into clarification and sub-phase 3a.
 - **Very small RFC**: For trivially simple ideas, each sub-phase may produce only 1-2 sentences. This is acceptable — the pipeline structure ensures all sections exist even if minimal.
-- **`_wip/` directory already exists from a different idea**: Phase 0's resume detection should verify that the `_wip/` content is contextually related to the current idea (by reading `01-problem.md` and comparing). If unrelated, warn the user and offer to delete and restart.
-- **Session crash during 3g (assemble)**: If the assemble step crashes after writing the final RFC but before deleting `_wip/`, the next session's Phase 0 should detect both the final RFC and the `_wip/` directory and prioritize the final RFC (entering normal review mode).
+- **Partial RFC from a different idea**: Phase 0's resume detection should verify that the RFC's Summary/Motivation are contextually related to the current idea. If unrelated, warn the user and offer to overwrite or create a new RFC.
+- **Session crash during harmonization (3g)**: If the harmonization pass crashes mid-rewrite, the RFC file may be in an inconsistent state. The next session's Phase 0 should detect the RFC and enter the review loop, where smithy-refine can identify and repair inconsistencies.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
 - **FR-001**: The system MUST replace the monolithic Phase 3 (Draft RFC) with sequential sub-phases 3a through 3g, each producing one or more RFC sections.
-- **FR-002**: Each sub-phase (3a-3f) MUST write its output to a numbered file in a `_wip/` subdirectory within the RFC folder before the next sub-phase begins.
-- **FR-003**: Each sub-phase (3b-3f) MUST read all prior `_wip/` files from disk before drafting its section, ensuring context flows forward without relying on the context window.
-- **FR-004**: Sub-phase 3g (Assemble) MUST read all `_wip/` files, concatenate them into the RFC template structure, perform a coherence/harmonization pass, write the final RFC to `<slug>.rfc.md`, and delete the `_wip/` directory.
+- **FR-002**: Each sub-phase (3a-3f) MUST append its output directly to `<slug>.rfc.md` before the next sub-phase begins.
+- **FR-003**: Each sub-phase (3b-3f) MUST pass the path to the accumulating `<slug>.rfc.md` to its sub-agent as context, ensuring prior sections inform the current one without relying on the context window.
+- **FR-004**: Sub-phase 3g (Harmonize) MUST read the complete `<slug>.rfc.md`, perform a coherence pass to smooth tone and fix cross-references, and rewrite the file in place.
 - **FR-005**: The RFC template MUST include a mandatory `## Personas` section positioned after `## Out of Scope` and before `## Proposal`.
 - **FR-006**: The RFC template MUST include a mandatory `## Out of Scope` section positioned after Goals and before Personas.
 - **FR-007**: A new shared `smithy-prose` sub-agent MUST be created at `src/templates/agent-skills/agents/smithy.prose.prompt` for drafting narrative/persuasive RFC sections (Summary, Motivation/Problem Statement).
 - **FR-007a**: The ignite orchestrator MUST dispatch `smithy-plan` for structured analytical sections (Goals, Out of Scope, Proposal, Design Considerations, Milestones).
-- **FR-007b**: The ignite orchestrator MUST dispatch `smithy-prose` for narrative sections (Summary, Motivation/Problem Statement, Personas) and `smithy-plan` for structured sections, writing each sub-agent's returned content to the corresponding `_wip/` file.
-- **FR-008**: Phase 0 MUST detect partial `_wip/` directories and offer to resume from the first missing sub-phase.
+- **FR-007b**: The ignite orchestrator MUST dispatch `smithy-prose` for narrative sections (Summary, Motivation/Problem Statement, Personas) and `smithy-plan` for structured sections, appending each sub-agent's returned content to `<slug>.rfc.md`.
+- **FR-008**: Phase 0 MUST detect partial RFC files (by parsing which template headings exist) and offer to resume from the first missing section's sub-phase.
 - **FR-009**: After each clarification phase completes, the system MUST write Q&A and assumptions to a `.clarify-log.md` file in the RFC folder.
 - **FR-010**: When a `.clarify-log.md` exists from a prior session, the system MUST pass its contents to smithy-clarify as additional context with instructions to avoid re-asking answered questions.
 - **FR-011**: Phase 0 audit categories MUST include "Persona Coverage" and "Out of Scope Completeness" alongside existing categories.
 - **FR-012**: The `audit-checklist-rfc.md` snippet MUST be updated to include persona coverage and out-of-scope completeness checks.
-- **FR-013**: The `_wip/` file naming convention MUST use zero-padded two-digit prefixes: `01-problem.md`, `02-personas.md`, `03-goals.md`, `04-proposal.md`, `05-decisions.md`, `06-milestones.md`.
-
 ### Key Entities
 
-- **`_wip/` directory**: Temporary subdirectory within an RFC folder that holds intermediate sub-phase outputs during piecewise drafting. Deleted after successful assembly.
 - **`.clarify-log.md`**: Persistent file in the RFC folder that records Q&A and assumptions from each clarification session for cross-session deduplication.
 - **`smithy-prose` sub-agent**: New shared sub-agent specialized for narrative/persuasive writing. Dispatched for Summary, Motivation/Problem Statement, and other prose-heavy sections across any smithy command.
 
@@ -227,7 +225,7 @@ As a developer reviewing an existing RFC via `smithy.ignite` Phase 0, I want the
 - **SC-002**: The Personas section in generated RFCs contains at least one named persona with a description (Issue #49 resolved).
 - **SC-003**: The Out of Scope section in generated RFCs contains explicit content — either exclusions or "None identified" (Issue #50 resolved).
 - **SC-004**: Running `smithy.ignite` on the same idea twice in separate sessions does not re-ask questions that were answered and logged in `.clarify-log.md`.
-- **SC-005**: Interrupting an `smithy.ignite` session mid-pipeline and restarting successfully resumes from the last completed sub-phase without losing prior work.
+- **SC-005**: Interrupting a `smithy.ignite` session mid-pipeline and restarting successfully resumes from the first missing section (detected by parsing RFC headings) without losing prior work.
 - **SC-006**: The `audit-checklist-rfc.md` snippet includes persona coverage and out-of-scope completeness checks, and `smithy.audit` flags RFCs missing these sections.
 - **SC-007**: The ignite prompt template dispatches smithy-prose for narrative sections and smithy-plan for structured sections, keeping the orchestrator focused on pipeline management rather than inline drafting.
 - **SC-008**: The `smithy-prose` sub-agent produces compelling narrative framing (impact, urgency, stakeholder value) that is qualitatively distinct from bullet-point-style output.

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
@@ -22,60 +22,27 @@ RFC → Milestone → Feature → User Story → Slice → Tasks
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1: Piecewise RFC Generation (Priority: P1)
+### User Story 1: Updated RFC Template Schema (Priority: P1)
 
-As a developer using `smithy.ignite`, I want the RFC to be built section by section with intermediate file writes so that each section gets dedicated attention and no section is silently skipped or underwritten.
+As a developer using `smithy.ignite`, I want the RFC template to include all sections that downstream commands expect so that the generated RFC is complete and parseable by `smithy.render` and `smithy.mark`.
 
-**Why this priority**: This is the core structural change that addresses the root cause of inconsistent section quality and large output variance. All other stories depend on this pipeline existing.
+**Why this priority**: The template schema defines what sections the RFC contains. All other stories depend on the template having slots for Personas and Out of Scope. Without these slots, no amount of piecewise drafting can produce them in the final RFC.
 
-**Independent Test**: Run `smithy.ignite` with a broad idea description. Verify that `_wip/` files are created sequentially (01-problem.md through 06-milestones.md) during drafting, and that the final assembled RFC contains all sections with substantive content.
-
-**Acceptance Scenarios**:
-
-1. **Given** a user provides a broad idea description, **When** ignite reaches Phase 3, **Then** it dispatches sub-agents for each RFC section group (smithy-prose for narrative sections, smithy-plan for structured sections), writing each output to a numbered file in `docs/rfcs/<YYYY-NNN-slug>/_wip/`.
-2. **Given** sub-phase 3d (Proposal) is being drafted via smithy-plan, **When** the sub-agent begins, **Then** it receives file paths to `_wip/01-problem.md`, `_wip/02-personas.md`, and `_wip/03-goals.md` as context, ensuring prior sections inform the current one.
-3. **Given** all sub-phases 3a-3f have completed, **When** sub-phase 3g (Assemble) runs, **Then** the orchestrator reads all `_wip/` files, concatenates them into the RFC template structure, performs a coherence/harmonization pass, writes the final RFC to `<slug>.rfc.md`, and deletes the `_wip/` directory.
-4. **Given** a sub-agent writes its section to disk, **When** the sub-agent returns, **Then** the next sub-phase can begin in a fresh context without requiring the prior section to remain in the orchestrator's context window.
-
----
-
-### User Story 2: Mandatory Personas Section (Priority: P1)
-
-As a developer using `smithy.ignite`, I want personas identified during clarification to always appear as a dedicated section in the final RFC so that downstream commands (mark, render) can reference them for user stories and feature scoping.
-
-**Why this priority**: Directly addresses Issue #49. Personas are consistently discussed during clarification but lost in the one-shot draft because the RFC template has no section for them.
-
-**Independent Test**: Run `smithy.ignite` and verify the generated RFC contains a `## Personas` section with at least one persona described, and that this section appears between Goals and Proposal in the final document.
+**Independent Test**: Read the RFC template in the ignite prompt and verify it contains: Summary, Motivation/Problem Statement, Goals, Out of Scope, Personas, Proposal, Design Considerations, Decisions, Open Questions, Milestones.
 
 **Acceptance Scenarios**:
 
-1. **Given** the user runs `smithy.ignite` with any idea, **When** the RFC is generated, **Then** the final RFC contains a `## Personas` section listing identified users/stakeholders with descriptions.
-2. **Given** the Personas section is drafted in sub-phase 3b, **When** sub-phase 3b completes, **Then** the personas are written to `_wip/02-personas.md` and are available for subsequent sub-phases to reference.
-3. **Given** the Phase 2 clarification identifies personas, **When** the sub-phases draft the RFC, **Then** the personas from clarification appear in the Personas section (not lost between clarification and drafting).
+1. **Given** the RFC template in the ignite prompt, **When** it is rendered, **Then** it includes `## Personas` between Out of Scope and Proposal.
+2. **Given** the RFC template in the ignite prompt, **When** it is rendered, **Then** it includes `## Out of Scope` after Goals (before Personas).
+3. **Given** the Phase 3g assemble step uses the template as its structure guide, **When** it assembles the final RFC, **Then** all template sections are present in the output.
 
 ---
 
-### User Story 3: Mandatory Out of Scope Section (Priority: P1)
-
-As a developer using `smithy.ignite`, I want the RFC to always include an explicit Out of Scope section so that scope boundaries are clearly documented and downstream commands know what is excluded.
-
-**Why this priority**: Directly addresses Issue #50. The clarification phase asks about scope but the RFC template has no section to receive the answer, so it is consistently omitted.
-
-**Independent Test**: Run `smithy.ignite` and verify the generated RFC contains a `## Out of Scope` section, even if the content is "None identified at this time."
-
-**Acceptance Scenarios**:
-
-1. **Given** the user runs `smithy.ignite` with any idea, **When** the RFC is generated, **Then** the final RFC contains a `## Out of Scope` section after the Goals section.
-2. **Given** clarification identifies items as out of scope, **When** the RFC is drafted, **Then** those items appear in the Out of Scope section.
-3. **Given** nothing is identified as out of scope during clarification, **When** the RFC is drafted, **Then** the Out of Scope section contains a placeholder (e.g., "None identified at this time") rather than being omitted.
-
----
-
-### User Story 4: Shared Smithy-Prose Sub-Agent (Priority: P1)
+### User Story 2: Shared Smithy-Prose Sub-Agent (Priority: P1)
 
 As a developer using `smithy.ignite`, I want narrative/persuasive RFC sections (Summary, Motivation/Problem Statement) to be drafted by a dedicated `smithy-prose` sub-agent so that these sections receive focused prose-writing attention distinct from structured analytical sections.
 
-**Why this priority**: The problem statement is the foundation the entire RFC builds on. It's fundamentally different from structured sections (goals lists, milestone tables) — it requires compelling narrative framing. A dedicated sub-agent with prose-tuned instructions produces better results than generic inline drafting. This agent is shared across commands, justifying it as a proper sub-agent.
+**Why this priority**: The problem statement is the foundation the entire RFC builds on. It's fundamentally different from structured sections (goals lists, milestone tables) — it requires compelling narrative framing. A dedicated sub-agent with prose-tuned instructions produces better results than generic inline drafting. This agent must exist before the piecewise pipeline can dispatch it.
 
 **Independent Test**: Dispatch smithy-prose with a problem description and context files. Verify it produces a well-structured Summary and Motivation/Problem Statement with compelling narrative framing, and writes the output to the designated `_wip/` file.
 
@@ -88,11 +55,11 @@ As a developer using `smithy.ignite`, I want narrative/persuasive RFC sections (
 
 ---
 
-### User Story 5: Smithy-Plan for Structured RFC Sections (Priority: P1)
+### User Story 3: Smithy-Plan for Structured RFC Sections (Priority: P1)
 
 As a developer using `smithy.ignite`, I want structured analytical RFC sections (Goals, Out of Scope, Proposal, Milestones) to be drafted by dispatching `smithy-plan` sub-agents so that each structured section gets focused analytical attention with codebase awareness.
 
-**Why this priority**: Structured sections like Goals, Proposal, and Milestones require analytical decomposition — the same kind of work smithy-plan already does well. Reusing smithy-plan for these sections leverages an existing, proven sub-agent rather than relying on the orchestrator to draft inline.
+**Why this priority**: Structured sections like Goals, Proposal, and Milestones require analytical decomposition — the same kind of work smithy-plan already does well. Reusing smithy-plan for these sections leverages an existing, proven sub-agent rather than relying on the orchestrator to draft inline. This dispatch pattern must be defined before the pipeline can use it.
 
 **Independent Test**: During sub-phase 3c (Goals + Out of Scope), verify that smithy-plan is dispatched with the clarification output and prior `_wip/` files as context, and that it produces a structured Goals list and Out of Scope section written to `_wip/03-goals.md`.
 
@@ -105,7 +72,56 @@ As a developer using `smithy.ignite`, I want structured analytical RFC sections 
 
 ---
 
-### User Story 6: Session Resume from Partial State (Priority: P2)
+### User Story 4: Piecewise RFC Generation (Priority: P1)
+
+As a developer using `smithy.ignite`, I want the RFC to be built section by section with intermediate file writes so that each section gets dedicated attention and no section is silently skipped or underwritten.
+
+**Why this priority**: This is the core orchestration that wires together the template (Story 1), smithy-prose (Story 2), and smithy-plan (Story 3) into a working pipeline. It addresses the root cause of inconsistent section quality and large output variance.
+
+**Independent Test**: Run `smithy.ignite` with a broad idea description. Verify that `_wip/` files are created sequentially (01-problem.md through 06-milestones.md) during drafting, and that the final assembled RFC contains all sections with substantive content.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user provides a broad idea description, **When** ignite reaches Phase 3, **Then** it dispatches sub-agents for each RFC section group (smithy-prose for narrative sections, smithy-plan for structured sections), writing each output to a numbered file in `docs/rfcs/<YYYY-NNN-slug>/_wip/`.
+2. **Given** sub-phase 3d (Proposal) is being drafted via smithy-plan, **When** the sub-agent begins, **Then** it receives file paths to `_wip/01-problem.md`, `_wip/02-personas.md`, and `_wip/03-goals.md` as context, ensuring prior sections inform the current one.
+3. **Given** all sub-phases 3a-3f have completed, **When** sub-phase 3g (Assemble) runs, **Then** the orchestrator reads all `_wip/` files, concatenates them into the RFC template structure, performs a coherence/harmonization pass, writes the final RFC to `<slug>.rfc.md`, and deletes the `_wip/` directory.
+4. **Given** a sub-agent writes its section to disk, **When** the sub-agent returns, **Then** the next sub-phase can begin in a fresh context without requiring the prior section to remain in the orchestrator's context window.
+
+---
+
+### User Story 5: Mandatory Personas Section (Priority: P1)
+
+As a developer using `smithy.ignite`, I want personas identified during clarification to always appear as a dedicated section in the final RFC so that downstream commands (mark, render) can reference them for user stories and feature scoping.
+
+**Why this priority**: Directly addresses Issue #49. Personas are consistently discussed during clarification but lost in the one-shot draft because the RFC template previously had no section for them. With the template updated (Story 1) and smithy-prose available (Story 2), this story ensures the pipeline actually produces the section.
+
+**Independent Test**: Run `smithy.ignite` and verify the generated RFC contains a `## Personas` section with at least one persona described, and that this section appears between Out of Scope and Proposal in the final document.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user runs `smithy.ignite` with any idea, **When** the RFC is generated, **Then** the final RFC contains a `## Personas` section listing identified users/stakeholders with descriptions.
+2. **Given** the Personas section is drafted in sub-phase 3b, **When** sub-phase 3b completes, **Then** the personas are written to `_wip/02-personas.md` and are available for subsequent sub-phases to reference.
+3. **Given** the Phase 2 clarification identifies personas, **When** the sub-phases draft the RFC, **Then** the personas from clarification appear in the Personas section (not lost between clarification and drafting).
+
+---
+
+### User Story 6: Mandatory Out of Scope Section (Priority: P1)
+
+As a developer using `smithy.ignite`, I want the RFC to always include an explicit Out of Scope section so that scope boundaries are clearly documented and downstream commands know what is excluded.
+
+**Why this priority**: Directly addresses Issue #50. The clarification phase asks about scope but the RFC template previously had no section to receive the answer. With the template updated (Story 1) and smithy-plan dispatched for scope (Story 3), this story ensures the pipeline actually produces the section.
+
+**Independent Test**: Run `smithy.ignite` and verify the generated RFC contains a `## Out of Scope` section, even if the content is "None identified at this time."
+
+**Acceptance Scenarios**:
+
+1. **Given** the user runs `smithy.ignite` with any idea, **When** the RFC is generated, **Then** the final RFC contains a `## Out of Scope` section after the Goals section.
+2. **Given** clarification identifies items as out of scope, **When** the RFC is drafted, **Then** those items appear in the Out of Scope section.
+3. **Given** nothing is identified as out of scope during clarification, **When** the RFC is drafted, **Then** the Out of Scope section contains a placeholder (e.g., "None identified at this time") rather than being omitted.
+
+---
+
+### User Story 7: Session Resume from Partial State (Priority: P2)
 
 As a developer whose `smithy.ignite` session was interrupted mid-pipeline, I want to resume from where I left off so that I don't lose the work already completed in earlier sub-phases.
 
@@ -121,7 +137,7 @@ As a developer whose `smithy.ignite` session was interrupted mid-pipeline, I wan
 
 ---
 
-### User Story 7: Cross-Session Question Deduplication (Priority: P2)
+### User Story 8: Cross-Session Question Deduplication (Priority: P2)
 
 As a developer iterating on an RFC across multiple `smithy.ignite` sessions, I want previously asked clarification questions to not be re-asked so that repeat sessions are faster and less redundant.
 
@@ -137,7 +153,7 @@ As a developer iterating on an RFC across multiple `smithy.ignite` sessions, I w
 
 ---
 
-### User Story 8: Updated Phase 0 Audit Categories (Priority: P2)
+### User Story 9: Updated Phase 0 Audit Categories (Priority: P2)
 
 As a developer reviewing an existing RFC via `smithy.ignite` Phase 0, I want the audit to check for persona coverage and out-of-scope completeness so that the review catches the same gaps that the new template sections are designed to prevent.
 
@@ -150,22 +166,6 @@ As a developer reviewing an existing RFC via `smithy.ignite` Phase 0, I want the
 1. **Given** the Phase 0 review loop runs on an existing RFC, **When** the audit categories are evaluated, **Then** "Persona Coverage" and "Out of Scope Completeness" are included alongside existing categories (Problem Statement, Goals, Milestones, Feasibility, Scope, Stakeholders).
 2. **Given** the `audit-checklist-rfc.md` snippet is used by `smithy.audit`, **When** it audits an RFC, **Then** it includes checks for persona coverage and out-of-scope completeness.
 3. **Given** an RFC has a Personas section but it contains only vague references, **When** the audit runs, **Then** it flags the section as Weak rather than Sound.
-
----
-
-### User Story 9: Updated RFC Template Schema (Priority: P1)
-
-As a developer using `smithy.ignite`, I want the RFC template to include all sections that downstream commands expect so that the generated RFC is complete and parseable by `smithy.render` and `smithy.mark`.
-
-**Why this priority**: The template schema defines what sections the RFC contains. Without updating it, the piecewise pipeline would still produce an RFC missing Personas and Out of Scope even if sub-phases draft them, because the assemble step uses the template as its structure guide.
-
-**Independent Test**: Read the RFC template in the ignite prompt and verify it contains: Summary, Motivation/Problem Statement, Goals, Out of Scope, Personas, Proposal, Design Considerations, Decisions, Open Questions, Milestones.
-
-**Acceptance Scenarios**:
-
-1. **Given** the RFC template in the ignite prompt, **When** it is rendered, **Then** it includes `## Personas` between Goals and Proposal.
-2. **Given** the RFC template in the ignite prompt, **When** it is rendered, **Then** it includes `## Out of Scope` after Goals (before Personas).
-3. **Given** the Phase 3g assemble step uses the template as its structure guide, **When** it assembles the final RFC, **Then** all template sections are present in the output.
 
 ---
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
@@ -13,6 +13,8 @@
 - Q: Should the 3g assemble step just concatenate or also harmonize? → A: Concatenate + harmonize. Assemble reads all `_wip/` files, concatenates into RFC structure, then does a coherence pass to smooth tone and fix cross-references before writing the final file.
 - Q: How should Phase 0 handle partial `_wip/` state from interrupted sessions? → A: Resume from last incomplete sub-phase. Detect which `_wip/` files exist, skip completed sub-phases, resume from the first missing one. User is told which phases completed and where resumption starts.
 - Q: Should Phase 0 audit categories be updated for new Personas and Out of Scope sections? → A: Yes, update both Phase 0 inline categories and the `audit-checklist-rfc.md` snippet to add Persona Coverage and Out of Scope Completeness.
+- Q: Should sub-phase instructions be extracted into snippets or delegated to sub-agents? → A: Delegate to sub-agents. Create a new shared `smithy-prose` sub-agent for narrative/persuasive sections (Summary, Motivation). Use `smithy-plan` for structured analytical sections (scope derivation, milestone decomposition). Drop ignite-specific snippets — they aren't shared content. The ignite orchestrator becomes primarily a dispatcher.
+- Q: Should smithy-prose be reusable across commands or ignite-only? → A: Shared across commands. Design as a general narrative-writing sub-agent that any command can dispatch for prose-heavy sections.
 
 ## Artifact Hierarchy
 
@@ -30,10 +32,10 @@ As a developer using `smithy.ignite`, I want the RFC to be built section by sect
 
 **Acceptance Scenarios**:
 
-1. **Given** a user provides a broad idea description, **When** ignite reaches Phase 3, **Then** it drafts each RFC section as a separate sub-phase (3a through 3f), writing each to a numbered file in `docs/rfcs/<YYYY-NNN-slug>/_wip/`.
-2. **Given** sub-phase 3d (Proposal) is being drafted, **When** the agent begins writing, **Then** it reads `_wip/01-problem.md`, `_wip/02-personas.md`, and `_wip/03-goals.md` from disk before drafting, ensuring context flows forward.
-3. **Given** all sub-phases 3a-3f have completed, **When** sub-phase 3g (Assemble) runs, **Then** it reads all `_wip/` files, concatenates them into the RFC template structure, performs a coherence/harmonization pass, writes the final RFC to `<slug>.rfc.md`, and deletes the `_wip/` directory.
-4. **Given** a sub-phase is writing its section, **When** the section is written to disk, **Then** the next sub-phase can begin without requiring the prior section to remain in the context window.
+1. **Given** a user provides a broad idea description, **When** ignite reaches Phase 3, **Then** it dispatches sub-agents for each RFC section group (smithy-prose for narrative sections, smithy-plan for structured sections), writing each output to a numbered file in `docs/rfcs/<YYYY-NNN-slug>/_wip/`.
+2. **Given** sub-phase 3d (Proposal) is being drafted via smithy-plan, **When** the sub-agent begins, **Then** it receives file paths to `_wip/01-problem.md`, `_wip/02-personas.md`, and `_wip/03-goals.md` as context, ensuring prior sections inform the current one.
+3. **Given** all sub-phases 3a-3f have completed, **When** sub-phase 3g (Assemble) runs, **Then** the orchestrator reads all `_wip/` files, concatenates them into the RFC template structure, performs a coherence/harmonization pass, writes the final RFC to `<slug>.rfc.md`, and deletes the `_wip/` directory.
+4. **Given** a sub-agent writes its section to disk, **When** the sub-agent returns, **Then** the next sub-phase can begin in a fresh context without requiring the prior section to remain in the orchestrator's context window.
 
 ---
 
@@ -69,23 +71,41 @@ As a developer using `smithy.ignite`, I want the RFC to always include an explic
 
 ---
 
-### User Story 4: Sub-Phase Snippet Extraction (Priority: P1)
+### User Story 4: Shared Smithy-Prose Sub-Agent (Priority: P1)
 
-As a maintainer of the smithy template system, I want each sub-phase's instructions extracted into separate snippet files so that the ignite prompt remains maintainable and each sub-phase can be reviewed/tested independently.
+As a developer using `smithy.ignite`, I want narrative/persuasive RFC sections (Summary, Motivation/Problem Statement) to be drafted by a dedicated `smithy-prose` sub-agent so that these sections receive focused prose-writing attention distinct from structured analytical sections.
 
-**Why this priority**: The ignite prompt is already 249 lines. Adding 6 sub-phase specifications inline would make it unmanageable. Snippets are the established codebase pattern and this is a prerequisite for the piecewise pipeline to be maintainable.
+**Why this priority**: The problem statement is the foundation the entire RFC builds on. It's fundamentally different from structured sections (goals lists, milestone tables) — it requires compelling narrative framing. A dedicated sub-agent with prose-tuned instructions produces better results than generic inline drafting. This agent is shared across commands, justifying it as a proper sub-agent.
 
-**Independent Test**: Verify that the ignite prompt uses `{{>ignite-phase3a}}` style partial includes for each sub-phase, that the snippet files exist in `src/templates/agent-skills/snippets/`, and that Dotprompt resolves them correctly at deploy time.
+**Independent Test**: Dispatch smithy-prose with a problem description and context files. Verify it produces a well-structured Summary and Motivation/Problem Statement with compelling narrative framing, and writes the output to the designated `_wip/` file.
 
 **Acceptance Scenarios**:
 
-1. **Given** the refactored ignite prompt, **When** it references sub-phase 3a, **Then** it includes the instruction via a Handlebars partial (e.g., `{{>ignite-phase3a}}`).
-2. **Given** snippet files exist for each sub-phase, **When** they are placed in `src/templates/agent-skills/snippets/`, **Then** they follow the naming convention `ignite-phase3a.md`, `ignite-phase3b.md`, etc.
-3. **Given** the ignite prompt is deployed via `smithy init`, **When** Dotprompt resolves partials, **Then** all sub-phase snippets are inlined into the final deployed prompt.
+1. **Given** a new `smithy-prose` sub-agent definition exists at `src/templates/agent-skills/agents/smithy.prose.prompt`, **When** it is dispatched by the ignite orchestrator during sub-phase 3a, **Then** it drafts the Summary and Motivation/Problem Statement sections and writes them to `_wip/01-problem.md`.
+2. **Given** smithy-prose receives the idea description and clarification output as context, **When** it drafts the narrative sections, **Then** the output uses persuasive framing (impact of not solving, urgency, stakeholder value) rather than dry bullet-point style.
+3. **Given** smithy-prose is designed as a shared sub-agent, **When** other commands (render, mark) need narrative sections drafted, **Then** they can dispatch smithy-prose with their own context without modification.
+4. **Given** the ignite orchestrator dispatches smithy-prose, **When** the sub-agent completes, **Then** its output is a file on disk that subsequent sub-phases can read, enabling context-scarcity handling.
 
 ---
 
-### User Story 5: Session Resume from Partial State (Priority: P2)
+### User Story 5: Smithy-Plan for Structured RFC Sections (Priority: P1)
+
+As a developer using `smithy.ignite`, I want structured analytical RFC sections (Goals, Out of Scope, Proposal, Milestones) to be drafted by dispatching `smithy-plan` sub-agents so that each structured section gets focused analytical attention with codebase awareness.
+
+**Why this priority**: Structured sections like Goals, Proposal, and Milestones require analytical decomposition — the same kind of work smithy-plan already does well. Reusing smithy-plan for these sections leverages an existing, proven sub-agent rather than relying on the orchestrator to draft inline.
+
+**Independent Test**: During sub-phase 3c (Goals + Out of Scope), verify that smithy-plan is dispatched with the clarification output and prior `_wip/` files as context, and that it produces a structured Goals list and Out of Scope section written to `_wip/03-goals.md`.
+
+**Acceptance Scenarios**:
+
+1. **Given** sub-phase 3c (Goals + Out of Scope) begins, **When** the orchestrator dispatches smithy-plan, **Then** smithy-plan receives the clarification output, `_wip/01-problem.md`, and `_wip/02-personas.md` as context and produces structured Goals and Out of Scope sections.
+2. **Given** sub-phase 3d (Proposal + Design Considerations) begins, **When** the orchestrator dispatches smithy-plan, **Then** smithy-plan receives the reconciled approach from Phase 1.5 plus all prior `_wip/` files and produces the Proposal and Design Considerations sections.
+3. **Given** sub-phase 3f (Milestones) begins, **When** the orchestrator dispatches smithy-plan, **Then** smithy-plan produces milestone decomposition with success criteria, informed by the accumulated `_wip/` context.
+4. **Given** smithy-plan is dispatched for a structured section, **When** it completes, **Then** its output is written to the designated `_wip/` file by the orchestrator.
+
+---
+
+### User Story 6: Session Resume from Partial State (Priority: P2)
 
 As a developer whose `smithy.ignite` session was interrupted mid-pipeline, I want to resume from where I left off so that I don't lose the work already completed in earlier sub-phases.
 
@@ -101,7 +121,7 @@ As a developer whose `smithy.ignite` session was interrupted mid-pipeline, I wan
 
 ---
 
-### User Story 6: Cross-Session Question Deduplication (Priority: P2)
+### User Story 7: Cross-Session Question Deduplication (Priority: P2)
 
 As a developer iterating on an RFC across multiple `smithy.ignite` sessions, I want previously asked clarification questions to not be re-asked so that repeat sessions are faster and less redundant.
 
@@ -117,7 +137,7 @@ As a developer iterating on an RFC across multiple `smithy.ignite` sessions, I w
 
 ---
 
-### User Story 7: Updated Phase 0 Audit Categories (Priority: P2)
+### User Story 8: Updated Phase 0 Audit Categories (Priority: P2)
 
 As a developer reviewing an existing RFC via `smithy.ignite` Phase 0, I want the audit to check for persona coverage and out-of-scope completeness so that the review catches the same gaps that the new template sections are designed to prevent.
 
@@ -133,7 +153,7 @@ As a developer reviewing an existing RFC via `smithy.ignite` Phase 0, I want the
 
 ---
 
-### User Story 8: Updated RFC Template Schema (Priority: P1)
+### User Story 9: Updated RFC Template Schema (Priority: P1)
 
 As a developer using `smithy.ignite`, I want the RFC template to include all sections that downstream commands expect so that the generated RFC is complete and parseable by `smithy.render` and `smithy.mark`.
 
@@ -167,7 +187,9 @@ As a developer using `smithy.ignite`, I want the RFC template to include all sec
 - **FR-004**: Sub-phase 3g (Assemble) MUST read all `_wip/` files, concatenate them into the RFC template structure, perform a coherence/harmonization pass, write the final RFC to `<slug>.rfc.md`, and delete the `_wip/` directory.
 - **FR-005**: The RFC template MUST include a mandatory `## Personas` section positioned between Goals and Proposal.
 - **FR-006**: The RFC template MUST include a mandatory `## Out of Scope` section positioned after Goals and before Personas.
-- **FR-007**: Sub-phase instructions MUST be extracted into snippet files in `src/templates/agent-skills/snippets/` and included via Handlebars partials.
+- **FR-007**: A new shared `smithy-prose` sub-agent MUST be created at `src/templates/agent-skills/agents/smithy.prose.prompt` for drafting narrative/persuasive RFC sections (Summary, Motivation/Problem Statement).
+- **FR-007a**: The ignite orchestrator MUST dispatch `smithy-plan` for structured analytical sections (Goals, Out of Scope, Proposal, Design Considerations, Milestones).
+- **FR-007b**: The ignite orchestrator MUST dispatch `smithy-prose` for narrative sections (Summary, Motivation/Problem Statement) and `smithy-plan` for structured sections, writing each sub-agent's output to the corresponding `_wip/` file.
 - **FR-008**: Phase 0 MUST detect partial `_wip/` directories and offer to resume from the first missing sub-phase.
 - **FR-009**: After each clarification phase completes, the system MUST write Q&A and assumptions to a `.clarify-log.md` file in the RFC folder.
 - **FR-010**: When a `.clarify-log.md` exists from a prior session, the system MUST pass its contents to smithy-clarify as additional context with instructions to avoid re-asking answered questions.
@@ -179,23 +201,23 @@ As a developer using `smithy.ignite`, I want the RFC template to include all sec
 
 - **`_wip/` directory**: Temporary subdirectory within an RFC folder that holds intermediate sub-phase outputs during piecewise drafting. Deleted after successful assembly.
 - **`.clarify-log.md`**: Persistent file in the RFC folder that records Q&A and assumptions from each clarification session for cross-session deduplication.
-- **Sub-phase snippet**: A Markdown file in `src/templates/agent-skills/snippets/` containing the instructions for one sub-phase of the piecewise pipeline (e.g., `ignite-phase3a.md`).
+- **`smithy-prose` sub-agent**: New shared sub-agent specialized for narrative/persuasive writing. Dispatched for Summary, Motivation/Problem Statement, and other prose-heavy sections across any smithy command.
 
 ## Assumptions
 
-- Sub-agent prompts (smithy-clarify, smithy-plan, smithy-reconcile, smithy-refine) do not need modification — they are generic enough to handle the new invocation patterns.
-- No TypeScript code changes are required — this is purely a prompt template and snippet change.
-- The existing Dotprompt/Handlebars partial resolution system handles nested snippet includes correctly.
+- Existing sub-agent prompts (smithy-clarify, smithy-plan, smithy-reconcile, smithy-refine) do not need modification — they are generic enough to handle the new invocation patterns. smithy-plan's interface (planning context, feature description, codebase file paths, additional directives) already supports being dispatched for individual RFC sections.
+- No TypeScript code changes are required — this is a prompt template change plus one new sub-agent definition (`smithy-prose`).
 - The competing plans phase (Phase 1.5) with three lenses and smithy-reconcile remains unchanged in structure, though it now benefits from richer context when sub-phases reference its output.
 - smithy-scout is NOT added to the ignite pipeline (ignite works from ideas/PRDs, not existing code).
+- smithy-prose is designed as a shared sub-agent from day one, but adoption by other commands (render, mark) is deferred to future work.
 
 ## Out of Scope
 
-- Changes to other smithy commands (mark, render, cut, forge, strike) — they consume RFCs but their templates are not modified by this feature.
-- New sub-agent definitions — no new agent files are created; all piecewise orchestration happens within the ignite template via snippets.
-- TypeScript code changes to `src/cli.ts`, `src/commands/`, or `src/agents/` — this is a prompt-only change.
-- Gemini/Codex deployment considerations — the ignite template deploys the same way; only the content changes.
+- Changes to other smithy commands (mark, render, cut, forge, strike) — they consume RFCs but their templates are not modified by this feature. Adoption of smithy-prose by other commands is future work.
+- TypeScript code changes to `src/cli.ts`, `src/commands/`, or `src/agents/` — this is a prompt-only change plus a new agent definition file.
+- Gemini/Codex deployment considerations — the ignite template deploys the same way; only the content changes. smithy-prose deploys as a standard sub-agent.
 - Per-section clarification passes — the reconciled approach uses a single upfront clarify pass, not per-section runs.
+- Ignite-specific snippets — sub-phase instructions are delegated to sub-agents (smithy-prose, smithy-plan), not extracted into ignite-specific snippets.
 
 ## Success Criteria *(mandatory)*
 
@@ -207,4 +229,5 @@ As a developer using `smithy.ignite`, I want the RFC template to include all sec
 - **SC-004**: Running `smithy.ignite` on the same idea twice in separate sessions does not re-ask questions that were answered and logged in `.clarify-log.md`.
 - **SC-005**: Interrupting an `smithy.ignite` session mid-pipeline and restarting successfully resumes from the last completed sub-phase without losing prior work.
 - **SC-006**: The `audit-checklist-rfc.md` snippet includes persona coverage and out-of-scope completeness checks, and `smithy.audit` flags RFCs missing these sections.
-- **SC-007**: The ignite prompt template uses snippet partials for sub-phase instructions, keeping the main template under 150 lines (excluding snippet content).
+- **SC-007**: The ignite prompt template dispatches smithy-prose for narrative sections and smithy-plan for structured sections, keeping the orchestrator focused on pipeline management rather than inline drafting.
+- **SC-008**: The `smithy-prose` sub-agent produces compelling narrative framing (impact, urgency, stakeholder value) that is qualitatively distinct from bullet-point-style output.

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
@@ -185,7 +185,7 @@ As a developer reviewing an existing RFC via `smithy.ignite` Phase 0, I want the
 - **FR-002**: Each sub-phase (3a-3f) MUST write its output to a numbered file in a `_wip/` subdirectory within the RFC folder before the next sub-phase begins.
 - **FR-003**: Each sub-phase (3b-3f) MUST read all prior `_wip/` files from disk before drafting its section, ensuring context flows forward without relying on the context window.
 - **FR-004**: Sub-phase 3g (Assemble) MUST read all `_wip/` files, concatenate them into the RFC template structure, perform a coherence/harmonization pass, write the final RFC to `<slug>.rfc.md`, and delete the `_wip/` directory.
-- **FR-005**: The RFC template MUST include a mandatory `## Personas` section positioned between Goals and Proposal.
+- **FR-005**: The RFC template MUST include a mandatory `## Personas` section positioned after `## Out of Scope` and before `## Proposal`.
 - **FR-006**: The RFC template MUST include a mandatory `## Out of Scope` section positioned after Goals and before Personas.
 - **FR-007**: A new shared `smithy-prose` sub-agent MUST be created at `src/templates/agent-skills/agents/smithy.prose.prompt` for drafting narrative/persuasive RFC sections (Summary, Motivation/Problem Statement).
 - **FR-007a**: The ignite orchestrator MUST dispatch `smithy-plan` for structured analytical sections (Goals, Out of Scope, Proposal, Design Considerations, Milestones).


### PR DESCRIPTION
Addresses issues #49 (personas lost) and #50 (missing out-of-scope)
by restructuring ignite from one-shot RFC drafting to a sequential
sub-phase pipeline with intermediate file writes, mandatory Personas
and Out of Scope sections, and cross-session question deduplication.

https://claude.ai/code/session_01YJ1u6iAuArem4zqkVkBaxd