### PR TITLE
Add automated Smithy template upgrade workflow

### DIFF
--- a/.github/workflows/smithy-upgrade.yml
+++ b/.github/workflows/smithy-upgrade.yml
@@ -1,0 +1,61 @@
+name: Smithy self-upgrade
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Publish to npm"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  upgrade:
+    # workflow_run fires on all completions; only act on successful publishes.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      - name: Install latest Smithy CLI
+        run: npm install -g @balexda/smithy@latest
+
+      - name: Show installed version
+        run: smithy --version
+
+      - name: Run smithy update
+        run: smithy update -y
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: smithy/auto-upgrade
+          delete-branch: true
+          commit-message: "chore: upgrade Smithy templates"
+          title: "chore: upgrade Smithy templates to latest"
+          body: |
+            Automated upgrade run by `.github/workflows/smithy-upgrade.yml`.
+
+            - Installed `@balexda/smithy@latest` globally
+            - Ran `smithy update -y` against the repo manifest
+
+            Review the diff in `.claude/` and `.smithy/smithy-manifest.json`
+            before merging.
+
+            > Note: this workflow requires *Settings → Actions → General →
+            > Workflow permissions → "Allow GitHub Actions to create and
+            > approve pull requests"* to be enabled.
+          labels: |
+            smithy-upgrade
+            automated


### PR DESCRIPTION
## Summary
- Primary outcome: Automate Smithy template upgrades via scheduled GitHub Actions workflow
- Notable behaviour changes: Repository will automatically create PRs when new Smithy versions are published
- Follow-up work deferred: None

## Context
This workflow enables the repository to stay synchronized with the latest Smithy CLI templates without manual intervention. It triggers either on-demand (via `workflow_dispatch`) or automatically after successful npm package publication, reducing maintenance burden and ensuring templates remain current.

## Implementation Notes
- **Workflow triggers**: Manual dispatch or automatic trigger after "Publish to npm" workflow completes successfully
- **Key steps**:
  1. Checks out repository code
  2. Sets up Node.js 24 with npm caching
  3. Installs latest `@balexda/smithy` CLI globally
  4. Runs `smithy update -y` to upgrade templates
  5. Creates a pull request with the changes via `peter-evans/create-pull-request@v7`
- **PR details**: Auto-generated PRs target `smithy/auto-upgrade` branch with clear commit message and body explaining the changes
- **Permissions**: Requires GitHub Actions to have `contents: write` and `pull-requests: write` permissions (must be enabled in repository settings)
- **Impacted areas**: `.claude/`, `.smithy/smithy-manifest.json`, and any other template directories managed by Smithy

## Risks & Mitigations
| Risk | Mitigation |
|------|-----------|
| Workflow fails silently if Smithy CLI is unavailable | Workflow includes explicit version check step (`smithy --version`) to catch installation failures early |
| PR created with breaking template changes | PR body explicitly requests manual review of diffs before merging; labels help with triage |
| Workflow permissions not enabled | Documentation in PR body notes the required GitHub Actions permission setting |

## Rollback Plan
- Delete `.github/workflows/smithy-upgrade.yml` to disable the workflow
- Close any auto-generated PRs without merging
- No data or code state changes required; workflow is purely additive

## Testing
- No testing needed; this is a workflow configuration file that will be validated by GitHub Actions on first execution
- Workflow can be tested manually via `workflow_dispatch` trigger before relying on automatic publication trigger

https://claude.ai/code/session_01QKrx6JNvmXKwCH9a1Nnr7R