### PR TITLE
Add Specification Debt sections to strike, ignite, and render templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,8 @@ Smithy provides a collection of workflow prompts, each for a different stage/sty
 
 - **smithy-plan** — Design sub-agent: explores codebase, proposes approach, identifies risks and tradeoffs. Runs in parallel with focus lenses for competing perspectives (used by strike in agent mode)
 - **smithy-reconcile** — Reconciliation sub-agent: synthesizes outputs from multiple competing smithy-plan runs into a single coherent plan (used by strike in agent mode)
-- **smithy-clarify** — Ambiguity scanning and assumption/question triage (used by strike, ignite, mark, cut, render)
-- **smithy-refine** — Artifact review and refinement questions (used by mark, cut, ignite, render in Phase 0)
+- **smithy-clarify** — Ambiguity scanning and triage into assumptions and specification debt (used by strike, ignite, mark, cut, render)
+- **smithy-refine** — Artifact review and refinement findings (used by mark, cut, ignite, render in Phase 0)
 - **smithy-implement** — TDD implementation: failing test → code → commit (used by forge)
 - **smithy-review** — Code review with auto-fix (used by forge)
 - **smithy-scout** — Pre-planning consistency scan (used by render, mark, cut)

--- a/specs/2026-04-08-003-reduce-interaction-friction/02-track-specification-debt.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/02-track-specification-debt.tasks.md
@@ -74,10 +74,10 @@ Primary changes are in `src/templates/agent-skills/agents/smithy.clarify.prompt`
 
 ### Tasks
 
-- [ ] In `src/templates/agent-skills/commands/smithy.strike.prompt`, insert `## Specification Debt` into the Phase 4 strike document template between `## Decisions` and `## Single Slice` (around line 134). The strike document has no `## Assumptions` section; positioning debt after Decisions is the structural analogue — Decisions are resolved ambiguities, Specification Debt is unresolved ones. Use the same debt table structure as in Slice 2.
-- [ ] In `src/templates/agent-skills/commands/smithy.ignite.prompt`, insert `## Specification Debt` into the Phase 3 RFC template between `## Open Questions` and `## Milestones` (around line 209). RFCs use Open Questions rather than Assumptions; debt is conceptually adjacent to open questions. Use the same debt table structure.
-- [ ] In `src/templates/agent-skills/commands/smithy.render.prompt`, insert `## Specification Debt` into the Phase 3 feature map template before `## Cross-Milestone Dependencies` (after the last `### Feature N` entry, around line 247). Feature maps have neither `## Assumptions` nor `## Out of Scope` sections. This placement is a documented variant of FR-006's ordering rule for templates that do not follow the Assumptions → Debt → Out of Scope structure. Add a brief inline comment in the template: `<!-- Specification Debt appears here for templates without ## Assumptions sections -->`.
-- [ ] Add Tier 2 test assertions in `src/templates.test.ts` verifying each of strike, ignite, and render templates contains `## Specification Debt`.
+- [x] In `src/templates/agent-skills/commands/smithy.strike.prompt`, insert `## Specification Debt` into the Phase 4 strike document template between `## Decisions` and `## Single Slice` (around line 134). The strike document has no `## Assumptions` section; positioning debt after Decisions is the structural analogue — Decisions are resolved ambiguities, Specification Debt is unresolved ones. Use the same debt table structure as in Slice 2.
+- [x] In `src/templates/agent-skills/commands/smithy.ignite.prompt`, insert `## Specification Debt` into the Phase 3 RFC template between `## Open Questions` and `## Milestones` (around line 209). RFCs use Open Questions rather than Assumptions; debt is conceptually adjacent to open questions. Use the same debt table structure.
+- [x] In `src/templates/agent-skills/commands/smithy.render.prompt`, insert `## Specification Debt` into the Phase 3 feature map template before `## Cross-Milestone Dependencies` (after the last `### Feature N` entry, around line 247). Feature maps have neither `## Assumptions` nor `## Out of Scope` sections. This placement is a documented variant of FR-006's ordering rule for templates that do not follow the Assumptions → Debt → Out of Scope structure. Add a brief inline comment in the template: `<!-- Specification Debt appears here for templates without ## Assumptions sections -->`.
+- [x] Add Tier 2 test assertions in `src/templates.test.ts` verifying each of strike, ignite, and render templates contains `## Specification Debt`.
 
 **PR Outcome**: All five planning artifact templates (spec, tasks, strike, RFC, feature map) contain a `## Specification Debt` section. FR-005 and SC-003 are satisfied.
 
@@ -154,7 +154,7 @@ Recommended implementation sequence:
 
 - [x] **Slice 1** — The clarify triage engine must produce `debt_items` and `bail_out` fields before any parent command can consume them. This is the foundational change.
 - [x] **Slice 2** — Mark and cut get their debt sections and population instructions. These are the primary consumers of Slice 1's output and the most important pipeline to validate early.
-- [ ] **Slice 3** — Remaining templates (strike, ignite, render) can land in parallel with or after Slice 2; they are independent of it. Recommended after Slice 2 to let the mark/cut debt section format stabilize first.
+- [x] **Slice 3** — Remaining templates (strike, ignite, render) can land in parallel with or after Slice 2; they are independent of it. Recommended after Slice 2 to let the mark/cut debt section format stabilize first.
 - [x] **Slice 4** — Debt inheritance and bail-out require both Slice 1 (the `bail_out` field) and Slice 2 (the tasks template debt section structure) to be complete before wiring inheritance into cut.
 - [ ] **Slice 5** — Phase 0 resolution, audit checklists, and tests depend on all prior slices. Tests added here validate changes from Slices 1–4.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -350,7 +350,7 @@ describe('getComposedTemplates', () => {
     const markdownBlockMatch = ignite.match(/```markdown\r?\n([\s\S]*?)\r?\n```/);
     expect(markdownBlockMatch).not.toBeNull();
 
-    const markdownBlock = markdownBlockMatch![1];
+    const markdownBlock = markdownBlockMatch![1]!;
     const openQuestionsIdx = markdownBlock.indexOf('\n## Open Questions\n');
     const debtIdx = markdownBlock.indexOf('\n## Specification Debt\n');
     const milestonesIdx = markdownBlock.indexOf('\n## Milestones\n');

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -345,9 +345,15 @@ describe('getComposedTemplates', () => {
     const ignite = composed.commands.get('smithy.ignite.md')!;
     expect(ignite).toBeDefined();
 
-    const openQuestionsIdx = ignite.indexOf('## Open Questions');
-    const debtIdx = ignite.indexOf('## Specification Debt');
-    const milestonesIdx = ignite.indexOf('## Milestones');
+    // Scope assertions to the markdown code fence block to avoid matching
+    // instructional text that references these headings in backticks
+    const markdownBlockMatch = ignite.match(/```markdown\r?\n([\s\S]*?)\r?\n```/);
+    expect(markdownBlockMatch).not.toBeNull();
+
+    const markdownBlock = markdownBlockMatch![1];
+    const openQuestionsIdx = markdownBlock.indexOf('\n## Open Questions\n');
+    const debtIdx = markdownBlock.indexOf('\n## Specification Debt\n');
+    const milestonesIdx = markdownBlock.indexOf('\n## Milestones\n');
 
     expect(openQuestionsIdx).toBeGreaterThan(-1);
     expect(debtIdx).toBeGreaterThan(-1);

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -325,6 +325,51 @@ describe('getComposedTemplates', () => {
     expect(debtIdx).toBeLessThan(dependencyIdx);
   });
 
+  it('strike template contains ## Specification Debt between ## Decisions and ## Single Slice', () => {
+    const strike = composed.commands.get('smithy.strike.md')!;
+    expect(strike).toBeDefined();
+
+    const decisionsIdx = strike.indexOf('## Decisions');
+    const debtIdx = strike.indexOf('## Specification Debt');
+    const singleSliceIdx = strike.indexOf('## Single Slice');
+
+    expect(decisionsIdx).toBeGreaterThan(-1);
+    expect(debtIdx).toBeGreaterThan(-1);
+    expect(singleSliceIdx).toBeGreaterThan(-1);
+
+    expect(debtIdx).toBeGreaterThan(decisionsIdx);
+    expect(debtIdx).toBeLessThan(singleSliceIdx);
+  });
+
+  it('ignite template contains ## Specification Debt between ## Open Questions and ## Milestones', () => {
+    const ignite = composed.commands.get('smithy.ignite.md')!;
+    expect(ignite).toBeDefined();
+
+    const openQuestionsIdx = ignite.indexOf('## Open Questions');
+    const debtIdx = ignite.indexOf('## Specification Debt');
+    const milestonesIdx = ignite.indexOf('## Milestones');
+
+    expect(openQuestionsIdx).toBeGreaterThan(-1);
+    expect(debtIdx).toBeGreaterThan(-1);
+    expect(milestonesIdx).toBeGreaterThan(-1);
+
+    expect(debtIdx).toBeGreaterThan(openQuestionsIdx);
+    expect(debtIdx).toBeLessThan(milestonesIdx);
+  });
+
+  it('render template contains ## Specification Debt before ## Cross-Milestone Dependencies', () => {
+    const render = composed.commands.get('smithy.render.md')!;
+    expect(render).toBeDefined();
+
+    const debtIdx = render.indexOf('## Specification Debt');
+    const crossMilestoneIdx = render.indexOf('## Cross-Milestone Dependencies');
+
+    expect(debtIdx).toBeGreaterThan(-1);
+    expect(crossMilestoneIdx).toBeGreaterThan(-1);
+
+    expect(debtIdx).toBeLessThan(crossMilestoneIdx);
+  });
+
   it('command templates without partials are returned as-is', () => {
     const strike = composed.commands.get('smithy.strike.md')!;
     expect(strike).toBeDefined();

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -327,6 +327,14 @@ influence downstream design decisions. Keep this at "WHAT not HOW" level.>
 - <Genuinely unresolved question 1>
 - <Genuinely unresolved question 2>
 
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | <what is unresolved> | <clarify scan category> | High | Medium | open | — |
+
+_If no debt items, write: "None — all ambiguities resolved."_
+
 ## Milestones
 
 ### Milestone 1: <Title>

--- a/src/templates/agent-skills/commands/smithy.render.prompt
+++ b/src/templates/agent-skills/commands/smithy.render.prompt
@@ -244,6 +244,15 @@ this format:
 
 <!-- Repeat for each feature -->
 
+<!-- Specification Debt appears here for templates without ## Assumptions sections -->
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | <what is unresolved> | <clarify scan category> | High | Medium | open | — |
+
+_If no debt items, write: "None — all ambiguities resolved."_
+
 ## Cross-Milestone Dependencies
 
 Direction must be either `depends on` or `depended upon by`.

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -133,6 +133,14 @@ Once approved, write a single strike document to `specs/strikes/YYYY-MM-DD-<slug
 
 <Important decisions and tradeoffs made during the interactive planning phase.>
 
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | <what is unresolved> | <clarify scan category> | High | Medium | open | — |
+
+_If no debt items, write: "None — all ambiguities resolved."_
+
 ## Single Slice
 
 **Goal**: <What this slice delivers as a standalone increment.>


### PR DESCRIPTION
## Source

- **Spec**: `specs/2026-04-08-003-reduce-interaction-friction/reduce-interaction-friction.spec.md`
- **Tasks**: `specs/2026-04-08-003-reduce-interaction-friction/02-track-specification-debt.tasks.md`

## Slice

**Slice 3: Remaining Artifact Templates — Strike, Ignite, Render**

Add `## Specification Debt` sections to the strike, ignite, and render artifact templates so that all five planning artifact types satisfy FR-005.

## Addresses

- **FR-005**: All planning templates MUST include `## Specification Debt` section
- **SC-003**: Every planning artifact contains a `## Specification Debt` section (even if empty)
- **Acceptance Scenario 2.2** (completing all 5 templates)

## Tasks completed

- [x] Insert `## Specification Debt` into strike template between `## Decisions` and `## Single Slice`
- [x] Insert `## Specification Debt` into ignite RFC template between `## Open Questions` and `## Milestones`
- [x] Insert `## Specification Debt` into render feature map template before `## Cross-Milestone Dependencies` (with HTML comment for templates without `## Assumptions` sections)
- [x] Add Tier 2 test assertions verifying section presence and ordering for strike, ignite, and render

## Review

No review findings. The changes are scoped template text insertions with consistent debt table structure matching the format established in Slice 2 (mark/cut templates).

## Documentation

**Auto-fixes applied:**
- Updated `CLAUDE.md` sub-agent descriptions for `smithy-clarify` and `smithy-refine` to remove stale references to "questions" (pre-existing staleness from Slice 1)

**Flagged for future stories (no action needed now):**
- `smithy.strike` described as "Interactive planning" in CLAUDE.md — will become stale when Story 3 (One-Shot Planning) lands
- FR-003 in spec still says "alongside questions" — should be updated to reflect the two-category world
- `smithy-review` "auto-fix" description — will become stale when Story 4 (Unified Review Pattern) lands

## Validation

| Command | Result |
|---------|--------|
| `npm run build` | Pass — `dist/cli.js` 45.85 KB |
| `npm run typecheck` | Pass — no errors |
| `npm test` | Pass — 8 test files, 209 tests (including 3 new assertions) |

https://claude.ai/code/session_01FtW6DuMxVdWYyxqy9b18cg