### PR TITLE
Update behavioral logic for table-based dependency order in mark, cut, and forge

### DIFF
--- a/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
@@ -106,7 +106,7 @@
   - If only legacy `## Story Dependency Order` exists, write-back skips silently
   - No checkbox-flip language remains in Phase 5 or in the Rules section
 
-- [ ] **Remove "Mark Slice Complete" section and update "Story Completion Cascade" in smithy.forge**
+- [x] **Remove "Mark Slice Complete" section and update "Story Completion Cascade" in smithy.forge**
 
   Delete the "Mark Slice Complete" section in `smithy.forge.prompt` entirely — forge no longer writes to any `## Dependency Order` table. Rewrite "Story Completion Cascade" to explain that slice completion is derived from per-task checkboxes inside `## Slice N:` bodies, and that parent artifacts' `Artifact` columns are set by `smithy.mark` and `smithy.cut`, not forge. Satisfies AS 8.2.
 

--- a/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
@@ -95,7 +95,7 @@
   - If only legacy `## Feature Dependency Order` is present, write-back skips silently
   - Authoring-guidelines section contains no checkbox-flip instructions
 
-- [ ] **Update smithy.cut Phase 5 write-back to populate the spec Artifact column**
+- [x] **Update smithy.cut Phase 5 write-back to populate the spec Artifact column**
 
   Rewrite the Phase 5 spec write-back in `smithy.cut.prompt` so that after writing the tasks file, cut finds the matching `US<N>` row in the spec's `## Dependency Order` table and sets the `Artifact` cell to the repo-relative tasks file path. If the spec only has the legacy `## Story Dependency Order` section and no table, skip silently. Satisfies AS 8.1, AS 8.7.
 

--- a/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
@@ -84,7 +84,7 @@
   - Mark does not write to or migrate legacy files during the routing phase
   - No `[x]`/`[ ]` references remain in Phase 1c
 
-- [ ] **Update smithy.mark Phase 6 write-back to populate the Artifact column**
+- [x] **Update smithy.mark Phase 6 write-back to populate the Artifact column**
 
   Rewrite the Phase 6 feature-map write-back in `smithy.mark.prompt` so that after creating a spec folder, mark locates the matching `F<N>` row in the features file's `## Dependency Order` table and sets the `Artifact` cell to the spec folder path (replacing `—`). If the table is absent, create it in the 4-column format seeded from the feature list. If only the legacy checkbox format is present, skip silently. Satisfies AS 8.3, AS 8.7.
 

--- a/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md
@@ -73,7 +73,7 @@
 
 ### Tasks
 
-- [ ] **Rewrite smithy.mark routing to detect specc'd features from the Artifact column**
+- [x] **Rewrite smithy.mark routing to detect specc'd features from the Artifact column**
 
   Update Phase 1c of `smithy.mark.prompt` so that a feature is "specc'd" when its `## Dependency Order` table row's `Artifact` cell contains a path (not `—`). Add an explicit backward-compat clause: if the features file only contains the legacy `## Feature Dependency Order` checkbox section and no table, treat every feature as unspecced and do not modify the file during routing. Satisfies AS 8.3, AS 8.7.
 

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -413,21 +413,53 @@ Write the file to `specs/<folder>/<NN>-<story-slug>.tasks.md` (where `<NN>` is
 the zero-padded user story number).
 
 **Spec write-back**: After writing the tasks file, update the source `.spec.md`
-to reflect that this story has been cut. Find the `## Story Dependency Order`
-section in the spec file and flip the current user story's checkbox from
-`[ ]` to `[x]`, appending the repo-relative tasks file path:
+so its `## Dependency Order` 4-column table points at the newly-created tasks
+file for the current user story. The table is the authoritative link between
+the spec and its child tasks files — no checkboxes are flipped and no prose is
+rewritten.
 
-```markdown
-- [x] **User Story 3 Tasks: <Title>** — <rationale> → `specs/<folder>/03-story-slug.tasks.md`
-```
+Write-back procedure:
 
-If the `## Story Dependency Order` section does not exist in the spec (e.g.,
-older specs created before this section was introduced), skip the write-back
-silently — do not add the section or fail. Match the story by its number
-(`User Story <N>`) in the bold text. Update only the matching entry — do not
-modify other entries or rename rows cut has not touched. If the checkbox is
-already `[x]`, skip — the operation is idempotent. The checkbox tracks
-tasks-file creation, not implementation completeness.
+1. **Locate the `## Dependency Order` table** in the source `.spec.md` file
+   (locate by heading name, not by position). The table has the columns
+   `ID | Title | Depends On | Artifact`, with one `US<N>` row per user story.
+2. **Find the matching row** whose `ID` cell equals `US<N>` where `<N>` is the
+   current user story number (the one this tasks file was just created for).
+   Match by the `US<N>` identifier, not by title or row position.
+3. **Update the `Artifact` cell** on that row: replace `—` with the
+   repo-relative tasks file path (e.g.,
+   `specs/2026-03-14-004-webhook-support/03-story-slug.tasks.md`). Do not
+   touch the `ID`, `Title`, or `Depends On` cells. Do not touch any other row.
+4. **Idempotency**: If the matching row's `Artifact` cell already contains the
+   same repo-relative tasks file path, skip the write entirely — this is a
+   no-op. Do not append, duplicate, or rewrite the cell.
+5. **Table absent**: If the spec contains neither a `## Dependency Order`
+   table nor a legacy `## Story Dependency Order` section, create a new
+   `## Dependency Order` section at the end of the spec file. Seed the table
+   from the user story list parsed in Phase 1 — one `US<N>` row per story in
+   story-number order, with `Depends On` set to `—` for every row and
+   `Artifact` set to `—` for every row **except** the current story's row,
+   which gets the repo-relative tasks file path. Use this shape:
+
+   ```markdown
+   ## Dependency Order
+
+   | ID | Title | Depends On | Artifact |
+   |----|-------|------------|----------|
+   | US1 | <Story 1 title> | — | — |
+   | US2 | <Story 2 title> | — | — |
+   | US3 | <Story 3 title> | — | specs/<folder>/03-story-slug.tasks.md |
+   ```
+
+6. **Legacy format present**: If the spec contains only the legacy
+   `## Story Dependency Order` checkbox section and NO `## Dependency Order`
+   table, **skip write-back silently**. Do not migrate, rewrite, or annotate
+   the legacy section. Do not flip any checkbox. The tasks file is still
+   written to disk; only the source spec is left untouched. Mention in the
+   summary that the legacy spec was not updated.
+
+The `Artifact` cell is the single source of truth for "does this user story
+have a tasks file yet" — it replaces the legacy checkbox signal entirely.
 
 Then present a summary to the user:
 
@@ -473,9 +505,12 @@ ask again.
   for in-progress work from other stories.
 - **DO** note cross-story dependencies in the Dependency Order section (as
   "Cross-Story Dependencies") without pulling that work into your slices.
-- **DO** update the spec file's Story Dependency Order checkbox from `[ ]` to
-  `[x]` when writing the tasks file. The checkbox tracks tasks-file creation,
-  not implementation completeness. If the section is missing, skip silently.
+- **DO** update the spec file's `## Dependency Order` table after writing the
+  tasks file: set the matching `US<N>` row's `Artifact` cell to the
+  repo-relative tasks file path. The `Artifact` cell tracks tasks-file
+  creation, not implementation completeness. If only the legacy
+  `## Story Dependency Order` checkbox section is present (and no table),
+  skip the write-back silently — do not migrate legacy files.
 - **DO** use the structured task format (bold title + behavioral description +
   acceptance criteria bullets). See "Guidelines for task authoring" above.
 - **DO** reference acceptance scenarios by ID (e.g., "AS 2.1") rather than
@@ -495,7 +530,7 @@ ask again.
 1. **Audit findings and refinements** (if repeating the command on existing tasks).
 2. Created/updated files:
    - `specs/<folder>/<NN>-<story-slug>.tasks.md`
-   - `specs/<date>-<NNN>-<slug>/<slug>.spec.md` *(Story Dependency Order checkbox flipped to `[x]`)*
+   - `specs/<date>-<NNN>-<slug>/<slug>.spec.md` *(`## Dependency Order` table's `US<N>` row `Artifact` cell set to the tasks file path)*
 3. Summary report containing:
    - Slice count with titles.
    - FR and acceptance scenario coverage.

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -433,7 +433,12 @@ Write-back procedure:
 4. **Idempotency**: If the matching row's `Artifact` cell already contains the
    same repo-relative tasks file path, skip the write entirely — this is a
    no-op. Do not append, duplicate, or rewrite the cell.
-5. **Table absent**: If the spec contains neither a `## Dependency Order`
+5. **Row missing**: If the `## Dependency Order` table exists but contains no
+   row whose `ID` cell equals `US<N>`, append a new row to the end of the
+   table: set `ID` to `US<N>`, `Title` to the user story title from the story
+   list parsed in Phase 1, `Depends On` to `—`, and `Artifact` to the
+   repo-relative tasks file path.
+6. **Table absent**: If the spec contains neither a `## Dependency Order`
    table nor a legacy `## Story Dependency Order` section, create a new
    `## Dependency Order` section at the end of the spec file. Seed the table
    from the user story list parsed in Phase 1 — one `US<N>` row per story in
@@ -451,7 +456,7 @@ Write-back procedure:
    | US3 | <Story 3 title> | — | specs/<folder>/03-story-slug.tasks.md |
    ```
 
-6. **Legacy format present**: If the spec contains only the legacy
+7. **Legacy format present**: If the spec contains only the legacy
    `## Story Dependency Order` checkbox section and NO `## Dependency Order`
    table, **skip write-back silently**. Do not migrate, rewrite, or annotate
    the legacy section. Do not flip any checkbox. The tasks file is still

--- a/src/templates/agent-skills/commands/smithy.forge.prompt
+++ b/src/templates/agent-skills/commands/smithy.forge.prompt
@@ -220,37 +220,23 @@ For each stale doc found:
 
 ---
 
-## Mark Slice Complete
-
-For `.tasks.md` mode only:
-
-In the tasks file, find the `## Dependency Order` section and change the target
-slice's checkbox from `[ ]` to `[x]`. For example, if implementing Slice 2:
-
-```
-1. [x] **Slice 1** — ...   (already completed)
-2. [x] **Slice 2** — ...   ← mark this one
-3. [ ] **Slice 3** — ...   (not yet started)
-```
-
-Commit the change: `mark slice <N> complete in dependency order`
-
-This ensures the PR diff includes the Dependency Order context, making it easy
-for reviewers to see which slice was completed and what comes next.
-
----
-
 ## Story Completion Cascade
 
-Forge does **not** update the `## Story Dependency Order` or
-`## Feature Dependency Order` sections. Those single checkboxes track
-*artifact creation* (tasks file, spec folder) and are flipped by
-`smithy.cut` and `smithy.mark` respectively. Implementation progress lives in
-the per-slice checkboxes inside each `.tasks.md` and is the single source of
-truth for "done".
+Forge makes **no writes** to any `## Dependency Order` table. Slice completion
+is determined solely by the per-task checkboxes inside each `## Slice N:` body
+of the tasks file — when every `- [ ]` in a slice's task list has been flipped
+to `- [x]` by the implementation sub-agents, that slice is complete.
 
-After marking a slice complete, forge's bookkeeping ends at the tasks file.
-No cascade into the spec or feature map is required.
+Parent artifacts' `Artifact` columns — the spec's `## Dependency Order` table
+(populated by `smithy.cut` when it creates the tasks file) and the features
+file's `## Dependency Order` table (populated by `smithy.mark` when it creates
+the spec folder) — are not forge's responsibility. Those upstream commands own
+their own write-back into the table format.
+
+Implementation progress lives in the per-slice task checkboxes inside each
+`.tasks.md` and is the single source of truth for "done". No cascade writes
+into the spec, features file, or any other parent artifact are required after
+forge completes a slice.
 
 ---
 

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -464,7 +464,12 @@ Write-back procedure:
 4. **Idempotency**: If the matching row's `Artifact` cell already contains
    the correct spec folder path, skip the write entirely — this is a no-op.
    Do not append, duplicate, or rewrite the cell.
-5. **Table absent**: If the file contains neither a `## Dependency Order`
+5. **Row missing**: If the `## Dependency Order` table exists but contains no
+   row whose `ID` cell equals `F<N>`, append a new row to the end of the
+   table: set `ID` to `F<N>`, `Title` to the feature title from the feature
+   list parsed during Routing, `Depends On` to `—`, and `Artifact` to the
+   spec folder path.
+6. **Table absent**: If the file contains neither a `## Dependency Order`
    table nor a legacy `## Feature Dependency Order` section, create a new
    `## Dependency Order` section just before `## Cross-Milestone Dependencies`
    (or at the end of the file if that section is absent). Seed the table
@@ -483,7 +488,7 @@ Write-back procedure:
    | F3 | Webhook Support | — | — |
    ```
 
-6. **Legacy format present**: If the file contains only the legacy
+7. **Legacy format present**: If the file contains only the legacy
    `## Feature Dependency Order` checkbox section and NO `## Dependency Order`
    table, **skip write-back silently**. Do not migrate, rewrite, or annotate
    the legacy section. Do not flip any checkbox. The spec folder is still

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -538,7 +538,7 @@ Use the **smithy-refine** sub-agent. Pass it:
   | **Contract Completeness** | Do all integration boundaries have defined inputs, outputs, and error conditions? Are there contracts implied by requirements but not documented? |
   | **Ambiguity & Risk** | Are there vague terms, unstated assumptions, or scope boundaries that could be interpreted multiple ways? |
   | **Staleness** | Does the spec still reflect the current codebase reality? Have upstream changes invalidated any assumptions? |
-  | **Story Dependency Order** | If the spec contains a `## Story Dependency Order` section: does it list all user stories with a single `[ ]`/`[x]` checkbox and a `**User Story N Tasks: <Title>**` row title? Is the sequence logically justified? Do `[x]` entries match stories with `.tasks.md` files in the spec folder? If absent (legacy spec), treat as N/A. |
+  | **Dependency Order** | Does the spec contain a `## Dependency Order` 4-column table (`ID \| Title \| Depends On \| Artifact`)? Does it list every user story with a `US<N>` ID (no leading zeros)? Does each `Depends On` cell contain `—` or comma-separated same-table IDs (no prose)? Does each `Artifact` cell contain `—` or a repo-relative path to the corresponding `.tasks.md` file? Are any `- [ ]`/`- [x]` checkboxes present in the section (an error if so)? |
 
 - **Target files**: the spec (`.spec.md`), data model (`.data-model.md`), and
   contracts (`.contracts.md`) in the spec folder.

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -445,27 +445,53 @@ Existing contracts remain unchanged.
 Create the spec folder and write all three files to disk first.
 
 **Feature map write-back** (when input was a `.features.md`): Update the
-`.features.md` to track progress. If a `## Feature Dependency Order` section
-does not exist in the file, create it just before `## Cross-Milestone
-Dependencies` (or at the end of the file if that section is absent) with one
-single-checkbox entry per feature parsed during Routing, ordered by dependency
-graph with rationale. Then flip the current feature's checkbox from `[ ]` to
-`[x]` and append the spec folder path:
+`## Dependency Order` 4-column table in the `.features.md` so its `Artifact`
+column points at the newly-created spec folder for the current feature. The
+table is the authoritative link between the feature map and its child specs —
+no checkboxes are flipped and no prose is rewritten.
 
-```markdown
-## Feature Dependency Order
+Write-back procedure:
 
-Recommended specification sequence:
+1. **Locate the `## Dependency Order` table** in the `.features.md` file
+   (locate by heading name, not by position). The table has the columns
+   `ID | Title | Depends On | Artifact`, with one `F<N>` row per feature.
+2. **Find the matching row** whose `ID` cell equals `F<N>` where `<N>` is the
+   current feature number (the one this spec was just created for). Match by
+   the `F<N>` identifier, not by title or row position.
+3. **Update the `Artifact` cell** on that row: replace `—` with the spec
+   folder path (e.g., `specs/2026-03-14-004-webhook-support/`). Do not touch
+   the `ID`, `Title`, or `Depends On` cells. Do not touch any other row.
+4. **Idempotency**: If the matching row's `Artifact` cell already contains
+   the correct spec folder path, skip the write entirely — this is a no-op.
+   Do not append, duplicate, or rewrite the cell.
+5. **Table absent**: If the file contains neither a `## Dependency Order`
+   table nor a legacy `## Feature Dependency Order` section, create a new
+   `## Dependency Order` section just before `## Cross-Milestone Dependencies`
+   (or at the end of the file if that section is absent). Seed the table
+   from the feature list parsed during Routing — one `F<N>` row per feature
+   in feature-number order, with `Depends On` set to `—` for every row and
+   `Artifact` set to `—` for every row **except** the current feature's row,
+   which gets the spec folder path. Use this shape:
 
-- [x] **Feature 1 Spec: Template Deployment** — No dependencies; foundational. → `specs/2026-03-14-001-template-deployment/`
-- [ ] **Feature 2 Spec: Permission Management** — Depends on Feature 1 for deployment infrastructure.
-- [ ] **Feature 3 Spec: Webhook Support** — Independent; can parallelize with Feature 2.
-```
+   ```markdown
+   ## Dependency Order
 
-If the section already exists, update only the current feature's entry: flip
-its checkbox from `[ ]` to `[x]` and append the spec folder path after `→`.
-The checkbox tracks whether the spec folder has been created, not whether the
-feature is fully implemented.
+   | ID | Title | Depends On | Artifact |
+   |----|-------|------------|----------|
+   | F1 | Template Deployment | — | specs/2026-03-14-001-template-deployment/ |
+   | F2 | Permission Management | — | — |
+   | F3 | Webhook Support | — | — |
+   ```
+
+6. **Legacy format present**: If the file contains only the legacy
+   `## Feature Dependency Order` checkbox section and NO `## Dependency Order`
+   table, **skip write-back silently**. Do not migrate, rewrite, or annotate
+   the legacy section. Do not flip any checkbox. The spec folder is still
+   created on disk; only the feature map is left untouched. Mention in the
+   summary that the legacy feature map was not updated.
+
+The `Artifact` cell is the single source of truth for "does this feature
+have a spec yet" — it replaces the legacy checkbox signal entirely.
 
 Then present a summary to the user:
 

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -35,24 +35,29 @@ Before starting, determine the mode:
       feature map — expected `### Feature N: <Title>` headings."
    b. Extract the `**Source RFC**` path from the file header.
    c. Determine which features already have specs by checking the
-      `## Feature Dependency Order` section in the `.features.md` (locate by
+      `## Dependency Order` 4-column table in the `.features.md` (locate by
       heading name, not by position — it may appear before
-      `## Cross-Milestone Dependencies` or at the end of the file).
-      Each entry uses a single GFM task-list checkbox and an artifact-qualified
-      row title of the form `- [ ] **Feature N Spec: <Title>** — <rationale>`.
-      The checkbox tracks whether the spec folder for that feature exists:
-      `[ ]` means the spec has not been created yet, `[x]` means it has.
-      A feature is "specc'd" when its checkbox is `[x]`; unspecced when `[ ]`.
-      If the section does not exist yet, create it now with all features as
-      `- [ ] **Feature N Spec: <Title>** — <rationale>`, ordered by dependency
-      graph, write it to the file, and treat every feature as unspecced.
-      (Mark flips the checkbox from `[ ]` to `[x]` after creating a spec —
-      see Phase 6.)
+      `## Cross-Milestone Dependencies` or at the end of the file). The table
+      has columns `ID | Title | Depends On | Artifact`, with one `F<N>` row
+      per feature. A feature is "specc'd" when its row's `Artifact` cell
+      contains a non-`—` path (the path points to the feature's spec folder).
+      A feature is "unspecced" when its row's `Artifact` cell is `—` or when
+      the row is missing from the table.
+
+      **Backward-compat clause**: If the file contains only the legacy
+      `## Feature Dependency Order` checkbox section and NO `## Dependency Order`
+      table, treat every feature as unspecced and do NOT modify the file during
+      routing. Mark will not migrate or write to legacy files in this phase.
+
+      If neither a `## Dependency Order` table nor a legacy
+      `## Feature Dependency Order` section exists, treat every feature as
+      unspecced. Do NOT create the section during routing — section creation
+      and write-back happen in Phase 6.
    d. **With feature number**: If the number is out of range, list available
       features with their numbers and titles, then stop. If the feature is
       already specc'd (per step c), extract the spec folder path from its
-      checked entry (after the `→`) and go to **Phase 0** (Review Loop) with
-      that spec. Otherwise, go to **Phase 1** targeting that feature.
+      `Artifact` cell and go to **Phase 0** (Review Loop) with that spec.
+      Otherwise, go to **Phase 1** targeting that feature.
    e. **Without feature number**: Auto-select the first `### Feature N` that
       is not yet specc'd (per step c). If **all** features already have specs,
       present a table of features with their spec folder paths and ask the


### PR DESCRIPTION
## Source

- Spec: `specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.spec.md`
- Tasks: `specs/2026-04-12-004-smithy-status-skill/08-deterministic-dependency-order-format.tasks.md`

## Slice

**Slice 2** — Update behavioral logic for table-based dependency order

Routing and write-back logic in `smithy.mark`, `smithy.cut`, and `smithy.forge` now read and update the new 4-column `## Dependency Order` table format. Legacy artifacts encountered in the wild are handled gracefully with explicit skip-silently rules.

## Addresses

FR-020, FR-021, FR-022, FR-023, FR-024, FR-029; AS 8.1, AS 8.2, AS 8.3, AS 8.4, AS 8.7

## Tasks Completed

- [x] **Rewrite smithy.mark routing to detect specc'd features from the Artifact column** — Phase 1c now reads `## Dependency Order` table; `F<N>` row's `Artifact` cell (non-`—`) means specc'd. Backward-compat clause: legacy `## Feature Dependency Order`-only files → all features unspecced, no file modification.
- [x] **Update smithy.mark Phase 6 write-back to populate the Artifact column** — After creating a spec folder, mark finds the `F<N>` row and sets `Artifact` to the spec folder path. Creates table if absent; skips silently if only legacy format present; appends row if table exists but row is missing.
- [x] **Update smithy.cut Phase 5 write-back to populate the spec Artifact column** — After writing the tasks file, cut finds the `US<N>` row in the spec's `## Dependency Order` table and sets `Artifact` to the tasks file path. Creates table if absent; skips silently if only legacy format present; appends row if table exists but row is missing.
- [x] **Remove "Mark Slice Complete" section and update "Story Completion Cascade" in smithy.forge** — Removed `## Mark Slice Complete` entirely. Rewrote `## Story Completion Cascade`: forge makes no writes to any `## Dependency Order` table; slice completion is derived from per-task checkboxes inside `## Slice N:` bodies; parent `Artifact` columns are owned by `smithy.mark` and `smithy.cut`.

## Review

No auto-fixes were applied by the review sub-agent. Two escalated edge cases were resolved:

- **Missing row in an existing table** (escalated Findings 2 & 3): Both mark Phase 6 and cut Phase 5 write-back procedures now include a "Row missing" clause — when the table exists but the target `F<N>`/`US<N>` row is absent, a new row is appended with the correct `Artifact` value.

Minor findings noted for the record (not fixed):
- **Finding 4**: mark's Output section does not list the feature-map write-back result. Low impact.
- **Finding 5**: Idempotency check uses exact string match — trailing-slash consistency should be maintained when deriving spec folder paths.

## Documentation

**Maid auto-fix applied** (`maid: update Phase 0a audit row to check 4-column Dependency Order table`): The Phase 0a audit category row in `smithy.mark.prompt` still described the legacy `## Story Dependency Order` checkbox format. Updated to describe the new `## Dependency Order` 4-column table (US<N> IDs, `Depends On` comma-list, `Artifact` paths, no checkboxes).

**Known gap (deferred to Slice 3)**: The four `audit-checklist-*.md` snippets still describe the old checkbox format. Slice 3 is explicitly scoped to update them.

## Validation

```
npm run build     → ✅  dist/cli.js 45.85 KB, build success
npm run typecheck → ✅  clean
npm test          → ✅  8 test files, 209 tests passed
```