### PR TITLE
Add slice completion tracking to Smithy workflow

### DIFF
--- a/.claude/agents/smithy.reconcile-slices.md
+++ b/.claude/agents/smithy.reconcile-slices.md
@@ -164,8 +164,8 @@ Tasks:
 
 ### Dependency Order
 
-1. **Slice N** — <why this comes first>
-2. **Slice M** — <why this follows>
+1. [ ] **Slice N** — <why this comes first>
+2. [ ] **Slice M** — <why this follows>
 
 ### Conflicts
 

--- a/.claude/agents/smithy.slice.md
+++ b/.claude/agents/smithy.slice.md
@@ -158,8 +158,8 @@ Tasks:
 
 ### Dependency Order
 
-1. **Slice N** — <why this comes first>
-2. **Slice M** — <why this follows>
+1. [ ] **Slice N** — <why this comes first>
+2. [ ] **Slice M** — <why this follows>
 
 ### Decisions
 

--- a/.claude/commands/smithy.cut.md
+++ b/.claude/commands/smithy.cut.md
@@ -270,8 +270,8 @@ Draft the tasks file with this structure:
 
 Recommended implementation sequence:
 
-1. **Slice N** — <why this comes first>
-2. **Slice M** — <why this follows>
+1. [ ] **Slice N** — <why this comes first>
+2. [ ] **Slice M** — <why this follows>
 3. ...
 
 ### Cross-Story Dependencies

--- a/.claude/commands/smithy.forge.md
+++ b/.claude/commands/smithy.forge.md
@@ -184,20 +184,6 @@ After the sub-agent returns:
 
 ---
 
-## Validation
-
-After implementation, review, and documentation check, run the full validation
-suite against the **current HEAD** (which includes any maid auto-fix commits):
-- Build
-- Lint
-- Tests
-
-For `.strike.md` mode: also run through the **Validation Plan** checklist from the strike document and check off each item.
-
-Include the command output summary in your final response so reviewers know what passed locally.
-
----
-
 ## Mark Slice Complete
 
 For `.tasks.md` mode only:
@@ -215,6 +201,20 @@ Commit the change: `mark slice <N> complete in dependency order`
 
 This ensures the PR diff includes the Dependency Order context, making it easy
 for reviewers to see which slice was completed and what comes next.
+
+---
+
+## Validation
+
+After implementation, review, and documentation check, run the full validation
+suite against the **current HEAD** (which includes any maid auto-fix commits):
+- Build
+- Lint
+- Tests
+
+For `.strike.md` mode: also run through the **Validation Plan** checklist from the strike document and check off each item.
+
+Include the command output summary in your final response so reviewers know what passed locally.
 
 ---
 

--- a/.claude/commands/smithy.forge.md
+++ b/.claude/commands/smithy.forge.md
@@ -198,6 +198,26 @@ Include the command output summary in your final response so reviewers know what
 
 ---
 
+## Mark Slice Complete
+
+For `.tasks.md` mode only:
+
+In the tasks file, find the `## Dependency Order` section and change the target
+slice's checkbox from `[ ]` to `[x]`. For example, if implementing Slice 2:
+
+```
+1. [x] **Slice 1** — ...   (already completed)
+2. [x] **Slice 2** — ...   ← mark this one
+3. [ ] **Slice 3** — ...   (not yet started)
+```
+
+Commit the change: `mark slice <N> complete in dependency order`
+
+This ensures the PR diff includes the Dependency Order context, making it easy
+for reviewers to see which slice was completed and what comes next.
+
+---
+
 ## Pull Request
 
 Create the PR using `gh pr create` with:

--- a/src/templates/agent-skills/agents/smithy.reconcile-slices.prompt
+++ b/src/templates/agent-skills/agents/smithy.reconcile-slices.prompt
@@ -164,8 +164,8 @@ Tasks:
 
 ### Dependency Order
 
-1. **Slice N** — <why this comes first>
-2. **Slice M** — <why this follows>
+1. [ ] **Slice N** — <why this comes first>
+2. [ ] **Slice M** — <why this follows>
 
 ### Conflicts
 

--- a/src/templates/agent-skills/agents/smithy.slice.prompt
+++ b/src/templates/agent-skills/agents/smithy.slice.prompt
@@ -158,8 +158,8 @@ Tasks:
 
 ### Dependency Order
 
-1. **Slice N** — <why this comes first>
-2. **Slice M** — <why this follows>
+1. [ ] **Slice N** — <why this comes first>
+2. [ ] **Slice M** — <why this follows>
 
 ### Decisions
 

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -234,8 +234,8 @@ Draft the tasks file with this structure:
 
 Recommended implementation sequence:
 
-1. **Slice N** — <why this comes first>
-2. **Slice M** — <why this follows>
+1. [ ] **Slice N** — <why this comes first>
+2. [ ] **Slice M** — <why this follows>
 3. ...
 
 ### Cross-Story Dependencies

--- a/src/templates/agent-skills/commands/smithy.forge.prompt
+++ b/src/templates/agent-skills/commands/smithy.forge.prompt
@@ -220,20 +220,6 @@ For each stale doc found:
 
 ---
 
-## Validation
-
-After implementation, review, and documentation check, run the full validation
-suite against the **current HEAD** (which includes any maid auto-fix commits):
-- Build
-- Lint
-- Tests
-
-For `.strike.md` mode: also run through the **Validation Plan** checklist from the strike document and check off each item.
-
-Include the command output summary in your final response so reviewers know what passed locally.
-
----
-
 ## Mark Slice Complete
 
 For `.tasks.md` mode only:
@@ -251,6 +237,20 @@ Commit the change: `mark slice <N> complete in dependency order`
 
 This ensures the PR diff includes the Dependency Order context, making it easy
 for reviewers to see which slice was completed and what comes next.
+
+---
+
+## Validation
+
+After implementation, review, and documentation check, run the full validation
+suite against the **current HEAD** (which includes any maid auto-fix commits):
+- Build
+- Lint
+- Tests
+
+For `.strike.md` mode: also run through the **Validation Plan** checklist from the strike document and check off each item.
+
+Include the command output summary in your final response so reviewers know what passed locally.
 
 ---
 

--- a/src/templates/agent-skills/commands/smithy.forge.prompt
+++ b/src/templates/agent-skills/commands/smithy.forge.prompt
@@ -234,6 +234,26 @@ Include the command output summary in your final response so reviewers know what
 
 ---
 
+## Mark Slice Complete
+
+For `.tasks.md` mode only:
+
+In the tasks file, find the `## Dependency Order` section and change the target
+slice's checkbox from `[ ]` to `[x]`. For example, if implementing Slice 2:
+
+```
+1. [x] **Slice 1** — ...   (already completed)
+2. [x] **Slice 2** — ...   ← mark this one
+3. [ ] **Slice 3** — ...   (not yet started)
+```
+
+Commit the change: `mark slice <N> complete in dependency order`
+
+This ensures the PR diff includes the Dependency Order context, making it easy
+for reviewers to see which slice was completed and what comes next.
+
+---
+
 ## Pull Request
 
 Create the PR using `gh pr create` with:


### PR DESCRIPTION
## Summary
- Primary outcome: Introduce checkbox-based slice completion tracking in `.tasks.md` files to provide reviewers with clear dependency order context in PR diffs
- Notable behaviour changes: Dependency Order sections now use `[ ]` and `[x]` checkboxes to mark slice completion status
- Follow-up work deferred: None

## Context
This change enhances the Smithy slice-based development workflow by making slice completion status explicit and visible in PR diffs. When implementing slices, developers now mark completed slices with `[x]` checkboxes, allowing reviewers to immediately see which slice was completed and what comes next in the dependency order without needing to cross-reference external tracking systems.

## Implementation Notes
- Added "Mark Slice Complete" section to forge command documentation and prompt templates, instructing developers to update checkboxes in the Dependency Order section
- Updated all Dependency Order template examples across agent and command documentation to include `[ ]` checkboxes as the default unchecked state
- Changes applied consistently across:
  - `.claude/commands/smithy.forge.md` and its prompt template
  - `.claude/agents/smithy.slice.md` and `.claude/agents/smithy.reconcile-slices.md` and their prompt templates
  - `.claude/commands/smithy.cut.md` and its prompt template
- No architectural changes; this is a documentation and workflow enhancement

## Risks & Mitigations
- Risk: Developers may forget to mark slices complete | Mitigation: Clear instructions in forge command documentation with example format
- Risk: Inconsistent checkbox usage across projects | Mitigation: Standardized template format ensures consistency

## Rollback Plan
Revert the documentation changes. No code or data migration needed—this is purely documentation and workflow guidance.

## Testing
No testing needed. This is a documentation and workflow enhancement with no code logic changes. The checkbox format is human-readable markdown with no parsing dependencies.

https://claude.ai/code/session_019AUzF6UiqBFG9vWhUjgVz8