### PR TITLE
docs: add US9 task spec for updated Phase 0 audit categories

### DIFF
--- a/specs/2026-04-07-003-refactor-ignite-workflow/09-updated-phase-0-audit-categories.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/09-updated-phase-0-audit-categories.tasks.md
@@ -1,0 +1,72 @@
+# Tasks: Updated Phase 0 Audit Categories
+
+**Source**: `specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md` — User Story 9
+**Data Model**: `specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.data-model.md`
+**Contracts**: `specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.contracts.md`
+**Story Number**: 09
+
+---
+
+## Slice 1: Align Audit Categories with New RFC Sections
+
+**Goal**: Update the ignite Phase 0 audit categories table and the shared `audit-checklist-rfc.md` snippet so both include explicit checks for the new Personas and Out of Scope RFC sections. After this slice merges, reviewing an RFC through `smithy.ignite` Phase 0 or through `smithy.audit` surfaces gaps in persona coverage and out-of-scope completeness alongside the existing categories.
+
+**Justification**: Both audit surfaces (ignite Phase 0 review loop and the `smithy.audit` command) share the goal of catching the same gaps that the new RFC template sections from US1 are designed to prevent. Shipping the two updates together — plus the template-composition test that guards them — delivers one coherent reviewer-facing behavior change. Splitting them would leave one audit surface inconsistent with the other and the tests orphaned from the changes they cover.
+
+**Addresses**: FR-011, FR-012; Acceptance Scenarios US9-1, US9-2, US9-3
+
+### Tasks
+
+- [ ] **Add Persona Coverage and Out of Scope Completeness to Phase 0 audit table**
+
+  In `src/templates/agent-skills/commands/smithy.ignite.prompt`, extend the Phase 0a–0b audit categories table so it matches the category set defined in the `Updated Phase 0 Audit Categories` contract. Existing categories remain; the two new rows are inserted in the order and positions specified by the contract table. Satisfies AS US9-1.
+
+  _Acceptance criteria:_
+  - Table includes `Persona Coverage` and `Out of Scope Completeness` rows
+  - Existing categories (Problem Statement, Goals, Milestones, Feasibility, Scope, Stakeholders) are preserved
+  - Row ordering matches the contract's category table
+  - Check descriptions convey substantive coverage, not mere presence (supports AS US9-3)
+
+- [ ] **Rename snippet rows to match the new category names**
+
+  In `src/templates/agent-skills/snippets/audit-checklist-rfc.md`, update the existing `Persona Clarity` and `Scope Boundaries` rows to the contract-aligned names `Persona Coverage` and `Out of Scope Completeness`, and strengthen their check descriptions so an RFC with only vague persona references or implicit scope boundaries is flagged. Other rows in the snippet are left unchanged. Satisfies FR-012 and AS US9-2, US9-3.
+
+  _Acceptance criteria:_
+  - Snippet contains a `Persona Coverage` row and an `Out of Scope Completeness` row
+  - Neither `Persona Clarity` nor `Scope Boundaries` remains as a row label
+  - Check descriptions prompt reviewers to assess substantive content, not just section presence
+  - Unrelated rows (Ambiguity, Milestone Completeness, Feasibility, Decisions vs Open Questions) are unchanged
+
+- [ ] **Assert new audit categories render in both surfaces**
+
+  Extend `src/templates.test.ts` with assertions that the composed ignite command and composed audit command each expose the new category names. The ignite assertions target the Phase 0 audit table; the audit assertions target the rendered `audit-checklist-rfc` partial inside `smithy.audit.md`.
+
+  _Acceptance criteria:_
+  - Assertion that the composed `smithy.ignite.md` contains `Persona Coverage` and `Out of Scope Completeness`
+  - Assertion that the composed `smithy.audit.md` (which embeds the snippet via `{{>audit-checklist-rfc}}`) contains both new names
+  - Assertion that the composed `smithy.audit.md` no longer contains the retired `Persona Clarity` and `Scope Boundaries` labels
+  - `npm test` passes with no regressions elsewhere in the suite
+
+**PR Outcome**: Merging this PR gives reviewers a single, consistent audit vocabulary across the ignite Phase 0 review loop and the `smithy.audit` command. RFCs missing personas or out-of-scope content — or containing only vague versions of either — are flagged by both surfaces, and the template-composition test guards against regressions in either location.
+
+---
+
+## Specification Debt
+
+_None — all ambiguities resolved._
+
+---
+
+## Dependency Order
+
+Recommended implementation sequence:
+
+1. [ ] **Slice 1** — Only slice. Tasks within the slice are ordered sequentially: update the ignite Phase 0 table first, then the shared snippet, then add the template-composition assertions that cover both surfaces.
+
+### Cross-Story Dependencies
+
+| Dependency | Direction | Notes |
+|------------|-----------|-------|
+| User Story 1: Updated RFC Template Schema | depends on | This story's audit categories only make sense once the template actually contains the Personas and Out of Scope sections. Story 1 is complete. |
+| User Story 5: Mandatory Personas Section | depended upon by | US5 verifies that sub-phase 3b always produces a populated Personas section; this story's audit check catches the same gap on existing RFCs during the Phase 0 review loop. Independent but complementary. |
+| User Story 6: Mandatory Out of Scope Section | depended upon by | US6 verifies that sub-phase 3c always produces an Out of Scope section; this story's audit check catches the same gap on existing RFCs during the Phase 0 review loop. Independent but complementary. |

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
@@ -189,7 +189,7 @@ Recommended implementation sequence:
 - [x] **User Story 4: Piecewise RFC Generation** — Core orchestration that wires US1+US2+US3 together. Depends on all three preceding stories. → `specs/2026-04-07-003-refactor-ignite-workflow/04-piecewise-rfc-generation.tasks.md`
 - [ ] **User Story 5: Mandatory Personas Section** — Verifies the Personas section is produced end-to-end; depends on US1 (template slot) and US2 (smithy-prose dispatch). Can be validated after US4.
 - [ ] **User Story 6: Mandatory Out of Scope Section** — Verifies the Out of Scope section is produced end-to-end; depends on US1 (template slot) and US3 (smithy-plan dispatch). Can parallelize with US5.
-- [ ] **User Story 9: Updated Phase 0 Audit Categories** — Updates the review loop and audit snippet; depends on US1 (new sections defined). Can be done any time after US1.
+- [x] **User Story 9: Updated Phase 0 Audit Categories** — Updates the review loop and audit snippet; depends on US1 (new sections defined). Can be done any time after US1. → `specs/2026-04-07-003-refactor-ignite-workflow/09-updated-phase-0-audit-categories.tasks.md`
 - [ ] **User Story 7: Session Resume from Partial State** — Robustness enhancement; depends on US4 (direct-write approach) naturally leaving partial files on disk to detect.
 - [ ] **User Story 8: Cross-Session Question Deduplication** — Enhancement on top of the core pipeline; depends on US4 (sessions producing output files). Implement after core flow is solid.
 


### PR DESCRIPTION
## Summary
- Primary outcome: Document User Story 9 task breakdown for aligning Phase 0 audit categories with new RFC template sections (Personas and Out of Scope).
- Notable behaviour changes: None (specification document only).
- Follow-up work deferred: Implementation tasks listed in the spec are not yet started.

## Context
User Story 9 is part of the `2026-04-07-003-refactor-ignite-workflow` epic. It updates the ignite Phase 0 audit review loop and the shared `audit-checklist-rfc.md` snippet to include explicit checks for the new Personas and Out of Scope RFC sections introduced in US1. This ensures both audit surfaces (`smithy.ignite` and `smithy.audit`) use a consistent vocabulary and catch the same gaps.

This spec was referenced in the main epic spec but lacked a dedicated task breakdown. This PR adds that breakdown and marks US9 as specified in the epic roadmap.

## Implementation Notes
- **Document type**: Task specification (`.tasks.md` file following the established pattern from US1–US4).
- **Structure**: Single slice with three sequential tasks:
  1. Update Phase 0 audit table in `smithy.ignite.prompt`
  2. Rename and strengthen audit snippet rows in `audit-checklist-rfc.md`
  3. Add template-composition assertions to `templates.test.ts`
- **Acceptance criteria**: Defined per task to guide implementation and testing.
- **Dependencies**: Depends on US1 (template sections exist); complementary to US5 and US6 (which enforce section population during generation).

## Risks & Mitigations
- Risk: Audit category names drift between ignite and audit surfaces during implementation. | Mitigation: Template-composition test assertions verify both surfaces expose the same category names.
- Risk: Existing audit rows are accidentally removed or reordered. | Mitigation: Acceptance criteria explicitly require preservation and correct ordering; test assertions cover both old and new categories.

## Rollback Plan
Delete `specs/2026-04-07-003-refactor-ignite-workflow/09-updated-phase-0-audit-categories.tasks.md` and revert the roadmap entry in `refactor-ignite-workflow.spec.md` to unchecked status. No code or data changes.

## Testing
N/A — specification document only. Implementation tasks will include their own test assertions (template-composition tests in `templates.test.ts`).

https://claude.ai/code/session_01VPqCFThgASfDZ1n32E6ZFd