### PR TITLE
Add smithy-prose to sub-agent documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ Smithy provides a collection of workflow prompts, each for a different stage/sty
 - **smithy-review** — Code review with auto-fix (used by forge)
 - **smithy-scout** — Pre-planning consistency scan (used by render, mark, cut)
 - **smithy-maid** — Post-implementation doc staleness scan (used by forge)
+- **smithy-prose** — Narrative/persuasive prose drafting for RFC sections and planning artifacts (used by ignite for Summary, Motivation, Personas; designed for reuse by other commands)
 
 ## Key Concepts
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/02-shared-smithy-prose-sub-agent.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/02-shared-smithy-prose-sub-agent.tasks.md
@@ -61,7 +61,7 @@
 ### Tasks
 
 - [x] Update `CLAUDE.md` — in the "Sub-Agents (not user-invocable)" section (after the `smithy-maid` line, currently line 52), add: `- **smithy-prose** — Narrative/persuasive prose drafting for RFC sections and planning artifacts (used by ignite for Summary, Motivation, Personas; designed for reuse by other commands)`.
-- [ ] Update `src/templates/agent-skills/README.md` — in the Sub-Agent Roles table, add a new row after `smithy-maid`: `| smithy-prose | Narrative/persuasive section drafting | ignite (sub-phases 3a, 3b) |`.
+- [x] Update `src/templates/agent-skills/README.md` — in the Sub-Agent Roles table, add a new row after `smithy-maid`: `| smithy-prose | Narrative/persuasive section drafting | ignite (sub-phases 3a, 3b) |`.
 
 **PR Outcome**: CLAUDE.md and the agents README accurately list smithy-prose alongside the other sub-agents. Developers reading either file can discover the agent, understand its role, and know which commands invoke it — making it straightforward to dispatch from other future commands without modifying the agent itself.
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/02-shared-smithy-prose-sub-agent.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/02-shared-smithy-prose-sub-agent.tasks.md
@@ -60,7 +60,7 @@
 
 ### Tasks
 
-- [ ] Update `CLAUDE.md` — in the "Sub-Agents (not user-invocable)" section (after the `smithy-maid` line, currently line 52), add: `- **smithy-prose** — Narrative/persuasive prose drafting for RFC sections and planning artifacts (used by ignite for Summary, Motivation, Personas; designed for reuse by other commands)`.
+- [x] Update `CLAUDE.md` — in the "Sub-Agents (not user-invocable)" section (after the `smithy-maid` line, currently line 52), add: `- **smithy-prose** — Narrative/persuasive prose drafting for RFC sections and planning artifacts (used by ignite for Summary, Motivation, Personas; designed for reuse by other commands)`.
 - [ ] Update `src/templates/agent-skills/README.md` — in the Sub-Agent Roles table, add a new row after `smithy-maid`: `| smithy-prose | Narrative/persuasive section drafting | ignite (sub-phases 3a, 3b) |`.
 
 **PR Outcome**: CLAUDE.md and the agents README accurately list smithy-prose alongside the other sub-agents. Developers reading either file can discover the agent, understand its role, and know which commands invoke it — making it straightforward to dispatch from other future commands without modifying the agent itself.

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -53,3 +53,4 @@ Sub-agents are invoked by parent commands, not directly by users:
 | smithy-review | Code review with auto-fix | forge |
 | smithy-scout | Pre-planning consistency scan | render, mark, cut |
 | smithy-maid | Post-implementation doc cleanup | forge |
+| smithy-prose | Narrative/persuasive section drafting | ignite (sub-phases 3a, 3b) |

--- a/src/templates/agent-skills/agents/README.md
+++ b/src/templates/agent-skills/agents/README.md
@@ -19,6 +19,7 @@ Deployed to:
 | `smithy-review` | Code review with auto-fix capability | forge (after implementation) | opus |
 | `smithy-scout` | Pre-planning consistency scan (non-interactive) | render, mark, cut | sonnet |
 | `smithy-maid` | Post-implementation doc staleness scan (non-interactive) | forge (after review) | sonnet |
+| `smithy-prose` | Narrative/persuasive prose drafting for planning artifact sections | ignite (sub-phases 3a, 3b) | opus |
 
 ## Frontmatter Fields
 
@@ -48,6 +49,6 @@ Agents fall into two interaction styles:
    assumptions, ask questions one at a time, wait for responses. Return a
    structured summary to the parent when done.
 
-2. **Non-interactive** (scout, maid, implement, review): Do not talk to the
+2. **Non-interactive** (scout, maid, implement, review, prose): Do not talk to the
    user. Perform their work and return a structured report to the parent agent,
    which decides how to surface findings.


### PR DESCRIPTION
## Source

- Spec: `specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md`
- Tasks: `specs/2026-04-07-003-refactor-ignite-workflow/02-shared-smithy-prose-sub-agent.tasks.md`

## Slice

**Slice 2** — Add smithy-prose to the sub-agent roster in `CLAUDE.md` and `src/templates/agent-skills/README.md` so the project's documentation accurately reflects all deployed agents.

## Addresses

- FR-007 (agent must exist and be documented)
- Acceptance Scenario US2-3 (shared-agent design intent visible to future command authors)

## Tasks Completed

- [x] Added `- **smithy-prose** — Narrative/persuasive prose drafting for RFC sections and planning artifacts (used by ignite for Summary, Motivation, Personas; designed for reuse by other commands)` to `CLAUDE.md` after the smithy-maid line in the Sub-Agents section
- [x] Added `| smithy-prose | Narrative/persuasive section drafting | ignite (sub-phases 3a, 3b) |` row to the Sub-Agent Roles table in `src/templates/agent-skills/README.md` after smithy-maid

## Review

No issues found. Both entries match the task spec exactly — wording, placement, and format are correct. The CLAUDE.md entry explicitly says "designed for reuse by other commands," satisfying US2-3's requirement that shared-agent intent be visible to future command authors.

## Documentation

**Maid auto-fix applied** (`src/templates/agent-skills/agents/README.md`):
- Added `| smithy-prose | Narrative/persuasive prose drafting for planning artifact sections | ignite (sub-phases 3a, 3b) | opus |` row to the Current Agents table after smithy-maid
- Added `prose` to the Non-interactive agents list in the Interaction Patterns section

This file was not in the slice's task list but was flagged by smithy-maid as stale — it is the canonical per-directory agent reference that developers consult when working in `src/templates/agent-skills/agents/`.

## Validation

```
npm run build     ✅  ESM dist/cli.js 43.62 KB — Build success
npm run typecheck ✅  No type errors
npm test          ✅  8 test files, 191 tests passed (0 failures)
```