### PR TITLE
Add Story Dependency Order tracking to spec workflow

### DIFF
--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -309,7 +309,25 @@ tasks accordingly:
 ## Phase 5: Write & Review
 
 Write the file to `specs/<folder>/<NN>-<story-slug>.tasks.md` (where `<NN>` is
-the zero-padded user story number), then present a summary to the user:
+the zero-padded user story number).
+
+**Spec write-back**: After writing the tasks file, update the source `.spec.md`
+to reflect that this story has been cut. Find the `## Story Dependency Order`
+section in the spec file and change the checkbox for the current user story from
+`- [ ]` to `- [x]`, appending the tasks file path:
+
+```markdown
+- [x] **User Story 3: <Title>** — <rationale> → `03-story-slug.tasks.md`
+```
+
+If the `## Story Dependency Order` section does not exist in the spec (e.g.,
+older specs created before this section was introduced), skip the write-back
+silently — do not add the section or fail. Match the story by its number
+(`User Story <N>`) in the bold text. Update only the matching entry — do not
+modify other entries. If the entry is already `[x]`, skip — the operation is
+idempotent.
+
+Then present a summary to the user:
 
 1. Show a summary:
    - Number of slices with their titles.
@@ -353,6 +371,8 @@ ask again.
   for in-progress work from other stories.
 - **DO** note cross-story dependencies in the Dependency Order section (as
   "Cross-Story Dependencies") without pulling that work into your slices.
+- **DO** update the spec file's Story Dependency Order checkbox when writing the
+  tasks file. If the section is missing, skip silently.
 - **DO NOT** write tasks that reference specific line numbers or prescribe exact
   replacement code. Tasks must survive codebase drift between planning and
   implementation. Reference files, modules, and behaviors instead.
@@ -370,8 +390,9 @@ ask again.
 ## Output
 
 1. **Audit findings and refinements** (if repeating the command on existing tasks).
-2. Created/updated tasks file:
+2. Created/updated files:
    - `specs/<folder>/<NN>-<story-slug>.tasks.md`
+   - `specs/<folder>/<slug>.spec.md` *(Story Dependency Order checkbox updated)*
 3. Summary report containing:
    - Slice count with titles.
    - FR and acceptance scenario coverage.

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -314,10 +314,10 @@ the zero-padded user story number).
 **Spec write-back**: After writing the tasks file, update the source `.spec.md`
 to reflect that this story has been cut. Find the `## Story Dependency Order`
 section in the spec file and change the checkbox for the current user story from
-`- [ ]` to `- [x]`, appending the tasks file path:
+`- [ ]` to `- [x]`, appending the repo-relative tasks file path:
 
 ```markdown
-- [x] **User Story 3: <Title>** — <rationale> → `03-story-slug.tasks.md`
+- [x] **User Story 3: <Title>** — <rationale> → `specs/<folder>/03-story-slug.tasks.md`
 ```
 
 If the `## Story Dependency Order` section does not exist in the spec (e.g.,
@@ -392,7 +392,7 @@ ask again.
 1. **Audit findings and refinements** (if repeating the command on existing tasks).
 2. Created/updated files:
    - `specs/<folder>/<NN>-<story-slug>.tasks.md`
-   - `specs/<folder>/<slug>.spec.md` *(Story Dependency Order checkbox updated)*
+   - `specs/<date>-<NNN>-<slug>/<slug>.spec.md` *(Story Dependency Order checkbox updated)*
 3. Summary report containing:
    - Slice count with titles.
    - FR and acceptance scenario coverage.

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -224,6 +224,14 @@ As a <persona>, I want <goal> so that <benefit>.
 - <edge case 1>
 - ...
 
+## Story Dependency Order
+
+Recommended implementation sequence:
+
+- [ ] **User Story 1: <Title>** — <dependency rationale>
+- [ ] **User Story 2: <Title>** — <dependency rationale>
+- [ ] **User Story N: <Title>** — <dependency rationale>
+
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
@@ -273,6 +281,17 @@ Guidelines for the spec:
 - Do NOT include specific file paths, function names, or implementation details.
 - DO trace back to RFC sections when input is an RFC.
 - Populate the `## Specification Debt` section from clarify's returned `debt_items`. Assign sequential SD-NNN identifiers starting at SD-001. Carry the description, source_category, impact, confidence, and status fields directly from clarify's return. Leave Resolution as `—` for all `open` items.
+- The Story Dependency Order section lists all user stories in recommended
+  implementation sequence with `- [ ]` checkboxes. Order by dependency graph,
+  not by priority — stories with no dependencies come first, stories that depend
+  on others come after their prerequisites. Stories that can be implemented in
+  parallel should be noted as such in their rationale. Each entry includes a
+  brief rationale explaining why it is positioned where it is (e.g., "No
+  dependencies", "Depends on Story 1 for the auth module", "Can parallelize
+  with Story 2").
+- The `[ ]` checkboxes in Story Dependency Order are updated to `[x]` by
+  `smithy.cut` when it creates the tasks file for that story. Do NOT manually
+  check them during spec creation.
 
 ---
 
@@ -465,6 +484,7 @@ Use the **smithy-refine** sub-agent. Pass it:
   | **Contract Completeness** | Do all integration boundaries have defined inputs, outputs, and error conditions? Are there contracts implied by requirements but not documented? |
   | **Ambiguity & Risk** | Are there vague terms, unstated assumptions, or scope boundaries that could be interpreted multiple ways? |
   | **Staleness** | Does the spec still reflect the current codebase reality? Have upstream changes invalidated any assumptions? |
+  | **Story Dependency Order** | Does the spec contain a `## Story Dependency Order` section? Does it list all user stories? Is the implementation sequence logically justified? Do `[x]` entries match stories that have `.tasks.md` files? |
 
 - **Target files**: the spec (`.spec.md`), data model (`.data-model.md`), and
   contracts (`.contracts.md`) in the spec folder.

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -279,6 +279,8 @@ Guidelines for the spec:
 - Success criteria are measurable and testable.
 - Do NOT include implementation phases, milestones, or task breakdowns.
 - Do NOT include specific file paths, function names, or implementation details.
+  (Exception: the `→` links in Story Dependency Order are auto-appended by
+  `smithy.cut` and are cross-reference paths, not implementation details.)
 - DO trace back to RFC sections when input is an RFC.
 - Populate the `## Specification Debt` section from clarify's returned `debt_items`. Assign sequential SD-NNN identifiers starting at SD-001. Carry the description, source_category, impact, confidence, and status fields directly from clarify's return. Leave Resolution as `—` for all `open` items.
 - The Story Dependency Order section lists all user stories in recommended
@@ -484,7 +486,7 @@ Use the **smithy-refine** sub-agent. Pass it:
   | **Contract Completeness** | Do all integration boundaries have defined inputs, outputs, and error conditions? Are there contracts implied by requirements but not documented? |
   | **Ambiguity & Risk** | Are there vague terms, unstated assumptions, or scope boundaries that could be interpreted multiple ways? |
   | **Staleness** | Does the spec still reflect the current codebase reality? Have upstream changes invalidated any assumptions? |
-  | **Story Dependency Order** | Does the spec contain a `## Story Dependency Order` section? Does it list all user stories? Is the implementation sequence logically justified? Do `[x]` entries match stories that have `.tasks.md` files? |
+  | **Story Dependency Order** | If the spec contains a `## Story Dependency Order` section: does it list all user stories? Is the implementation sequence logically justified? Do `[x]` entries match stories that have `.tasks.md` files? If absent (legacy spec), treat as N/A. |
 
 - **Target files**: the spec (`.spec.md`), data model (`.data-model.md`), and
   contracts (`.contracts.md`) in the spec folder.

--- a/src/templates/agent-skills/snippets/audit-checklist-spec.md
+++ b/src/templates/agent-skills/snippets/audit-checklist-spec.md
@@ -11,4 +11,4 @@
 | **Contract Completeness** | Do all integration boundaries have defined inputs, outputs, and error conditions? Are there contracts implied by requirements but not documented? |
 | **Ambiguity & Risk** | Are there vague terms, unstated assumptions, or scope boundaries that could be interpreted multiple ways? |
 | **Staleness** | Does the spec still reflect the current codebase reality? Have upstream changes invalidated any assumptions? |
-| **Story Dependency Order** | Does the spec contain a `## Story Dependency Order` section after Edge Cases and before Requirements? Does it list every user story with a `- [ ]` or `- [x]` checkbox? Is the recommended sequence logically justified? Do `[x]` entries match stories with `.tasks.md` files in the spec folder? |
+| **Story Dependency Order** | If the spec contains a `## Story Dependency Order` section: does it list every user story with a `- [ ]` or `- [x]` checkbox? Is the recommended sequence logically justified? Do `[x]` entries match stories with `.tasks.md` files in the spec folder? If the section is absent (legacy specs predating this convention), treat as N/A — do not flag. |

--- a/src/templates/agent-skills/snippets/audit-checklist-spec.md
+++ b/src/templates/agent-skills/snippets/audit-checklist-spec.md
@@ -11,3 +11,4 @@
 | **Contract Completeness** | Do all integration boundaries have defined inputs, outputs, and error conditions? Are there contracts implied by requirements but not documented? |
 | **Ambiguity & Risk** | Are there vague terms, unstated assumptions, or scope boundaries that could be interpreted multiple ways? |
 | **Staleness** | Does the spec still reflect the current codebase reality? Have upstream changes invalidated any assumptions? |
+| **Story Dependency Order** | Does the spec contain a `## Story Dependency Order` section after Edge Cases and before Requirements? Does it list every user story with a `- [ ]` or `- [x]` checkbox? Is the recommended sequence logically justified? Do `[x]` entries match stories with `.tasks.md` files in the spec folder? |


### PR DESCRIPTION
## Summary
- **Primary outcome**: Introduce a `## Story Dependency Order` section to spec templates that tracks implementation sequence and integrates with `smithy.cut` to auto-update checkboxes when tasks are created.
- **Notable behaviour changes**: `smithy.cut` now updates the source `.spec.md` file to mark completed stories; `smithy.mark` includes a new Story Dependency Order section in generated specs; audit checklist validates the section exists and is consistent with generated tasks files.
- **Follow-up work deferred**: None.

## Context
This change establishes a bidirectional link between spec planning and task execution. Previously, once a spec was created, there was no way to track which user stories had been cut into tasks. The Story Dependency Order section provides:
1. A single source of truth for recommended implementation sequence (ordered by dependency graph, not priority)
2. Automatic checkbox updates when `smithy.cut` creates tasks, providing visibility into progress
3. Audit validation to catch staleness (e.g., `[x]` entries without corresponding `.tasks.md` files)

This unlocks better project tracking and helps prevent stories from being cut out of order.

## Implementation Notes

### Key Changes

**`smithy.mark.prompt`** (spec generation):
- Added `## Story Dependency Order` section template after Edge Cases, before Requirements
- Section includes checkbox format (`- [ ]`) and rationale field for each story
- Added guidelines explaining that checkboxes are updated by `smithy.cut`, not manually during spec creation
- Clarified ordering principle: dependency graph order, not priority; parallel stories noted in rationale

**`smithy.cut.prompt`** (task generation):
- Added "Spec write-back" phase after writing tasks file
- Locates `## Story Dependency Order` section in source `.spec.md`
- Updates matching story entry from `- [ ]` to `- [x]`, appending tasks file path
- Gracefully skips if section missing (older specs) — no error, no section creation
- Operation is idempotent (skips if already `[x]`)
- Updated output section to list both created/updated files (tasks + spec)
- Added DO/DO NOT guidance for spec write-back behavior

**`audit-checklist-spec.md`** (audit validation):
- Added Story Dependency Order row to checklist
- Validates section exists, lists all stories, has justified sequence, and `[x]` entries match `.tasks.md` files

### Architectural Choices
- **Graceful degradation**: Missing Story Dependency Order section doesn't fail `smithy.cut` — allows older specs to work without modification
- **Idempotent updates**: Repeated `smithy.cut` calls on same story are safe
- **Append-only checkbox**: Only `[ ]` → `[x]` transition; never reverts
- **Rationale field**: Encourages explicit dependency reasoning during spec creation, improving handoff clarity

### Impacted Modules
- Agent skill prompts: `smithy.mark` and `smithy.cut` commands
- Audit checklist: spec validation rules

## Risks & Mitigations

| Risk | Mitigation |
|------|-----------|
| Spec file corruption if write-back fails mid-operation | Spec write-back is a simple find-and-replace on a single line; low risk. If it fails, user can manually update or re-run `smithy.cut`. |
| Older specs without Story Dependency Order section cause `smithy.cut` to fail | Explicitly skip silently if section missing; no error thrown. |
| Audit checklist flags specs as invalid if Story Dependency Order missing | Audit guidance clarifies section is optional for older specs; `[x]` entries only validated if section exists. |
| User manually checks boxes in Story Dependency Order during spec creation | Guidelines in `smithy.mark` explicitly state checkboxes are updated by `smithy.cut`, not manually. |

## Rollback Plan
- Revert changes to `smithy.mark.prompt`, `smithy.cut.prompt`, and `audit-checklist-spec.md`
- Existing specs without Story Dependency Order section continue to work (no breaking change)
- Existing tasks files remain valid; no data migration needed

##

https://claude.ai/code/session_01Xx45b3UjUVSmdqgwx9gLNh