### PR TITLE
Update smithy agent-skill to 0.2.8

### DIFF
--- a/.claude/commands/smithy.audit.md
+++ b/.claude/commands/smithy.audit.md
@@ -111,6 +111,7 @@ Use the checklist matching the artifact's extension. Each checklist defines what
 | **Contract Completeness** | Do all integration boundaries have defined inputs, outputs, and error conditions? Are there contracts implied by requirements but not documented? |
 | **Ambiguity & Risk** | Are there vague terms, unstated assumptions, or scope boundaries that could be interpreted multiple ways? |
 | **Staleness** | Does the spec still reflect the current codebase reality? Have upstream changes invalidated any assumptions? |
+| **Story Dependency Order** | If the spec contains a `## Story Dependency Order` section: does it list every user story with a `- [ ]` or `- [x]` checkbox? Is the recommended sequence logically justified? Do `[x]` entries match stories with `.tasks.md` files in the spec folder? If the section is absent (legacy specs predating this convention), treat as N/A — do not flag. |
 ## Audit Checklist (.tasks.md)
 
 | Category | What to check |

--- a/.claude/commands/smithy.cut.md
+++ b/.claude/commands/smithy.cut.md
@@ -266,6 +266,16 @@ Draft the tasks file with this structure:
 
 ---
 
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | <what is unresolved> | <clarify scan category> | High | Medium | open | — |
+
+_If no debt items, write: "None — all ambiguities resolved."_
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
@@ -295,6 +305,7 @@ Guidelines for slicing:
 - Slices are numbered sequentially starting at 1.
 - Include tests, docs, and validation steps within the slice that introduces the
   code — do not batch these into a separate "testing slice".
+- Populate the `## Specification Debt` section with debt items from cut's own clarify run. Assign SD-NNN identifiers. Leave Resolution as `—` for all `open` items. Inherited items from the upstream spec are added by Slice 4 — do not duplicate them here until that slice lands.
 
 Guidelines for task authoring:
 
@@ -334,7 +345,25 @@ tasks accordingly:
 ## Phase 5: Write & Review
 
 Write the file to `specs/<folder>/<NN>-<story-slug>.tasks.md` (where `<NN>` is
-the zero-padded user story number), then present a summary to the user:
+the zero-padded user story number).
+
+**Spec write-back**: After writing the tasks file, update the source `.spec.md`
+to reflect that this story has been cut. Find the `## Story Dependency Order`
+section in the spec file and change the checkbox for the current user story from
+`- [ ]` to `- [x]`, appending the repo-relative tasks file path:
+
+```markdown
+- [x] **User Story 3: <Title>** — <rationale> → `specs/<folder>/03-story-slug.tasks.md`
+```
+
+If the `## Story Dependency Order` section does not exist in the spec (e.g.,
+older specs created before this section was introduced), skip the write-back
+silently — do not add the section or fail. Match the story by its number
+(`User Story <N>`) in the bold text. Update only the matching entry — do not
+modify other entries. If the entry is already `[x]`, skip — the operation is
+idempotent.
+
+Then present a summary to the user:
 
 1. Show a summary:
    - Number of slices with their titles.
@@ -378,6 +407,8 @@ ask again.
   for in-progress work from other stories.
 - **DO** note cross-story dependencies in the Dependency Order section (as
   "Cross-Story Dependencies") without pulling that work into your slices.
+- **DO** update the spec file's Story Dependency Order checkbox when writing the
+  tasks file. If the section is missing, skip silently.
 - **DO NOT** write tasks that reference specific line numbers or prescribe exact
   replacement code. Tasks must survive codebase drift between planning and
   implementation. Reference files, modules, and behaviors instead.
@@ -395,8 +426,9 @@ ask again.
 ## Output
 
 1. **Audit findings and refinements** (if repeating the command on existing tasks).
-2. Created/updated tasks file:
+2. Created/updated files:
    - `specs/<folder>/<NN>-<story-slug>.tasks.md`
+   - `specs/<date>-<NNN>-<slug>/<slug>.spec.md` *(Story Dependency Order checkbox updated)*
 3. Summary report containing:
    - Slice count with titles.
    - FR and acceptance scenario coverage.

--- a/.claude/commands/smithy.ignite.md
+++ b/.claude/commands/smithy.ignite.md
@@ -197,9 +197,53 @@ Use the **smithy-clarify** sub-agent. Pass it:
 canonical title formats and check for repo-level overrides in the project's
 CLAUDE.md. Apply those conventions to all headings in this artifact.
 
-After each sub-phase's smithy-plan call returns, the orchestrator appends the
-returned content to `<slug>.rfc.md` before dispatching the next sub-phase. This
-is the append-and-continue protocol for all sub-phases below.
+### RFC File Creation
+
+Before any sub-phase begins, create the RFC folder and file:
+
+1. Create the folder `docs/rfcs/<YYYY>-<NNN>-<slug>/` if it doesn't exist.
+2. Create `docs/rfcs/<YYYY>-<NNN>-<slug>/<slug>.rfc.md` with only the RFC header — nothing else:
+
+```markdown
+# RFC: <Title>
+
+**Created**: YYYY-MM-DD  |  **Status**: Draft
+```
+
+Do not add a template skeleton or empty section placeholders. Each sub-phase
+will append its own section headings and content. The RFC template code fence
+below is a reference for section ordering and format — do not copy it into the
+file.
+
+### Append-and-Continue Protocol
+
+After each sub-phase's sub-agent returns, the orchestrator appends the returned
+content to `<slug>.rfc.md` before dispatching the next sub-phase. This is the
+append-and-continue protocol for sub-phases 3a–3f. For inline sub-phase 3e, the
+orchestrator appends directly. Sub-phase 3g is an exception: it rewrites the
+entire file in place (harmonize pass) rather than appending.
+
+### Sub-phase 3a: Summary + Motivation
+
+Dispatch **smithy-prose** with:
+
+- **section_assignment**: "Summary and Motivation / Problem Statement"
+- **idea_description**: the user's idea description or PRD content from intake
+- **clarify_output**: the Q&A and assumptions from Phase 2 clarification
+- **rfc_file_path**: do not pass (this is the first sub-phase; the RFC file contains only the header)
+
+After smithy-prose returns, append the returned content to `<slug>.rfc.md`.
+
+### Sub-phase 3b: Personas
+
+Dispatch **smithy-prose** with:
+
+- **section_assignment**: "Personas"
+- **idea_description**: the user's idea description or PRD content from intake
+- **clarify_output**: the Q&A and assumptions from Phase 2 clarification
+- **rfc_file_path**: the path to the accumulating `<slug>.rfc.md` (which at this point contains the header plus Summary and Motivation)
+
+After smithy-prose returns, append the returned content to the RFC file.
 
 ### Sub-phase 3c: Goals + Out of Scope
 
@@ -223,6 +267,24 @@ Dispatch **smithy-plan** with:
 
 Append the returned content to the RFC file.
 
+### Sub-phase 3e: Decisions + Open Questions
+
+This sub-phase is orchestrator-inline — no sub-agent dispatch.
+
+Synthesize the **Decisions** and **Open Questions** sections directly from the
+clarification record (Phase 2 output) and the reconciled approach (Phase 1.5):
+
+- **Decisions**: Items that were discussed and resolved during clarification or
+  reconciliation. Each entry states what was decided and why.
+- **Open Questions**: Items that remain genuinely unresolved and need further
+  investigation or stakeholder input.
+
+Refer to the "Decisions vs Open Questions" guidance below the template code
+fence for the distinction between these two sections.
+
+Append both formatted sections (`## Decisions` and `## Open Questions`) to the
+RFC file.
+
 ### Sub-phase 3f: Milestones
 
 Dispatch **smithy-plan** with:
@@ -233,6 +295,20 @@ Dispatch **smithy-plan** with:
 - **Additional planning directives**: produce milestone decomposition only, with each milestone formatted as `### Milestone N: <Title>` followed by `**Description**` and `**Success Criteria**` bullets matching the RFC template
 
 Append the returned content to the RFC file.
+
+### Sub-phase 3g: Harmonize
+
+This sub-phase is orchestrator-inline — no sub-agent dispatch.
+
+1. Read the complete `<slug>.rfc.md` from disk.
+2. Perform a coherence pass:
+   - Smooth tone across sections written by different sub-agents.
+   - Fix cross-references between sections (e.g., a Milestone referencing a Goal
+     by name, a Proposal referencing a Persona).
+   - Verify that every expected RFC template section is present and non-empty.
+3. Rewrite the file in place with the harmonized content.
+
+Confirm the harmonize step completed before proceeding to Phase 4.
 
 
 **Important — Decisions vs Open Questions**: Items discussed during clarification
@@ -311,18 +387,24 @@ influence downstream design decisions. Keep this at "WHAT not HOW" level.>
 
 ## Phase 4: Write & Review
 
-1. Create the folder `docs/rfcs/<YYYY>-<NNN>-<slug>/` if it doesn't exist.
-2. Write the RFC to `docs/rfcs/<YYYY>-<NNN>-<slug>/<slug>.rfc.md`.
-3. Present a **summary** of the draft — title, problem statement, milestone
-   count and titles, key decisions.
-4. **Do NOT dump the full RFC contents into the terminal.** The file is on
+Phase 3 already created the RFC folder, wrote the file piecewise through
+sub-phases 3a–3f, and harmonized it in sub-phase 3g. Skip folder creation
+and file write — proceed directly to review:
+
+1. Present a **summary** of the harmonized RFC — title, milestone count and
+   titles, key decisions.
+2. Point the user to the file on disk:
+   `docs/rfcs/<YYYY>-<NNN>-<slug>/<slug>.rfc.md`.
+3. **Do NOT dump the full RFC contents into the terminal.** The file is on
    disk — the user can review it in their editor.
-5. **STOP and ask**: "Review the RFC at `<path>` and let me know if you'd like
+4. **STOP and ask**: "Review the RFC at `<path>` and let me know if you'd like
    changes, or approve to move on."
 
-If the user wants changes, incorporate them, update the file on disk, and ask
-again. Once approved, suggest the next step: "Ready for `smithy.render` to
-break a milestone into features."
+If the user wants changes, incorporate them by updating the existing file in
+place (do not rewrite from scratch). Ask again after each round of changes.
+Once approved, suggest the next step: "Ready for `smithy.render` to break a
+milestone into features."
+
 
 ---
 

--- a/.claude/commands/smithy.mark.md
+++ b/.claude/commands/smithy.mark.md
@@ -268,6 +268,14 @@ As a <persona>, I want <goal> so that <benefit>.
 - <edge case 1>
 - ...
 
+## Story Dependency Order
+
+Recommended implementation sequence:
+
+- [ ] **User Story 1: <Title>** — <dependency rationale>
+- [ ] **User Story 2: <Title>** — <dependency rationale>
+- [ ] **User Story N: <Title>** — <dependency rationale>
+
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
@@ -283,6 +291,14 @@ As a <persona>, I want <goal> so that <benefit>.
 ## Assumptions
 
 - ...
+
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | <what is unresolved> | <clarify scan category> | High | Medium | open | — |
+
+_If no debt items, write: "None — all ambiguities resolved."_
 
 ## Out of Scope
 
@@ -307,7 +323,21 @@ Guidelines for the spec:
 - Success criteria are measurable and testable.
 - Do NOT include implementation phases, milestones, or task breakdowns.
 - Do NOT include specific file paths, function names, or implementation details.
+  (Exception: the `→` links in Story Dependency Order are auto-appended by
+  `smithy.cut` and are cross-reference paths, not implementation details.)
 - DO trace back to RFC sections when input is an RFC.
+- Populate the `## Specification Debt` section from clarify's returned `debt_items`. Assign sequential SD-NNN identifiers starting at SD-001. Carry the description, source_category, impact, confidence, and status fields directly from clarify's return. Leave Resolution as `—` for all `open` items.
+- The Story Dependency Order section lists all user stories in recommended
+  implementation sequence with `- [ ]` checkboxes. Order by dependency graph,
+  not by priority — stories with no dependencies come first, stories that depend
+  on others come after their prerequisites. Stories that can be implemented in
+  parallel should be noted as such in their rationale. Each entry includes a
+  brief rationale explaining why it is positioned where it is (e.g., "No
+  dependencies", "Depends on Story 1 for the auth module", "Can parallelize
+  with Story 2").
+- The `[ ]` checkboxes in Story Dependency Order are updated to `[x]` by
+  `smithy.cut` when it creates the tasks file for that story. Do NOT manually
+  check them during spec creation.
 
 ---
 
@@ -500,6 +530,7 @@ Use the **smithy-refine** sub-agent. Pass it:
   | **Contract Completeness** | Do all integration boundaries have defined inputs, outputs, and error conditions? Are there contracts implied by requirements but not documented? |
   | **Ambiguity & Risk** | Are there vague terms, unstated assumptions, or scope boundaries that could be interpreted multiple ways? |
   | **Staleness** | Does the spec still reflect the current codebase reality? Have upstream changes invalidated any assumptions? |
+  | **Story Dependency Order** | If the spec contains a `## Story Dependency Order` section: does it list all user stories? Is the implementation sequence logically justified? Do `[x]` entries match stories that have `.tasks.md` files? If absent (legacy spec), treat as N/A. |
 
 - **Target files**: the spec (`.spec.md`), data model (`.data-model.md`), and
   contracts (`.contracts.md`) in the spec folder.

--- a/.claude/skills/smithy.pr-review/SKILL.md
+++ b/.claude/skills/smithy.pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: smithy.pr-review
-description: "GitHub PR review operations: list inline comments, reply to comments, check CI run status. Use when handling review feedback on an open pull request."
+description: "GitHub PR review operations: list inline comments, reply to comments. Use when handling review feedback on an open pull request."
 allowed-tools: Bash(bash *smithy.pr-review/scripts/find-pr.sh) Bash(bash *smithy.pr-review/scripts/get-comments.sh *) Bash(bash *smithy.pr-review/scripts/reply-comment.sh *)
 ---
 # smithy.pr-review

--- a/.claude/skills/smithy.pr-review/scripts/find-pr.sh
+++ b/.claude/skills/smithy.pr-review/scripts/find-pr.sh
@@ -9,6 +9,13 @@
 set -euo pipefail
 
 BRANCH=$(git branch --show-current)
+
+# Detached HEAD — no branch to look up
+if [ -z "$BRANCH" ]; then
+  echo '{}'
+  exit 0
+fi
+
 PR_JSON=$(gh pr list --head "$BRANCH" --json number --state open --limit 1)
 
 # Check if any PR exists

--- a/.claude/skills/smithy.pr-review/scripts/get-comments.sh
+++ b/.claude/skills/smithy.pr-review/scripts/get-comments.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # get-comments.sh — Fetch unresolved PR review threads with full reply chains
 #
-# Usage: bash .claude/skills/smithy.pr-review/scripts/get-comments.sh <owner/repo> <pr-number>
+# Usage: bash ${CLAUDE_SKILL_DIR}/scripts/get-comments.sh <owner/repo> <pr-number>
 #
 # Output: JSON array of unresolved review threads. Each thread has:
 #   - isResolved (always false in output — resolved threads are filtered)

--- a/.claude/skills/smithy.pr-review/scripts/reply-comment.sh
+++ b/.claude/skills/smithy.pr-review/scripts/reply-comment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # reply-comment.sh — Post an inline reply to a PR review comment
 #
-# Usage: bash .claude/skills/smithy.pr-review/scripts/reply-comment.sh <owner/repo> <pr-number> <comment-id> <body-file>
+# Usage: bash ${CLAUDE_SKILL_DIR}/scripts/reply-comment.sh <owner/repo> <pr-number> <comment-id> <body-file>
 #
 # body-file: path to a JSON file with content: {"body": "your reply text"}
 # Write it with a heredoc before calling this script to avoid quoting issues:
@@ -9,7 +9,7 @@
 #   cat > /tmp/smithy_reply_<id>.json << 'EOF'
 #   {"body": "Fixed in abc1234: changed X to Y because Z"}
 #   EOF
-#   bash .claude/skills/smithy.pr-review/scripts/reply-comment.sh owner/repo 42 123456 /tmp/smithy_reply_123456.json
+#   bash ${CLAUDE_SKILL_DIR}/scripts/reply-comment.sh owner/repo 42 123456 /tmp/smithy_reply_123456.json
 
 set -euo pipefail
 

--- a/.smithy/smithy-manifest.json
+++ b/.smithy/smithy-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "smithyVersion": "0.2.7",
+  "smithyVersion": "0.2.8",
   "deployLocation": "repo",
   "agents": [
     "claude"

--- a/specs/2026-03-14-001-smithy-command-redesign/01-workshop-idea-into-rfc.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/01-workshop-idea-into-rfc.tasks.md
@@ -62,5 +62,5 @@ _None — all ambiguities resolved._
 
 Recommended implementation sequence:
 
-- [ ] **Slice 1** — Core template must exist before the review loop can be added or tested.
-- [ ] **Slice 2** — Adds review loop on top of the working template from Slice 1.
+- [x] **Slice 1** — Core template must exist before the review loop can be added or tested.
+- [x] **Slice 2** — Adds review loop on top of the working template from Slice 1.

--- a/specs/2026-03-14-001-smithy-command-redesign/01-workshop-idea-into-rfc.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/01-workshop-idea-into-rfc.tasks.md
@@ -52,9 +52,15 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — Core template must exist before the review loop can be added or tested.
-2. **Slice 2** — Adds review loop on top of the working template from Slice 1.
+- [ ] **Slice 1** — Core template must exist before the review loop can be added or tested.
+- [ ] **Slice 2** — Adds review loop on top of the working template from Slice 1.

--- a/specs/2026-03-14-001-smithy-command-redesign/02-break-milestone-into-features.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/02-break-milestone-into-features.tasks.md
@@ -67,5 +67,5 @@ _None — all ambiguities resolved._
 
 Recommended implementation sequence:
 
-- [ ] **Slice 1** — Core template must exist before the review loop can be added or tested.
-- [ ] **Slice 2** — Adds review loop on top of the working template from Slice 1.
+- [x] **Slice 1** — Core template must exist before the review loop can be added or tested.
+- [x] **Slice 2** — Adds review loop on top of the working template from Slice 1.

--- a/specs/2026-03-14-001-smithy-command-redesign/02-break-milestone-into-features.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/02-break-milestone-into-features.tasks.md
@@ -57,9 +57,15 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — Core template must exist before the review loop can be added or tested.
-2. **Slice 2** — Adds review loop on top of the working template from Slice 1.
+- [ ] **Slice 1** — Core template must exist before the review loop can be added or tested.
+- [ ] **Slice 2** — Adds review loop on top of the working template from Slice 1.

--- a/specs/2026-03-14-001-smithy-command-redesign/03-specify-a-feature.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/03-specify-a-feature.tasks.md
@@ -52,9 +52,15 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — Must come first because Slice 2 deletes the source file that Slice 1 copies from.
-2. **Slice 2** — Safe to do after Slice 1 since the new template is in place.
+- [x] **Slice 1** — Must come first because Slice 2 deletes the source file that Slice 1 copies from.
+- [x] **Slice 2** — Safe to do after Slice 1 since the new template is in place.

--- a/specs/2026-03-14-001-smithy-command-redesign/04-slice-story-into-tasks.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/04-slice-story-into-tasks.tasks.md
@@ -29,8 +29,14 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — Single verification slice, no dependencies.
+- [x] **Slice 1** — Single verification slice, no dependencies.

--- a/specs/2026-03-14-001-smithy-command-redesign/05-implement-slice-as-pr.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/05-implement-slice-as-pr.tasks.md
@@ -35,8 +35,14 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — Single slice; the rewrite is self-contained.
+- [x] **Slice 1** — Single slice; the rewrite is self-contained.

--- a/specs/2026-03-14-001-smithy-command-redesign/06-fast-track-idea-to-implementation.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/06-fast-track-idea-to-implementation.tasks.md
@@ -38,8 +38,14 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — Single slice; self-contained template rewrite.
+- [x] **Slice 1** — Single slice; self-contained template rewrite.

--- a/specs/2026-03-14-001-smithy-command-redesign/07-context-aware-artifact-review.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/07-context-aware-artifact-review.tasks.md
@@ -76,10 +76,16 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — Checklists must exist in source templates before they can be extracted
-2. **Slice 2** — Composition logic must exist before init can use it
-3. **Slice 3** — Connects everything: rewritten audit template + init wiring
+- [x] **Slice 1** — Checklists must exist in source templates before they can be extracted
+- [x] **Slice 2** — Composition logic must exist before init can use it
+- [x] **Slice 3** — Connects everything: rewritten audit template + init wiring

--- a/specs/2026-03-14-001-smithy-command-redesign/08-create-tickets-from-artifacts.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/08-create-tickets-from-artifacts.tasks.md
@@ -52,9 +52,15 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — Must come first because Slice 2 deletes the source file whose patterns Slice 1 draws from.
-2. **Slice 2** — Safe after Slice 1 since the new template is in place.
+- [x] **Slice 1** — Must come first because Slice 2 deletes the source file whose patterns Slice 1 draws from.
+- [x] **Slice 2** — Safe after Slice 1 since the new template is in place.

--- a/specs/2026-03-14-001-smithy-command-redesign/smithy-command-redesign.spec.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/smithy-command-redesign.spec.md
@@ -217,6 +217,19 @@ As a developer, I want to point `smithy.orders` at any artifact and have it crea
 - Running `cut` with a user story number that doesn't exist in the spec — should error listing available user stories.
 - A feature spec with more than 99 user stories — should error indicating the feature needs to be split.
 
+## Story Dependency Order
+
+Recommended implementation sequence:
+
+- [x] **User Story 6 — Strike: Fast Track Idea to Implementation** — Foundational entry point; the most-used command and standalone. No pipeline dependencies. → `specs/2026-03-14-001-smithy-command-redesign/06-fast-track-idea-to-implementation.tasks.md`
+- [x] **User Story 3 — Mark: Specify a Feature** — Core artifact producer; second entry point into the system. Required before cut and forge can be tested end-to-end. → `specs/2026-03-14-001-smithy-command-redesign/03-specify-a-feature.tasks.md`
+- [x] **User Story 4 — Cut: Slice a User Story into Tasks** — Depends on mark output (`.spec.md`). Bridges spec to implementation. → `specs/2026-03-14-001-smithy-command-redesign/04-slice-story-into-tasks.tasks.md`
+- [x] **User Story 5 — Forge: Implement a Slice as a PR** — Terminal pipeline step; depends on cut output (`.tasks.md`). → `specs/2026-03-14-001-smithy-command-redesign/05-implement-slice-as-pr.tasks.md`
+- [x] **User Story 7 — Audit: Context-Aware Artifact Review** — Quality gate; independent of pipeline order but benefits from stable artifact conventions. Can parallelize with mark/cut/forge. → `specs/2026-03-14-001-smithy-command-redesign/07-context-aware-artifact-review.tasks.md`
+- [x] **User Story 1 — Ignite: Workshop Broad Idea into RFC** — Upper-pipeline extension; depends on core loop (mark/cut/forge) being solid first. → `specs/2026-03-14-001-smithy-command-redesign/01-workshop-idea-into-rfc.tasks.md`
+- [x] **User Story 2 — Render: Break Milestone into Features** — Depends on ignite output (`.rfc.md`). → `specs/2026-03-14-001-smithy-command-redesign/02-break-milestone-into-features.tasks.md`
+- [x] **User Story 8 — Orders: Create Tickets from Artifacts** — Productivity accelerator; depends on stable artifact conventions across all other stories. Implement last. → `specs/2026-03-14-001-smithy-command-redesign/08-create-tickets-from-artifacts.tasks.md`
+
 ## Requirements
 
 ### Functional Requirements
@@ -253,6 +266,10 @@ As a developer, I want to point `smithy.orders` at any artifact and have it crea
 - The `command: true` frontmatter convention for Claude Code slash commands remains.
 - GitHub CLI (`gh`) is available for `orders` and `forge` ticket/PR operations.
 - The existing `specs/strikes/` convention for strike output is preserved.
+
+## Specification Debt
+
+_None — all ambiguities resolved._
 
 ## Out of Scope
 

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/01-create-smithy-issue-templates-during-init.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/01-create-smithy-issue-templates-during-init.tasks.md
@@ -51,9 +51,15 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — Templates and utility must exist before the init flow can call them
-2. **Slice 2** — Wires everything together into the user-facing feature; depends on Slice 1's utility functions
+- [ ] **Slice 1** — Templates and utility must exist before the init flow can call them
+- [ ] **Slice 2** — Wires everything together into the user-facing feature; depends on Slice 1's utility functions

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-smithy-templates.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-smithy-templates.tasks.md
@@ -54,9 +54,15 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — establishes the template resolution algorithm, variable context definitions, and built-in default templates. Must come first because Slice 2 references these sections.
-2. **Slice 2** — restructures the body construction to use the pipeline and adds tests. Depends on Slice 1's resolution phase and context tables being in place.
+- [ ] **Slice 1** — establishes the template resolution algorithm, variable context definitions, and built-in default templates. Must come first because Slice 2 references these sections.
+- [ ] **Slice 2** — restructures the body construction to use the pipeline and adds tests. Depends on Slice 1's resolution phase and context tables being in place.

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/03-commit-or-gitignore-smithy-dir.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/03-commit-or-gitignore-smithy-dir.tasks.md
@@ -32,8 +32,14 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — This is the only slice. It depends on Story 1 (template creation) being implemented first, as the prompt is triggered by successful template creation.
+- [ ] **Slice 1** — This is the only slice. It depends on Story 1 (template creation) being implemented first, as the prompt is triggered by successful template creation.

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/04-orders-falls-back-to-defaults.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/04-orders-falls-back-to-defaults.tasks.md
@@ -48,9 +48,15 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — Default template files must exist first so Slice 2 can reference their content inline in the prompt.
-2. **Slice 2** — Adds resolution, interpolation, and fallback logic to the orders prompt, consuming Slice 1's templates.
+- [ ] **Slice 1** — Default template files must exist first so Slice 2 can reference their content inline in the prompt.
+- [ ] **Slice 2** — Adds resolution, interpolation, and fallback logic to the orders prompt, consuming Slice 1's templates.

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.spec.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.spec.md
@@ -100,6 +100,15 @@ As a developer who hasn't created `.smithy/` templates, I want `smithy.orders` t
 - `.smithy/` is gitignored but the user later wants to commit it — this is a manual git operation, not smithy's responsibility.
 - `.smithy/` contains extra files beyond the 4 known templates (e.g., `README.md`, custom templates) — overwrite during init replaces only the 4 known files and leaves extras untouched.
 
+## Story Dependency Order
+
+Recommended implementation sequence:
+
+- [x] **User Story 1 — Create `.smithy/` issue templates during init** — Foundational; templates must exist before `orders` can use them. Init is the natural setup point. → `specs/2026-03-21-002-smithy-orders-issue-templates/01-create-smithy-issue-templates-during-init.tasks.md`
+- [x] **User Story 3 — Commit-or-gitignore choice for `.smithy/`** — Setup-time decision that accompanies template creation (User Story 1). Can parallelize with User Story 1. → `specs/2026-03-21-002-smithy-orders-issue-templates/03-commit-or-gitignore-smithy-dir.tasks.md`
+- [x] **User Story 2 — Orders uses `.smithy/` templates when creating issues** — Core value proposition; depends on templates existing (User Story 1). → `specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-smithy-templates.tasks.md`
+- [x] **User Story 4 — Orders falls back to built-in defaults** — Fallback path; depends on orders integration being implemented (User Story 2) to validate the fallback is correct. → `specs/2026-03-21-002-smithy-orders-issue-templates/04-orders-falls-back-to-defaults.tasks.md`
+
 ## Requirements
 
 ### Functional Requirements
@@ -215,6 +224,10 @@ Run `smithy.{{next_step}}` to implement this slice as a PR.
 - The `{{variable}}` names defined in these templates become the interface between templates and `orders` — changes require coordination.
 - GitHub CLI (`gh`) is available and authenticated for issue creation.
 - Smithy artifacts (specs, RFCs, etc.) are checked into the repo so that repo-relative paths in issue bodies are valid references.
+
+## Specification Debt
+
+_None — all ambiguities resolved._
 
 ## Out of Scope
 

--- a/specs/2026-04-06-003-smithy-evals-framework/01-validate-headless-execution-assumptions.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/01-validate-headless-execution-assumptions.tasks.md
@@ -38,11 +38,17 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — This is the only slice. It is the prerequisite for all other stories in the spec.
+- [x] **Slice 1** — This is the only slice. It is the prerequisite for all other stories in the spec.
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-06-003-smithy-evals-framework/02-reference-fixture-exists-and-is-deployable.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/02-reference-fixture-exists-and-is-deployable.tasks.md
@@ -69,12 +69,18 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — fixture source files are the foundation; the deployment test depends on them existing.
-2. **Slice 2** — deployment verification test; depends on Slice 1 and on `dist/cli.js` (built by the `pretest` script).
+- [x] **Slice 1** — fixture source files are the foundation; the deployment test depends on them existing.
+- [x] **Slice 2** — deployment verification test; depends on Slice 1 and on `dist/cli.js` (built by the `pretest` script).
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-06-003-smithy-evals-framework/03-execute-skill-headlessly-and-capture-output.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/03-execute-skill-headlessly-and-capture-output.tasks.md
@@ -75,13 +75,19 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1: Stream Parser and Shared Types** — no upstream dependencies; must land before Slice 2 can import from it.
-2. **Slice 2: Runner with Fixture Management** — depends on Slice 1; delivers the core US3 capability.
-3. **Slice 3: Entry Point and Build Tooling** — depends on Slice 2; wires everything into a runnable CLI.
+- [x] **Slice 1: Stream Parser and Shared Types** — no upstream dependencies; must land before Slice 2 can import from it.
+- [x] **Slice 2: Runner with Fixture Management** — depends on Slice 1; delivers the core US3 capability.
+- [x] **Slice 3: Entry Point and Build Tooling** — depends on Slice 2; wires everything into a runnable CLI.
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-06-003-smithy-evals-framework/04-validate-output-structure.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/04-validate-output-structure.tasks.md
@@ -43,12 +43,18 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1: StructuralValidator and SubAgentVerifier Library** — pure module with no runtime dependencies; establishes the vitest config for all evals tests; Slice 2 imports from it.
-2. **Slice 2: Wire Validator into the Orchestrator** — depends on Slice 1 exports; narrow orchestrator change that delivers the user-visible outcome.
+- [x] **Slice 1: StructuralValidator and SubAgentVerifier Library** — pure module with no runtime dependencies; establishes the vitest config for all evals tests; Slice 2 imports from it.
+- [ ] **Slice 2: Wire Validator into the Orchestrator** — depends on Slice 1 exports; narrow orchestrator change that delivers the user-visible outcome.
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.spec.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.spec.md
@@ -216,6 +216,22 @@ Plan and scout are tested **both** ways:
 - **Indirectly** via strike (US5, US6) — verifying they are dispatched as sub-agents and their output appears in strike's output.
 - **Standalone** via their own YAML eval scenarios — invoking them directly as sub-agents with their own structural expectations (e.g., `## Plan` with 4 sections for plan, `## Scout Report` with severity tables for scout). This validates their output structure independently of strike's orchestration.
 
+## Story Dependency Order
+
+Recommended implementation sequence:
+
+- [x] **User Story 1: Validate Headless Execution Assumptions** — Must be confirmed first; the entire framework depends on `claude -p` assumptions. Blocks all other stories. → `specs/2026-04-06-003-smithy-evals-framework/01-validate-headless-execution-assumptions.tasks.md`
+- [x] **User Story 2: Reference Fixture Exists and Is Deployable** — Every eval case requires a fixture. Depends on US1 assumptions being validated. → `specs/2026-04-06-003-smithy-evals-framework/02-reference-fixture-exists-and-is-deployable.tasks.md`
+- [x] **User Story 3: Execute a Skill Headlessly and Capture Output** — Foundational runner capability; nothing else works without headless capture. Depends on US1 and US2. → `specs/2026-04-06-003-smithy-evals-framework/03-execute-skill-headlessly-and-capture-output.tasks.md`
+- [x] **User Story 4: Validate Output Structure** — Core validation logic; depends on US3 (captured output to validate). → `specs/2026-04-06-003-smithy-evals-framework/04-validate-output-structure.tasks.md`
+- [ ] **User Story 9: Eval Summary Report** — Reporting layer; depends on US3 and US4 producing results to summarize.
+- [ ] **User Story 5: Verify Strike End-to-End Output** — First full eval case; depends on US3 (runner) and US4 (structural validator) being implemented.
+- [ ] **User Story 6: Verify Sub-Agent Invocation** — Extends US5; depends on US5 strike eval infrastructure and the stream-json parser for detecting dispatch events.
+- [ ] **User Story 7: Define Eval Scenarios Declaratively** — Maintainability improvement; depends on at least one eval case (US5) existing to migrate. Can parallelize with US5/US6.
+- [ ] **User Story 8: Fixture Contains Deliberate Inconsistencies for Scout** — Enhancement to the fixture (US2); depends on basic eval framework working (US5+). Can parallelize with US7.
+- [ ] **User Story 10: Baseline Structural Expectations** — Optional regression layer; depends on structural evals (US4, US5) being stable first.
+- [ ] **User Story 11: Cost and Time Transparency** — Developer experience enhancement; can be added any time after US9 (summary report) exists.
+
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
@@ -252,6 +268,10 @@ Plan and scout are tested **both** ways:
 - Both OAuth (via `claude login`) and `ANTHROPIC_API_KEY` are valid for authentication in headless mode — the spike ran successfully with OAuth only. The eval runner must support both.
 - Developers running evals have the `claude` CLI installed and authenticated locally.
 - A minimal 5-6 file fixture is sufficient for strike/plan/scout to produce structurally meaningful output.
+
+## Specification Debt
+
+_None — all ambiguities resolved._
 
 ## Out of Scope
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/01-updated-rfc-template-schema.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/01-updated-rfc-template-schema.tasks.md
@@ -22,3 +22,17 @@
 - [ ] Task 5 (pending assignment by orchestrator)
 - [ ] Task 6 (pending assignment by orchestrator)
 - [ ] Task 7 (pending assignment by orchestrator)
+
+---
+
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
+## Dependency Order
+
+Recommended implementation sequence:
+
+- [ ] **Slice 1** — Only slice. Insert Out of Scope and Personas sections into the Phase 3 RFC template.

--- a/specs/2026-04-07-003-refactor-ignite-workflow/01-updated-rfc-template-schema.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/01-updated-rfc-template-schema.tasks.md
@@ -35,4 +35,4 @@ _None — all ambiguities resolved._
 
 Recommended implementation sequence:
 
-- [ ] **Slice 1** — Only slice. Insert Out of Scope and Personas sections into the Phase 3 RFC template.
+- [x] **Slice 1** — Only slice. Insert Out of Scope and Personas sections into the Phase 3 RFC template.

--- a/specs/2026-04-07-003-refactor-ignite-workflow/02-shared-smithy-prose-sub-agent.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/02-shared-smithy-prose-sub-agent.tasks.md
@@ -67,12 +67,18 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — creates the agent file and passes automated tests; must be merged before the orchestrator (Story 4) can reference smithy-prose in the ignite prompt
-2. **Slice 2** — documentation updates; depends on Slice 1 being merged so the file being documented actually exists
+- [x] **Slice 1** — creates the agent file and passes automated tests; must be merged before the orchestrator (Story 4) can reference smithy-prose in the ignite prompt
+- [x] **Slice 2** — documentation updates; depends on Slice 1 being merged so the file being documented actually exists
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/03-smithy-plan-for-structured-rfc-sections.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/03-smithy-plan-for-structured-rfc-sections.tasks.md
@@ -30,11 +30,17 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — Only slice. The prompt change and test augmentation are tightly coupled (the test verifies the rendering of the prompt change) and belong in a single PR. Covers Acceptance Scenarios US3-1, US3-2, US3-3, US3-4.
+- [x] **Slice 1** — Only slice. The prompt change and test augmentation are tightly coupled (the test verifies the rendering of the prompt change) and belong in a single PR. Covers Acceptance Scenarios US3-1, US3-2, US3-3, US3-4.
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/04-piecewise-rfc-generation.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/04-piecewise-rfc-generation.tasks.md
@@ -37,11 +37,17 @@
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — Only slice. All tasks within the slice are ordered sequentially: RFC creation and protocol note (tasks 1–2) must precede 3a (task 3), which must precede 3b (task 4); 3e (task 5) inserts between the already-present 3d and 3f; 3g (task 6) inserts after the already-present 3f; Phase 4 update (task 7) and tests (task 8) complete the PR.
+- [x] **Slice 1** — Only slice. All tasks within the slice are ordered sequentially: RFC creation and protocol note (tasks 1–2) must precede 3a (task 3), which must precede 3b (task 4); 3e (task 5) inserts between the already-present 3d and 3f; 3g (task 6) inserts after the already-present 3f; Phase 4 update (task 7) and tests (task 8) complete the PR.
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
@@ -178,6 +178,20 @@ As a developer reviewing an existing RFC via `smithy.ignite` Phase 0, I want the
 - **Partial RFC from a different idea**: Phase 0's resume detection should verify that the RFC's Summary/Motivation are contextually related to the current idea. If unrelated, warn the user and offer to overwrite or create a new RFC.
 - **Session crash during harmonization (3g)**: If the harmonization pass crashes mid-rewrite, the RFC file may be in an inconsistent state. The next session's Phase 0 should detect the RFC and enter the review loop, where smithy-refine can identify and repair inconsistencies.
 
+## Story Dependency Order
+
+Recommended implementation sequence:
+
+- [x] **User Story 1: Updated RFC Template Schema** — Foundational; defines the slots all other stories write into. All piecewise generation stories depend on the template having the correct sections. → `specs/2026-04-07-003-refactor-ignite-workflow/01-updated-rfc-template-schema.tasks.md`
+- [x] **User Story 2: Shared Smithy-Prose Sub-Agent** — Must exist before the piecewise pipeline can dispatch it for narrative sections (3a, 3b). → `specs/2026-04-07-003-refactor-ignite-workflow/02-shared-smithy-prose-sub-agent.tasks.md`
+- [x] **User Story 3: Smithy-Plan for Structured RFC Sections** — Defines the dispatch pattern for structured sections; required before piecewise orchestration can be wired together. Can parallelize with US2. → `specs/2026-04-07-003-refactor-ignite-workflow/03-smithy-plan-for-structured-rfc-sections.tasks.md`
+- [x] **User Story 4: Piecewise RFC Generation** — Core orchestration that wires US1+US2+US3 together. Depends on all three preceding stories. → `specs/2026-04-07-003-refactor-ignite-workflow/04-piecewise-rfc-generation.tasks.md`
+- [ ] **User Story 5: Mandatory Personas Section** — Verifies the Personas section is produced end-to-end; depends on US1 (template slot) and US2 (smithy-prose dispatch). Can be validated after US4.
+- [ ] **User Story 6: Mandatory Out of Scope Section** — Verifies the Out of Scope section is produced end-to-end; depends on US1 (template slot) and US3 (smithy-plan dispatch). Can parallelize with US5.
+- [ ] **User Story 9: Updated Phase 0 Audit Categories** — Updates the review loop and audit snippet; depends on US1 (new sections defined). Can be done any time after US1.
+- [ ] **User Story 7: Session Resume from Partial State** — Robustness enhancement; depends on US4 (direct-write approach) naturally leaving partial files on disk to detect.
+- [ ] **User Story 8: Cross-Session Question Deduplication** — Enhancement on top of the core pipeline; depends on US4 (sessions producing output files). Implement after core flow is solid.
+
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
@@ -208,6 +222,10 @@ As a developer reviewing an existing RFC via `smithy.ignite` Phase 0, I want the
 - The competing plans phase (Phase 1.5) with three lenses and smithy-reconcile remains unchanged in structure, though it now benefits from richer context when sub-phases reference its output.
 - smithy-scout is NOT added to the ignite pipeline (ignite works from ideas/PRDs, not existing code).
 - smithy-prose is designed as a shared sub-agent from day one, but adoption by other commands (render, mark) is deferred to future work.
+
+## Specification Debt
+
+_None — all ambiguities resolved._
 
 ## Out of Scope
 

--- a/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
@@ -123,13 +123,19 @@ test case validates end-to-end triage behavior.
 
 ---
 
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
 ## Dependency Order
 
 Recommended implementation sequence:
 
-1. **Slice 1** — Core triage logic must exist before parent commands can render
+- [x] **Slice 1** — Core triage logic must exist before parent commands can render
    the annotation. This is the foundational behavioral change.
-2. **Slice 2** — Depends on Slice 1's annotation format being defined. Ensures
+- [x] **Slice 2** — Depends on Slice 1's annotation format being defined. Ensures
    annotation visibility in downstream artifacts and provides verification.
 
 ### Cross-Story Dependencies

--- a/specs/2026-04-08-003-reduce-interaction-friction/02-track-specification-debt.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/02-track-specification-debt.tasks.md
@@ -152,11 +152,11 @@ Primary changes are in `src/templates/agent-skills/agents/smithy.clarify.prompt`
 
 Recommended implementation sequence:
 
-1. **Slice 1** — The clarify triage engine must produce `debt_items` and `bail_out` fields before any parent command can consume them. This is the foundational change.
-2. **Slice 2** — Mark and cut get their debt sections and population instructions. These are the primary consumers of Slice 1's output and the most important pipeline to validate early.
-3. **Slice 3** — Remaining templates (strike, ignite, render) can land in parallel with or after Slice 2; they are independent of it. Recommended after Slice 2 to let the mark/cut debt section format stabilize first.
-4. **Slice 4** — Debt inheritance and bail-out require both Slice 1 (the `bail_out` field) and Slice 2 (the tasks template debt section structure) to be complete before wiring inheritance into cut.
-5. **Slice 5** — Phase 0 resolution, audit checklists, and tests depend on all prior slices. Tests added here validate changes from Slices 1–4.
+- [x] **Slice 1** — The clarify triage engine must produce `debt_items` and `bail_out` fields before any parent command can consume them. This is the foundational change.
+- [x] **Slice 2** — Mark and cut get their debt sections and population instructions. These are the primary consumers of Slice 1's output and the most important pipeline to validate early.
+- [ ] **Slice 3** — Remaining templates (strike, ignite, render) can land in parallel with or after Slice 2; they are independent of it. Recommended after Slice 2 to let the mark/cut debt section format stabilize first.
+- [ ] **Slice 4** — Debt inheritance and bail-out require both Slice 1 (the `bail_out` field) and Slice 2 (the tasks template debt section structure) to be complete before wiring inheritance into cut.
+- [ ] **Slice 5** — Phase 0 resolution, audit checklists, and tests depend on all prior slices. Tests added here validate changes from Slices 1–4.
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-08-003-reduce-interaction-friction/reduce-interaction-friction.spec.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/reduce-interaction-friction.spec.md
@@ -222,6 +222,15 @@ returned as a finding for the parent command to act on.
   runs non-interactively, applies changes, creates a new PR with the
   diff from the previous version.
 
+## Story Dependency Order
+
+Recommended implementation sequence:
+
+- [x] **User Story 1: Relax Critical Decision Blocking** — Smallest, most contained change; prerequisite for one-shot mode since Critical items always blocking prevents one-shot from fully proceeding. → `specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md`
+- [x] **User Story 2: Track Specification Debt** — Foundational for one-shot mode; without it, unresolved items would be silently dropped. Depends on US1 triage matrix update. → `specs/2026-04-08-003-reduce-interaction-friction/02-track-specification-debt.tasks.md`
+- [ ] **User Story 3: One-Shot Planning Workflows** — Core friction-reduction change; depends on US1 (relaxed triage) and US2 (debt tracking) to maintain quality without gates.
+- [ ] **User Story 4: Unified Review Pattern** — Quality assurance layer for one-shot; depends on US3 (one-shot mode existing) to add the automated review before PR creation.
+
 ## Requirements
 
 ### Functional Requirements
@@ -314,8 +323,7 @@ returned as a finding for the parent command to act on.
 
 ## Specification Debt
 
-_No specification debt items. All clarification questions were resolved during
-the session._
+_None — all ambiguities resolved._
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary
- Primary outcome: Update smithy agent-skill deployment to version 0.2.8
- Notable behaviour changes: Enhanced mark, cut, ignite commands with dependency ordering and progress tracking; updated pr-review skill scripts
- Follow-up work deferred (if any): None

## Context
- Routine version bump deploying latest smithy template improvements to this repo.
- Unlocks dependency ordering in spec workflows and progress tracking in task files.

## Implementation Notes
- Manifest version bumped from 0.2.7 to 0.2.8
- Updated commands: smithy.audit, smithy.cut, smithy.ignite, smithy.mark
- Updated skill: smithy.pr-review (SKILL.md and shell scripts)

## Risks & Mitigations
- Risk: Template changes alter workflow behavior | Mitigation: Changes are additive (new sections/features), no existing behavior removed

## Rollback Plan
- Run `smithy update` targeting 0.2.7 to restore previous templates

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npx tsc --noEmit`)

### Template Generation
- [x] Claude Commands: `.claude/commands/` file content updated
- [x] Claude Skills: `.claude/skills/` file content updated
