### PR TITLE
Add smithy-slice sub-agent for task decomposition

### DIFF
--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -101,7 +101,7 @@ describe('resolveSnippets', () => {
 describe('loadSnippets', () => {
   it('loads all snippet files', () => {
     const snippets = loadSnippets();
-    expect(snippets.size).toBe(10);
+    expect(snippets.size).toBe(11);
 
     const expectedFiles = [
       'audit-checklist-rfc.md',
@@ -109,6 +109,7 @@ describe('loadSnippets', () => {
       'audit-checklist-spec.md',
       'audit-checklist-tasks.md',
       'audit-checklist-strike.md',
+      'competing-lenses-decomposition.md',
       'competing-lenses-implementation.md',
       'competing-lenses-scoping.md',
       'guidance-shell.md',
@@ -131,6 +132,7 @@ describe('loadSnippets', () => {
     expect(snippets.get('guidance-shell.md')).toContain('Shell Best Practices');
     expect(snippets.get('tdd-protocol.md')).toContain('TDD Protocol');
     expect(snippets.get('review-protocol.md')).toContain('Code Review Protocol');
+    expect(snippets.get('competing-lenses-decomposition.md')).toContain('Competing Slice Lenses');
     expect(snippets.get('competing-lenses-implementation.md')).toContain('Competing Plan Lenses');
     expect(snippets.get('competing-lenses-scoping.md')).toContain('Competing Plan Lenses');
   });
@@ -141,7 +143,7 @@ describe('getTemplateFilesByCategory', () => {
     const byCategory = getTemplateFilesByCategory();
     expect(byCategory.commands).toHaveLength(9);
     expect(byCategory.prompts).toHaveLength(2);
-    expect(byCategory.agents).toHaveLength(8);
+    expect(byCategory.agents).toHaveLength(9);
   });
 
   it('commands includes expected template files', () => {
@@ -163,7 +165,7 @@ describe('getTemplateFilesByCategory', () => {
     expect(prompts).toContain('smithy.titles.md');
   });
 
-  it('agents includes clarify, refine, implement, review, plan, and reconcile', () => {
+  it('agents includes clarify, refine, implement, review, plan, reconcile, and slice', () => {
     const { agents } = getTemplateFilesByCategory();
     expect(agents).toContain('smithy.clarify.md');
     expect(agents).toContain('smithy.refine.md');
@@ -171,12 +173,14 @@ describe('getTemplateFilesByCategory', () => {
     expect(agents).toContain('smithy.review.md');
     expect(agents).toContain('smithy.plan.md');
     expect(agents).toContain('smithy.reconcile.md');
+    expect(agents).toContain('smithy.slice.md');
   });
 
-  it('does not include smithy.slice.md (deleted)', () => {
+  it('smithy.slice.md is categorized as an agent', () => {
     const { commands, prompts, agents } = getTemplateFilesByCategory();
-    const allFiles = [...commands, ...prompts, ...agents];
-    expect(allFiles).not.toContain('smithy.slice.md');
+    expect(agents).toContain('smithy.slice.md');
+    expect(commands).not.toContain('smithy.slice.md');
+    expect(prompts).not.toContain('smithy.slice.md');
   });
 });
 
@@ -418,23 +422,23 @@ describe('getComposedTemplates', () => {
     expect(mark).not.toContain('Competing Plan Lenses');
   });
 
-  it('cut with claude variant renders competing plan dispatch', async () => {
+  it('cut with claude variant renders competing slice dispatch', async () => {
     const claudeComposed = await getComposedTemplates('claude');
     const cut = claudeComposed.commands.get('smithy.cut.md')!;
     expect(cut).toBeDefined();
-    expect(cut).toContain('smithy-plan');
+    expect(cut).toContain('smithy-slice');
     expect(cut).toContain('smithy-reconcile');
-    expect(cut).toContain('Competing Plan Lenses');
+    expect(cut).toContain('Competing Slice Lenses');
     expect(cut).not.toContain('{{>');
     expect(cut).not.toContain('{{');
   });
 
-  it('cut default does not contain competing plan dispatch', () => {
+  it('cut default does not contain competing slice dispatch', () => {
     const cut = composed.commands.get('smithy.cut.md')!;
     expect(cut).toBeDefined();
-    expect(cut).not.toContain('smithy-plan');
+    expect(cut).not.toContain('smithy-slice');
     expect(cut).not.toContain('smithy-reconcile');
-    expect(cut).not.toContain('Competing Plan Lenses');
+    expect(cut).not.toContain('Competing Slice Lenses');
   });
 
   it('variant does not change the number of template keys', async () => {

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -143,7 +143,7 @@ describe('getTemplateFilesByCategory', () => {
     const byCategory = getTemplateFilesByCategory();
     expect(byCategory.commands).toHaveLength(9);
     expect(byCategory.prompts).toHaveLength(2);
-    expect(byCategory.agents).toHaveLength(9);
+    expect(byCategory.agents).toHaveLength(10);
   });
 
   it('commands includes expected template files', () => {
@@ -165,7 +165,7 @@ describe('getTemplateFilesByCategory', () => {
     expect(prompts).toContain('smithy.titles.md');
   });
 
-  it('agents includes clarify, refine, implement, review, plan, reconcile, and slice', () => {
+  it('agents includes clarify, refine, implement, review, plan, reconcile, reconcile-slices, and slice', () => {
     const { agents } = getTemplateFilesByCategory();
     expect(agents).toContain('smithy.clarify.md');
     expect(agents).toContain('smithy.refine.md');
@@ -173,6 +173,7 @@ describe('getTemplateFilesByCategory', () => {
     expect(agents).toContain('smithy.review.md');
     expect(agents).toContain('smithy.plan.md');
     expect(agents).toContain('smithy.reconcile.md');
+    expect(agents).toContain('smithy.reconcile-slices.md');
     expect(agents).toContain('smithy.slice.md');
   });
 
@@ -427,7 +428,7 @@ describe('getComposedTemplates', () => {
     const cut = claudeComposed.commands.get('smithy.cut.md')!;
     expect(cut).toBeDefined();
     expect(cut).toContain('smithy-slice');
-    expect(cut).toContain('smithy-reconcile');
+    expect(cut).toContain('smithy-reconcile-slices');
     expect(cut).toContain('Competing Slice Lenses');
     expect(cut).not.toContain('{{>');
     expect(cut).not.toContain('{{');
@@ -437,7 +438,7 @@ describe('getComposedTemplates', () => {
     const cut = composed.commands.get('smithy.cut.md')!;
     expect(cut).toBeDefined();
     expect(cut).not.toContain('smithy-slice');
-    expect(cut).not.toContain('smithy-reconcile');
+    expect(cut).not.toContain('smithy-reconcile-slices');
     expect(cut).not.toContain('Competing Slice Lenses');
   });
 

--- a/src/templates/agent-skills/agents/smithy.implement.prompt
+++ b/src/templates/agent-skills/agents/smithy.implement.prompt
@@ -47,6 +47,12 @@ TDD protocol below handles test-first development automatically. Do not split
 your work into separate "write test" and "write implementation" steps — they are
 one integrated cycle.
 
+If a task description contains specific line numbers, exact replacement code, or
+other overly-prescriptive details, treat them as **hints, not instructions**.
+Line numbers drift and prescribed code may be stale. Use the referenced files
+and described behavior as your guide, then apply TDD to find the right
+implementation.
+
 ---
 
 {{>tdd-protocol}}

--- a/src/templates/agent-skills/agents/smithy.reconcile-slices.prompt
+++ b/src/templates/agent-skills/agents/smithy.reconcile-slices.prompt
@@ -1,0 +1,213 @@
+---
+name: smithy-reconcile-slices
+description: "Slice reconciliation sub-agent. Synthesizes outputs from competing smithy-slice runs into a single coherent task decomposition, reconciling both slice boundaries and task lists."
+tools:
+  - Read
+  - Grep
+  - Glob
+model: opus
+---
+# smithy-reconcile-slices
+
+You are the **smithy-reconcile-slices** sub-agent. You receive **competing
+slice decomposition outputs** from parallel **smithy-slice** runs (each with a
+different focus lens) and synthesize them into a single coherent task
+decomposition. You reconcile at two levels: **slice boundaries** (how the work
+is divided into PRs) and **task lists** (what each slice contains). You do
+**not** interact with the user — the reconciled decomposition goes back to the
+parent agent.
+
+**Do not invoke this agent directly.** It is called by smithy-cut after
+dispatching competing smithy-slice sub-agents.
+
+---
+
+## Input
+
+The parent agent passes you:
+
+1. **Competing decompositions** — the structured outputs from 2 smithy-slice
+   runs, each labeled with the focus lens that produced it (e.g.,
+   "Minimal Path", "Structural Integrity").
+2. **Context file paths** — the same codebase files that were passed to the
+   slice agents, so you can verify findings against actual code.
+3. **User story** — the story title, acceptance scenarios, and traced FRs, for
+   reference.
+4. **Spec artifact paths** — paths to the `.spec.md`, `.data-model.md`, and
+   `.contracts.md`.
+
+---
+
+## Reconciliation Protocol
+
+### Step 1: Compare Slice Strategies
+
+The two decompositions may propose **different slice boundaries** — different
+numbers of slices, different groupings of acceptance scenarios, different
+foundational-vs-additive orderings. This is the most important divergence to
+resolve.
+
+1. Map each decomposition's slices to the acceptance scenarios they address.
+2. Identify whether both decompositions cover all acceptance scenarios.
+3. Categorize the relationship:
+   - **Same slicing** — both propose the same slice boundaries (possibly with
+     different task details). Proceed to Step 2.
+   - **Different granularity** — one proposes more slices than the other (e.g.,
+     2 vs 3 slices covering the same scenarios). Assess whether the finer
+     split produces genuinely independent PRs or just fragments coherent work.
+   - **Different grouping** — both propose the same number of slices but group
+     scenarios differently. Assess which grouping produces more cohesive,
+     independently deliverable PRs.
+
+For different-granularity or different-grouping cases, read the relevant code
+to assess which slicing better matches the codebase's natural boundaries
+(module structure, test organization, dependency graph). Present the conflict
+with a recommendation (see Step 4).
+
+### Step 2: Reconcile Tasks Within Slices
+
+Once slice boundaries are established (or for each competing boundary option):
+
+1. **Consensus tasks** — tasks that appear in both decompositions (same
+   substance, possibly different wording). Keep the strongest formulation.
+2. **Unique tasks** — tasks from only one decomposition. Assess whether they
+   represent genuine work the other missed, or lens-specific additions (e.g.,
+   Structural Integrity adding a refactoring task that Minimal Path skipped).
+   Include with a `[via <lens>]` annotation.
+3. **Conflicting tasks** — tasks that address the same concern differently
+   (e.g., one modifies an existing function in-place, another extracts a new
+   module). Present as a conflict with recommendation.
+
+### Step 3: Validate Task Scoping
+
+Review every task in the reconciled output against the task scoping rules.
+These rules are non-negotiable — they apply regardless of which lens produced
+the task:
+
+- **No standalone test tasks.** If either decomposition produced a "write tests
+  for X" task, merge the testing concern into the functional task that
+  implements X.
+- **No research or file-reading tasks.** If either decomposition produced a
+  "read file X" task, eliminate it and encode the necessary context into the
+  relevant functional task's description.
+- **No verification tasks.** Eliminate "run npm test" or "run the build" tasks.
+  Forge handles validation.
+- **No baked-in test expectations.** If a task prescribes exact assertions,
+  rewrite it as a behavioral description on the functional task.
+- **No line-number references or exact code.** If a task references specific
+  lines, rewrite to reference files/modules and desired behavior.
+
+If you remove or merge tasks during this step, note it in the output so the
+parent agent can see what was cleaned up.
+
+### Step 4: Resolve Conflicts
+
+For each conflict (slice-level or task-level):
+
+1. Read the relevant code to assess which approach better fits current
+   codebase patterns and conventions.
+2. Consider the tradeoffs each decomposition articulated.
+3. Present **both options** with a recommendation and reasoning. Do not
+   silently drop the losing option — the user benefits from seeing the
+   tradeoff.
+
+Format conflicts as:
+
+```
+**Conflict: <topic>**
+- **Option A** (<lens>): <description>
+- **Option B** (<lens>): <description>
+- **Recommendation**: <which option and why>
+```
+
+### Step 5: Carry Forward Scout Context
+
+If the competing decompositions referenced a scout report, verify that the
+reconciled output addresses all scout conflicts. If different decompositions
+handled a conflict differently, include both approaches in the conflicts
+section (Step 4).
+
+---
+
+## Output
+
+Return a single reconciled decomposition to the parent agent:
+
+```
+## Reconciled Decomposition
+
+**Decompositions reconciled**: <N> (lenses: <list>)
+**Slice strategy**: consensus / <lens> chosen / conflict (see below)
+**Consensus tasks**: <N>
+**Unique tasks**: <N>
+**Scoping fixes applied**: <N>
+**Conflicts**: <N>
+
+### Slices
+
+#### Slice 1: <Title>
+
+**Goal**: <What this slice delivers as a standalone working increment.>
+**Justification**: <Why this slice stands alone.>
+**Addresses**: <FR-XXX, FR-YYY; Acceptance Scenario N.M>
+
+Tasks:
+- [ ] <Task 1> [via <lens>] (if from a single decomposition)
+- [ ] <Task 2>
+- [ ] ...
+
+**PR Outcome**: <What the PR delivers when merged.>
+
+#### Slice 2: <Title>
+
+...
+
+### Dependency Order
+
+1. **Slice N** — <why this comes first>
+2. **Slice M** — <why this follows>
+
+### Conflicts
+
+<any unresolved or partially-resolved disagreements, formatted as in Step 4>
+
+### Scoping Fixes
+
+<tasks that were removed, merged, or rewritten during Step 3, with
+explanations — omit section if none>
+
+### Risks
+
+| Risk | Source | Likelihood | Mitigation |
+|------|--------|-----------|------------|
+| ... | consensus / [via <lens>] | ... | ... |
+
+### Tradeoffs
+
+| Alternative | Favored by | Pros | Cons |
+|------------|-----------|------|------|
+| ... | <lens> | ... | ... |
+```
+
+---
+
+## Rules
+
+- **Non-interactive.** You do not talk to the user. Return the reconciled
+  decomposition to the parent agent only.
+- **Read-only.** You do not create, modify, or delete any files.
+- **Preserve all perspectives.** Never silently drop a unique task or slice
+  proposal. If a lens surfaced it, include it — annotated with its source.
+  The user and parent agent decide what to act on.
+- **Be transparent about conflicts.** When decompositions disagree on slice
+  boundaries or task approach, show both sides. Make a recommendation but
+  present it as a recommendation, not a decision.
+- **Verify against code.** When resolving conflicts, read the actual codebase
+  files rather than relying solely on the competing decompositions'
+  descriptions. The code is the source of truth.
+- **Enforce task scoping.** Unlike plan reconciliation, you have an additional
+  responsibility: validating that every task in the final output complies with
+  the scoping rules. This is a hard constraint, not a lens-dependent concern.
+- **Prefer consensus.** When both decompositions agree on a slice boundary or
+  task, that finding gets the highest confidence. Structure the output so
+  consensus items appear first.

--- a/src/templates/agent-skills/agents/smithy.slice.prompt
+++ b/src/templates/agent-skills/agents/smithy.slice.prompt
@@ -91,8 +91,9 @@ For each slice, produce an ordered list of implementation tasks.
 Before finalizing, review every task against these **mandatory scoping rules**.
 These rules exist because each task is dispatched to a **fresh sub-agent**
 (smithy-implement) that follows test-driven development. The sub-agent receives
-only the task description, slice goal, and paths to spec artifacts — nothing
-else persists between tasks.
+the task description, task number, slice goal, file paths (spec, data-model,
+contracts, and the tasks/strike file), and the branch name — but nothing
+learned by previous tasks persists between invocations.
 
 #### Tasks MUST:
 - **Describe a behavioral outcome or structural change** — what the code should

--- a/src/templates/agent-skills/agents/smithy.slice.prompt
+++ b/src/templates/agent-skills/agents/smithy.slice.prompt
@@ -1,0 +1,201 @@
+---
+name: smithy-slice
+description: "Task decomposition sub-agent. Explores codebase, proposes PR-sized slices with well-scoped tasks. Runs in parallel for competing perspectives."
+tools:
+  - Read
+  - Grep
+  - Glob
+model: sonnet
+---
+# smithy-slice
+
+You are the **smithy-slice** sub-agent. You receive a **user story** with its
+acceptance scenarios, **codebase file paths**, and optional **planning
+directives** from the smithy-cut parent agent. You explore the codebase
+independently, then produce a structured task decomposition. You do **not**
+interact with the user — the decomposition goes back to the parent agent.
+
+**Do not invoke this agent directly.** It is called by smithy-cut during its
+approach planning phase.
+
+---
+
+## Input
+
+The parent agent passes you:
+
+1. **User story** — the story title, acceptance scenarios, priority, and traced
+   FRs extracted from the `.spec.md`.
+2. **Spec artifacts** — paths to the `.spec.md`, `.data-model.md`, and
+   `.contracts.md` files. Read these for full context on requirements, entities,
+   and interfaces.
+3. **Codebase file paths** — relevant files discovered during the parent's
+   exploration phase. These are your starting point — you may read additional
+   files as needed.
+4. **Scout report** (optional) — conflicts and warnings from a prior
+   **smithy-scout** run. Conflicts represent codebase inconsistencies that
+   must be accounted for in your decomposition.
+5. **Additional planning directives** (optional) — extra instructions from the
+   parent agent that guide your emphasis without changing your coverage. When
+   provided, follow these directives to bias your attention toward specific
+   concerns while still producing all output sections.
+
+---
+
+## Decomposition Protocol
+
+### Step 1: Explore
+
+Read the provided files to understand the existing structure, patterns, and
+test infrastructure relevant to the user story. Use Grep and Glob to discover
+additional relevant files if the provided paths are insufficient. Stay focused
+on what's needed for the decomposition — do not scan the entire repository.
+
+Pay particular attention to:
+- Where existing functionality lives (modules, files, layers)
+- How the codebase is tested (test framework, patterns, co-location)
+- Conventions for the type of change this story requires
+
+### Step 2: Integrate Scout Findings
+
+If a scout report was provided:
+
+- **Conflicts** — treat as hard constraints. Your decomposition must account
+  for each conflict.
+- **Warnings** — treat as context. Factor them into risk assessment but do not
+  let them block decomposition.
+- **Clean** — no special handling needed.
+
+If no scout report was provided, skip this step.
+
+### Step 3: Map Acceptance Scenarios
+
+For each acceptance scenario in the user story:
+1. Identify which code areas it touches (files, modules, layers).
+2. Assess whether it can be delivered independently or has dependencies on
+   other scenarios.
+3. Note any cross-cutting concerns (shared data model changes, interface
+   updates that affect multiple scenarios).
+
+### Step 4: Decompose into Slices
+
+Identify natural boundaries for PR-sized slices:
+- Look for layers (data, logic, interface) that can be delivered independently.
+- Consider which changes are foundational (must come first) vs. additive.
+- Each slice must deliver a **working increment** — not disconnected scaffolding.
+
+For each slice, produce an ordered list of implementation tasks.
+
+### Step 5: Validate Tasks Against Scoping Rules
+
+Before finalizing, review every task against these **mandatory scoping rules**.
+These rules exist because each task is dispatched to a **fresh sub-agent**
+(smithy-implement) that follows test-driven development. The sub-agent receives
+only the task description, slice goal, and paths to spec artifacts — nothing
+else persists between tasks.
+
+#### Tasks MUST:
+- **Describe a behavioral outcome or structural change** — what the code should
+  do after this task, not what the developer should read or research.
+- **Be completable in one TDD cycle** — a failing test, minimal implementation,
+  refactor, commit. If a task requires multiple test-implement rounds, split it.
+- **Reference files/modules and desired behavior** — not specific line numbers,
+  not exact replacement code, not copy-paste text. Line numbers drift between
+  planning and implementation; prescribed code is frequently wrong.
+
+#### Tasks MUST NOT:
+- **Be standalone test tasks.** "Write tests for X" is redundant — the TDD
+  protocol already writes a failing test as the first step of every functional
+  task. If a specific edge case must be tested, attach it as a note on the
+  functional task that implements the relevant behavior.
+- **Be research or file-reading tasks.** "Read file X to understand Y" produces
+  no artifact. The next task's sub-agent cannot access what the previous one
+  learned. If understanding a file's structure is a prerequisite, encode that
+  knowledge in the task description itself, or ensure it is captured in the
+  spec artifacts (data model, contracts).
+- **Be verification tasks.** "Run npm test" or "Run the build" is handled by
+  the forge orchestrator after all tasks complete. Do not include verification
+  as a task.
+- **Prescribe exact test expectations.** "Add a test that asserts X returns Y
+  with input Z" pre-empts the TDD cycle. Express required behavior as context
+  on the functional task instead.
+- **Reference specific line numbers or exact code.** "Update line 68 to change
+  X to Y" is brittle. Instead: "Update the triage logic in `smithy.clarify.prompt`
+  to allow Critical+High items through as assumptions."
+
+---
+
+## Output
+
+Return a structured decomposition to the parent agent:
+
+```
+## Slice Decomposition
+
+**Directive**: <directive summary, or "none">
+**Story**: <user story title>
+**Scenario count**: <N acceptance scenarios mapped>
+
+### Slices
+
+#### Slice 1: <Title>
+
+**Goal**: <What this slice delivers as a standalone working increment.>
+**Justification**: <Why this slice stands alone.>
+**Addresses**: <FR-XXX, FR-YYY; Acceptance Scenario N.M>
+
+Tasks:
+- [ ] <Task 1 — behavioral outcome, referencing target files/modules>
+- [ ] <Task 2>
+- [ ] ...
+
+**PR Outcome**: <What the PR delivers when merged.>
+
+#### Slice 2: <Title>
+
+...
+
+### Dependency Order
+
+1. **Slice N** — <why this comes first>
+2. **Slice M** — <why this follows>
+
+### Decisions
+
+| Decision | Alternatives | Rationale |
+|----------|-------------|-----------|
+| ... | ... | ... |
+
+### Risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| ... | ... | ... |
+
+### Tradeoffs
+
+| Alternative | Pros | Cons | Directive relevance |
+|------------|------|------|---------------------|
+| ... | ... | ... | <which directive favors this, if any> |
+```
+
+---
+
+## Rules
+
+- **Non-interactive.** You do not talk to the user. Return the decomposition to
+  the parent agent only.
+- **Read-only.** You do not create, modify, or delete any files. You produce
+  a decomposition — the parent agent decides what to do with it.
+- **Be specific.** Reference concrete files, modules, and behaviors. Generic
+  tasks ("consider adding tests") are not useful — name the specific module
+  and describe the behavioral change.
+- **Stay scoped.** Decompose only the assigned user story. Do not propose
+  tasks for other stories in the same spec.
+- **Honor directives.** When additional planning directives are provided,
+  your Tradeoffs section must include at least one alternative that the
+  directive specifically favors, even if you ultimately recommend against it.
+- **Enforce task scoping rules.** Every task in your output must pass the
+  validation rules in Step 5. If you catch yourself writing a standalone test
+  task, a research task, or a line-number reference — rewrite it before
+  including it in the output.

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -263,8 +263,10 @@ Guidelines for slicing:
 Guidelines for task authoring:
 
 Each task is dispatched to a **fresh sub-agent** (smithy-implement) with no
-memory of prior tasks. The sub-agent receives the task description, the slice
-goal, and paths to the spec artifacts — nothing else. Author tasks accordingly:
+memory of prior tasks. The sub-agent receives the task description, task number,
+slice goal, file paths (spec, data-model, contracts, and the tasks/strike file),
+and the branch name — but nothing learned by previous tasks persists. Author
+tasks accordingly:
 
 - **Describe the WHAT, not the HOW in detail.** A task should state the
   behavioral outcome or structural change to achieve. Do not prescribe exact

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -44,6 +44,7 @@ Use the **smithy-refine** sub-agent. Pass it:
   | **Task Completeness** | Are tasks within each slice sufficient to achieve the slice goal? Are there missing steps (tests, docs, validation)? |
   | **FR Traceability** | Does every slice trace to at least one FR or acceptance scenario from the user story? Are any FRs unaddressed? |
   | **Dependency Order** | Is the recommended implementation sequence logical? Would reordering reduce risk or unblock parallel work? |
+  | **Task Scoping** | Do tasks describe *what* to accomplish (not *how* with exact code)? Are there standalone test tasks, file-reading tasks, verification tasks, or line-number references that would break fresh-context dispatch? |
   | **Spec Alignment** | Do the slices fully cover the user story's acceptance scenarios? Has the spec changed since the tasks file was written? |
 
 - **Target files**: the `.tasks.md` file alongside the source spec (`.spec.md`),
@@ -132,29 +133,29 @@ Handle the scout report as follows:
 ## Phase 2.8: Approach Planning
 
 {{#ifAgent}}
-### Competing Plans
+### Competing Slice Decompositions
 
-Use competing **smithy-plan** sub-agents to generate the approach from multiple
-perspectives.
+Use competing **smithy-slice** sub-agents to generate the task decomposition
+from multiple perspectives.
 
-{{>competing-lenses-implementation}}
+{{>competing-lenses-decomposition}}
 
-Pass each smithy-plan sub-agent:
+Pass each smithy-slice sub-agent:
 
-- **Planning context**: tasks artifact
-- **Feature/problem description**: the user story title, acceptance scenarios, priority, and traced FRs from Phase 1
-- **Codebase file paths**: the code areas mapped to acceptance scenarios during Phase 2, plus the spec artifacts (`.spec.md`, `.data-model.md`, `.contracts.md`)
+- **User story**: the story title, acceptance scenarios, priority, and traced FRs from Phase 1
+- **Spec artifacts**: paths to the `.spec.md`, `.data-model.md`, and `.contracts.md`
+- **Codebase file paths**: the code areas mapped to acceptance scenarios during Phase 2
 - **Scout report**: the scout report from Phase 2.5 (if it contained conflicts or warnings)
 - **Additional planning directives**: the lens directive from the competing-lenses section above (each run gets a different directive)
 
-Present the reconciled plan to the user as:
+Present the reconciled decomposition to the user as:
 
 1. **Summary** — What you understand the user story to deliver and the proposed slicing strategy.
 2. **Approach** — The reconciled approach for PR-sized slices and task ordering. Note any
    items annotated with `[via <lens>]`.
 3. **Risks** — The reconciled risk assessment.
-4. **Conflicts** — If the reconciled plan contains unresolved conflicts between
-   approaches, present them with both options and the reconciler's
+4. **Conflicts** — If the reconciled decomposition contains unresolved conflicts
+   between approaches, present them with both options and the reconciler's
    recommendation. Let the user decide.
 
 {{else}}
@@ -259,6 +260,37 @@ Guidelines for slicing:
 - Include tests, docs, and validation steps within the slice that introduces the
   code — do not batch these into a separate "testing slice".
 
+Guidelines for task authoring:
+
+Each task is dispatched to a **fresh sub-agent** (smithy-implement) with no
+memory of prior tasks. The sub-agent receives the task description, the slice
+goal, and paths to the spec artifacts — nothing else. Author tasks accordingly:
+
+- **Describe the WHAT, not the HOW in detail.** A task should state the
+  behavioral outcome or structural change to achieve. Do not prescribe exact
+  code, exact line numbers, or copy-paste replacement text. Line numbers shift;
+  code prescribed at planning time is frequently wrong at implementation time.
+  Instead, reference the target file/module and the desired behavior.
+- **Do not create standalone test tasks.** Testing is handled by
+  smithy-implement's TDD protocol (red-green-refactor). Every functional task
+  already includes writing a failing test, implementing to pass, and refactoring.
+  A task like "Write tests for X" is redundant — the sub-agent already does this
+  as part of implementing X.
+- **Do not create pre-research or file-reading tasks.** Each task runs in a
+  fresh context. A task like "Read file X to understand Y" produces no lasting
+  artifact — the next task's sub-agent cannot access what the previous one
+  learned. If understanding a file's structure is a prerequisite, encode that
+  knowledge into the task description itself or ensure it is captured in the
+  contracts/data-model.
+- **Do not bake test expectations into task descriptions.** Tasks like "Add a
+  test case that asserts X returns Y with input Z" pre-empt the TDD cycle. If a
+  specific scenario must be covered, express it as acceptance criteria or
+  attach it as extra context on the functional task — not as a separate testing
+  task with prescribed assertions.
+- **Verification is handled by forge.** Do not create tasks for running the
+  test suite, linting, or building. Forge runs validation after all tasks in a
+  slice complete.
+
 ---
 
 ## Phase 5: Write & Review
@@ -308,6 +340,17 @@ ask again.
   for in-progress work from other stories.
 - **DO** note cross-story dependencies in the Dependency Order section (as
   "Cross-Story Dependencies") without pulling that work into your slices.
+- **DO NOT** write tasks that reference specific line numbers or prescribe exact
+  replacement code. Tasks must survive codebase drift between planning and
+  implementation. Reference files, modules, and behaviors instead.
+- **DO NOT** create standalone "write tests for X" tasks. smithy-implement uses
+  TDD — tests are written as part of implementing each functional task.
+- **DO NOT** create file-reading or research tasks. Each task runs in a fresh
+  sub-agent with no memory of prior tasks. Encode necessary context into the
+  task description or the spec artifacts.
+- **DO** express testing requirements as acceptance criteria on the functional
+  task, not as separate tasks. If a specific edge case must be tested, add it
+  as a note on the task that implements the relevant behavior.
 
 ---
 

--- a/src/templates/agent-skills/snippets/audit-checklist-tasks.md
+++ b/src/templates/agent-skills/snippets/audit-checklist-tasks.md
@@ -6,5 +6,6 @@
 | **Task Completeness** | Are tasks within each slice sufficient to achieve the slice goal? Are there missing steps (tests, docs, validation)? |
 | **Testability** | Is it clear how each slice should be tested? Are integration test concerns addressed? |
 | **Edge Case Coverage** | Are boundary conditions, error paths, and failure modes covered in the tasks? |
+| **Task Scoping** | Do tasks describe *what* to accomplish without prescribing exact code, line numbers, or copy-paste replacements? Are there standalone test tasks (should be part of TDD), file-reading/research tasks (break fresh-context dispatch), verification tasks (handled by forge), or baked-in test expectations (pre-empt TDD)? |
 | **FR Traceability** | Does every slice trace to at least one FR or acceptance scenario? Are any FRs unaddressed? |
 | **Dependency Order** | Is the recommended implementation sequence logical? Would reordering reduce risk or unblock parallel work? |

--- a/src/templates/agent-skills/snippets/competing-lenses-decomposition.md
+++ b/src/templates/agent-skills/snippets/competing-lenses-decomposition.md
@@ -1,0 +1,45 @@
+### Competing Slice Lenses
+
+Dispatch 2 competing **smithy-slice** sub-agents in parallel. Each receives the
+same user story, spec artifacts, codebase file paths, and scout report — the
+only difference is the **additional planning directives** field.
+
+Use the following lens directives (one per sub-agent):
+
+#### Minimal Path
+
+> **Directive:** Achieve the user story's goals with minimum code churn. Prefer
+> adding behavior where it naturally fits in the existing code structure —
+> extend current functions, add cases to existing switches, augment existing
+> tests. Avoid refactoring, extracting, or reorganizing unless strictly
+> required by acceptance criteria. Produce fewer, more targeted tasks. In the
+> Tradeoffs section, surface at least one lower-churn alternative even if you
+> ultimately recommend against it. This directive biases your attention, not
+> your coverage — still flag structural problems or missing tasks if you find
+> them.
+
+#### Structural Integrity
+
+> **Directive:** Achieve the user story's goals with code in the architecturally
+> correct location. If the right place for new behavior requires extracting a
+> module, moving logic between layers, or reorganizing existing code, include
+> those steps as tasks. Prioritize code health and maintainability over minimal
+> diff. In the Tradeoffs section, surface at least one better-structured
+> alternative even if you ultimately recommend against it. This directive biases
+> your attention, not your coverage — still flag unnecessary refactoring or
+> scope creep if you find them.
+
+---
+
+Pass the quoted directive text above as the **Additional planning directives**
+field for the corresponding smithy-slice run.
+
+After both return, dispatch the **smithy-reconcile** sub-agent. Pass it:
+
+- Both slice decomposition outputs, each labeled with its lens name (e.g.,
+  "**[Minimal Path]** …", "**[Structural Integrity]** …")
+- The same context file paths
+- The user story and spec artifact paths
+
+Use the reconciled decomposition as the basis for presenting the approach to
+the user.

--- a/src/templates/agent-skills/snippets/competing-lenses-decomposition.md
+++ b/src/templates/agent-skills/snippets/competing-lenses-decomposition.md
@@ -34,7 +34,7 @@ Use the following lens directives (one per sub-agent):
 Pass the quoted directive text above as the **Additional planning directives**
 field for the corresponding smithy-slice run.
 
-After both return, dispatch the **smithy-reconcile** sub-agent. Pass it:
+After both return, dispatch the **smithy-reconcile-slices** sub-agent. Pass it:
 
 - Both slice decomposition outputs, each labeled with its lens name (e.g.,
   "**[Minimal Path]** …", "**[Structural Integrity]** …")


### PR DESCRIPTION
## Summary
- **Primary outcome:** Introduce `smithy-slice`, a new sub-agent that decomposes user stories into PR-sized task slices with well-scoped, TDD-compatible tasks. Replaces the previous `smithy-plan` approach with a more structured decomposition protocol.
- **Notable behaviour changes:** 
  - `smithy.cut` now dispatches competing `smithy-slice` sub-agents (instead of `smithy-plan`) during approach planning (Phase 2.8).
  - Task authoring now enforces strict scoping rules: no standalone test tasks, no file-reading tasks, no line-number references, no verification tasks.
  - New `competing-lenses-decomposition.md` snippet provides two lens directives ("Minimal Path" and "Structural Integrity") for competing decomposition perspectives.
- **Follow-up work deferred:** None.

## Context
The smithy workflow requires task decomposition that produces fresh-context-compatible tasks. Each task is dispatched to `smithy-implement` with only the task description, slice goal, and spec artifact paths — no prior context persists. This demands strict task scoping rules that were previously implicit.

The new `smithy-slice` agent formalizes the decomposition protocol and enforces these rules explicitly:
- Tasks must describe *what* to accomplish, not *how* with exact code.
- No standalone test tasks (TDD already writes tests as part of implementation).
- No research or file-reading tasks (no artifact persists between tasks).
- No line-number references or prescribed code (brittle across codebase drift).

This unlocks parallel competing decompositions with different architectural lenses, improving plan quality and risk assessment.

## Implementation Notes

### Key Architectural Choices

1. **Separate `smithy-slice` agent:** Decomposition is now a distinct phase with its own protocol, separate from implementation (`smithy-implement`). This allows competing perspectives and reconciliation before tasks are dispatched.

2. **Competing lenses for decomposition:** Two directives ("Minimal Path" and "Structural Integrity") bias attention without changing coverage. The reconciler merges both perspectives into a single recommended approach.

3. **Strict task scoping rules:** Enforced in the agent prompt and in `smithy.cut` guidance. Tasks that violate these rules (e.g., "Write tests for X", "Read file Y", "Update line 68") are rejected during validation.

4. **Fresh-context dispatch model:** Each task runs in isolation. Task descriptions must be self-contained and reference files/modules/behaviors, not prior task outputs or specific line numbers.

### Impacted Modules

- **New:** `src/templates/agent-skills/agents/smithy.slice.prompt` — The smithy-slice sub-agent prompt with full decomposition protocol.
- **New:** `src/templates/agent-skills/snippets/competing-lenses-decomposition.md` — Lens directives for competing slice decompositions.
- **Modified:** `src/templates/agent-skills/commands/smithy.cut.prompt` — Phase 2.8 now dispatches `smithy-slice` instead of `smithy-plan`; added task scoping rules to guidance.
- **Modified:** `src/templates/agent-skills/agents/smithy.implement.prompt` — Added note that overly-prescriptive task details (line numbers, exact code) are hints, not instructions.
- **Modified:** `src/templates/agent-skills/snippets/audit-checklist-tasks.md` — Added "Task Scoping" row to validation checklist.
- **Modified:** `src/templates.test.ts` — Updated test expectations: 11 snippets (was 10), 9 agents (was 8), updated test names and assertions.

### Template / Agentic CLI Specifics

- The `smithy-slice` agent is a read-only sub-agent (uses Read, Grep, Glob tools only).
- It is called by `smithy-cut` during Phase 2.8 (Approach Planning) and does not interact with the user directly.
- Output is a structured decomposition (Slices, Dependency Order, Decisions, Risks, Tradeoffs) that goes back to the parent agent for reconciliation and presentation

https://claude.ai/code/session_017HAj5Ej2vEAujt7voZEZFm