### PR TITLE
Add task breakdown for relaxing critical decision blocking

### DIFF
--- a/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
@@ -1,0 +1,130 @@
+# Tasks: Relax Critical Decision Blocking
+
+**Source**: `specs/2026-04-08-003-reduce-interaction-friction/reduce-interaction-friction.spec.md` — User Story 1
+**Data Model**: `specs/2026-04-08-003-reduce-interaction-friction/reduce-interaction-friction.data-model.md`
+**Contracts**: `specs/2026-04-08-003-reduce-interaction-friction/reduce-interaction-friction.contracts.md`
+**Story Number**: 01
+
+---
+
+## Slice 1: Update Triage Rules and Critical Assumption Annotation
+
+**Goal**: Modify smithy-clarify's triage logic so Critical+High-confidence
+candidates become assumptions with a `[Critical Assumption]` annotation instead
+of mandatory questions.
+
+**Justification**: This slice delivers the core behavioral change — after
+merging, any planning command that invokes smithy-clarify will stop blocking on
+Critical+High items. The triage rule, annotation format, impact guideline, edge
+case safety, and verification are all in one file (`smithy.clarify.prompt`),
+making this an atomic, testable unit.
+
+**Addresses**: FR-001, FR-002 (partial — annotation in clarify output);
+Acceptance Scenarios 1.1 (Critical+High → assumption), 1.2 (all High →
+all assumptions), 1.3 (Critical+Low → stays in Questions)
+
+### Tasks
+
+- [ ] Update the Critical row in the Impact guidelines table (Step 2, line 68)
+  to remove "Must be confirmed with the user." Replace with: "Getting this wrong
+  would invalidate the artifact or cause significant rework. When confidence is
+  High, proceed as a `[Critical Assumption]`."
+- [ ] Rewrite the Assumptions criteria in Step 3 (lines 88–93). Change from
+  `Impact is **not Critical**, AND Confidence is **High**` to
+  `Confidence is **High**` (any Impact level). Add: "If Impact is **Critical**
+  and Confidence is **High**, the item becomes an assumption with a
+  `[Critical Assumption]` annotation."
+- [ ] Update the Questions criteria in Step 3 (lines 98–104). Change "All
+  Critical-impact items — regardless of confidence" to "Critical-impact items
+  where Confidence is **not High**" (Critical+Medium and Critical+Low still
+  become questions). Adjust the fill-up-to-5 rule accordingly.
+- [ ] Update the edge case rule in Step 3 (lines 109–111). Change "convert the
+  single highest-impact assumption back into a question" to "convert the single
+  lowest-impact non-Critical assumption back into a question." This prevents
+  FR-001 from being undermined when the fallback triggers.
+- [ ] Update the assumption rendering format in Step 4 (lines 117–122). Add
+  the `[Critical Assumption]` annotation to the example block:
+  `> - _Assumption text_ [Critical Assumption] [Impact: Critical · Confidence: High]`
+- [ ] Update the return summary in the Rules section (lines 160–165) to note
+  that the assumptions list includes `[Critical Assumption]` annotations for
+  Critical-impact items promoted to assumptions.
+- [ ] Update the frontmatter description (line 3) from "triages findings into
+  assumptions and questions" to "triages findings into assumptions (including
+  Critical Assumptions) and questions."
+- [ ] Add a Tier 2 test assertion in `src/templates.test.ts` (after line 236)
+  that validates the composed `smithy.clarify.md` template contains
+  `[Critical Assumption]`. This catches accidental regression if the annotation
+  text is removed during future edits.
+
+**PR Outcome**: smithy-clarify allows Critical+High-confidence items through as
+assumptions with `[Critical Assumption]` annotation. All other triage rules
+remain unchanged. The Questions category is preserved for non-High-confidence
+items.
+
+---
+
+## Slice 2: Annotation Visibility in Parent Command Artifacts
+
+**Goal**: Ensure the `[Critical Assumption]` annotation renders correctly in
+mark's artifact Clarifications section, clean up stale clarify-related
+instructions in parent commands, and add an agent test case for end-to-end
+verification.
+
+**Justification**: This slice completes FR-002's requirement that the annotation
+be "visible in the artifact's Clarifications section." While Slice 1 adds the
+annotation to clarify's output, mark's Clarifications section template only
+shows the Q&A format. This slice makes the template explicit about assumptions.
+It also cleans up stale instructions that will become actively wrong when
+Story 3 lands.
+
+**Addresses**: FR-002 (completeness — annotation in artifact Clarifications
+section); Acceptance Scenario 1.4 (user can challenge via Clarifications section)
+
+### Tasks
+
+- [ ] Update the Clarifications section template in `smithy.mark.prompt`
+  (lines 192–197). Add an assumptions subsection example after the Q&A list:
+  ```
+  ### Assumptions (from clarification)
+  - _Assumption text_ `[Critical Assumption]`
+  - _Assumption text_
+  ```
+  This makes the template explicit about rendering assumptions (with annotations)
+  alongside Q&A in the Clarifications section.
+- [ ] Update the stale instruction in `smithy.mark.prompt` (line 498). Change
+  "DO internally generate all clarifying questions first, then present them
+  one at a time with recommended answers" to "DO invoke smithy-clarify for
+  ambiguity scanning and triage." The parent command delegates clarification
+  entirely to the sub-agent.
+- [ ] Update the identical stale instruction in `smithy.cut.prompt` (line 295).
+  Apply the same change as above.
+- [ ] Add an A-series agent test case in `tests/Agent.tests.md` (after the last
+  existing test) that exercises Critical+High triage behavior:
+  - **Steps**: Invoke clarify with a feature description that produces a
+    Critical+High candidate (e.g., "Add payment processing" which has Critical
+    impact on data handling).
+  - **Expected**: The Critical+High item appears in the assumptions block with
+    `[Critical Assumption]` annotation, not in the questions list.
+
+**PR Outcome**: Mark's artifact template explicitly renders assumptions
+(including `[Critical Assumption]` annotations) in the Clarifications section.
+Stale instructions in mark and cut are corrected. An agent test case validates
+end-to-end triage behavior.
+
+---
+
+## Dependency Order
+
+Recommended implementation sequence:
+
+1. **Slice 1** — Core triage logic must exist before parent commands can render
+   the annotation. This is the foundational behavioral change.
+2. **Slice 2** — Depends on Slice 1's annotation format being defined. Ensures
+   annotation visibility in downstream artifacts and provides verification.
+
+### Cross-Story Dependencies
+
+| Dependency | Direction | Notes |
+|------------|-----------|-------|
+| User Story 2: Track Specification Debt | depended upon by | Story 1's acceptance scenarios 1.1 and 1.3 reference "debt items" as the disposition for non-High-confidence candidates. In Story 1, these items remain in the existing Questions category. When Story 2 lands, Questions becomes Debt — Story 1's triage changes are forward-compatible with this replacement. |
+| User Story 3: One-Shot Planning Workflows | depended upon by | Story 3 removes the Questions category entirely (FR-012) and makes clarify non-interactive. Story 1 preserves Questions and interactivity. Story 3 will also remove the edge case rule (lines 109-111) that Story 1 modifies defensively. |

--- a/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
@@ -16,7 +16,8 @@ of mandatory questions.
 **Justification**: This slice delivers the core behavioral change — after
 merging, any planning command that invokes smithy-clarify will stop blocking on
 Critical+High items. The triage rule, annotation format, impact guideline, edge
-case safety, and verification are all in one file (`smithy.clarify.prompt`),
+case safety, and verification are all in one file
+(`src/templates/agent-skills/agents/smithy.clarify.prompt`),
 making this an atomic, testable unit.
 
 **Addresses**: FR-001, FR-002 (partial — annotation in clarify output);
@@ -24,6 +25,9 @@ Acceptance Scenarios 1.1 (Critical+High → assumption), 1.2 (all High →
 all assumptions), 1.3 (Critical+Low → stays in Questions)
 
 ### Tasks
+
+All line references below are in
+`src/templates/agent-skills/agents/smithy.clarify.prompt`.
 
 - [ ] Update the Critical row in the Impact guidelines table (Step 2, line 68)
   to remove "Must be confirmed with the user." Replace with: "Getting this wrong
@@ -83,7 +87,7 @@ section); Acceptance Scenario 1.4 (user can challenge via Clarifications section
 
 ### Tasks
 
-- [ ] Replace the Clarifications section template in `smithy.mark.prompt`
+- [ ] Replace the Clarifications section template in `src/templates/agent-skills/commands/smithy.mark.prompt`
   (lines 192–197). The current `Q: <question> → A: <answer>` format assumes
   interactive Q&A which is being eliminated across the board. Replace with an
   assumptions-first format:
@@ -97,12 +101,12 @@ section); Acceptance Scenario 1.4 (user can challenge via Clarifications section
   ```
   This positions the Clarifications section for the one-shot world where
   assumptions (and later, debt summaries from Story 2) are the primary content.
-- [ ] Update the stale instruction in `smithy.mark.prompt` (line 498). Change
+- [ ] Update the stale instruction in `src/templates/agent-skills/commands/smithy.mark.prompt` (line 498). Change
   "DO internally generate all clarifying questions first, then present them
   one at a time with recommended answers" to "DO invoke smithy-clarify for
   ambiguity scanning and triage." The parent command delegates clarification
   entirely to the sub-agent; interactive question presentation is eliminated.
-- [ ] Update the identical stale instruction in `smithy.cut.prompt` (line 295).
+- [ ] Update the identical stale instruction in `src/templates/agent-skills/commands/smithy.cut.prompt` (line 295).
   Apply the same change as above.
 - [ ] Add an A-series agent test case in `tests/Agent.tests.md` (after the last
   existing test) that exercises Critical+High triage behavior:

--- a/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
@@ -65,37 +65,43 @@ items.
 
 ## Slice 2: Annotation Visibility in Parent Command Artifacts
 
-**Goal**: Ensure the `[Critical Assumption]` annotation renders correctly in
-mark's artifact Clarifications section, clean up stale clarify-related
-instructions in parent commands, and add an agent test case for end-to-end
-verification.
+**Goal**: Transition mark's Clarifications section template toward its one-shot
+format — assumptions as primary content with `[Critical Assumption]` annotations
+visible — and clean up stale interactive-mode instructions in parent commands.
 
-**Justification**: This slice completes FR-002's requirement that the annotation
-be "visible in the artifact's Clarifications section." While Slice 1 adds the
-annotation to clarify's output, mark's Clarifications section template only
-shows the Q&A format. This slice makes the template explicit about assumptions.
-It also cleans up stale instructions that will become actively wrong when
-Story 3 lands.
+**Justification**: The entire pipeline is going one-shot (Story 3). In that
+world there are no interactive Q&A pairs — the Clarifications section contains
+only assumptions and debt (with debt potentially triggering bail-out). Story 1
+starts this transition: the `Q: → A:` format in mark's Clarifications template
+(lines 192–197) is a dead end. This slice replaces it with assumption-first
+rendering, completing FR-002's requirement that `[Critical Assumption]` be
+visible in the artifact. It also removes stale instructions that reference
+interactive clarification behavior.
 
 **Addresses**: FR-002 (completeness — annotation in artifact Clarifications
 section); Acceptance Scenario 1.4 (user can challenge via Clarifications section)
 
 ### Tasks
 
-- [ ] Update the Clarifications section template in `smithy.mark.prompt`
-  (lines 192–197). Add an assumptions subsection example after the Q&A list:
+- [ ] Replace the Clarifications section template in `smithy.mark.prompt`
+  (lines 192–197). The current `Q: <question> → A: <answer>` format assumes
+  interactive Q&A which is being eliminated across the board. Replace with an
+  assumptions-first format:
   ```
-  ### Assumptions (from clarification)
+  ## Clarifications
+
+  ### Session YYYY-MM-DD
+
   - _Assumption text_ `[Critical Assumption]`
   - _Assumption text_
   ```
-  This makes the template explicit about rendering assumptions (with annotations)
-  alongside Q&A in the Clarifications section.
+  This positions the Clarifications section for the one-shot world where
+  assumptions (and later, debt summaries from Story 2) are the primary content.
 - [ ] Update the stale instruction in `smithy.mark.prompt` (line 498). Change
   "DO internally generate all clarifying questions first, then present them
   one at a time with recommended answers" to "DO invoke smithy-clarify for
   ambiguity scanning and triage." The parent command delegates clarification
-  entirely to the sub-agent.
+  entirely to the sub-agent; interactive question presentation is eliminated.
 - [ ] Update the identical stale instruction in `smithy.cut.prompt` (line 295).
   Apply the same change as above.
 - [ ] Add an A-series agent test case in `tests/Agent.tests.md` (after the last
@@ -103,13 +109,13 @@ section); Acceptance Scenario 1.4 (user can challenge via Clarifications section
   - **Steps**: Invoke clarify with a feature description that produces a
     Critical+High candidate (e.g., "Add payment processing" which has Critical
     impact on data handling).
-  - **Expected**: The Critical+High item appears in the assumptions block with
-    `[Critical Assumption]` annotation, not in the questions list.
+  - **Expected**: The Critical+High item appears in the assumptions list with
+    `[Critical Assumption]` annotation, not as an interactive question.
 
-**PR Outcome**: Mark's artifact template explicitly renders assumptions
-(including `[Critical Assumption]` annotations) in the Clarifications section.
-Stale instructions in mark and cut are corrected. An agent test case validates
-end-to-end triage behavior.
+**PR Outcome**: Mark's Clarifications template uses assumption-first format
+(anticipating one-shot), `[Critical Assumption]` annotations are visible in
+artifacts. Stale interactive instructions in mark and cut are removed. Agent
+test case validates end-to-end triage behavior.
 
 ---
 
@@ -127,4 +133,4 @@ Recommended implementation sequence:
 | Dependency | Direction | Notes |
 |------------|-----------|-------|
 | User Story 2: Track Specification Debt | depended upon by | Story 1's acceptance scenarios 1.1 and 1.3 reference "debt items" as the disposition for non-High-confidence candidates. In Story 1, these items remain in the existing Questions category. When Story 2 lands, Questions becomes Debt — Story 1's triage changes are forward-compatible with this replacement. |
-| User Story 3: One-Shot Planning Workflows | depended upon by | Story 3 removes the Questions category entirely (FR-012) and makes clarify non-interactive. Story 1 preserves Questions and interactivity. Story 3 will also remove the edge case rule (lines 109-111) that Story 1 modifies defensively. |
+| User Story 3: One-Shot Planning Workflows | depended upon by | Story 3 removes the Questions category entirely (FR-012) and makes clarify non-interactive. Story 1 preserves Questions in the triage but begins the transition in artifact templates: Slice 2 replaces mark's Q&A-based Clarifications format with assumption-first rendering, anticipating the one-shot world where Q&A pairs do not exist. Story 3 will also remove the edge case rule (lines 109-111) that Story 1 modifies defensively. |


### PR DESCRIPTION
## Summary
- **Primary outcome**: Document the implementation tasks for User Story 1 (Relax Critical Decision Blocking) from the reduce-interaction-friction specification, broken into two implementable slices with clear dependencies.
- **Notable behaviour changes**: None yet — this is a task specification document. When implemented, Critical+High-confidence items will become assumptions with `[Critical Assumption]` annotation instead of blocking questions.
- **Follow-up work deferred**: Implementation of the actual code changes described in these tasks (Slices 1 and 2).

## Context
This task document operationalizes [User Story 1 from the reduce-interaction-friction specification](specs/2026-04-08-003-reduce-interaction-friction/reduce-interaction-friction.spec.md), which aims to reduce interaction friction by allowing high-confidence critical decisions to proceed as documented assumptions rather than mandatory blocking questions.

The specification defines acceptance scenarios (1.1–1.4) and functional requirements (FR-001, FR-002) that require:
1. Triage rule changes in `smithy.clarify.prompt` to promote Critical+High items to assumptions
2. Annotation visibility in parent command artifacts (mark, cut)
3. End-to-end verification via agent tests

This task breakdown enables parallel planning and phased implementation while maintaining forward compatibility with dependent stories (Story 2: Track Specification Debt, Story 3: One-Shot Planning Workflows).

## Implementation Notes

### Slice Structure
The work is divided into two slices with clear dependencies:

- **Slice 1** (Core triage logic): Modifies `smithy.clarify.prompt` to change how Critical+High candidates are classified, adds `[Critical Assumption]` annotation format, and adds a Tier 2 template test. This is the foundational change that all downstream work depends on.

- **Slice 2** (Visibility & cleanup): Updates parent command templates (`smithy.mark.prompt`, `smithy.cut.prompt`) to explicitly render assumptions in Clarifications sections, removes stale instructions that conflict with the clarify sub-agent delegation model, and adds an A-series agent test case for end-to-end verification.

### Key Architectural Choices
- **Annotation in clarify output**: The `[Critical Assumption]` annotation is added at the source (clarify's triage output) rather than injected downstream. This ensures consistency and makes the assumption's criticality explicit to all consumers.
- **Defensive edge case rule update**: Slice 1 modifies the fallback rule (lines 109–111) to prevent non-Critical assumptions from being demoted when the 5-item limit is hit, protecting FR-001 from being undermined.
- **Forward compatibility**: The Questions category is preserved in Slice 1 even though Story 2 will rename it to Debt and Story 3 will remove it entirely. This allows Slice 1 to land independently without blocking on downstream stories.

### Impacted Modules
- `smithy.clarify.prompt` — Triage rules, annotation format, edge case handling
- `smithy.mark.prompt` — Clarifications section template, stale instruction cleanup
- `smithy.cut.prompt` — Stale instruction cleanup
- `src/templates.test.ts` — New Tier 2 assertion for annotation presence
- `tests/Agent.tests.md` — New A-series test case for Critical+High triage behavior

## Risks & Mitigations

| Risk | Mitigation |
|------|-----------|
| Annotation text removed during future edits | Tier 2 test assertion in `src/templates.test.ts` validates `[Critical Assumption]` is present in composed template |
| Edge case rule change undermines FR-001 | Defensive update to demote only non-Critical assumptions, preserving Critical items in assumptions list |
| Stale instructions in mark/cut cause confusion | Slice 2 explicitly updates instructions to reflect clarify sub-agent delegation model |
| Forward compatibility with Story 2/3 | Questions category preserved; Story 2 renames it to Debt, Story 3 removes it. Triage logic is compatible with both. |

## Rollback Plan
This is a task specification document (no code changes yet). Once implementation tasks are completed:
- Revert changes to `

https://claude.ai/code/session_013gvNbABtfK2WQoskcqf15T