### PR TITLE
Refine Out of Scope section requirements and RFC pipeline docs

### DIFF
--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.contracts.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.contracts.md
@@ -137,9 +137,10 @@ Each sub-phase follows this protocol:
 #### Process
 
 1. Read the complete `<slug>.rfc.md`
-2. Perform coherence pass (smooth tone across sections, fix cross-references)
-3. Verify all template sections are present and non-empty
-4. Rewrite the file in place
+2. Reorder sections to match the RFC template structure (sub-phases draft in execution order, which may differ from template order)
+3. Perform coherence pass (smooth tone across sections, fix cross-references)
+4. Verify all template sections are present and non-empty
+5. Rewrite the file in place
 
 ### Clarify Log Contract
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
@@ -112,13 +112,14 @@ As a developer using `smithy.ignite`, I want the RFC to always include an explic
 
 **Why this priority**: Directly addresses Issue #50. The clarification phase asks about scope but the RFC template previously had no section to receive the answer. With the template updated (Story 1) and smithy-plan dispatched for scope (Story 3), this story ensures the pipeline actually produces the section.
 
-**Independent Test**: Run `smithy.ignite` and verify the generated RFC contains a `## Out of Scope` section, even if the content is "None identified at this time."
+**Independent Test**: Verify that sub-phase 3c's dispatch to smithy-plan includes "Out of Scope" in its section assignment, and that the generated RFC contains a `## Out of Scope` section with substantive content or an explicit "None identified at this time" placeholder, positioned after Goals and before Personas.
 
 **Acceptance Scenarios**:
 
-1. **Given** the user runs `smithy.ignite` with any idea, **When** the RFC is generated, **Then** the final RFC contains a `## Out of Scope` section after the Goals section.
-2. **Given** clarification identifies items as out of scope, **When** the RFC is drafted, **Then** those items appear in the Out of Scope section.
-3. **Given** nothing is identified as out of scope during clarification, **When** the RFC is drafted, **Then** the Out of Scope section contains a placeholder (e.g., "None identified at this time") rather than being omitted.
+1. **Given** the user runs `smithy.ignite` with any idea, **When** the RFC is generated, **Then** the final RFC contains a `## Out of Scope` section after Goals and before Personas.
+2. **Given** the Out of Scope section is drafted in sub-phase 3c alongside Goals, **When** sub-phase 3c dispatches smithy-plan, **Then** smithy-plan produces an explicit Out of Scope section and the orchestrator appends it to `<slug>.rfc.md`.
+3. **Given** clarification identifies items as out of scope, **When** the RFC is drafted, **Then** those items appear in the Out of Scope section.
+4. **Given** nothing is identified as out of scope during clarification, **When** the RFC is drafted, **Then** the Out of Scope section contains a placeholder (e.g., "None identified at this time") rather than being omitted.
 
 ---
 
@@ -214,6 +215,7 @@ Recommended implementation sequence:
 
 - **`.clarify-log.md`**: Persistent file in the RFC folder that records Q&A and assumptions from each clarification session for cross-session deduplication.
 - **`smithy-prose` sub-agent**: New shared sub-agent specialized for narrative/persuasive writing. Dispatched for Summary, Motivation/Problem Statement, and other prose-heavy sections across any smithy command.
+- **`<slug>.rfc.md`**: The RFC file itself, written to incrementally by the piecewise pipeline. Each sub-phase (3a-3f) appends its sections; the harmonize step (3g) rewrites in place. Also serves as the resume checkpoint for interrupted sessions.
 
 ## Assumptions
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
@@ -215,7 +215,7 @@ Recommended implementation sequence:
 
 - **`.clarify-log.md`**: Persistent file in the RFC folder that records Q&A and assumptions from each clarification session for cross-session deduplication.
 - **`smithy-prose` sub-agent**: New shared sub-agent specialized for narrative/persuasive writing. Dispatched for Summary, Motivation/Problem Statement, and other prose-heavy sections across any smithy command.
-- **`<slug>.rfc.md`**: The RFC file itself, written to incrementally by the piecewise pipeline. Each sub-phase (3a-3f) appends its sections; the harmonize step (3g) rewrites in place. Also serves as the resume checkpoint for interrupted sessions.
+- **`<slug>.rfc.md`**: The RFC file itself, written incrementally by the piecewise pipeline. Each sub-phase (3a-3f) appends its sections; the harmonize step (3g) rewrites in place. Also serves as the resume checkpoint for interrupted sessions.
 
 ## Assumptions
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
@@ -200,7 +200,7 @@ Recommended implementation sequence:
 - **FR-001**: The system MUST replace the monolithic Phase 3 (Draft RFC) with sequential sub-phases 3a through 3g, each producing one or more RFC sections.
 - **FR-002**: Each sub-phase (3a-3f) MUST append its output directly to `<slug>.rfc.md` before the next sub-phase begins.
 - **FR-003**: Each sub-phase (3b-3f) MUST pass the path to the accumulating `<slug>.rfc.md` to its sub-agent as context, ensuring prior sections inform the current one without relying on the context window.
-- **FR-004**: Sub-phase 3g (Harmonize) MUST read the complete `<slug>.rfc.md`, perform a coherence pass to smooth tone and fix cross-references, and rewrite the file in place.
+- **FR-004**: Sub-phase 3g (Harmonize) MUST read the complete `<slug>.rfc.md`, reorder sections to match the RFC template structure, perform a coherence pass to smooth tone and fix cross-references, and rewrite the file in place.
 - **FR-005**: The RFC template MUST include a mandatory `## Personas` section positioned after `## Out of Scope` and before `## Proposal`.
 - **FR-006**: The RFC template MUST include a mandatory `## Out of Scope` section positioned after Goals and before Personas.
 - **FR-007**: A new shared `smithy-prose` sub-agent MUST be created at `src/templates/agent-skills/agents/smithy.prose.prompt` for drafting narrative/persuasive RFC sections (Summary, Motivation/Problem Statement).


### PR DESCRIPTION
## Summary
- **Primary outcome**: Clarified the Independent Test and Acceptance Scenarios for Story 4 (Out of Scope section) to explicitly require sub-phase 3c dispatch integration and section positioning; documented the RFC file as a persistent, incrementally-written artifact in the piecewise pipeline.
- **Notable behaviour changes**: Out of Scope section must now be positioned after Goals and before Personas (not just after Goals); sub-phase 3c must explicitly dispatch smithy-plan with Out of Scope in its section assignment.
- **Follow-up work deferred**: Implementation of sub-phase 3c dispatch logic and smithy-plan integration (covered in Story 3).

## Context
- **Why now**: Addresses Issue #50 and ensures the refactored ignite workflow spec is precise about section ordering and orchestration responsibilities before implementation begins.
- **User story**: Developers using `smithy.ignite` need a guaranteed Out of Scope section in generated RFCs, with clear positioning and content handling (substantive or explicit placeholder).

## Implementation Notes
- **Key changes**:
  1. Updated Independent Test to verify sub-phase 3c dispatch includes "Out of Scope" in section assignment and that the final RFC contains the section with proper positioning (after Goals, before Personas).
  2. Expanded Acceptance Scenarios from 3 to 4 cases, adding explicit scenario for sub-phase 3c dispatch and smithy-plan orchestration.
  3. Added `<slug>.rfc.md` to the Artifacts section, documenting it as the persistent RFC file written incrementally by the piecewise pipeline (sub-phases 3a–3f append, 3g harmonizes) and as the resume checkpoint for interrupted sessions.

- **Architectural rationale**: 
  - Explicit section positioning (after Goals, before Personas) ensures consistent RFC structure across all generated documents.
  - Sub-phase 3c dispatch requirement clarifies the orchestration boundary: the clarification phase identifies scope, sub-phase 3c requests smithy-plan to draft the section, and the orchestrator appends it to the RFC file.
  - Documenting `<slug>.rfc.md` as a persistent, incrementally-written artifact makes the piecewise pipeline's resume mechanism explicit.

- **Impacted modules**: Specification only; no code changes. Implementation will affect:
  - Orchestrator logic (sub-phase 3c dispatch and section appending)
  - smithy-plan prompt/dispatch configuration (Out of Scope section assignment)
  - RFC template (section ordering)

## Risks & Mitigations
| Risk | Mitigation |
|------|-----------|
| Section positioning requirement (after Goals, before Personas) may conflict with existing RFC templates or smithy-plan output order. | Validate RFC template and smithy-plan output during Story 1 (template update) and Story 3 (smithy-plan dispatch) implementation. |
| Incrementally-written RFC file may cause merge conflicts or data loss if multiple sub-phases write concurrently. | Implement file locking or sequential sub-phase execution in the orchestrator. |

## Rollback Plan
- This is a specification document change only. Rollback: revert the diff to restore the previous Independent Test and Acceptance Scenarios.

## Testing
- **No testing needed**: This is a specification refinement. Automated tests will be added during implementation of Stories 1, 3, and 4.

## Issue
- Closes #50

https://claude.ai/code/session_01RXtu8QKg3ijNn3LyaDpKJT