### PR TITLE
Add reference fixture and deployment verification test

### DIFF
--- a/evals/fixture.test.ts
+++ b/evals/fixture.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const CLI = path.resolve('dist/cli.js');
+const FIXTURE_DIR = path.resolve('evals/fixture');
+
+const EXCLUDED_DIRS = new Set(['node_modules', '.claude', '.smithy', 'dist']);
+
+function hashDirectory(dirPath: string): string {
+  const hash = crypto.createHash('sha256');
+  const entries: string[] = [];
+
+  function collectFiles(dir: string, prefix: string): void {
+    const items = fs.readdirSync(dir, { withFileTypes: true });
+    for (const item of items) {
+      if (EXCLUDED_DIRS.has(item.name)) continue;
+      const rel = prefix ? `${prefix}/${item.name}` : item.name;
+      if (item.isDirectory()) {
+        collectFiles(path.join(dir, item.name), rel);
+      } else {
+        entries.push(rel);
+      }
+    }
+  }
+
+  collectFiles(dirPath, '');
+  entries.sort();
+
+  for (const rel of entries) {
+    hash.update(rel);
+    hash.update(fs.readFileSync(path.join(dirPath, rel)));
+  }
+
+  return hash.digest('hex');
+}
+
+describe('evals/fixture deployment', () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('smithy init deploys skills into the fixture copy', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-fixture-'));
+    fs.cpSync(FIXTURE_DIR, tmpDir, { recursive: true });
+
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+
+    // .claude directories exist
+    const commandsDir = path.join(tmpDir, '.claude', 'commands');
+    const promptsDir = path.join(tmpDir, '.claude', 'prompts');
+    const agentsDir = path.join(tmpDir, '.claude', 'agents');
+
+    expect(fs.existsSync(commandsDir)).toBe(true);
+    expect(fs.existsSync(promptsDir)).toBe(true);
+    expect(fs.existsSync(agentsDir)).toBe(true);
+
+    // Each contains at least one .md file
+    const commandFiles = fs.readdirSync(commandsDir).filter(f => f.endsWith('.md'));
+    const promptFiles = fs.readdirSync(promptsDir).filter(f => f.endsWith('.md'));
+    const agentFiles = fs.readdirSync(agentsDir).filter(f => f.endsWith('.md'));
+
+    expect(commandFiles.length).toBeGreaterThan(0);
+    expect(promptFiles.length).toBeGreaterThan(0);
+    expect(agentFiles.length).toBeGreaterThan(0);
+
+    // Key skills for strike evals are present
+    expect(commandFiles).toContain('smithy.strike.md');
+    expect(agentFiles).toContain('smithy.plan.md');
+  });
+
+  it('source fixture directory is not modified by deployment (FR-011)', () => {
+    const hashBefore = hashDirectory(FIXTURE_DIR);
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-fixture-'));
+    fs.cpSync(FIXTURE_DIR, tmpDir, { recursive: true });
+
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+
+    const hashAfter = hashDirectory(FIXTURE_DIR);
+
+    expect(hashAfter).toBe(hashBefore);
+  });
+});

--- a/evals/fixture.test.ts
+++ b/evals/fixture.test.ts
@@ -29,6 +29,7 @@ function hashDirectory(dirPath: string): string {
 
   for (const rel of entries) {
     hash.update(rel);
+    hash.update('\0');
     hash.update(fs.readFileSync(path.join(dirPath, rel)));
   }
 

--- a/evals/fixture.test.ts
+++ b/evals/fixture.test.ts
@@ -8,8 +8,6 @@ import path from 'node:path';
 const CLI = path.resolve('dist/cli.js');
 const FIXTURE_DIR = path.resolve('evals/fixture');
 
-const EXCLUDED_DIRS = new Set(['node_modules', '.claude', '.smithy', 'dist']);
-
 function hashDirectory(dirPath: string): string {
   const hash = crypto.createHash('sha256');
   const entries: string[] = [];
@@ -17,7 +15,6 @@ function hashDirectory(dirPath: string): string {
   function collectFiles(dir: string, prefix: string): void {
     const items = fs.readdirSync(dir, { withFileTypes: true });
     for (const item of items) {
-      if (EXCLUDED_DIRS.has(item.name)) continue;
       const rel = prefix ? `${prefix}/${item.name}` : item.name;
       if (item.isDirectory()) {
         collectFiles(path.join(dir, item.name), rel);

--- a/evals/fixture/.gitignore
+++ b/evals/fixture/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.claude/
+.smithy/
+dist/

--- a/evals/fixture/README.md
+++ b/evals/fixture/README.md
@@ -1,0 +1,32 @@
+# Smithy Eval Fixture
+
+This is a minimal Express TypeScript API project used as the **reference fixture** for Smithy eval scenarios. It is **not a real application** — it exists solely to give eval agents a concrete, stable codebase with specific file paths, route patterns, and data types that plans can reference.
+
+## Project Structure
+
+- `src/index.ts` — Express app entry point. Mounts the users router at `/api/users` and starts the server on a configurable `PORT`.
+- `src/types.ts` — TypeScript interfaces (`User`, `CreateUserRequest`) used by route handlers.
+- `src/routes/users.ts` — Express Router with three user CRUD handlers: list, get by id, and create.
+- `package.json` — Node project manifest with Express as a dependency.
+- `tsconfig.json` — TypeScript config targeting ES2022 with CommonJS module resolution.
+
+## Intentional Gap
+
+The app intentionally has **no health check endpoint**. This gap is the primary eval prompt target — eval scenarios ask agents to "add a health check endpoint" and validate that the resulting plan references the specific files and structures in this fixture.
+
+## Usage
+
+This fixture is **read by AI agents, not executed**. Do not run `npm install` in this directory. At eval time, the eval runner copies this directory to a temp location, deploys Smithy skills into the copy via `smithy init -a claude -y`, and runs `claude -p` against it.
+
+To manually test Smithy skill deployment against a copy:
+
+```bash
+cp -r evals/fixture /tmp/fixture-test
+node dist/cli.js init -a claude -y -d /tmp/fixture-test
+# Inspect /tmp/fixture-test/.claude/ for deployed skills
+rm -rf /tmp/fixture-test
+```
+
+## Adding Files
+
+Only add files to this fixture when a specific eval scenario requires them. Keep the fixture minimal to reduce maintenance burden and ensure eval stability.

--- a/evals/fixture/README.md
+++ b/evals/fixture/README.md
@@ -7,7 +7,7 @@ This is a minimal Express TypeScript API project used as the **reference fixture
 - `src/index.ts` — Express app entry point. Mounts the users router at `/api/users` and starts the server on a configurable `PORT`.
 - `src/types.ts` — TypeScript interfaces (`User`, `CreateUserRequest`) used by route handlers.
 - `src/routes/users.ts` — Express Router with three user CRUD handlers: list, get by id, and create.
-- `package.json` — Node project manifest with Express as a dependency.
+- `package.json` — Node project manifest with Express as a runtime dependency, and TypeScript, `@types/express`, and `@types/node` as dev dependencies.
 - `tsconfig.json` — TypeScript config targeting ES2022 with CommonJS module resolution.
 
 ## Intentional Gap

--- a/evals/fixture/package.json
+++ b/evals/fixture/package.json
@@ -11,7 +11,7 @@
     "express": "^4.21.0"
   },
   "devDependencies": {
-    "@types/express": "^5.0.0",
+    "@types/express": "^4.17.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.6.0"
   }

--- a/evals/fixture/package.json
+++ b/evals/fixture/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "smithy-eval-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Minimal Express API project used as the reference fixture for Smithy eval scenarios. Not a real application — exists solely to give eval agents a concrete, stable codebase to plan against.",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "express": "^4.21.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/evals/fixture/src/index.ts
+++ b/evals/fixture/src/index.ts
@@ -1,0 +1,12 @@
+import express from 'express';
+import usersRouter from './routes/users';
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use('/api/users', usersRouter);
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/evals/fixture/src/routes/users.ts
+++ b/evals/fixture/src/routes/users.ts
@@ -1,0 +1,32 @@
+import { Router, Request, Response } from 'express';
+import { User, CreateUserRequest } from '../types';
+
+const router = Router();
+
+const users: User[] = [];
+let nextId = 1;
+
+// GET / — list all users
+router.get('/', (_req: Request, res: Response) => {
+  res.json(users);
+});
+
+// GET /:id — get user by id
+router.get('/:id', (req: Request, res: Response) => {
+  const user = users.find((u) => u.id === parseInt(req.params.id, 10));
+  if (!user) {
+    res.status(404).json({ error: 'User not found' });
+    return;
+  }
+  res.json(user);
+});
+
+// POST / — create a new user
+router.post('/', (req: Request<{}, {}, CreateUserRequest>, res: Response) => {
+  const { name, email } = req.body;
+  const user: User = { id: nextId++, name, email };
+  users.push(user);
+  res.status(201).json(user);
+});
+
+export default router;

--- a/evals/fixture/src/types.ts
+++ b/evals/fixture/src/types.ts
@@ -1,0 +1,10 @@
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+export interface CreateUserRequest {
+  name: string;
+  email: string;
+}

--- a/evals/fixture/tsconfig.json
+++ b/evals/fixture/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/specs/2026-04-06-003-smithy-evals-framework/02-reference-fixture-exists-and-is-deployable.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/02-reference-fixture-exists-and-is-deployable.tasks.md
@@ -17,21 +17,21 @@
 
 ### Tasks
 
-- [ ] **Create `evals/fixture/.gitignore`** — list `node_modules/`, `.claude/`, `.smithy/`, `dist/` as ignored entries. Create this first so subsequent git operations do not accidentally stage generated artifacts.
+- [x] **Create `evals/fixture/.gitignore`** — list `node_modules/`, `.claude/`, `.smithy/`, `dist/` as ignored entries. Create this first so subsequent git operations do not accidentally stage generated artifacts.
 
-- [ ] **Create `evals/fixture/package.json`** — minimal Node project manifest: `private: true`, `name: smithy-eval-fixture`, `description` identifying it as an eval fixture, `build` and `start` scripts, `express` as a dependency, TypeScript and `@types` as dev dependencies. Do NOT run `npm install` — the fixture is read by AI agents, not executed.
+- [x] **Create `evals/fixture/package.json`** — minimal Node project manifest: `private: true`, `name: smithy-eval-fixture`, `description` identifying it as an eval fixture, `build` and `start` scripts, `express` as a dependency, TypeScript and `@types` as dev dependencies. Do NOT run `npm install` — the fixture is read by AI agents, not executed.
 
-- [ ] **Create `evals/fixture/tsconfig.json`** — minimal standalone TypeScript config using `commonjs` module resolution (this is an independent Express project, not part of the Smithy ESM build), targeting ES2022, with `strict` enabled, `src/` as the root, `dist/` as the output.
+- [x] **Create `evals/fixture/tsconfig.json`** — minimal standalone TypeScript config using `commonjs` module resolution (this is an independent Express project, not part of the Smithy ESM build), targeting ES2022, with `strict` enabled, `src/` as the root, `dist/` as the output.
 
-- [ ] **Create `evals/fixture/README.md`** — brief description for AI agents to read when planning. Cover: what the project is (eval fixture, not a real app), what the files do, the intentional health-check gap, and how to manually deploy Smithy skills against a copy for local testing. Include a note that additions should only be made when a specific eval scenario requires them.
+- [x] **Create `evals/fixture/README.md`** — brief description for AI agents to read when planning. Cover: what the project is (eval fixture, not a real app), what the files do, the intentional health-check gap, and how to manually deploy Smithy skills against a copy for local testing. Include a note that additions should only be made when a specific eval scenario requires them.
 
-- [ ] **Create `evals/fixture/src/types.ts`** — `User` and `CreateUserRequest` TypeScript interfaces exported for use by route handlers.
+- [x] **Create `evals/fixture/src/types.ts`** — `User` and `CreateUserRequest` TypeScript interfaces exported for use by route handlers.
 
-- [ ] **Create `evals/fixture/src/routes/users.ts`** — Express Router with three user CRUD handlers using an in-memory array: `GET /` (list), `GET /:id` (get by id, 404 if not found), `POST /` (create). Imports types from `../types`.
+- [x] **Create `evals/fixture/src/routes/users.ts`** — Express Router with three user CRUD handlers using an in-memory array: `GET /` (list), `GET /:id` (get by id, 404 if not found), `POST /` (create). Imports types from `../types`.
 
-- [ ] **Create `evals/fixture/src/index.ts`** — Express app entry point that mounts the users router at `/api/users` and starts the server on a configurable `PORT`. Intentionally has **no health check endpoint** — that gap is the primary eval prompt target.
+- [x] **Create `evals/fixture/src/index.ts`** — Express app entry point that mounts the users router at `/api/users` and starts the server on a configurable `PORT`. Intentionally has **no health check endpoint** — that gap is the primary eval prompt target.
 
-- [ ] **Verify fixture structure** — confirm the directory contains exactly the source and config files listed above with no generated artifacts (no `.claude/`, `.smithy/`, `node_modules/`, or `dist/`).
+- [x] **Verify fixture structure** — confirm the directory contains exactly the source and config files listed above with no generated artifacts (no `.claude/`, `.smithy/`, `node_modules/`, or `dist/`).
 
 **PR Outcome**: A committed Express TypeScript project in `evals/fixture/` providing a stable, controlled evaluation target. Eval agents can reference `src/routes/users.ts`, `src/types.ts`, and `src/index.ts` by path when producing plans. The intentionally absent health check endpoint drives the primary strike/plan eval prompt.
 
@@ -51,9 +51,9 @@
 
 ### Tasks
 
-- [ ] **Read `src/cli.test.ts` lines 36–73** before writing any code. The fixture test must follow the same established patterns: `path.resolve('dist/cli.js')` for the CLI path, `fs.mkdtempSync` + `fs.rmSync({ recursive, force })` + `afterEach` cleanup, and `{ cwd: tmpDir }` on `execFileSync` (not the `-d` flag). Consistency with the existing test style matters.
+- [x] **Read `src/cli.test.ts` lines 36–73** before writing any code. The fixture test must follow the same established patterns: `path.resolve('dist/cli.js')` for the CLI path, `fs.mkdtempSync` + `fs.rmSync({ recursive, force })` + `afterEach` cleanup, and `{ cwd: tmpDir }` on `execFileSync` (not the `-d` flag). Consistency with the existing test style matters.
 
-- [ ] **Create `evals/fixture.test.ts`** with a `describe('evals/fixture deployment')` block containing two test cases:
+- [x] **Create `evals/fixture.test.ts`** with a `describe('evals/fixture deployment')` block containing two test cases:
   1. **Deployment test** — copies the fixture to a temp dir, runs `smithy init -a claude -y` with `cwd: tmpDir`, then asserts that `.claude/commands/`, `.claude/prompts/`, and `.claude/agents/` exist in the temp dir, each containing at least one `.md` file. Also asserts that `smithy.strike.md` is in commands and `smithy.plan.md` is in agents (the key skills for strike evals).
   2. **Immutability test (FR-011)** — computes a SHA-256 hash of the source `evals/fixture/` directory before running `smithy init` against a temp copy, then re-hashes after, and asserts the two hashes are equal. The hash function must sort files by relative path for determinism, read files as binary (no encoding) for cross-platform consistency, and exclude `node_modules/`, `.claude/`, `.smithy/`, and `dist/` directories.
 
@@ -61,9 +61,9 @@
 
   Use `fs.cpSync(src, dest, { recursive: true })` (Node ≥16.7) to copy the fixture to temp. `path.resolve('evals/fixture')` resolves correctly from the repo root where vitest runs.
 
-- [ ] **Run `npm test`** and confirm both new test cases pass alongside all existing tests. The `pretest` hook builds `dist/cli.js` automatically. Expected outcome: 2 new passing tests in `evals/fixture.test.ts`, no regressions.
+- [x] **Run `npm test`** and confirm both new test cases pass alongside all existing tests. The `pretest` hook builds `dist/cli.js` automatically. Expected outcome: 2 new passing tests in `evals/fixture.test.ts`, no regressions.
 
-- [ ] **If vitest does not discover `evals/fixture.test.ts`**: the default vitest glob `**/*.test.ts` should pick it up automatically since `evals/` is under the project root. If it is missing from the test run, add a `vitest.config.ts` at the repo root with an `include` array covering both `src/**/*.test.ts` and `evals/**/*.test.ts`, then re-run `npm test`.
+- [x] **If vitest does not discover `evals/fixture.test.ts`**: the default vitest glob `**/*.test.ts` should pick it up automatically since `evals/` is under the project root. If it is missing from the test run, add a `vitest.config.ts` at the repo root with an `include` array covering both `src/**/*.test.ts` and `evals/**/*.test.ts`, then re-run `npm test`.
 
 **PR Outcome**: An automated deployment verification test that proves Acceptance Scenario 2.1 on every `npm test` run. The inline `hashDirectory` helper establishes the SHA-256 checksum approach that US3 will extract into `evals/lib/fixture.ts` for FR-011 compliance in the eval runner. Any template change that breaks fixture deployment will fail this test immediately.
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,5 +40,6 @@
     "noUncheckedSideEffectImports": true,
     "moduleDetection": "force",
     "skipLibCheck": true,
-  }
+  },
+  "exclude": ["evals/fixture"]
 }


### PR DESCRIPTION
Create a minimal TypeScript Express API project in evals/fixture/ as
the stable evaluation target for Smithy eval scenarios. The fixture has
an intentionally missing health check endpoint that drives the primary
eval prompt.

Add evals/fixture.test.ts with two tests:
- Deployment test: copies fixture to temp, runs smithy init, verifies
  .claude/{commands,prompts,agents}/ contain expected skill files
- Immutability test (FR-011): SHA-256 hashes the source fixture before
  and after deployment to a temp copy, asserts source is unchanged

Addresses: FR-002 (fixture directory), FR-011 (source not modified),
Acceptance Scenario 2.1 (smithy init deploys into fixture)

https://claude.ai/code/session_01SHW3BChgwCZtF3Dwt24CFp