### PR TITLE
Fix detached HEAD handling and update smithy skill docs

### DIFF
--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -420,7 +420,7 @@ describe('getComposedTemplates', () => {
     // Sub-phase dispatch identifiers from Phase 3 (Story 3)
     expect(ignite).toContain('3c');
     expect(ignite).toContain('3d');
-    expect(ignite).toContain('3f');
+    expect(ignite).toContain('3e');
   });
 
   it('ignite default does not contain competing plan dispatch', () => {

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -180,7 +180,7 @@ Dispatch **smithy-plan** with:
 
 Append the returned content to the RFC file.
 
-### Sub-phase 3f: Milestones
+### Sub-phase 3e: Milestones
 
 Dispatch **smithy-plan** with:
 

--- a/src/templates/agent-skills/skills/smithy.pr-review/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.pr-review/SKILL.prompt
@@ -1,6 +1,6 @@
 ---
 name: smithy.pr-review
-description: "GitHub PR review operations: list inline comments, reply to comments, check CI run status. Use when handling review feedback on an open pull request."
+description: "GitHub PR review operations: list inline comments, reply to comments. Use when handling review feedback on an open pull request."
 allowed-tools: Bash(bash *smithy.pr-review/scripts/find-pr.sh) Bash(bash *smithy.pr-review/scripts/get-comments.sh *) Bash(bash *smithy.pr-review/scripts/reply-comment.sh *)
 ---
 # smithy.pr-review

--- a/src/templates/agent-skills/skills/smithy.pr-review/scripts/find-pr.sh
+++ b/src/templates/agent-skills/skills/smithy.pr-review/scripts/find-pr.sh
@@ -9,6 +9,13 @@
 set -euo pipefail
 
 BRANCH=$(git branch --show-current)
+
+# Detached HEAD — no branch to look up
+if [ -z "$BRANCH" ]; then
+  echo '{}'
+  exit 0
+fi
+
 PR_JSON=$(gh pr list --head "$BRANCH" --json number --state open --limit 1)
 
 # Check if any PR exists

--- a/src/templates/agent-skills/skills/smithy.pr-review/scripts/get-comments.sh
+++ b/src/templates/agent-skills/skills/smithy.pr-review/scripts/get-comments.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # get-comments.sh — Fetch unresolved PR review threads with full reply chains
 #
-# Usage: bash .claude/skills/smithy.pr-review/scripts/get-comments.sh <owner/repo> <pr-number>
+# Usage: bash ${CLAUDE_SKILL_DIR}/scripts/get-comments.sh <owner/repo> <pr-number>
 #
 # Output: JSON array of unresolved review threads. Each thread has:
 #   - isResolved (always false in output — resolved threads are filtered)

--- a/src/templates/agent-skills/skills/smithy.pr-review/scripts/reply-comment.sh
+++ b/src/templates/agent-skills/skills/smithy.pr-review/scripts/reply-comment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # reply-comment.sh — Post an inline reply to a PR review comment
 #
-# Usage: bash .claude/skills/smithy.pr-review/scripts/reply-comment.sh <owner/repo> <pr-number> <comment-id> <body-file>
+# Usage: bash ${CLAUDE_SKILL_DIR}/scripts/reply-comment.sh <owner/repo> <pr-number> <comment-id> <body-file>
 #
 # body-file: path to a JSON file with content: {"body": "your reply text"}
 # Write it with a heredoc before calling this script to avoid quoting issues:
@@ -9,7 +9,7 @@
 #   cat > /tmp/smithy_reply_<id>.json << 'EOF'
 #   {"body": "Fixed in abc1234: changed X to Y because Z"}
 #   EOF
-#   bash .claude/skills/smithy.pr-review/scripts/reply-comment.sh owner/repo 42 123456 /tmp/smithy_reply_123456.json
+#   bash ${CLAUDE_SKILL_DIR}/scripts/reply-comment.sh owner/repo 42 123456 /tmp/smithy_reply_123456.json
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Primary outcome: Handle detached HEAD state gracefully in PR lookup script; update documentation and fix test expectations
- Notable behaviour changes: `find-pr.sh` now returns empty JSON object when in detached HEAD state instead of failing
- Follow-up work deferred: None

## Context
The `find-pr.sh` script was failing when executed in a detached HEAD state (e.g., during certain CI/CD workflows) because `git branch --show-current` returns empty. This change makes the script resilient to this state while also cleaning up documentation references and correcting a sub-phase identifier.

## Implementation Notes
- **Detached HEAD handling**: Added early exit in `find-pr.sh` that returns `{}` when no branch is available, allowing graceful degradation
- **Documentation updates**: Standardized script usage documentation to use `${CLAUDE_SKILL_DIR}` variable instead of hardcoded `.claude/skills/` paths for better portability
- **Skill description**: Removed reference to "check CI run status" from `smithy.pr-review` description as this capability is not implemented in the allowed tools
- **Test correction**: Updated test expectation from `3f` to `3e` to match the corrected sub-phase identifier in the prompt
- **Sub-phase renaming**: Corrected sub-phase identifier from `3f` to `3e` for the Milestones phase in the ignite prompt

## Risks & Mitigations
- Risk: Scripts using hardcoded paths may not work if `${CLAUDE_SKILL_DIR}` is not set | Mitigation: This is a documentation-only change; actual script execution paths are controlled by the skill framework
- Risk: Returning `{}` on detached HEAD may mask legitimate errors | Mitigation: Detached HEAD is a valid state in CI/CD; returning empty result allows graceful handling upstream

## Rollback Plan
Revert the commit to restore original script behavior and documentation.

## Testing
- Existing unit test updated to expect correct sub-phase identifier (`3e` instead of `3f`)
- No additional testing needed; changes are defensive (graceful degradation) and documentation-only

https://claude.ai/code/session_01EGu56BJKJ66hdk4T55NP9a