### PR TITLE
Add Out of Scope and Personas sections to ignite RFC template

### DIFF
--- a/specs/2026-04-07-003-refactor-ignite-workflow/01-updated-rfc-template-schema.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/01-updated-rfc-template-schema.tasks.md
@@ -1,0 +1,24 @@
+# Tasks: Updated RFC Template Schema
+
+**Source**: `specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md` — User Story 1
+**Data Model**: `specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.data-model.md`
+**Contracts**: `specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.contracts.md`
+**Story Number**: 01
+
+---
+
+## Slice 1: Insert Out of Scope and Personas into Phase 3 RFC Template
+
+**Goal**: Insert `## Out of Scope` and `## Personas` sections into the Phase 3 RFC template in `src/templates/agent-skills/commands/smithy.ignite.prompt`, in the correct positions (after Goals, before Proposal), with placeholder content matching the existing section style.
+
+**Addresses**: FR-005, FR-006; Acceptance Scenarios US1-1, US1-2
+
+### Tasks
+
+- [x] Read `src/templates/agent-skills/commands/smithy.ignite.prompt` to locate the Phase 3 RFC template block (the fenced markdown block inside `## Phase 3: Draft RFC`). Note the exact lines of the `## Goals` section and `## Proposal` section within the code fence.
+- [x] In the template block, insert `## Out of Scope` immediately after the `## Goals` section (after its placeholder bullets, before `## Proposal`), with placeholder content for explicitly excluded capabilities.
+- [x] Immediately after `## Out of Scope`, insert `## Personas` (still before `## Proposal`), with placeholder content for persona roles and benefits.
+- [x] Verify the resulting section order in the template block is: Summary, Motivation / Problem Statement, Goals, Out of Scope, Personas, Proposal, Design Considerations, Decisions, Open Questions, Milestones.
+- [ ] Task 5 (pending assignment by orchestrator)
+- [ ] Task 6 (pending assignment by orchestrator)
+- [ ] Task 7 (pending assignment by orchestrator)

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -352,6 +352,34 @@ describe('getComposedTemplates', () => {
     expect(ignite).not.toContain('Competing Plan Lenses');
   });
 
+  it('ignite RFC template contains Out of Scope and Personas sections in correct order', () => {
+    const ignite = composed.commands.get('smithy.ignite.md')!;
+    expect(ignite).toBeDefined();
+
+    // The RFC template code fence must contain these sections in order:
+    // Goals -> Out of Scope -> Personas -> Proposal
+    const goalsIdx = ignite.indexOf('## Goals');
+    const outOfScopeIdx = ignite.indexOf('## Out of Scope');
+    const personasIdx = ignite.indexOf('## Personas');
+    const proposalIdx = ignite.indexOf('## Proposal');
+
+    expect(goalsIdx).toBeGreaterThan(-1);
+    expect(outOfScopeIdx).toBeGreaterThan(-1);
+    expect(personasIdx).toBeGreaterThan(-1);
+    expect(proposalIdx).toBeGreaterThan(-1);
+
+    // Verify ordering
+    expect(outOfScopeIdx).toBeGreaterThan(goalsIdx);
+    expect(personasIdx).toBeGreaterThan(outOfScopeIdx);
+    expect(proposalIdx).toBeGreaterThan(personasIdx);
+
+    // Verify placeholder content exists
+    expect(ignite).toContain('<Explicitly excluded capability 1>');
+    expect(ignite).toContain('<Explicitly excluded capability 2>');
+    expect(ignite).toContain('<Persona 1');
+    expect(ignite).toContain('<Persona 2');
+  });
+
   it('render with claude variant renders competing plan dispatch', async () => {
     const claudeComposed = await getComposedTemplates('claude');
     const render = claudeComposed.commands.get('smithy.render.md')!;

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -180,6 +180,16 @@ of not solving it?>
 - <Goal 2>
 - <Goal 3>
 
+## Out of Scope
+
+- <Explicitly excluded capability 1>
+- <Explicitly excluded capability 2>
+
+## Personas
+
+- <Persona 1 — role and how they benefit from this RFC>
+- <Persona 2 — role and how they benefit>
+
 ## Proposal
 
 <The "WHAT" — describe what will be built at a high level. Focus on outcomes


### PR DESCRIPTION
## Source
- Spec: `specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md` — User Story 1
- Tasks: `specs/2026-04-07-003-refactor-ignite-workflow/01-updated-rfc-template-schema.tasks.md`

## Slice
**Slice 1**: Insert `## Out of Scope` and `## Personas` sections into the Phase 3 RFC template in `src/templates/agent-skills/commands/smithy.ignite.prompt`, in the correct positions (after Goals, before Proposal), and add an ordering regression test.

## Addresses
- FR-005: `## Personas` section added to RFC template, positioned after `## Out of Scope` and before `## Proposal`
- FR-006: `## Out of Scope` section added to RFC template, positioned after `## Goals` and before `## Personas`
- Acceptance Scenarios 1.1, 1.2

## Tasks Completed
- [x] Located the Phase 3 RFC template block (fenced markdown inside `## Phase 3: Draft RFC`)
- [x] Inserted `## Out of Scope` immediately after `## Goals`, with bullet-list placeholder content
- [x] Inserted `## Personas` immediately after `## Out of Scope`, before `## Proposal`, with bullet-list placeholder content
- [x] Verified section order: Summary → Motivation / Problem Statement → Goals → **Out of Scope** → **Personas** → Proposal → Design Considerations → Decisions → Open Questions → Milestones
- [x] Added ordering regression test in `src/templates.test.ts` using `indexOf` comparisons (Goals < Out of Scope < Personas < Proposal), plus placeholder content assertions
- [x] All 190 tests pass

## Review
No findings — clean, minimal implementation. Placeholder style matches existing sections (`- <angle-bracket descriptor>`).

## Documentation Notes
The following items are out of scope for this slice and tracked in future stories:
- **Phase 0 audit categories** (`smithy.ignite.prompt` lines 60–67): adding "Out of Scope Completeness" and "Persona Coverage" rows is User Story 9's responsibility
- **`audit-checklist-rfc.md`** snippet rename/update to match contracted category names is also User Story 9
- **`smithy.prose.prompt`** sub-agent creation is User Story 2

## Validation
```
npm test
8 test files passed, 190 tests passed
```