### PR TITLE
Migrate authoring templates to 4-column Dependency Order table

### DIFF
--- a/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
@@ -49,7 +49,7 @@
   - No `1. [ ] **Slice N` or `- [ ] **Slice` numbered/bulleted-checkbox format remains
   - Per-task checkboxes inside `## Slice N:` bodies are preserved unchanged
 
-- [ ] **Add Dependency Order table to smithy.ignite RFC template**
+- [x] **Add Dependency Order table to smithy.ignite RFC template**
 
   In `src/templates/agent-skills/commands/smithy.ignite.prompt`, add a `## Dependency Order` section immediately after the final `### Milestone N:` block in the RFC template code fence. Update the sub-phase 3f instructions to direct the drafting agent to produce this table alongside milestones. Satisfies AS 8.4, AS 8.5, AS 8.6, AS 8.7.
 

--- a/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Migrate smithy.mark spec template to US-ID Dependency Order table**
+- [x] **Migrate smithy.mark spec template to US-ID Dependency Order table**
 
   In `src/templates/agent-skills/commands/smithy.mark.prompt`, replace the `## Story Dependency Order` checkbox-list template in Phase 3 (Specify) with a `## Dependency Order` 4-column table using `US<N>` IDs. Also update the authoring-guidelines section so no checkbox-format instructions remain. Satisfies AS 8.1, AS 8.5, AS 8.6, AS 8.7.
 

--- a/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
@@ -29,7 +29,7 @@
   - `Artifact` column contains `—` in the template placeholder
   - No `- [ ]` or `- [x]` checkbox syntax appears in the spec template or its authoring guidelines
 
-- [ ] **Migrate smithy.render features template to F-ID Dependency Order table**
+- [x] **Migrate smithy.render features template to F-ID Dependency Order table**
 
   In `src/templates/agent-skills/commands/smithy.render.prompt`, replace the `## Feature Dependency Order` checkbox-list template in Phase 3 (Draft Feature Map) with a `## Dependency Order` 4-column table using `F<N>` IDs. Update the Rules section to remove checkbox-based instructions. Satisfies AS 8.3, AS 8.5, AS 8.6, AS 8.7.
 

--- a/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
@@ -39,7 +39,7 @@
   - Rules section contains no `[ ]`/`[x]` checkbox mechanics or `**Feature N Spec:` row-title format
   - No `- [ ] **Feature N Spec:` patterns remain in the template
 
-- [ ] **Migrate smithy.cut tasks template to S-ID Dependency Order table**
+- [x] **Migrate smithy.cut tasks template to S-ID Dependency Order table**
 
   In `src/templates/agent-skills/commands/smithy.cut.prompt`, replace the numbered-checkbox `## Dependency Order` template in Phase 4 (Slice) with a 4-column table using `S<N>` IDs. Per-task checkboxes inside each `## Slice N:` body are not affected — those track implementation progress. Satisfies AS 8.2, AS 8.5, AS 8.6, AS 8.7.
 

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -270,9 +270,10 @@ _If no debt items, write: "None — all ambiguities resolved."_
 
 Recommended implementation sequence:
 
-1. [ ] **Slice N** — <why this comes first>
-2. [ ] **Slice M** — <why this follows>
-3. ...
+| ID | Title | Depends On | Artifact |
+|----|-------|-----------|----------|
+| S1 | <Title> | — | — |
+| S2 | <Title> | — | — |
 
 ### Cross-Story Dependencies
 

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -297,6 +297,7 @@ Guidelines for slicing:
 - Include tests, docs, and validation steps within the slice that introduces the
   code — do not batch these into a separate "testing slice".
 - Populate the `## Specification Debt` section with both (1) inherited items from the source spec (carried over in Phase 1) and (2) new items from cut's own clarify run. Inherited items use status `inherited`; new items use status `open`. Assign new SD-NNN identifiers to cut's own items, continuing from where the inherited list left off.
+- In the `## Dependency Order` table, `Depends On` must be exactly `—` or a comma-separated list of same-table `S<N>` IDs (e.g., `S1` or `S1, S2`); do not use prose. `Artifact` must always be `—` for every slice row — slices live inline as `## Slice N:` bodies and have no separate artifact file.
 
 Guidelines for task authoring:
 

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -246,10 +246,10 @@ RFC file.
 
 Dispatch **smithy-plan** with:
 
-- **Planning context**: "Draft the Milestones section for this RFC, with per-milestone success criteria"
+- **Planning context**: "Draft the Milestones section and Dependency Order table for this RFC"
 - **Feature/problem description**: the user's idea description plus the clarification output
 - **Codebase file paths**: the path to the accumulating `<slug>.rfc.md` (containing all prior sections)
-- **Additional planning directives**: produce milestone decomposition only, with each milestone formatted as `### Milestone N: <Title>` followed by `**Description**` and `**Success Criteria**` bullets matching the RFC template
+- **Additional planning directives**: produce the milestone decomposition followed immediately by a `## Dependency Order` 4-column table with `M<N>` IDs. Each milestone must be formatted as `### Milestone N: <Title>` followed by `**Description**` and `**Success Criteria**` bullets. The Dependency Order table uses columns `ID | Title | Depends On | Artifact` — `Artifact` starts as `—`. Do not use checkboxes.
 
 Append the returned content to the RFC file.
 
@@ -352,6 +352,15 @@ _If no debt items, write: "None — all ambiguities resolved."_
 **Success Criteria**:
 - <Measurable outcome 1>
 - <Measurable outcome 2>
+
+## Dependency Order
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|-----------|----------|
+| M1 | <Title> | — | — |
+| M2 | <Title> | — | — |
 ```
 
 ## Phase 4: Write & Review

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -249,7 +249,7 @@ Dispatch **smithy-plan** with:
 - **Planning context**: "Draft the Milestones section and Dependency Order table for this RFC"
 - **Feature/problem description**: the user's idea description plus the clarification output
 - **Codebase file paths**: the path to the accumulating `<slug>.rfc.md` (containing all prior sections)
-- **Additional planning directives**: produce the milestone decomposition followed immediately by a `## Dependency Order` 4-column table with `M<N>` IDs. Each milestone must be formatted as `### Milestone N: <Title>` followed by `**Description**` and `**Success Criteria**` bullets. The Dependency Order table uses columns `ID | Title | Depends On | Artifact` — `Artifact` starts as `—`. Do not use checkboxes.
+- **Additional planning directives**: produce the milestone decomposition followed immediately by a `## Dependency Order` 4-column table with `M<N>` IDs. Each milestone must be formatted as `### Milestone N: <Title>` followed by `**Description**` and `**Success Criteria**` bullets. The Dependency Order table uses columns `ID | Title | Depends On | Artifact`. In `Depends On`, each cell must be exactly `—` or a comma-separated list of `M<N>` IDs from the same table (e.g., `M1` or `M1, M2`); do not use prose or any other format. In `Artifact`, each cell starts as `—`; do not use checkboxes.
 
 Append the returned content to the RFC file.
 

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -237,13 +237,15 @@ As a <persona>, I want <goal> so that <benefit>.
 - <edge case 1>
 - ...
 
-## Story Dependency Order
+## Dependency Order
 
 Recommended implementation sequence:
 
-- [ ] **User Story 1 Tasks: <Title>** — <dependency rationale>
-- [ ] **User Story 2 Tasks: <Title>** — <dependency rationale>
-- [ ] **User Story N Tasks: <Title>** — <dependency rationale>
+| ID | Title | Depends On | Artifact |
+|----|-------|-----------|----------|
+| US1 | <Title> | — | — |
+| US2 | <Title> | — | — |
+| USN | <Title> | — | — |
 
 ## Requirements *(mandatory)*
 
@@ -292,25 +294,16 @@ Guidelines for the spec:
 - Success criteria are measurable and testable.
 - Do NOT include implementation phases, milestones, or task breakdowns.
 - Do NOT include specific file paths, function names, or implementation details.
-  (Exception: the `→` links in Story Dependency Order are auto-appended by
-  `smithy.cut` when it flips the checkbox, and are cross-reference paths,
-  not implementation details.)
 - DO trace back to RFC sections when input is an RFC.
 - Populate the `## Specification Debt` section from clarify's returned `debt_items`. Assign sequential SD-NNN identifiers starting at SD-001. Carry the description, source_category, impact, confidence, and status fields directly from clarify's return. Leave Resolution as `—` for all `open` items.
-- The Story Dependency Order section lists all user stories in recommended
-  implementation sequence with single-checkbox rows of the form
-  `- [ ] **User Story N Tasks: <Title>** — <rationale>`. Order by dependency
-  graph, not by priority — stories with no dependencies come first, stories that
-  depend on others come after their prerequisites. Stories that can be
-  implemented in parallel should be noted as such in their rationale. Each entry
-  includes a brief rationale explaining why it is positioned where it is (e.g.,
-  "No dependencies", "Depends on Story 1 for the auth module", "Can parallelize
-  with Story 2").
-- The checkbox on each Story Dependency Order row tracks whether the story's
-  `.tasks.md` file has been created: `smithy.cut` flips it from `[ ]` to `[x]`
-  when it writes the tasks file. It does NOT represent implementation
-  completeness — per-slice progress lives inside each `.tasks.md`. Do NOT
-  manually check story rows during spec creation.
+- The `## Dependency Order` section lists all user stories in recommended
+  implementation sequence as a 4-column table using `US<N>` IDs (e.g., `US1`,
+  `US2`). Order rows by dependency graph, not by priority — stories with no
+  dependencies come first, stories that depend on others come after their
+  prerequisites. The `Depends On` column contains `—` or a comma-separated list
+  of same-table IDs (e.g., `US1, US3`); no prose justifications. The `Artifact`
+  column starts as `—` and is populated by `smithy.cut` when it creates the
+  tasks file. Do NOT use checkboxes in the `## Dependency Order` section.
 
 ---
 

--- a/src/templates/agent-skills/commands/smithy.render.prompt
+++ b/src/templates/agent-skills/commands/smithy.render.prompt
@@ -254,12 +254,14 @@ this format:
 
 _If no debt items, write: "None — all ambiguities resolved."_
 
-## Feature Dependency Order
+## Dependency Order
 
 Recommended specification sequence:
 
-- [ ] **Feature 1 Spec: <Title>** — <dependency rationale>
-- [ ] **Feature 2 Spec: <Title>** — <dependency rationale>
+| ID | Title | Depends On | Artifact |
+|----|-------|-----------|----------|
+| F1 | <Title> | — | — |
+| F2 | <Title> | — | — |
 
 ## Cross-Milestone Dependencies
 
@@ -307,13 +309,10 @@ again. Once approved, suggest the next step:
   parallel by other agents. Each agent owns exactly one milestone.
 - **DO** note cross-milestone dependencies in the feature map (as
   "Cross-Milestone Dependencies") without pulling that work into your features.
-- **DO** include a `## Feature Dependency Order` section listing every feature
-  with a single-checkbox row of the form
-  `- [ ] **Feature N Spec: <Title>** — <dependency rationale>`. Order features
-  by dependency graph — features with no dependencies come first, dependent
-  features come after their prerequisites. Include rationale for each entry
-  (e.g., "No dependencies; foundational", "Depends on Feature 1 for X", "Can
-  parallelize with Feature 2"). All items start as `[ ]` — `smithy.mark`
-  flips the checkbox to `[x]` and appends the spec folder path when it creates
-  the spec. The checkbox tracks spec-folder creation, not implementation
-  completeness; per-slice progress lives inside each story's `.tasks.md`.
+- **DO** include a `## Dependency Order` section listing every feature as a
+  4-column table with `F<N>` IDs (e.g., `F1`, `F2`). Order rows by dependency
+  graph — features with no dependencies come first, dependent features come
+  after their prerequisites. The `Depends On` column contains `—` or a
+  comma-separated list of same-table IDs. The `Artifact` column starts as `—`
+  and is populated by `smithy.mark` when it creates the spec folder. Do NOT
+  use checkboxes in the `## Dependency Order` section.


### PR DESCRIPTION
## Source

- Spec: `specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.spec.md` — User Story 8
- Tasks: `specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md`

## Slice

**Slice 1 of 3** — Migrate Output Templates to 4-Column Dependency Order Table

Every authoring command (`smithy.mark`, `smithy.render`, `smithy.cut`, `smithy.ignite`) now emits a `## Dependency Order` 4-column table with canonical per-level IDs and no checkboxes anywhere inside the section.

**Addresses**: FR-020, FR-021, FR-022, FR-023, FR-024; AS 8.1, AS 8.2, AS 8.3, AS 8.4, AS 8.5, AS 8.6, AS 8.7

## Tasks Completed

- [x] **Migrate smithy.mark spec template to US-ID Dependency Order table** — Replaced `## Story Dependency Order` checkbox list in Phase 3 with a `## Dependency Order` 4-column table using `US<N>` IDs. Removed checkbox-format instructions from authoring guidelines; added table-format guidance with `Depends On` / `Artifact` column semantics.
- [x] **Migrate smithy.render features template to F-ID Dependency Order table** — Replaced `## Feature Dependency Order` checkbox list in Phase 3 with a `## Dependency Order` 4-column table using `F<N>` IDs. Updated Rules section to describe the table format and prohibit checkboxes.
- [x] **Migrate smithy.cut tasks template to S-ID Dependency Order table** — Replaced the numbered-checkbox `1. [ ] **Slice N` Dependency Order block in Phase 4 with a 4-column table using `S<N>` IDs. Per-task checkboxes inside `## Slice N:` bodies are preserved unchanged.
- [x] **Add Dependency Order table to smithy.ignite RFC template** — Added `## Dependency Order` section immediately after the final `### Milestone N:` block in the RFC template code fence. Updated sub-phase 3f instructions to direct the drafting agent to produce both the milestones list and the Dependency Order table with `M<N>` IDs.

## Review

No auto-fixes applied. All review findings (legacy references in routing, write-back logic, audit checklists) are intentionally out of scope for this slice:

- Behavioral read/write logic (`smithy.mark` Phase 1c routing + Phase 6 write-back, `smithy.cut` Phase 5 write-back, `smithy.forge` Story Completion Cascade) → **Slice 2**
- Audit checklist snippets and `templates.test.ts` regression tests → **Slice 3**

> **SD-012 note**: Slices 1 and 2 are not independently releasable — after Slice 1, `smithy.mark`'s Phase 1c routing still looks for the legacy `## Feature Dependency Order` heading. Recommend shipping Slices 1 and 2 together in a paired merge.

## Validation

```
npm run build  ✓  dist/cli.js 45.85 KB
npm test       ✓  209 passed (8 test files)
```