### PR TITLE
Wire structural validator into eval orchestrator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,6 @@ The evals framework (under `evals/`) — implemented:
 
 Pending:
 - YAML-defined scenario loading (`evals/cases/`)
-- Wiring validator into the orchestrator (`run-evals.ts` Slice 2)
 
 See **[specs/2026-04-06-003-smithy-evals-framework/](specs/2026-04-06-003-smithy-evals-framework/)** for the feature specification.
 

--- a/evals/run-evals.ts
+++ b/evals/run-evals.ts
@@ -88,25 +88,27 @@ console.log(`  Fixture: ${fixtureDir}`);
 console.log(`  Timeout: ${timeoutSec}s`);
 console.log('');
 
+let output;
 try {
-  const output = await runScenario(scenario, fixtureDir);
+  output = await runScenario(scenario, fixtureDir);
+} catch (err) {
+  console.error(`Error running scenario: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+}
 
-  const status = output.timed_out
-    ? 'TIMEOUT'
-    : output.exit_code !== 0
-      ? `FAIL (exit ${output.exit_code})`
-      : 'OK';
+console.log(`  Duration:  ${output.duration_ms}ms`);
+if (output.timed_out) console.log('  Timed out: yes');
+if (output.exit_code !== 0) console.log(`  Exit code: ${output.exit_code}`);
+console.log(`  Text length: ${output.extracted_text.length} chars`);
+console.log(`  Stream events: ${output.stream_events.length}`);
 
-  console.log(`Process: ${status}`);
-  console.log(`  Duration:  ${output.duration_ms}ms`);
-  console.log(`  Text length: ${output.extracted_text.length} chars`);
-  console.log(`  Stream events: ${output.stream_events.length}`);
+// ---------------------------------------------------------------------------
+// Structural validation (FR-005, FR-006)
+// ---------------------------------------------------------------------------
 
-  // ---------------------------------------------------------------------------
-  // Structural validation (FR-005, FR-006)
-  // ---------------------------------------------------------------------------
-
-  const structuralChecks: CheckResult[] = validateStructure(
+let allChecks: CheckResult[];
+try {
+  const structuralChecks = validateStructure(
     output.extracted_text,
     scenario.structural_expectations,
   );
@@ -121,29 +123,29 @@ try {
     );
   }
 
-  const allChecks = [...structuralChecks, ...subAgentChecks];
-
-  console.log('');
-  console.log('Checks:');
-  for (const check of allChecks) {
-    if (check.passed) {
-      console.log(`  [PASS] ${check.check_name}`);
-    } else {
-      console.log(
-        `  [FAIL] ${check.check_name} — expected: ${check.expected}, actual: ${check.actual}`,
-      );
-    }
-  }
-
-  const anyCheckFailed = allChecks.some((c) => !c.passed);
-  const exitCode =
-    output.exit_code !== 0 || output.timed_out || anyCheckFailed ? 1 : 0;
-
-  console.log('');
-  console.log(`Result: ${exitCode === 0 ? 'PASS' : 'FAIL'}`);
-
-  process.exit(exitCode);
+  allChecks = [...structuralChecks, ...subAgentChecks];
 } catch (err) {
-  console.error(`Error running scenario: ${err instanceof Error ? err.message : String(err)}`);
+  console.error(`Validation error: ${err instanceof Error ? err.message : String(err)}`);
   process.exit(1);
 }
+
+console.log('');
+console.log('Checks:');
+for (const check of allChecks) {
+  if (check.passed) {
+    console.log(`  [PASS] ${check.check_name}`);
+  } else {
+    console.log(
+      `  [FAIL] ${check.check_name} — expected: ${check.expected}, actual: ${check.actual}`,
+    );
+  }
+}
+
+const anyCheckFailed = allChecks.some((c) => !c.passed);
+const exitCode =
+  output.exit_code !== 0 || output.timed_out || anyCheckFailed ? 1 : 0;
+
+console.log('');
+console.log(`Result: ${exitCode === 0 ? 'PASS' : 'FAIL'}`);
+
+process.exit(exitCode);

--- a/evals/run-evals.ts
+++ b/evals/run-evals.ts
@@ -2,12 +2,15 @@
  * Minimal orchestrator entry point for the Smithy evals framework.
  *
  * Accepts --fixture and --timeout CLI flags; calls preflight() on startup;
- * runs a single hardcoded smoke-test scenario and prints a brief result summary.
+ * runs a single hardcoded smoke-test scenario, validates output structure,
+ * prints per-check pass/fail results to stdout, and exits with code 1 if
+ * any check fails or the process exits non-zero or times out.
  *
  * US7 will replace the hardcoded scenario with YAML loading.
  * US9 will extend the result summary into a full EvalReport.
  *
- * Addresses: FR-003 (fail-fast on startup), FR-010; Acceptance Scenario 3.3
+ * Addresses: FR-003 (fail-fast on startup), FR-005, FR-006, FR-010;
+ * Acceptance Scenarios 3.3, 4.1, 4.2, 4.3
  */
 
 import { parseArgs } from 'node:util';

--- a/evals/run-evals.ts
+++ b/evals/run-evals.ts
@@ -97,7 +97,7 @@ try {
       ? `FAIL (exit ${output.exit_code})`
       : 'OK';
 
-  console.log(`Result: ${status}`);
+  console.log(`Process: ${status}`);
   console.log(`  Duration:  ${output.duration_ms}ms`);
   console.log(`  Text length: ${output.extracted_text.length} chars`);
   console.log(`  Stream events: ${output.stream_events.length}`);
@@ -138,6 +138,9 @@ try {
   const anyCheckFailed = allChecks.some((c) => !c.passed);
   const exitCode =
     output.exit_code !== 0 || output.timed_out || anyCheckFailed ? 1 : 0;
+
+  console.log('');
+  console.log(`Result: ${exitCode === 0 ? 'PASS' : 'FAIL'}`);
 
   process.exit(exitCode);
 } catch (err) {

--- a/evals/run-evals.ts
+++ b/evals/run-evals.ts
@@ -15,7 +15,9 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { preflight, runScenario } from './lib/runner.js';
-import type { EvalScenario } from './lib/types.js';
+import { validateStructure, verifySubAgents } from './lib/structural.js';
+import { extractSubAgentDispatches } from './lib/parse-stream.js';
+import type { CheckResult, EvalScenario } from './lib/types.js';
 
 // ---------------------------------------------------------------------------
 // CLI flags
@@ -97,7 +99,44 @@ try {
   console.log(`  Text length: ${output.extracted_text.length} chars`);
   console.log(`  Stream events: ${output.stream_events.length}`);
 
-  process.exit(output.exit_code === 0 && !output.timed_out ? 0 : 1);
+  // ---------------------------------------------------------------------------
+  // Structural validation (FR-005, FR-006)
+  // ---------------------------------------------------------------------------
+
+  const structuralChecks: CheckResult[] = validateStructure(
+    output.extracted_text,
+    scenario.structural_expectations,
+  );
+
+  let subAgentChecks: CheckResult[] = [];
+  if (scenario.sub_agent_evidence && scenario.sub_agent_evidence.length > 0) {
+    const dispatches = extractSubAgentDispatches(output.stream_events);
+    subAgentChecks = verifySubAgents(
+      output.extracted_text,
+      dispatches,
+      scenario.sub_agent_evidence,
+    );
+  }
+
+  const allChecks = [...structuralChecks, ...subAgentChecks];
+
+  console.log('');
+  console.log('Checks:');
+  for (const check of allChecks) {
+    if (check.passed) {
+      console.log(`  [PASS] ${check.check_name}`);
+    } else {
+      console.log(
+        `  [FAIL] ${check.check_name} — expected: ${check.expected}, actual: ${check.actual}`,
+      );
+    }
+  }
+
+  const anyCheckFailed = allChecks.some((c) => !c.passed);
+  const exitCode =
+    output.exit_code !== 0 || output.timed_out || anyCheckFailed ? 1 : 0;
+
+  process.exit(exitCode);
 } catch (err) {
   console.error(`Error running scenario: ${err instanceof Error ? err.message : String(err)}`);
   process.exit(1);

--- a/specs/2026-04-06-003-smithy-evals-framework/04-validate-output-structure.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/04-validate-output-structure.tasks.md
@@ -37,7 +37,7 @@
 
 ### Tasks
 
-- [ ] Update `evals/run-evals.ts` to import `validateStructure` and `verifySubAgents` from `./lib/structural.js` and `extractSubAgentDispatches` from `./lib/parse-stream.js`. After `runScenario` returns, call `validateStructure(output.extracted_text, scenario.structural_expectations)` to obtain `structuralChecks: CheckResult[]`. If `scenario.sub_agent_evidence` is defined and non-empty, call `extractSubAgentDispatches(output.stream_events)` then `verifySubAgents(output.extracted_text, dispatches, scenario.sub_agent_evidence)` to obtain `subAgentChecks: CheckResult[]`. Print each `CheckResult` to stdout using the format `  [PASS] <check_name>` or `  [FAIL] <check_name> — expected: <expected>, actual: <actual>`. Determine the final exit code as `1` if (a) the process exited with a non-zero code, (b) it timed out, or (c) any `CheckResult` has `passed: false`; otherwise `0`. The existing hardcoded smoke-test scenario (`required_headings: ['## Plan']`) remains unchanged — updating it to reflect actual strike output is a US5 concern, and the `[FAIL]` from a missing `## Plan` heading demonstrates the validator is working correctly.
+- [x] Update `evals/run-evals.ts` to import `validateStructure` and `verifySubAgents` from `./lib/structural.js` and `extractSubAgentDispatches` from `./lib/parse-stream.js`. After `runScenario` returns, call `validateStructure(output.extracted_text, scenario.structural_expectations)` to obtain `structuralChecks: CheckResult[]`. If `scenario.sub_agent_evidence` is defined and non-empty, call `extractSubAgentDispatches(output.stream_events)` then `verifySubAgents(output.extracted_text, dispatches, scenario.sub_agent_evidence)` to obtain `subAgentChecks: CheckResult[]`. Print each `CheckResult` to stdout using the format `  [PASS] <check_name>` or `  [FAIL] <check_name> — expected: <expected>, actual: <actual>`. Determine the final exit code as `1` if (a) the process exited with a non-zero code, (b) it timed out, or (c) any `CheckResult` has `passed: false`; otherwise `0`. The existing hardcoded smoke-test scenario (`required_headings: ['## Plan']`) remains unchanged — updating it to reflect actual strike output is a US5 concern, and the `[FAIL]` from a missing `## Plan` heading demonstrates the validator is working correctly.
 
 **PR Outcome**: `npm run eval` prints per-check structural results alongside the scenario status. Structural regressions surface as named `[FAIL]` entries with actionable context. Exit code reflects both process health and validation outcomes.
 
@@ -54,7 +54,7 @@ _None — all ambiguities resolved._
 Recommended implementation sequence:
 
 - [x] **Slice 1: StructuralValidator and SubAgentVerifier Library** — pure module with no runtime dependencies; establishes the vitest config for all evals tests; Slice 2 imports from it.
-- [ ] **Slice 2: Wire Validator into the Orchestrator** — depends on Slice 1 exports; narrow orchestrator change that delivers the user-visible outcome.
+- [x] **Slice 2: Wire Validator into the Orchestrator** — depends on Slice 1 exports; narrow orchestrator change that delivers the user-visible outcome.
 
 ### Cross-Story Dependencies
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,7 +14,7 @@ Smithy's testing covers three tiers (see [CONTRIBUTING.md](../CONTRIBUTING.md#te
 |------|--------|-------------|
 | [Agent.tests.md](Agent.tests.md) | Claude Code agent or developer in a Claude Code session | Verifies deployed prompts, slash commands, permissions, stale cleanup, and sub-agent output structure |
 | [Manual.tests.md](Manual.tests.md) | Developer at an interactive terminal | Verifies Inquirer-based prompts that cannot be driven programmatically |
-| `evals/` (planned) | Developer running `npm run eval` locally | Executes skills via `claude -p` headless mode against a reference fixture, validates output structure |
+| `evals/` | Developer running `npm run eval` locally | Executes skills via `claude -p` headless mode against a reference fixture, validates output structure |
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- **Primary outcome:** The eval orchestrator now validates output structure against scenario expectations and reports per-check pass/fail results to stdout, with exit code reflecting validation outcomes.
- **Notable behaviour changes:** `npm run eval` now prints `[PASS]` / `[FAIL]` lines for each structural check and sub-agent verification, and exits with code 1 if any check fails (in addition to process exit code or timeout).
- **Follow-up work deferred:** YAML-defined scenario loading (US7) and full EvalReport generation (US9) remain planned.

## Context
This implements **Slice 2** of FR-005/FR-006 (output structure validation) in the Smithy evals framework specification ([specs/2026-04-06-003-smithy-evals-framework/04-validate-output-structure.tasks.md](specs/2026-04-06-003-smithy-evals-framework/04-validate-output-structure.tasks.md)).

Slice 1 (StructuralValidator and SubAgentVerifier library) was completed in a prior commit. This slice wires those validators into `run-evals.ts` to deliver the user-visible outcome: developers running `npm run eval` now see actionable per-check validation results, enabling rapid detection of structural regressions in skill output.

Addresses acceptance scenarios 4.1–4.3 (structural validation with expected/actual context) and enables fail-fast feedback on output quality.

## Implementation Notes

**Key changes to `evals/run-evals.ts`:**
1. Added imports for `validateStructure` and `verifySubAgents` (from `./lib/structural.js`) and `extractSubAgentDispatches` (from `./lib/parse-stream.js`).
2. After `runScenario()` completes, call `validateStructure(output.extracted_text, scenario.structural_expectations)` to obtain structural checks.
3. If `scenario.sub_agent_evidence` is defined and non-empty, extract sub-agent dispatches from stream events and call `verifySubAgents()` to obtain additional checks.
4. Print each `CheckResult` in the format `  [PASS] <check_name>` or `  [FAIL] <check_name> — expected: <expected>, actual: <actual>`.
5. Exit code is now `1` if (a) process exited non-zero, (b) timed out, or (c) any check failed; otherwise `0`.

**Architectural notes:**
- The hardcoded smoke-test scenario (`required_headings: ['## Plan']`) is intentionally unchanged; it will fail until actual strike output includes that heading (US5 concern).
- Validation is synchronous and runs after scenario completion, before exit.
- No new runtime dependencies introduced; uses existing types (`CheckResult`, `EvalScenario`).

**Impacted modules:**
- `evals/run-evals.ts` (orchestrator entry point)
- Documentation updates: `tests/README.md` (evals tier no longer marked "planned"), `CONTRIBUTING.md` (removed "Wiring validator" from pending list)

## Risks & Mitigations

| Risk | Mitigation |
|------|-----------|
| Hardcoded scenario fails on every run, masking real issues | Intentional; demonstrates validator is working. US5 will update scenario to match actual output. Developers can ignore `[FAIL]` for `## Plan` heading during development. |
| Exit code change breaks CI/CD pipelines expecting 0 | Documented in spec; pipelines should expect exit code 1 until scenario is updated (US5). |

## Rollback Plan
- Revert `evals/run-evals.ts` to previous version (removes validation calls and restores simple exit code logic).
- Revert documentation changes in `tests/README.md` and `CONTRIBUTING.md`.
- No data or configuration changes; safe to roll back at any time.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npx tsc --noEmit`)
- [x] Existing evals tests pass (

https://claude.ai/code/session_01CEDG2GpfnT8yutMq5c5FCr