### PR TITLE
Transition mark/cut to assumption-first clarification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ node dist/cli.js update  # Test update flow
 Smithy has three testing tiers, each tested differently:
 
 1. **CLI behavior** (Tier 1) — init/uninit/update flows, option parsing, file deployment, idempotency. Covered by `npm test` (automated, CI) and interactive terminal tests (H1-H4).
-2. **Agent-skill file validation** (Tier 2) — template composition, partial resolution, frontmatter, agent variants, file categorization. Covered by `npm test` (automated, CI) and agent-session tests (A1-A5).
+2. **Agent-skill file validation** (Tier 2) — template composition, partial resolution, frontmatter, agent variants, file categorization. Covered by `npm test` (automated, CI) and agent-session tests (A1-A6).
 3. **Agent-skill execution behavior** (Tier 3) — skills produce correct output when invoked by an AI agent, sub-agents are dispatched, output structure matches expectations. Covered by evals framework (`npm run eval`, local on-demand, not CI). **Status: in development.**
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for test file details. Agent and human test cases are in **[tests/](tests/)**: [tests/Agent.tests.md](tests/Agent.tests.md) (A-series), [tests/Manual.tests.md](tests/Manual.tests.md) (H-series).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Tests that templates compose correctly (snippet/partial resolution, frontmatter 
 |-----------|-------|
 | `src/templates.test.ts` | Template composition, partial resolution, frontmatter, agent variants, file categorization |
 
-**Agent tests** (Claude Code session) — verify deployed prompts are visible, slash commands are invocable, permissions are enforced, and stale artifacts are cleaned up. See **[tests/Agent.tests.md](tests/Agent.tests.md)** (A1-A5).
+**Agent tests** (Claude Code session) — verify deployed prompts are visible, slash commands are invocable, permissions are enforced, and stale artifacts are cleaned up. See **[tests/Agent.tests.md](tests/Agent.tests.md)** (A1-A6).
 
 ### Tier 3: Agent-Skill Execution Behavior (evals)
 
@@ -61,7 +61,7 @@ See **[specs/2026-04-06-003-smithy-evals-framework/](specs/2026-04-06-003-smithy
 Before publishing a new version:
 
 1. All automated tests pass: `npm test`
-2. Agent tests (A1-A5) verified in a Claude Code session
+2. Agent tests (A1-A6) verified in a Claude Code session
 3. Human tests (H1-H4) verified in an interactive terminal
 4. Evals pass (when available): `npm run eval`
 5. Trigger the **Publish to npm** workflow with both test gate checkboxes checked

--- a/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
@@ -87,7 +87,7 @@ section); Acceptance Scenario 1.4 (user can challenge via Clarifications section
 
 ### Tasks
 
-- [ ] Replace the Clarifications section template in `src/templates/agent-skills/commands/smithy.mark.prompt`
+- [x] Replace the Clarifications section template in `src/templates/agent-skills/commands/smithy.mark.prompt`
   (lines 192–197). The current `Q: <question> → A: <answer>` format assumes
   interactive Q&A which is being eliminated across the board. Replace with an
   assumptions-first format:

--- a/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
@@ -101,7 +101,7 @@ section); Acceptance Scenario 1.4 (user can challenge via Clarifications section
   ```
   This positions the Clarifications section for the one-shot world where
   assumptions (and later, debt summaries from Story 2) are the primary content.
-- [ ] Update the stale instruction in `src/templates/agent-skills/commands/smithy.mark.prompt` (line 498). Change
+- [x] Update the stale instruction in `src/templates/agent-skills/commands/smithy.mark.prompt` (line 498). Change
   "DO internally generate all clarifying questions first, then present them
   one at a time with recommended answers" to "DO invoke smithy-clarify for
   ambiguity scanning and triage." The parent command delegates clarification

--- a/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
@@ -108,7 +108,7 @@ section); Acceptance Scenario 1.4 (user can challenge via Clarifications section
   entirely to the sub-agent; interactive question presentation is eliminated.
 - [x] Update the identical stale instruction in `src/templates/agent-skills/commands/smithy.cut.prompt` (line 295).
   Apply the same change as above.
-- [ ] Add an A-series agent test case in `tests/Agent.tests.md` (after the last
+- [x] Add an A-series agent test case in `tests/Agent.tests.md` (after the last
   existing test) that exercises Critical+High triage behavior:
   - **Steps**: Invoke clarify with a feature description that produces a
     Critical+High candidate (e.g., "Add payment processing" which has Critical

--- a/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
@@ -106,7 +106,7 @@ section); Acceptance Scenario 1.4 (user can challenge via Clarifications section
   one at a time with recommended answers" to "DO invoke smithy-clarify for
   ambiguity scanning and triage." The parent command delegates clarification
   entirely to the sub-agent; interactive question presentation is eliminated.
-- [ ] Update the identical stale instruction in `src/templates/agent-skills/commands/smithy.cut.prompt` (line 295).
+- [x] Update the identical stale instruction in `src/templates/agent-skills/commands/smithy.cut.prompt` (line 295).
   Apply the same change as above.
 - [ ] Add an A-series agent test case in `tests/Agent.tests.md` (after the last
   existing test) that exercises Critical+High triage behavior:

--- a/src/templates/agent-skills/agents/smithy.clarify.prompt
+++ b/src/templates/agent-skills/agents/smithy.clarify.prompt
@@ -1,6 +1,6 @@
 ---
 name: smithy-clarify
-description: "Shared clarification sub-agent. Scans for ambiguity across provided categories, then triages findings into assumptions and questions with confidence/impact scoring. Invoked by other smithy agents."
+description: "Shared clarification sub-agent. Scans for ambiguity across provided categories, then triages findings into assumptions (including Critical Assumptions) and questions with confidence/impact scoring. Invoked by other smithy agents."
 tools:
   - Read
   - Grep

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -292,7 +292,7 @@ ask again.
 - **DO** keep slices PR-sized. If a slice feels too large, split it further.
 - **DO** use zero-padded two-digit numbering for the filename (`01-`, `02-`,
   ..., `99-`) for consistent sort order.
-- **DO** internally generate all clarifying questions first, then present them one at a time with recommended answers.
+- **DO** invoke smithy-clarify for ambiguity scanning and triage.
 - **DO** read all three spec artifacts (spec, data model, contracts) before
   slicing — the data model and contracts inform implementation boundaries.
 - **DO** explore the codebase to ground slices in reality — don't slice in

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -193,8 +193,8 @@ Draft the `<slug>.spec.md` file with this structure:
 
 ### Session YYYY-MM-DD
 
-- Q: <question> → A: <answer>
-- ...
+- _Assumption text_ `[Critical Assumption]`
+- _Assumption text_
 
 ## Artifact Hierarchy
 

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -495,7 +495,7 @@ through Phase 0).
 - **DO** number user stories sequentially — downstream commands depend on this.
 - **DO** order user stories by priority (P1 first, then P2, then P3) and renumber
   them when priorities change during refinement.
-- **DO** internally generate all clarifying questions first, then present them one at a time with recommended answers.
+- **DO** invoke smithy-clarify for ambiguity scanning and triage.
 - **DO** create the git branch and spec folder automatically.
 - **DO** write minimal placeholder files for data-model and contracts when they
   don't apply, rather than omitting them.

--- a/tests/Agent.tests.md
+++ b/tests/Agent.tests.md
@@ -143,3 +143,27 @@ ls /tmp/smithy-test/.claude/commands/smithy.oldname.md 2>/dev/null && echo "FAIL
 - [ ] Risks table has columns: `Risk | Likelihood | Mitigation`
 - [ ] Tradeoffs table has columns: `Alternative | Pros | Cons | Directive relevance`
 - [ ] References concrete elements (file paths, function names, entities) rather than generic advice
+
+---
+
+## A6: smithy-clarify promotes Critical+High items to assumptions
+
+**Purpose**: Verify that smithy-clarify treats Critical+High-confidence candidates as `[Critical Assumption]` assumptions rather than interactive questions.
+
+**Steps**:
+1. Build and deploy the latest templates:
+   ```bash
+   npm run build
+   node dist/cli.js update -d /path/to/SmithyCLI
+   ```
+2. Invoke smithy-clarify as a sub-agent (or via a general-purpose agent acting as smithy-clarify) with this input:
+   - **Criteria**: standard clarify categories (Functional Scope, Domain & Data Model, etc.)
+   - **Context**: "Add payment processing to the checkout flow. Payment data must be stored securely and comply with PCI-DSS. Support Stripe and PayPal as providers."
+   - **Special instructions**: none
+3. Inspect the returned output.
+
+**Expected**:
+- [ ] The item about PCI-DSS compliance or data storage (Critical impact, High confidence) appears in the **assumptions list**, not in the questions list
+- [ ] That assumption carries a `[Critical Assumption]` annotation in the format `[Impact: Critical · Confidence: High]`
+- [ ] No Critical+High item appears as an interactive question
+- [ ] Non-High-confidence items (if any) remain in the questions section


### PR DESCRIPTION
## Source

- Spec: `specs/2026-04-08-003-reduce-interaction-friction/reduce-interaction-friction.spec.md`
- Tasks: `specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md`

## Slice

**Slice 2: Annotation Visibility in Parent Command Artifacts**

Transition mark's Clarifications section template toward its one-shot format — assumptions as primary content with `[Critical Assumption]` annotations visible — and clean up stale interactive-mode instructions in parent commands.

## Addresses

- **FR-002** (completeness — `[Critical Assumption]` annotation visible in artifact Clarifications section)
- **Acceptance Scenario 1.4** (user can challenge assumptions via Clarifications section)

## Tasks completed

- [x] Replace the Clarifications section template in `smithy.mark.prompt` (lines 192–197) — `Q: → A:` format replaced with assumption-first format including `[Critical Assumption]` example
- [x] Update stale instruction in `smithy.mark.prompt` (line 498) — "present questions one at a time" → "invoke smithy-clarify for ambiguity scanning and triage"
- [x] Update identical stale instruction in `smithy.cut.prompt` (line 295) — same change as above
- [x] Add A6 agent test case in `tests/Agent.tests.md` — exercises Critical+High triage with a payment processing scenario, validates `[Critical Assumption]` annotation in output

## Review

No auto-fixes were applied. One minor note:

- **Minor** (`tests/Agent.tests.md` line 169): A6 Expected bullet 4 says "Non-High-confidence items (if any) remain in the questions section." Correct for current state (Story 1 preserves Questions), but will need updating when Story 2 replaces Questions with Debt.

## Documentation

Maid auto-fixes applied in commit `08a3958`:
- `CLAUDE.md` and `CONTRIBUTING.md`: updated agent test range from `A1-A5` to `A1-A6`
- `smithy.clarify.prompt` frontmatter: added "(including Critical Assumptions)" to description — Slice 1 task that was marked complete but not applied

Flagged for future stories (no changes needed now):
- `smithy.render.prompt` and `smithy.ignite.prompt` carry identical stale interactive clarification instructions — flagged for Story 3
- `smithy.clarify.prompt` interactive user-ownership rule (lines 158–164) contradicts FR-012 — Story 3 work
- `CLAUDE.md` smithy-clarify description will need updating after Story 2 replaces Questions with Debt

## Validation

```
npm run build     → ⚡️ Build success in 55ms
npm run typecheck → clean (no errors)
npm test          → 8 test files, 189 tests passed
```