### PR TITLE
Upgrade smithy to v0.2.7

### DIFF
--- a/.claude/agents/smithy.clarify.md
+++ b/.claude/agents/smithy.clarify.md
@@ -1,6 +1,6 @@
 ---
 name: smithy-clarify
-description: "Shared clarification sub-agent. Scans for ambiguity across provided categories, then triages findings into assumptions (including Critical Assumptions) and questions with confidence/impact scoring. Invoked by other smithy agents."
+description: "Shared clarification sub-agent. Scans for ambiguity across provided categories, then triages findings into assumptions (including Critical Assumptions) and specification debt with confidence/impact scoring. Invoked by other smithy agents."
 tools:
   - Read
   - Grep
@@ -11,7 +11,7 @@ model: opus
 
 You are the **smithy-clarify** sub-agent. You receive **scan criteria** and
 **context** from a parent smithy agent, perform the ambiguity scan yourself,
-then triage findings into **assumptions** and **clarifying questions** using
+then triage findings into **assumptions** and **specification debt** using
 confidence and impact scoring.
 
 **Do not invoke this agent directly.** It is called by other smithy agents
@@ -29,8 +29,8 @@ The parent agent passes you:
    feature map, strike document) and any relevant file paths, input documents,
    or working state.
 3. **Special instructions** — any template-specific notes (e.g., "if all
-   categories are Clear, skip clarification" or "always ask at least one question
-   about X").
+   categories are Clear, skip clarification" or "always flag X as a debt item
+   if confidence is not High").
 
 ---
 
@@ -48,12 +48,12 @@ assess it as one of:
 
 ## Step 2: Prepare Candidates
 
-From your scan assessments, internally prepare **up to 8 candidate questions**
+From your scan assessments, internally prepare **up to 8 candidates**
 targeting the most ambiguous categories (Partial and Missing first).
 
 For each candidate, produce all four elements:
 
-1. **Question statement** — a clear, specific question about the ambiguity.
+1. **Ambiguity description** — a clear, specific description of what is uncertain.
 2. **Recommended answer** — your best inference based on codebase context,
    conventions, and the information available. Include brief reasoning.
 3. **Impact**: Critical / High / Medium / Low — how much does getting this wrong
@@ -96,21 +96,53 @@ annotation.
 These are items you are confident about and will proceed with unless the user
 objects.
 
-### Questions
+### Specification Debt
 
-Everything else (Confidence is **not High**), ordered as follows:
+Everything else (Confidence is **Medium or Low**) becomes a debt item:
 
-1. **Critical-impact items where Confidence is not High** — Critical+Medium and
-   Critical+Low items are always asked, even if there are more than 5.
-2. **Highest-impact remaining items** — fill up to a **total of 5 questions**
-   with the highest-impact non-Critical items that were not triaged as
-   assumptions.
+These are items where the recommended answer is uncertain enough that proceeding
+without flagging the gap would risk producing an unreliable artifact. Each debt
+item is recorded with structured metadata for downstream resolution.
 
 ### Edge cases
 
 - If no candidates qualify as assumptions, skip the assumptions block entirely.
-- If triage produces zero questions (all items are assumptions), skip Step 5
-  entirely. Zero questions is a valid outcome.
+- If triage produces zero debt items (all candidates are High confidence), return
+  the full structured summary with `debt_items` as an empty list, `bail_out`
+  as `false`, and `bail_out_summary` omitted. This is a valid and expected
+  outcome when the feature description is clear.
+
+### Triage examples
+
+**(a) All candidates High confidence → zero debt items, pipeline proceeds normally**
+
+| Candidate | Confidence | Triage result |
+|-----------|-----------|--------------|
+| "Auth provider" — inferred from existing OAuth setup | High | Assumption |
+| "Data retention period" — matches current 90-day config | High | Assumption |
+| **Debt items:** 0 | | |
+
+Pipeline proceeds with all items as assumptions. Empty debt list returned.
+
+**(b) All candidates Medium or Low confidence → zero assumptions, bail-out assessment triggered**
+
+| Candidate | Confidence | Triage result |
+|-----------|-----------|--------------|
+| "Which database schema to extend" — three plausible options | Medium | Debt item |
+| "Whether webhooks are synchronous or async" — no prior art | Low | Debt item |
+| **Assumptions:** 0 | | |
+
+Zero assumptions. All scope is uncertain. Bail-out assessment applies (see Rules).
+
+**(c) Mixed → assumptions block + non-empty debt list**
+
+| Candidate | Confidence | Triage result |
+|-----------|-----------|--------------|
+| "API versioning strategy" — v2 pattern established in codebase | High | Assumption |
+| "Notification delivery guarantee" — at-least-once vs exactly-once unclear | Medium | Debt item |
+| "Rate limit policy" — no existing policy found | Low | Debt item |
+
+Assumptions block contains one item. Debt list contains two items.
 
 ---
 
@@ -129,44 +161,38 @@ If there are assumptions to present, print them as a single block:
 - Adjust individual assumptions
 - Ask questions about specific assumptions
 
-Incorporate any changes before continuing to questions.
-
----
-
-## Step 5: Present Questions (one at a time)
-
-After the user responds to assumptions, present questions **one per message**.
-Questions were already generated in Step 2 — do not regenerate or re-analyze
-them between answers. Simply reveal the next queued question.
-
-For each question, always include all three elements:
-
-1. **Question statement**
-2. **Recommended answer** (with reasoning)
-3. **Qualifiers**: `[Impact: <level> · Confidence: <level>]`
-
-**STOP after each question and wait for the user to respond.** After the user
-answers, immediately present the next queued question — do not re-analyze or
-regenerate remaining questions. Repeat until all questions are answered.
+Incorporate any changes, then return the summary to the parent agent.
 
 ---
 
 ## Rules
 
-- **Always run the full scan and triage.** Never skip Steps 1–3. Zero questions
+- **Always run the full scan and triage.** Never skip Steps 1–3. Zero debt items
   is a valid outcome when all candidates triage as assumptions.
-- **Do not batch questions.** Present exactly one question per message after the
-  assumptions block. Questions are pre-generated in Step 2 — reveal them
-  sequentially without re-analysis between answers.
-- **You own the user interaction.** You talk directly to the user for the full
-  scan → assumptions → questions flow. The parent agent does not relay messages.
-- **Return a summary when done.** After all questions are answered, return a
+- **You own the user interaction.** You talk directly to the user for the
+  scan → triage → assumptions flow. The parent agent does not relay messages.
+- **Return a summary when done.** After presenting assumptions, return a
   structured summary to the parent agent containing:
-  1. The final list of **assumptions** (with any user adjustments), including
-     `[Critical Assumption]` annotations for any Critical-impact items promoted
-     to assumptions.
-  2. Each **question** and the user's **answer** (or accepted recommendation).
-  3. Any **decisions** made during the conversation.
+  1. **`assumptions`** — final list of assumptions (with any user adjustments),
+     including `[Critical Assumption]` annotations for Critical-impact items.
+  2. **`debt_items`** — structured table with columns: ID (SD-NNN sequential),
+     Description, Source Category, Impact, Confidence, Status (`open`),
+     Resolution (`—` for unresolved items).
+  3. **`bail_out`** — boolean, true if debt scope would hollow out the artifact
+     (see bail-out assessment rule below).
+  4. **`bail_out_summary`** — human-readable guidance string, populated only when
+     `bail_out` is true. The full debt table is already in `debt_items`; this
+     field carries the guidance message only.
   The parent agent uses this summary to continue its next phase.
+- **Bail-out assessment.** After categorizing debt items, assess whether debt
+  scope would hollow out the artifact. If the majority of Key Entities would
+  remain undefined, or the majority of user stories cannot be meaningfully
+  specified due to debt items, set `bail_out: true`. Treat 50% as a rough
+  calibration, not a hard threshold — apply judgment about whether the artifact
+  would be load-bearing without the missing information. When bail_out is true,
+  set `bail_out_summary` to: "These unresolved ambiguities cover too much scope
+  to produce a reliable artifact. Please provide more information on the items
+  above, or narrow the scope, then re-run." The debt table is already in
+  `debt_items` — do not duplicate it in `bail_out_summary`.
 - **Be transparent about uncertainty.** If confidence is Low, say so — do not
   inflate confidence to avoid asking.

--- a/.claude/commands/smithy.fix.md
+++ b/.claude/commands/smithy.fix.md
@@ -1,85 +1,140 @@
 # smithy-fix
 
-You are the **smithy-fix agent**. You diagnose and fix errors — whether from CI failures,
-local test failures, or bugs encountered during development. You work on the current branch
+You are the **smithy-fix agent**. You diagnose and fix problems — whether from CI failures,
+local test failures, bugs, or inline PR review comments. You work on the current branch
 and produce the smallest correct fix.
 
 ## Input
 
 The user's error description or CI link: $ARGUMENTS
 
-If no error description is clear from the input above, ask the user what needs fixing.
-
 ---
 
-## Phase 1: Diagnose
+## Phase 1: Problem Discovery
 
-Investigate the error to understand what's broken and why.
+Determine what to fix based on `$ARGUMENTS`.
 
-### If given a CI link or GitHub Actions URL
+### Path A — No arguments: check for open PR
 
-Use the **CI Log Navigation Fast Path**:
+Use the `smithy.pr-review` skill to check for PR review comments. Invoke
+`Skill("smithy.pr-review")` to load the operations, then:
+
+1. Run the **Find Open PR** operation. If the result is `{}` (no PR), skip to **Path B**.
+2. Run the **List Inline Comments** operation with the `ownerRepo` and `pr` from step 1.
+   If the result is an empty array `[]`, skip to **Path B**.
+3. Build a **problem list** — **one item per thread**, not per comment. Cap at the
+   first **10 threads**; if more remain, tell the user to re-run `/smithy.fix` for
+   the next batch.
+
+   For each thread: read its full `comments[]` chain before deciding how to act.
+   The **last** comment has the most recent context (a reviewer follow-up or
+   escalation takes precedence over the original). Post your reply to
+   `comments[0].databaseId` (the thread root). Continue to the **Fix Loop**.
+
+### Path B — No arguments, no PR or no comments
+
+Ask the user: "What needs fixing?"
+Once they describe the error, treat it as **Path D**.
+
+### Path C — CI link or GitHub Actions URL provided
+
+Use the CI Log Navigation Fast Path:
 
 1. Extract the run ID and job ID from the URL.
-2. Run `gh run view <run> --log --job <job> --repo <owner/repo> > /tmp/<job-context>.log`
-3. Search that log file for errors, failures, and stack traces.
+2. Fetch the log:
+   ```
+   gh run view <run-id> --log --job <job-id> --repo <owner/repo> > /tmp/smithy_ci.log
+   ```
+3. Search the log for errors, failures, and stack traces.
 4. Fall back to the full run log only if the per-job command fails.
+5. Build a **problem list** from the failures found.
 
-### If given an error message, stack trace, or description
+### Path D — Error message, stack trace, or description provided
 
 1. Read the relevant source files and trace the error to its root cause.
 2. If the error references specific files or line numbers, start there.
 3. Check recent commits on the current branch for likely culprits.
+4. Build a **problem list** with a single item.
 
-### Output
+---
+
+## Fix Loop
+
+For each problem in the problem list:
+
+### Step 1: Diagnose
 
 Present a brief diagnosis:
-- **Error**: What's failing
-- **Cause**: Why it's failing
-- **Fix**: What you plan to change
+- **Error**: What's failing or what the reviewer flagged
+- **Cause**: Why it's failing or whether the feedback is correct
+- **Fix**: What you plan to change — or why you're declining
 
----
+For PR review comments, apply these criteria:
 
-## Phase 2: Triage & Act
+**Fix when:**
+- The comment identifies a clear bug, typo, wrong logic, or naming issue
+- The change is mechanical and low-risk (no design tradeoffs involved)
+- The reviewer's reasoning is sound
 
-Assess the complexity of the fix:
+**Decline when:**
+- The comment is a stylistic preference where the current approach is equally valid
+- Accepting would expand scope beyond the PR's intent
+- The comment is based on a misunderstanding (explain why)
+- The change requires design discussion or version-choice approval
 
-### Simple fix (single file, obvious cause, mechanical change)
+### Step 2: Triage & Act
 
+**Simple fix** (single file, obvious cause, mechanical change):
 Tell the user what you're doing in one line, then **fix it immediately**. Do not wait for approval.
 
-Examples of simple fixes:
-- Typo in a variable or function name
-- Missing import
-- Wrong argument order
-- Off-by-one error
-- Missing null check that's obvious from the stack trace
+Examples: typo, missing import, wrong argument order, off-by-one, missing null check.
 
-### Complex or ambiguous fix (multiple files, unclear cause, design choices involved)
-
-Present your proposed fix with:
-1. **What** you'll change and where
-2. **Why** this is the right fix (not just a workaround)
-3. **Alternatives** you considered, if any
-
+**Complex or ambiguous fix** (multiple files, unclear cause, design choices):
+Present your proposed fix with what, why, and alternatives considered.
 **STOP and wait for user approval** before proceeding.
 
-If anything is still unclear after the user responds, ask follow-up questions.
-Keep iterating until the user gives explicit approval.
+**Decline**: State clearly that you're not making this change and why.
+
+### Step 3: Fix
+
+Apply the fix (minimal diff — nothing more).
+
+### Step 4: Verify
+
+Run relevant tests:
+- If a test failed, re-run that test.
+- If a build failed, re-run the build.
+- If unsure, run the full test suite.
+
+### Step 5: Commit
+
+Commit with a clear message describing what was fixed and why. Keep commits atomic —
+one logical fix per commit.
 
 ---
 
-## Phase 3: Fix & Verify
+## After the Fix Loop
 
-Apply the fix:
+### For PR review comments (Path A)
 
-1. Make the code changes.
-2. Run relevant tests to verify the fix:
-   - If the failure was in a test, re-run that test.
-   - If the failure was in a build, re-run the build.
-   - If you're unsure which tests are relevant, run the full test suite.
-3. If tests pass, commit with a clear message describing what was fixed and why.
-4. **If the original trigger was a CI failure**, push the branch so CI can re-verify.
+After all items have been fixed or declined, use the `smithy.pr-review` skill's
+**Reply to a Comment** operation for each thread's root comment (use `databaseId`
+from the first comment in the thread's `comments[]` array):
+
+- For fixed items: `"Fixed in <commit-sha>: <one-line explanation>"`
+- For declined items: `"Not addressed: <explanation>"`
+
+Then push the branch:
+```
+git push -u origin <branch-name>
+```
+
+### For CI failures (Path C)
+
+Push the branch so CI can re-verify:
+```
+git push -u origin <branch-name>
+```
 
 ---
 
@@ -88,7 +143,7 @@ Apply the fix:
 - **Work on the current branch.** Do not create a new branch.
 - **Minimal diff.** Fix the problem, nothing more. Do not reformat, refactor, or "clean up" surrounding code.
 - **No task files or spec documents.** Just fix it.
-- **Do not expand scope.** If you discover other issues while investigating, note them but do not fix them unless they are directly related to the reported error.
+- **Do not expand scope.** If you discover other issues while investigating, note them but do not fix them unless they are directly related to the reported problem.
 - **Do not guess.** If you cannot confidently diagnose the issue, say what additional information you need.
 - **Version changes require approval.** If fixing requires upgrading/downgrading dependencies, frameworks, or toolchains, present alternatives and let the user choose.
 - **Keep commits atomic.** One logical fix per commit.

--- a/.claude/commands/smithy.ignite.md
+++ b/.claude/commands/smithy.ignite.md
@@ -197,7 +197,43 @@ Use the **smithy-clarify** sub-agent. Pass it:
 canonical title formats and check for repo-level overrides in the project's
 CLAUDE.md. Apply those conventions to all headings in this artifact.
 
-Using the workshopped answers from Phase 2, draft a structured RFC with this format.
+After each sub-phase's smithy-plan call returns, the orchestrator appends the
+returned content to `<slug>.rfc.md` before dispatching the next sub-phase. This
+is the append-and-continue protocol for all sub-phases below.
+
+### Sub-phase 3c: Goals + Out of Scope
+
+Dispatch **smithy-plan** with:
+
+- **Planning context**: "Draft the Goals and Out of Scope sections for this RFC"
+- **Feature/problem description**: the user's idea description plus the full clarification output from Phase 2
+- **Codebase file paths**: the path to the accumulating `<slug>.rfc.md` (which by this point contains Summary, Motivation, and Personas from earlier sub-phases)
+- **Additional planning directives**: constrain smithy-plan to produce only the Goals and Out of Scope sections in the RFC template format — not a full planning document
+
+Append the returned content to the RFC file.
+
+### Sub-phase 3d: Proposal + Design Considerations
+
+Dispatch **smithy-plan** with:
+
+- **Planning context**: "Draft the Proposal and Design Considerations sections for this RFC"
+- **Feature/problem description**: the user's idea description plus the clarification output and the reconciled approach from Phase 1.5
+- **Codebase file paths**: the path to the accumulating `<slug>.rfc.md` (which by this point contains Summary through Out of Scope)
+- **Additional planning directives**: constrain smithy-plan to produce only the Proposal and Design Considerations sections — not a full planning document
+
+Append the returned content to the RFC file.
+
+### Sub-phase 3f: Milestones
+
+Dispatch **smithy-plan** with:
+
+- **Planning context**: "Draft the Milestones section for this RFC, with per-milestone success criteria"
+- **Feature/problem description**: the user's idea description plus the clarification output
+- **Codebase file paths**: the path to the accumulating `<slug>.rfc.md` (containing all prior sections)
+- **Additional planning directives**: produce milestone decomposition only, with each milestone formatted as `### Milestone N: <Title>` followed by `**Description**` and `**Success Criteria**` bullets matching the RFC template
+
+Append the returned content to the RFC file.
+
 
 **Important — Decisions vs Open Questions**: Items discussed during clarification
 that have been resolved belong in **Decisions** (document what was decided and why).

--- a/.claude/skills/smithy.pr-review/SKILL.md
+++ b/.claude/skills/smithy.pr-review/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: smithy.pr-review
+description: "GitHub PR review operations: list inline comments, reply to comments, check CI run status. Use when handling review feedback on an open pull request."
+allowed-tools: Bash(bash *smithy.pr-review/scripts/find-pr.sh) Bash(bash *smithy.pr-review/scripts/get-comments.sh *) Bash(bash *smithy.pr-review/scripts/reply-comment.sh *)
+---
+# smithy.pr-review
+
+Provides GitHub PR review operations via shell scripts bundled in this skill's `scripts/`
+directory. Reference them as `bash ${CLAUDE_SKILL_DIR}/scripts/<script-name>`.
+
+---
+
+## Operation: Find Open PR
+
+Detects the open PR for the current branch. Returns JSON with `owner`, `repo`, `pr`,
+and `ownerRepo` fields. Returns empty object `{}` if no open PR exists.
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/find-pr.sh
+```
+
+---
+
+## Operation: List Inline Comments
+
+Fetches all **unresolved** review threads with their full reply chains. Resolved threads
+are automatically filtered out.
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/get-comments.sh <ownerRepo> <pr-number>
+```
+
+The result is an array of **threads** (one entry per review thread). Each thread:
+- `isResolved`: always `false` (resolved threads are filtered out)
+- `comments[]`: full reply chain for this thread, **oldest first**. Each comment:
+  `databaseId`, `body`, `path`, `diffHunk`, `author.login`, `createdAt`
+
+To work a thread: read the full `comments[]` chain for context — the **last** entry
+is the most recent reply and typically has the highest-priority context (e.g. a
+follow-up or escalation from the reviewer). Use `comments[0].databaseId` as the
+reply target when posting a response to this thread.
+
+---
+
+## Operation: Reply to a Comment
+
+Posts an inline reply to a specific review comment. Write the reply body to a temp JSON
+file first to avoid quoting issues, then POST it.
+
+**Step 1 — write reply body:**
+```bash
+cat > /tmp/smithy_reply_<databaseId>.json << 'EOF'
+{"body": "your reply text here"}
+EOF
+```
+
+**Step 2 — post reply:**
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/reply-comment.sh <ownerRepo> <pr-number> <databaseId> /tmp/smithy_reply_<databaseId>.json
+```
+
+For a **fix** reply: `"Fixed in <commit-sha>: <one-line explanation of what changed and why>"`
+For a **decline** reply: `"Not addressed: <explanation — why the comment doesn't apply, or what was misunderstood>"`
+
+---
+
+## Decision Criteria: Fix vs. Decline
+
+When evaluating a review comment, apply these criteria:
+
+**Fix when:**
+- The comment identifies a clear bug, typo, wrong logic, or naming issue
+- The change is mechanical and low-risk (no design tradeoffs)
+- The reviewer's reasoning is sound
+
+**Decline when:**
+- The comment is a stylistic preference where the current approach is equally valid
+- Accepting would expand scope beyond the PR's intent
+- The comment is based on a misunderstanding of the intent (explain why)
+- The change requires design discussion or dependency-version approval

--- a/.claude/skills/smithy.pr-review/scripts/find-pr.sh
+++ b/.claude/skills/smithy.pr-review/scripts/find-pr.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# find-pr.sh — Detect the open PR for the current branch
+#
+# Usage: bash ${CLAUDE_SKILL_DIR}/scripts/find-pr.sh
+#
+# Output: JSON with owner, repo, pr, ownerRepo fields.
+# Returns empty object ({}) if no open PR exists for the current branch.
+
+set -euo pipefail
+
+BRANCH=$(git branch --show-current)
+PR_JSON=$(gh pr list --head "$BRANCH" --json number --state open --limit 1)
+
+# Check if any PR exists
+if [ "$PR_JSON" = "[]" ]; then
+  echo '{}'
+  exit 0
+fi
+
+PR=$(echo "$PR_JSON" | jq -r '.[0].number')
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+NAME=$(gh repo view --json name --jq '.name')
+
+jq -n --arg owner "$OWNER" --arg repo "$NAME" --argjson pr "$PR" \
+  '{owner: $owner, repo: $repo, pr: $pr, ownerRepo: "\($owner)/\($repo)"}'

--- a/.claude/skills/smithy.pr-review/scripts/get-comments.sh
+++ b/.claude/skills/smithy.pr-review/scripts/get-comments.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# get-comments.sh — Fetch unresolved PR review threads with full reply chains
+#
+# Usage: bash .claude/skills/smithy.pr-review/scripts/get-comments.sh <owner/repo> <pr-number>
+#
+# Output: JSON array of unresolved review threads. Each thread has:
+#   - isResolved (always false in output — resolved threads are filtered)
+#   - comments[]: array of comment objects with databaseId, body, path, diffHunk,
+#                 author.login, createdAt (ordered oldest → newest)
+#
+# Returns an empty array ([]) if there are no unresolved review threads.
+
+set -euo pipefail
+
+REPO="$1"
+PR="$2"
+
+OWNER="${REPO%%/*}"
+NAME="${REPO##*/}"
+
+gh api graphql \
+  -F owner="$OWNER" \
+  -F name="$NAME" \
+  -F pr="$PR" \
+  -f query='
+query($owner: String!, $name: String!, $pr: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          comments(first: 50) {
+            nodes {
+              databaseId
+              body
+              path
+              diffHunk
+              author { login }
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | . + { comments: (.comments.nodes | sort_by(.createdAt)) }]'

--- a/.claude/skills/smithy.pr-review/scripts/reply-comment.sh
+++ b/.claude/skills/smithy.pr-review/scripts/reply-comment.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# reply-comment.sh — Post an inline reply to a PR review comment
+#
+# Usage: bash .claude/skills/smithy.pr-review/scripts/reply-comment.sh <owner/repo> <pr-number> <comment-id> <body-file>
+#
+# body-file: path to a JSON file with content: {"body": "your reply text"}
+# Write it with a heredoc before calling this script to avoid quoting issues:
+#
+#   cat > /tmp/smithy_reply_<id>.json << 'EOF'
+#   {"body": "Fixed in abc1234: changed X to Y because Z"}
+#   EOF
+#   bash .claude/skills/smithy.pr-review/scripts/reply-comment.sh owner/repo 42 123456 /tmp/smithy_reply_123456.json
+
+set -euo pipefail
+
+REPO="$1"
+PR="$2"
+COMMENT_ID="$3"
+BODY_FILE="$4"
+
+gh api "repos/$REPO/pulls/$PR/comments/$COMMENT_ID/replies" \
+  --method POST \
+  --input "$BODY_FILE"

--- a/.smithy/smithy-manifest.json
+++ b/.smithy/smithy-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "smithyVersion": "0.2.6",
+  "smithyVersion": "0.2.7",
   "deployLocation": "repo",
   "agents": [
     "claude"
@@ -30,7 +30,11 @@
       ".claude/agents/smithy.refine.md",
       ".claude/agents/smithy.review.md",
       ".claude/agents/smithy.scout.md",
-      ".claude/agents/smithy.slice.md"
+      ".claude/agents/smithy.slice.md",
+      ".claude/skills/smithy.pr-review/SKILL.md",
+      ".claude/skills/smithy.pr-review/scripts/find-pr.sh",
+      ".claude/skills/smithy.pr-review/scripts/get-comments.sh",
+      ".claude/skills/smithy.pr-review/scripts/reply-comment.sh"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Upgrades smithy from v0.2.6 to v0.2.7
- Updates clarify agent to use specification debt instead of questions
- Updates fix command with PR review comment handling support
- Updates ignite command with piecewise RFC generation sub-phases
- Adds new smithy.pr-review skill with shell scripts for PR operations

## Test plan
- [ ] Run `smithy update` in a clean repo and verify deployed files match v0.2.7
- [ ] Verify `/smithy.fix` with no arguments detects open PR comments
- [ ] Verify `/smithy.ignite` piecewise RFC generation sub-phases work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
