### PR TITLE
Fix Smithy CLI version resolution in upgrade workflow

### DIFF
--- a/.claude/agents/smithy.clarify.md
+++ b/.claude/agents/smithy.clarify.md
@@ -132,7 +132,7 @@ Pipeline proceeds with all items as assumptions. Empty debt list returned.
 | "Whether webhooks are synchronous or async" — no prior art | Low | Debt item |
 | **Assumptions:** 0 | | |
 
-Zero assumptions. All scope is uncertain. Bail-out assessment applies (see Rules).
+Zero assumptions. All scope is uncertain. Bail-out assessment applies (see Step 3).
 
 **(c) Mixed → assumptions block + non-empty debt list**
 
@@ -143,6 +143,19 @@ Zero assumptions. All scope is uncertain. Bail-out assessment applies (see Rules
 | "Rate limit policy" — no existing policy found | Low | Debt item |
 
 Assumptions block contains one item. Debt list contains two items.
+
+### Bail-out assessment
+
+After categorizing debt items, assess whether debt scope would hollow out the
+artifact. If the majority of Key Entities would remain undefined, or the
+majority of user stories cannot be meaningfully specified due to debt items,
+set `bail_out: true`. Treat 50% as a rough calibration, not a hard threshold —
+apply judgment about whether the artifact would be load-bearing without the
+missing information. When bail_out is true, set `bail_out_summary` to: "These
+unresolved ambiguities cover too much scope to produce a reliable artifact.
+Please provide more information on the items above, or narrow the scope, then
+re-run." The debt table is already in `debt_items` — do not duplicate it in
+`bail_out_summary`.
 
 ---
 
@@ -184,15 +197,8 @@ Incorporate any changes, then return the summary to the parent agent.
      `bail_out` is true. The full debt table is already in `debt_items`; this
      field carries the guidance message only.
   The parent agent uses this summary to continue its next phase.
-- **Bail-out assessment.** After categorizing debt items, assess whether debt
-  scope would hollow out the artifact. If the majority of Key Entities would
-  remain undefined, or the majority of user stories cannot be meaningfully
-  specified due to debt items, set `bail_out: true`. Treat 50% as a rough
-  calibration, not a hard threshold — apply judgment about whether the artifact
-  would be load-bearing without the missing information. When bail_out is true,
-  set `bail_out_summary` to: "These unresolved ambiguities cover too much scope
-  to produce a reliable artifact. Please provide more information on the items
-  above, or narrow the scope, then re-run." The debt table is already in
-  `debt_items` — do not duplicate it in `bail_out_summary`.
+- **Bail-out assessment.** See the bail-out assessment subsection in Step 3.
+  After categorizing debt items, assess scope and set `bail_out: true` when the
+  artifact would be hollowed out. The full heuristic is defined in Step 3.
 - **Be transparent about uncertainty.** If confidence is Low, say so — do not
   inflate confidence to avoid asking.

--- a/.claude/agents/smithy.reconcile-slices.md
+++ b/.claude/agents/smithy.reconcile-slices.md
@@ -96,9 +96,23 @@ the task:
   rewrite it as a behavioral description on the functional task.
 - **No line-number references or exact code.** If a task references specific
   lines, rewrite to reference files/modules and desired behavior.
+- **No test mechanics.** If a task prescribes stub configurations, mock
+  objects, assertion patterns, or test helper modifications, strip them and
+  express the underlying requirement as an acceptance criterion.
+- **No restated acceptance scenarios.** If a task copies acceptance scenario
+  content from the spec instead of referencing it by ID (e.g., "AS 2.1"),
+  replace with a reference. The implement agent receives the spec file path.
+- **No exact error strings or function signatures.** If a task embeds the
+  exact text of an error message, prescribes a specific API call, or pastes
+  a function or type signature, replace with a reference to the acceptance
+  scenario or contract that defines it.
+- **Format violations.** Every task must follow the structured format: bold
+  imperative title (max 12 words), 2–3 sentence behavioral description,
+  bulleted acceptance criteria (3–7 items). If a task is a freeform paragraph
+  or exceeds 150 words, rewrite it into the format. Trim prescriptive detail.
 
-If you remove or merge tasks during this step, note it in the output so the
-parent agent can see what was cleaned up.
+If you remove, merge, or reformat tasks during this step, note it in the
+output so the parent agent can see what was cleaned up.
 
 ### Step 4: Resolve Conflicts
 
@@ -152,9 +166,13 @@ Return a single reconciled decomposition to the parent agent:
 **Addresses**: <FR-XXX, FR-YYY; Acceptance Scenario N.M>
 
 Tasks:
-- [ ] <Task 1> [via <lens>] (if from a single decomposition)
-- [ ] <Task 2>
-- [ ] ...
+- [ ] **<Title — imperative verb phrase, max 12 words>** [via <lens>]
+
+  <Description — 2–3 sentences. Reference AS N.M by ID.>
+
+  _Acceptance criteria:_
+  - <observable invariant>
+  - ...
 
 **PR Outcome**: <What the PR delivers when merged.>
 

--- a/.claude/agents/smithy.slice.md
+++ b/.claude/agents/smithy.slice.md
@@ -103,6 +103,16 @@ learned by previous tasks persists between invocations.
 - **Reference files/modules and desired behavior** — not specific line numbers,
   not exact replacement code, not copy-paste text. Line numbers drift between
   planning and implementation; prescribed code is frequently wrong.
+- **Use the structured task format** — bold imperative title (max 12 words),
+  2–3 sentence behavioral description, then bulleted acceptance criteria
+  (3–7 items). See the Output section for the format template.
+- **Reference acceptance scenarios by ID** (e.g., "satisfies AS 2.1–2.3")
+  rather than restating their content. The implement agent receives the spec
+  file path and can look up scenarios directly. Inline behavioral detail only
+  when the task covers behavior that has no corresponding acceptance scenario.
+- **Stay under 150 words per task** (title + description + criteria combined).
+  Tasks exceeding this are almost certainly overspecified — split them or
+  remove prescriptive detail.
 
 #### Tasks MUST NOT:
 - **Be standalone test tasks.** "Write tests for X" is redundant — the TDD
@@ -123,6 +133,13 @@ learned by previous tasks persists between invocations.
 - **Reference specific line numbers or exact code.** "Update line 68 to change
   X to Y" is brittle. Instead: "Update the triage logic in `smithy.clarify.prompt`
   to allow Critical+High items through as assumptions."
+- **Prescribe test mechanics.** Stub configurations, mock objects, assertion
+  patterns, test helper modifications — these are implementation decisions
+  the TDD protocol handles. If a specific behavior must be verified, state it
+  as an acceptance criterion on the task, not as a test prescription.
+- **Embed exact error strings or function signatures.** Reference the
+  acceptance scenario that defines the expected wording instead of copying it
+  into the task. The implement agent reads the spec.
 
 ---
 
@@ -146,9 +163,14 @@ Return a structured decomposition to the parent agent:
 **Addresses**: <FR-XXX, FR-YYY; Acceptance Scenario N.M>
 
 Tasks:
-- [ ] <Task 1 — behavioral outcome, referencing target files/modules>
-- [ ] <Task 2>
-- [ ] ...
+- [ ] **<Title — imperative verb phrase, max 12 words>**
+
+  <Description — 2–3 sentences. Reference target files/modules
+   and acceptance scenarios by ID (e.g., "AS 2.1").>
+
+  _Acceptance criteria:_
+  - <observable invariant or behavior to verify>
+  - ...
 
 **PR Outcome**: <What the PR delivers when merged.>
 
@@ -188,9 +210,10 @@ Tasks:
   the parent agent only.
 - **Read-only.** You do not create, modify, or delete any files. You produce
   a decomposition — the parent agent decides what to do with it.
-- **Be specific.** Reference concrete files, modules, and behaviors. Generic
-  tasks ("consider adding tests") are not useful — name the specific module
-  and describe the behavioral change.
+- **Be specific, not prescriptive.** "Specific" means naming the target
+  module and the behavioral change. It does NOT mean dictating the
+  implementation approach, test structure, or exact code. Name the file and
+  the outcome — not the function call, the stub config, or the assertion.
 - **Stay scoped.** Decompose only the assigned user story. Do not propose
   tasks for other stories in the same spec.
 - **Honor directives.** When additional planning directives are provided,

--- a/.claude/commands/smithy.audit.md
+++ b/.claude/commands/smithy.audit.md
@@ -97,6 +97,7 @@ Use the checklist matching the artifact's extension. Each checklist defines what
 | **Gaps** | Are there milestone goals or success criteria that no feature addresses? |
 | **Overlap** | Are there features with unclear or overlapping boundaries? |
 | **Dependency Clarity** | Are inter-feature dependencies within the milestone evident, or are they hidden? |
+| **Feature Dependency Order** | If the feature map contains a `## Feature Dependency Order` section: does it list every feature with dual checkboxes (`[ ][ ]`, `[x][ ]`, or `[x][x]`)? Is the sequence logically justified? Do `[x][ ]`/`[x][x]` entries match features with spec folders? Do `[x][x]` entries match features whose specs have all stories complete? If absent (legacy feature map), treat as N/A. |
 | **RFC Alignment** | Does the feature map align with the RFC's stated goals and success criteria for this milestone? |
 ## Audit Checklist (.spec.md)
 
@@ -111,7 +112,7 @@ Use the checklist matching the artifact's extension. Each checklist defines what
 | **Contract Completeness** | Do all integration boundaries have defined inputs, outputs, and error conditions? Are there contracts implied by requirements but not documented? |
 | **Ambiguity & Risk** | Are there vague terms, unstated assumptions, or scope boundaries that could be interpreted multiple ways? |
 | **Staleness** | Does the spec still reflect the current codebase reality? Have upstream changes invalidated any assumptions? |
-| **Story Dependency Order** | If the spec contains a `## Story Dependency Order` section: does it list every user story with a `- [ ]` or `- [x]` checkbox? Is the recommended sequence logically justified? Do `[x]` entries match stories with `.tasks.md` files in the spec folder? If the section is absent (legacy specs predating this convention), treat as N/A — do not flag. |
+| **Story Dependency Order** | If the spec contains a `## Story Dependency Order` section: does it list every user story with dual checkboxes (`[ ][ ]`, `[x][ ]`, or `[x][x]`)? Is the recommended sequence logically justified? Do first-checked entries (`[x][ ]` or `[x][x]`) match stories with `.tasks.md` files in the spec folder? Do fully-checked entries (`[x][x]`) match stories whose tasks files have all slices complete? If the section is absent (legacy specs predating this convention), treat as N/A — do not flag. |
 ## Audit Checklist (.tasks.md)
 
 | Category | What to check |
@@ -120,7 +121,7 @@ Use the checklist matching the artifact's extension. Each checklist defines what
 | **Task Completeness** | Are tasks within each slice sufficient to achieve the slice goal? Are there missing steps (tests, docs, validation)? |
 | **Testability** | Is it clear how each slice should be tested? Are integration test concerns addressed? |
 | **Edge Case Coverage** | Are boundary conditions, error paths, and failure modes covered in the tasks? |
-| **Task Scoping** | Do tasks describe *what* to accomplish without prescribing exact code, line numbers, or copy-paste replacements? Are there standalone test tasks (should be part of TDD), file-reading/research tasks (break fresh-context dispatch), verification tasks (handled by forge), or baked-in test expectations (pre-empt TDD)? |
+| **Task Scoping** | Do tasks follow the structured format (bold title + behavioral description + acceptance criteria bullets)? Are any tasks over 150 words? Do tasks reference acceptance scenarios by ID rather than restating their content? Are test mechanics absent (no stub configs, mock patterns, assertion structures, exact error strings, exact function signatures)? Are there standalone test tasks (should be part of TDD), file-reading/research tasks (break fresh-context dispatch), verification tasks (handled by forge), or baked-in test expectations (pre-empt TDD)? |
 | **FR Traceability** | Does every slice trace to at least one FR or acceptance scenario? Are any FRs unaddressed? |
 | **Dependency Order** | Is the recommended implementation sequence logical? Would reordering reduce risk or unblock parallel work? |
 ## Audit Checklist (.strike.md)

--- a/.claude/commands/smithy.cut.md
+++ b/.claude/commands/smithy.cut.md
@@ -40,7 +40,7 @@ Use the **smithy-refine** sub-agent. Pass it:
   | **Task Completeness** | Are tasks within each slice sufficient to achieve the slice goal? Are there missing steps (tests, docs, validation)? |
   | **FR Traceability** | Does every slice trace to at least one FR or acceptance scenario from the user story? Are any FRs unaddressed? |
   | **Dependency Order** | Is the recommended implementation sequence logical? Would reordering reduce risk or unblock parallel work? |
-  | **Task Scoping** | Do tasks describe *what* to accomplish (not *how* with exact code)? Are there standalone test tasks, file-reading tasks, verification tasks, or line-number references that would break fresh-context dispatch? |
+  | **Task Scoping** | Do tasks follow the structured format (bold title + behavioral description + acceptance criteria bullets)? Are any tasks over 150 words? Do tasks reference acceptance scenarios by ID rather than restating their content? Are test mechanics absent (no stub configs, mock patterns, assertion structures)? Are there standalone test tasks, file-reading tasks, verification tasks, line-number references, exact code prescriptions, exact error strings, or exact function signatures that would break fresh-context dispatch or create brittleness? |
   | **Spec Alignment** | Do the slices fully cover the user story's acceptance scenarios? Has the spec changed since the tasks file was written? |
 
 - **Target files**: the `.tasks.md` file alongside the source spec (`.spec.md`),
@@ -67,13 +67,28 @@ Phase 0).
      artifacts (`.spec.md`, `.data-model.md`, `.contracts.md`).
    - **User story number** — validate it exists in the spec file.
 2. Read all three spec artifacts to build full context.
-3. Extract the target user story — its title, acceptance scenarios, priority,
+3. **Inherit upstream debt.** After reading the source spec's three artifact
+   files, also read the spec's `## Specification Debt` section. Extract all
+   items with `status: open` or `status: inherited`. Carry them forward into
+   the tasks file's `## Specification Debt` table with status `inherited` and
+   a description prefixed with
+   `inherited from spec: <original SD-NNN description>`. Preserve the
+   upstream SD-NNN identifiers in the ID column (cut's own new items will
+   continue numbering from where the inherited list leaves off — see Phase 4
+   guidelines). Leave the Resolution column as `—`. If the upstream
+   `## Specification Debt` section is absent, empty, or the table is
+   malformed, treat this as a non-blocking warning: append an italic note
+   directly below the `## Specification Debt` table heading (before any table
+   rows): `_Upstream spec debt could not be parsed — inheritance skipped._`
+   This keeps the warning outside the table so it does not break the
+   structured row format.
+4. Extract the target user story — its title, acceptance scenarios, priority,
    and any FRs that trace to it.
-4. Derive the **story slug** — a short kebab-case name from the user story
+5. Derive the **story slug** — a short kebab-case name from the user story
    title (e.g., "User Story 4: Slice a User Story into Tasks" →
    `slice-story-into-tasks`). Older specs may use an em dash (`—`) instead
    of a colon as the separator; accept both when parsing.
-5. Confirm the target to the user:
+6. Confirm the target to the user:
    - Spec folder path.
    - User story number and title.
    - Derived filename: `<NN>-<story-slug>.tasks.md`.
@@ -222,6 +237,12 @@ Use the **smithy-clarify** sub-agent. Pass it:
   flag as Partial/Missing if the spec itself is ambiguous about which story owns
   a piece of functionality. If all categories are Clear, skip to Phase 4.
 
+**Bail-out check**: If clarify returns `bail_out: true`, output the
+`debt_items` table and the `bail_out_summary` guidance message to the terminal
+so the user can see exactly which ambiguities need resolution. Do not write any
+artifact files. Stop and wait for the user to provide expanded information or
+narrow the scope, then re-run.
+
 ---
 
 ## Phase 4: Slice
@@ -252,9 +273,14 @@ Draft the tasks file with this structure:
 
 ### Tasks
 
-- [ ] <Task 1 — specific, actionable implementation step>
-- [ ] <Task 2>
-- [ ] ...
+- [ ] **<Title — imperative verb phrase, max 12 words>**
+
+  <Description — 2–3 sentences. Reference target files/modules
+   and acceptance scenarios by ID (e.g., "AS 2.1").>
+
+  _Acceptance criteria:_
+  - <observable invariant or behavior to verify>
+  - ...
 
 **PR Outcome**: <What the PR delivers when merged — observable behavior or capability.>
 
@@ -305,7 +331,7 @@ Guidelines for slicing:
 - Slices are numbered sequentially starting at 1.
 - Include tests, docs, and validation steps within the slice that introduces the
   code — do not batch these into a separate "testing slice".
-- Populate the `## Specification Debt` section with debt items from cut's own clarify run. Assign SD-NNN identifiers. Leave Resolution as `—` for all `open` items. Inherited items from the upstream spec are added by Slice 4 — do not duplicate them here until that slice lands.
+- Populate the `## Specification Debt` section with both (1) inherited items from the source spec (carried over in Phase 1) and (2) new items from cut's own clarify run. Inherited items use status `inherited`; new items use status `open`. Assign new SD-NNN identifiers to cut's own items, continuing from where the inherited list left off.
 
 Guidelines for task authoring:
 
@@ -313,32 +339,105 @@ Each task is dispatched to a **fresh sub-agent** (smithy-implement) with no
 memory of prior tasks. The sub-agent receives the task description, task number,
 slice goal, file paths (spec, data-model, contracts, and the tasks/strike file),
 and the branch name — but nothing learned by previous tasks persists. Author
-tasks accordingly:
+tasks accordingly.
 
-- **Describe the WHAT, not the HOW in detail.** A task should state the
-  behavioral outcome or structural change to achieve. Do not prescribe exact
-  code, exact line numbers, or copy-paste replacement text. Line numbers shift;
-  code prescribed at planning time is frequently wrong at implementation time.
-  Instead, reference the target file/module and the desired behavior.
-- **Do not create standalone test tasks.** Testing is handled by
-  smithy-implement's TDD protocol (red-green-refactor). Every functional task
-  already includes writing a failing test, implementing to pass, and refactoring.
-  A task like "Write tests for X" is redundant — the sub-agent already does this
-  as part of implementing X.
-- **Do not create pre-research or file-reading tasks.** Each task runs in a
-  fresh context. A task like "Read file X to understand Y" produces no lasting
-  artifact — the next task's sub-agent cannot access what the previous one
-  learned. If understanding a file's structure is a prerequisite, encode that
-  knowledge into the task description itself or ensure it is captured in the
-  contracts/data-model.
-- **Do not bake test expectations into task descriptions.** Tasks like "Add a
-  test case that asserts X returns Y with input Z" pre-empt the TDD cycle. If a
-  specific scenario must be covered, express it as acceptance criteria or
-  attach it as extra context on the functional task — not as a separate testing
-  task with prescribed assertions.
-- **Verification is handled by forge.** Do not create tasks for running the
-  test suite, linting, or building. Forge runs validation after all tasks in a
-  slice complete.
+### Task format (mandatory)
+
+Every task must use this structure:
+
+```
+- [ ] **<Title — imperative verb phrase, max 12 words>**
+
+  <Description — 2–3 sentences. Name the target file/module and the outcome.
+   Reference acceptance scenarios by ID (e.g., "AS 2.1").>
+
+  _Acceptance criteria:_
+  - <observable invariant or behavior to verify>
+  - <another criterion>
+  - ...
+```
+
+- **Title**: bold imperative verb phrase, max 12 words. Scannable at a glance.
+- **Description**: 2–3 sentences. States WHAT changes and WHERE.
+- **Acceptance criteria**: 3–7 bullets. Observable invariants — what the
+  implement agent verifies via TDD.
+- **Total length**: aim for 50–100 words. Tasks over 150 words are almost
+  certainly overspecified — split them or trim prescriptive detail.
+
+### Reference, don't restate
+
+The implement agent receives the spec file path and reads acceptance
+scenarios directly. **Reference scenarios by ID** (e.g., "satisfies
+AS 2.1–2.3") rather than restating their content in the task. Similarly,
+reference contracts and data model sections by name rather than copying
+their definitions.
+
+**Escape hatch**: inline behavioral detail only when the task covers
+behavior that has no corresponding acceptance scenario (e.g.,
+implementation-level concerns like check ordering). Even then, use the
+acceptance criteria bullet format — never wall-of-text.
+
+### Task format — before/after contrast
+
+**BAD** — overspecified, brittle, wall-of-text:
+
+> - [ ] Extend `checkSpawnDependencies()` in `src/deps.ts` to accept a
+>   required `baseImage: string` parameter and validate all four hard
+>   preconditions in order. (1) Keep the existing `isFinderAvailable()` gate.
+>   (2) Fix the git error message from `"git not found on PATH — required for
+>   spawn operations."` to `"git not found — required for spawn operations"`.
+>   (3) Add an `isOnPath("docker")` check returning `{ ok: false, error:
+>   "Docker not found — required for spawn operations" }` when docker is
+>   absent. (4) Add a git repository context check by running `git rev-parse
+>   --show-toplevel` via `execFileSync` ... In `src/deps.test.ts`, update the
+>   existing `checkSpawnDependencies` test suite: the `ok:true` test currently
+>   stubs only `["git"]` and must be updated to stub `["git", "docker"]` and
+>   account for the new `baseImage` parameter ...
+
+This task is ~300 words. It embeds exact error strings, exact function calls,
+exact stub configurations, and exact test modifications. All of this drifts
+between planning and implementation.
+
+**GOOD** — behavioral, scannable, referencing the spec:
+
+> - [ ] **Extend `checkSpawnDependencies()` to validate all spawn preconditions**
+>
+>   Add a `baseImage` parameter to the function in `src/deps.ts`. Expand it to
+>   validate all preconditions from US2 acceptance scenarios 2.1–2.5, returning
+>   the first failure encountered.
+>
+>   _Acceptance criteria:_
+>   - Existing finder-availability gate preserved
+>   - Git-missing error matches AS 2.1 wording
+>   - Docker-on-PATH check added (AS 2.2)
+>   - Git repo context check added (AS 2.4)
+>   - Base image check with pull fallback added (AS 2.3)
+>   - Check ordering: finder, git, docker, repo context, base image
+
+Same task, ~80 words. The implement agent looks up AS 2.1–2.5 in the spec
+for exact wording, uses TDD to determine test approach, and reads the
+existing code to find the right implementation pattern.
+
+### Prohibitions
+
+- **No standalone test tasks.** The TDD protocol writes tests as part of
+  every functional task. "Write tests for X" is redundant.
+- **No research or file-reading tasks.** Each task runs in a fresh context
+  with no memory of prior tasks. Encode necessary context into the task or
+  spec artifacts.
+- **No verification tasks.** Forge runs npm test/build after all tasks
+  complete.
+- **No baked-in test expectations.** "Assert X returns Y with input Z"
+  pre-empts TDD. Express required behavior as acceptance criteria instead.
+- **No line-number references or exact code.** Line numbers drift; prescribed
+  code is frequently wrong. Reference files/modules and behaviors.
+- **No test mechanics.** Do not prescribe stub configurations, mock objects,
+  assertion patterns, or test helper modifications. The TDD protocol
+  determines test approach. If a behavior must be verified, state it as an
+  acceptance criterion.
+- **No exact error strings or function signatures.** Reference the acceptance
+  scenario that defines the expected wording instead of copying it into the
+  task.
 
 ---
 
@@ -349,19 +448,20 @@ the zero-padded user story number).
 
 **Spec write-back**: After writing the tasks file, update the source `.spec.md`
 to reflect that this story has been cut. Find the `## Story Dependency Order`
-section in the spec file and change the checkbox for the current user story from
-`- [ ]` to `- [x]`, appending the repo-relative tasks file path:
+section in the spec file and change the first checkbox for the current user
+story from `[ ]` to `[x]` (i.e., `[ ][ ]` → `[x][ ]`), appending the
+repo-relative tasks file path:
 
 ```markdown
-- [x] **User Story 3: <Title>** — <rationale> → `specs/<folder>/03-story-slug.tasks.md`
+- [x][ ] **User Story 3: <Title>** — <rationale> → `specs/<folder>/03-story-slug.tasks.md`
 ```
 
 If the `## Story Dependency Order` section does not exist in the spec (e.g.,
 older specs created before this section was introduced), skip the write-back
 silently — do not add the section or fail. Match the story by its number
 (`User Story <N>`) in the bold text. Update only the matching entry — do not
-modify other entries. If the entry is already `[x]`, skip — the operation is
-idempotent.
+modify other entries or the second checkbox. If the first checkbox is already
+`[x]` (entry is `[x][ ]` or `[x][x]`), skip — the operation is idempotent.
 
 Then present a summary to the user:
 
@@ -407,19 +507,20 @@ ask again.
   for in-progress work from other stories.
 - **DO** note cross-story dependencies in the Dependency Order section (as
   "Cross-Story Dependencies") without pulling that work into your slices.
-- **DO** update the spec file's Story Dependency Order checkbox when writing the
-  tasks file. If the section is missing, skip silently.
-- **DO NOT** write tasks that reference specific line numbers or prescribe exact
-  replacement code. Tasks must survive codebase drift between planning and
-  implementation. Reference files, modules, and behaviors instead.
-- **DO NOT** create standalone "write tests for X" tasks. smithy-implement uses
-  TDD — tests are written as part of implementing each functional task.
-- **DO NOT** create file-reading or research tasks. Each task runs in a fresh
-  sub-agent with no memory of prior tasks. Encode necessary context into the
-  task description or the spec artifacts.
+- **DO** update the spec file's Story Dependency Order first checkbox
+  (`[ ][ ]` → `[x][ ]`) when writing the tasks file. Do not modify the second
+  checkbox. If the section is missing, skip silently.
+- **DO** use the structured task format (bold title + behavioral description +
+  acceptance criteria bullets). See "Guidelines for task authoring" above.
+- **DO** reference acceptance scenarios by ID (e.g., "AS 2.1") rather than
+  restating their content. The implement agent reads the spec directly.
+- **DO NOT** write tasks that reference specific line numbers, prescribe exact
+  code, embed exact error strings, or prescribe test mechanics (stubs, mocks,
+  assertion patterns). Tasks must survive codebase drift.
+- **DO NOT** create standalone test tasks, file-reading tasks, or verification
+  tasks. See "Prohibitions" in the task authoring guidelines.
 - **DO** express testing requirements as acceptance criteria on the functional
-  task, not as separate tasks. If a specific edge case must be tested, add it
-  as a note on the task that implements the relevant behavior.
+  task, not as separate tasks.
 
 ---
 
@@ -428,7 +529,7 @@ ask again.
 1. **Audit findings and refinements** (if repeating the command on existing tasks).
 2. Created/updated files:
    - `specs/<folder>/<NN>-<story-slug>.tasks.md`
-   - `specs/<date>-<NNN>-<slug>/<slug>.spec.md` *(Story Dependency Order checkbox updated)*
+   - `specs/<date>-<NNN>-<slug>/<slug>.spec.md` *(Story Dependency Order first checkbox updated)*
 3. Summary report containing:
    - Slice count with titles.
    - FR and acceptance scenario coverage.

--- a/.claude/commands/smithy.forge.md
+++ b/.claude/commands/smithy.forge.md
@@ -204,6 +204,66 @@ for reviewers to see which slice was completed and what comes next.
 
 ---
 
+## Story Completion Cascade
+
+For `.tasks.md` mode only. After marking the slice complete, check whether
+**all** slices in the `## Dependency Order` section are now `[x]`. If any
+slices remain `[ ]`, skip this section entirely.
+
+If ALL slices are complete, cascade completion upward through the artifact
+hierarchy:
+
+### Step 1: Update the source spec
+
+Read the source spec file (from the tasks file header `**Source**` field). Find
+this story's entry in the `## Story Dependency Order` section by matching
+`User Story <N>` in the bold text. The `<N>` comes from the tasks file header
+`**Story Number**` field — **strip any leading zeros** before matching (e.g.,
+`03` → `3`) since spec entries use unpadded numbers (`User Story 3`, not
+`User Story 03`).
+
+Only update entries whose first checkbox is already `[x]` — i.e., change
+`[x][ ]` → `[x][x]`. Do NOT update `[ ][ ]` entries (that would produce the
+invalid state `[ ][x]`):
+
+```
+- [x][x] **User Story N: <Title>** — <rationale> → `<tasks-file-path>`
+```
+
+If the entry is already `[x][x]`, skip. If the entry is `[ ][ ]` (first
+checkbox not set), skip with a warning — the spec write-back from cut may not
+have run. If the `## Story Dependency Order` section does not exist (legacy
+spec), skip silently.
+
+Commit the change: `mark story <N> complete in story dependency order`
+
+### Step 2: Check for feature completion
+
+After updating the spec, check whether **all** stories in the spec's
+`## Story Dependency Order` section are now `[x][x]`. If any stories are not
+fully complete (`[ ][ ]` or `[x][ ]`), skip this step.
+
+If ALL stories are `[x][x]`:
+
+1. Check the spec header for a `**Source Feature Map**` field.
+2. If the field is absent (spec was not created from a feature map), skip
+   silently.
+3. If present, read the feature map file at that path.
+4. Find this feature's entry in the `## Feature Dependency Order` section by
+   matching the spec folder path after `→` in the entry text.
+5. Only update entries whose first checkbox is already `[x]` — change
+   `[x][ ]` → `[x][x]`. Do NOT update `[ ][ ]` entries:
+   ```
+   - [x][x] **Feature N: <Title>** — <rationale> → `<spec-folder-path>/`
+   ```
+6. If the entry is already `[x][x]`, skip. If the entry is `[ ][ ]`, skip
+   with a warning. If the `## Feature Dependency Order` section does not exist
+   (legacy feature map), skip silently.
+
+Commit the change: `mark feature complete in feature dependency order`
+
+---
+
 ## Validation
 
 After implementation, review, and documentation check, run the full validation

--- a/.claude/commands/smithy.ignite.md
+++ b/.claude/commands/smithy.ignite.md
@@ -366,6 +366,14 @@ influence downstream design decisions. Keep this at "WHAT not HOW" level.>
 - <Genuinely unresolved question 1>
 - <Genuinely unresolved question 2>
 
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | <what is unresolved> | <clarify scan category> | High | Medium | open | — |
+
+_If no debt items, write: "None — all ambiguities resolved."_
+
 ## Milestones
 
 ### Milestone 1: <Title>

--- a/.claude/commands/smithy.mark.md
+++ b/.claude/commands/smithy.mark.md
@@ -31,12 +31,17 @@ Before starting, determine the mode:
       feature map — expected `### Feature N: <Title>` headings."
    b. Extract the `**Source RFC**` path from the file header.
    c. Determine which features already have specs by checking the
-      `## Spec Progress` checklist at the bottom of the `.features.md`. A
-      feature is "specc'd" when its entry is checked (`- [x]`). A feature is
-      unspecced when its entry is unchecked (`- [ ]`). If the checklist does
-      not exist yet, create it now with all features unchecked, write it to
-      the file, and treat every feature as unspecced. (Mark updates the
-      checklist after creating a spec — see Phase 6.)
+      `## Feature Dependency Order` section in the `.features.md` (locate by
+      heading name, not by position — it may appear before
+      `## Cross-Milestone Dependencies` or at the end of the file).
+      Each entry uses dual checkboxes: `- [ ][ ]` (unspecced),
+      `- [x][ ]` (spec created), or `- [x][x]` (fully implemented). A feature
+      is "specc'd" when its first checkbox is `[x]` (matches `[x][ ]` or
+      `[x][x]`). A feature is unspecced when its first checkbox is `[ ]`
+      (matches `[ ][ ]`). If the section does not exist yet, create it now
+      with all features as `- [ ][ ]`, ordered by dependency graph with
+      rationale, write it to the file, and treat every feature as unspecced.
+      (Mark updates the first checkbox after creating a spec — see Phase 6.)
    d. **With feature number**: If the number is out of range, list available
       features with their numbers and titles, then stop. If the feature is
       already specc'd (per step c), extract the spec folder path from its
@@ -213,6 +218,12 @@ Use the **smithy-clarify** sub-agent. Pass it:
 
 Record all Q&A and assumptions for inclusion in the Clarifications section of the spec.
 
+**Bail-out check**: If clarify returns `bail_out: true`, output the
+`debt_items` table and the `bail_out_summary` guidance message to the terminal
+so the user can see exactly which ambiguities need resolution. Do not write any
+artifact files. Stop and wait for the user to provide expanded information or
+narrow the scope, then re-run.
+
 ---
 
 ## Phase 3: Specify
@@ -272,9 +283,9 @@ As a <persona>, I want <goal> so that <benefit>.
 
 Recommended implementation sequence:
 
-- [ ] **User Story 1: <Title>** — <dependency rationale>
-- [ ] **User Story 2: <Title>** — <dependency rationale>
-- [ ] **User Story N: <Title>** — <dependency rationale>
+- [ ][ ] **User Story 1: <Title>** — <dependency rationale>
+- [ ][ ] **User Story 2: <Title>** — <dependency rationale>
+- [ ][ ] **User Story N: <Title>** — <dependency rationale>
 
 ## Requirements *(mandatory)*
 
@@ -324,20 +335,23 @@ Guidelines for the spec:
 - Do NOT include implementation phases, milestones, or task breakdowns.
 - Do NOT include specific file paths, function names, or implementation details.
   (Exception: the `→` links in Story Dependency Order are auto-appended by
-  `smithy.cut` and are cross-reference paths, not implementation details.)
+  `smithy.cut` when it updates the first checkbox, and are cross-reference
+  paths, not implementation details.)
 - DO trace back to RFC sections when input is an RFC.
 - Populate the `## Specification Debt` section from clarify's returned `debt_items`. Assign sequential SD-NNN identifiers starting at SD-001. Carry the description, source_category, impact, confidence, and status fields directly from clarify's return. Leave Resolution as `—` for all `open` items.
 - The Story Dependency Order section lists all user stories in recommended
-  implementation sequence with `- [ ]` checkboxes. Order by dependency graph,
-  not by priority — stories with no dependencies come first, stories that depend
-  on others come after their prerequisites. Stories that can be implemented in
-  parallel should be noted as such in their rationale. Each entry includes a
-  brief rationale explaining why it is positioned where it is (e.g., "No
-  dependencies", "Depends on Story 1 for the auth module", "Can parallelize
+  implementation sequence with `- [ ][ ]` dual checkboxes. Order by dependency
+  graph, not by priority — stories with no dependencies come first, stories that
+  depend on others come after their prerequisites. Stories that can be
+  implemented in parallel should be noted as such in their rationale. Each entry
+  includes a brief rationale explaining why it is positioned where it is (e.g.,
+  "No dependencies", "Depends on Story 1 for the auth module", "Can parallelize
   with Story 2").
-- The `[ ]` checkboxes in Story Dependency Order are updated to `[x]` by
-  `smithy.cut` when it creates the tasks file for that story. Do NOT manually
-  check them during spec creation.
+- The dual checkboxes in Story Dependency Order encode two states: the first
+  checkbox is updated from `[ ]` to `[x]` by `smithy.cut` when it creates the
+  tasks file (`[ ][ ]` → `[x][ ]`). The second checkbox is updated from `[ ]`
+  to `[x]` by `smithy.forge` when all slices in the tasks file are complete
+  (`[x][ ]` → `[x][x]`). Do NOT manually check them during spec creation.
 
 ---
 
@@ -474,21 +488,27 @@ Existing contracts remain unchanged.
 Create the spec folder and write all three files to disk first.
 
 **Feature map write-back** (when input was a `.features.md`): Update the
-`.features.md` to track progress. If a `## Spec Progress` section does not
-exist at the bottom of the file, create it with one checklist entry per
-feature parsed during Routing. Mark the current feature's entry as complete
-and include the spec folder path:
+`.features.md` to track progress. If a `## Feature Dependency Order` section
+does not exist in the file, create it just before `## Cross-Milestone
+Dependencies` (or at the end of the file if that section is absent) with one
+dual-checkbox
+entry per feature parsed during Routing, ordered by dependency graph with
+rationale. Then update the current feature's first checkbox to `[x]` and
+append the spec folder path:
 
 ```markdown
-## Spec Progress
+## Feature Dependency Order
 
-- [x] Feature 1: Template Deployment → `specs/2026-03-14-001-template-deployment/`
-- [ ] Feature 2: Permission Management
-- [ ] Feature 3: Webhook Support
+Recommended specification sequence:
+
+- [x][ ] **Feature 1: Template Deployment** — No dependencies; foundational. → `specs/2026-03-14-001-template-deployment/`
+- [ ][ ] **Feature 2: Permission Management** — Depends on Feature 1 for deployment infrastructure.
+- [ ][ ] **Feature 3: Webhook Support** — Independent; can parallelize with Feature 2.
 ```
 
-If the section already exists, update only the current feature's entry from
-`- [ ]` to `- [x]` and append the spec folder path.
+If the section already exists, update only the current feature's entry: change
+the first checkbox from `[ ]` to `[x]` (i.e., `[ ][ ]` → `[x][ ]`) and
+append the spec folder path after `→`. Do not modify the second checkbox.
 
 Then present a summary to the user:
 
@@ -530,7 +550,7 @@ Use the **smithy-refine** sub-agent. Pass it:
   | **Contract Completeness** | Do all integration boundaries have defined inputs, outputs, and error conditions? Are there contracts implied by requirements but not documented? |
   | **Ambiguity & Risk** | Are there vague terms, unstated assumptions, or scope boundaries that could be interpreted multiple ways? |
   | **Staleness** | Does the spec still reflect the current codebase reality? Have upstream changes invalidated any assumptions? |
-  | **Story Dependency Order** | If the spec contains a `## Story Dependency Order` section: does it list all user stories? Is the implementation sequence logically justified? Do `[x]` entries match stories that have `.tasks.md` files? If absent (legacy spec), treat as N/A. |
+  | **Story Dependency Order** | If the spec contains a `## Story Dependency Order` section: does it list all user stories with dual checkboxes (`[ ][ ]`, `[x][ ]`, or `[x][x]`)? Is the sequence logically justified? Do first-checked entries (`[x][ ]` or `[x][x]`) match stories with `.tasks.md` files? Do fully-checked entries (`[x][x]`) match stories whose tasks files have all slices complete? If absent (legacy spec), treat as N/A. |
 
 - **Target files**: the spec (`.spec.md`), data model (`.data-model.md`), and
   contracts (`.contracts.md`) in the spec folder.

--- a/.claude/commands/smithy.render.md
+++ b/.claude/commands/smithy.render.md
@@ -76,6 +76,7 @@ Use the **smithy-refine** sub-agent. Pass it:
   | **Gaps** | Are there milestone goals or success criteria that no feature addresses? |
   | **Overlap** | Are there features with unclear or overlapping boundaries? |
   | **Dependency Clarity** | Are inter-feature dependencies within the milestone evident, or are they hidden? |
+  | **Feature Dependency Order** | If the feature map contains a `## Feature Dependency Order` section: does it list every feature with dual checkboxes (`[ ][ ]`, `[x][ ]`, or `[x][x]`)? Is the recommended sequence logically justified? Do `[x][ ]` entries match features that have spec folders? Do `[x][x]` entries match features that have spec folders and whose stories are all marked `[x][x]` (or another equivalent completion signal)? If absent (legacy feature map), treat as N/A. |
   | **RFC Alignment** | Does the feature map align with the RFC's stated goals and success criteria for this milestone? |
 
 - **Target files**: the `.features.md` file and the source `.rfc.md` file
@@ -288,6 +289,22 @@ this format:
 
 <!-- Repeat for each feature -->
 
+<!-- Specification Debt appears here for templates without ## Assumptions sections -->
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | <what is unresolved> | <clarify scan category> | High | Medium | open | — |
+
+_If no debt items, write: "None — all ambiguities resolved."_
+
+## Feature Dependency Order
+
+Recommended specification sequence:
+
+- [ ][ ] **Feature 1: <Title>** — <dependency rationale>
+- [ ][ ] **Feature 2: <Title>** — <dependency rationale>
+
 ## Cross-Milestone Dependencies
 
 Direction must be either `depends on` or `depended upon by`.
@@ -334,3 +351,11 @@ again. Once approved, suggest the next step:
   parallel by other agents. Each agent owns exactly one milestone.
 - **DO** note cross-milestone dependencies in the feature map (as
   "Cross-Milestone Dependencies") without pulling that work into your features.
+- **DO** include a `## Feature Dependency Order` section listing every feature
+  with `- [ ][ ]` dual checkboxes and a dependency rationale. Order features by
+  dependency graph — features with no dependencies come first, dependent features
+  come after their prerequisites. Include rationale for each entry (e.g., "No
+  dependencies; foundational", "Depends on Feature 1 for X", "Can parallelize
+  with Feature 2"). All items start as `[ ][ ]` — `smithy.mark` updates the
+  first checkbox when a spec is created; `smithy.forge` updates the second when
+  implementation is complete.

--- a/.claude/commands/smithy.strike.md
+++ b/.claude/commands/smithy.strike.md
@@ -171,6 +171,14 @@ Once approved, write a single strike document to `specs/strikes/YYYY-MM-DD-<slug
 
 <Important decisions and tradeoffs made during the interactive planning phase.>
 
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | <what is unresolved> | <clarify scan category> | High | Medium | open | — |
+
+_If no debt items, write: "None — all ambiguities resolved."_
+
 ## Single Slice
 
 **Goal**: <What this slice delivers as a standalone increment.>

--- a/.github/workflows/smithy-upgrade.yml
+++ b/.github/workflows/smithy-upgrade.yml
@@ -28,11 +28,46 @@ jobs:
           node-version: 24
           cache: 'npm'
 
-      - name: Install latest Smithy CLI
-        run: npm install -g @balexda/smithy@latest
+      - name: Resolve target Smithy version from package.json
+        id: smithy-version
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Target Smithy version: ${VERSION}"
 
-      - name: Show installed version
-        run: smithy --version
+      - name: Install Smithy CLI at the just-published version
+        env:
+          VERSION: ${{ steps.smithy-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # npm publish → registry propagation for a brand-new version can
+          # lag a few seconds behind the triggering publish workflow. Retry
+          # with exponential backoff so we always install the version we
+          # intend to upgrade TO, rather than whatever @latest currently
+          # resolves to.
+          for attempt in 1 2 3 4 5; do
+            if npm install -g "@balexda/smithy@${VERSION}"; then
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::Failed to install @balexda/smithy@${VERSION} after 5 attempts"
+              exit 1
+            fi
+            sleep "$((attempt * 5))"
+          done
+
+      - name: Verify installed version matches
+        env:
+          VERSION: ${{ steps.smithy-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          INSTALLED=$(smithy --version)
+          echo "Installed: ${INSTALLED}  Expected: ${VERSION}"
+          if [ "${INSTALLED}" != "${VERSION}" ]; then
+            echo "::error::Installed Smithy version (${INSTALLED}) does not match target (${VERSION})"
+            exit 1
+          fi
 
       - name: Run smithy update
         run: smithy update -y
@@ -47,7 +82,8 @@ jobs:
           body: |
             Automated upgrade run by `.github/workflows/smithy-upgrade.yml`.
 
-            - Installed `@balexda/smithy@latest` globally
+            - Installed `@balexda/smithy` at the version in `package.json`
+              on the triggering commit
             - Ran `smithy update -y` against the repo manifest
 
             Review the diff in `.claude/` and `.smithy/smithy-manifest.json`

--- a/.smithy/smithy-manifest.json
+++ b/.smithy/smithy-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "smithyVersion": "0.2.8",
+  "smithyVersion": "0.3.1",
   "deployLocation": "repo",
   "agents": [
     "claude"


### PR DESCRIPTION
## Summary
- Primary outcome: Ensure the smithy-upgrade workflow installs the exact Smithy version from `package.json` rather than `@latest`, with retry logic and verification
- Notable behaviour changes: The workflow now resolves the target version upfront, retries installation with exponential backoff to handle registry propagation delays, and verifies the installed version matches the target
- Follow-up work deferred: None

## Context
The previous workflow installed `@balexda/smithy@latest` globally, which could result in installing a different version than intended if the npm registry hadn't fully propagated the newly published version. This change ensures the workflow installs the exact version specified in `package.json` on the triggering commit, with proper handling for registry propagation delays.

## Implementation Notes
- **Version Resolution**: Extract the target Smithy version from `package.json` at workflow start using Node.js
- **Retry Logic**: Implement exponential backoff (5s, 10s, 15s, 20s, 25s) when installing the specific version to account for npm registry propagation delays
- **Verification**: Add a post-install check that compares the installed version against the target version and fails explicitly if they don't match
- **Error Handling**: Use `set -euo pipefail` for strict shell error handling and provide clear error messages via GitHub Actions annotations

## Risks & Mitigations
| Risk | Mitigation |
|------|-----------|
| Registry propagation still exceeds 25 seconds | Workflow will fail fast with clear error message; can be re-run or timeout increased if needed |
| Version mismatch goes undetected | Added explicit verification step that compares installed vs. target version |

## Rollback Plan
Revert to the previous workflow step that installs `@balexda/smithy@latest` if the retry logic proves problematic.

## Testing
- CI will validate the workflow syntax and execution
- The verification step ensures the installed version matches expectations before proceeding with `smithy update`
- No additional manual testing required; this is a workflow infrastructure change

https://claude.ai/code/session_01M4QrxuxNEsDwWA2xaHcbrS