### PR TITLE
docs(specs): migrate existing artifacts to 4-column Dependency Order tables

### DIFF
--- a/specs/2026-03-14-001-smithy-command-redesign/01-workshop-idea-into-rfc.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/01-workshop-idea-into-rfc.tasks.md
@@ -60,7 +60,7 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — Core template must exist before the review loop can be added or tested.
-- [x] **Slice 2** — Adds review loop on top of the working template from Slice 1.
+| ID | Title                                      | Depends On | Artifact |
+|----|--------------------------------------------|------------|----------|
+| S1 | Core Ignite Template — New RFC Generation  | —          | —        |
+| S2 | Review Loop for Existing RFCs              | S1         | —        |

--- a/specs/2026-03-14-001-smithy-command-redesign/02-break-milestone-into-features.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/02-break-milestone-into-features.tasks.md
@@ -65,7 +65,7 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — Core template must exist before the review loop can be added or tested.
-- [x] **Slice 2** — Adds review loop on top of the working template from Slice 1.
+| ID | Title                                              | Depends On | Artifact |
+|----|----------------------------------------------------|------------|----------|
+| S1 | Core Render Template — New Feature Map Generation  | —          | —        |
+| S2 | Review Loop for Existing Feature Maps              | S1         | —        |

--- a/specs/2026-03-14-001-smithy-command-redesign/03-specify-a-feature.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/03-specify-a-feature.tasks.md
@@ -60,7 +60,7 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — Must come first because Slice 2 deletes the source file that Slice 1 copies from.
-- [x] **Slice 2** — Safe to do after Slice 1 since the new template is in place.
+| ID | Title                                               | Depends On | Artifact |
+|----|-----------------------------------------------------|------------|----------|
+| S1 | Create smithy.mark template from smithy.design     | —          | —        |
+| S2 | Remove legacy smithy.design and update references  | S1         | —        |

--- a/specs/2026-03-14-001-smithy-command-redesign/04-slice-story-into-tasks.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/04-slice-story-into-tasks.tasks.md
@@ -37,6 +37,6 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — Single verification slice, no dependencies.
+| ID | Title                                      | Depends On | Artifact |
+|----|--------------------------------------------|------------|----------|
+| S1 | Verify smithy.cut template spec alignment  | —          | —        |

--- a/specs/2026-03-14-001-smithy-command-redesign/05-implement-slice-as-pr.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/05-implement-slice-as-pr.tasks.md
@@ -43,6 +43,6 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — Single slice; the rewrite is self-contained.
+| ID | Title                                                      | Depends On | Artifact |
+|----|------------------------------------------------------------|------------|----------|
+| S1 | Rewrite smithy.forge template for slice-based workflow     | —          | —        |

--- a/specs/2026-03-14-001-smithy-command-redesign/06-fast-track-idea-to-implementation.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/06-fast-track-idea-to-implementation.tasks.md
@@ -46,6 +46,6 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — Single slice; self-contained template rewrite.
+| ID | Title                                                      | Depends On | Artifact |
+|----|------------------------------------------------------------|------------|----------|
+| S1 | Rewrite strike document structure and fix file extension  | —          | —        |

--- a/specs/2026-03-14-001-smithy-command-redesign/07-context-aware-artifact-review.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/07-context-aware-artifact-review.tasks.md
@@ -84,8 +84,8 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — Checklists must exist in source templates before they can be extracted
-- [x] **Slice 2** — Composition logic must exist before init can use it
-- [x] **Slice 3** — Connects everything: rewritten audit template + init wiring
+| ID | Title                                                         | Depends On | Artifact |
+|----|---------------------------------------------------------------|------------|----------|
+| S1 | Add audit checklist markers to producing command templates    | —          | —        |
+| S2 | Add audit template composition to templates.ts                | —          | —        |
+| S3 | Rewrite audit template and wire composition into init         | S1, S2     | —        |

--- a/specs/2026-03-14-001-smithy-command-redesign/08-create-tickets-from-artifacts.tasks.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/08-create-tickets-from-artifacts.tasks.md
@@ -60,7 +60,7 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — Must come first because Slice 2 deletes the source file whose patterns Slice 1 draws from.
-- [x] **Slice 2** — Safe after Slice 1 since the new template is in place.
+| ID | Title                                                           | Depends On | Artifact |
+|----|-----------------------------------------------------------------|------------|----------|
+| S1 | Create smithy.orders template with per-extension ticket mapping | —          | —        |
+| S2 | Remove legacy smithy.load and update references                 | S1         | —        |

--- a/specs/2026-03-14-001-smithy-command-redesign/smithy-command-redesign.spec.md
+++ b/specs/2026-03-14-001-smithy-command-redesign/smithy-command-redesign.spec.md
@@ -217,18 +217,18 @@ As a developer, I want to point `smithy.orders` at any artifact and have it crea
 - Running `cut` with a user story number that doesn't exist in the spec — should error listing available user stories.
 - A feature spec with more than 99 user stories — should error indicating the feature needs to be split.
 
-## Story Dependency Order
+## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **User Story 6 — Strike: Fast Track Idea to Implementation** — Foundational entry point; the most-used command and standalone. No pipeline dependencies. → `specs/2026-03-14-001-smithy-command-redesign/06-fast-track-idea-to-implementation.tasks.md`
-- [x] **User Story 3 — Mark: Specify a Feature** — Core artifact producer; second entry point into the system. Required before cut and forge can be tested end-to-end. → `specs/2026-03-14-001-smithy-command-redesign/03-specify-a-feature.tasks.md`
-- [x] **User Story 4 — Cut: Slice a User Story into Tasks** — Depends on mark output (`.spec.md`). Bridges spec to implementation. → `specs/2026-03-14-001-smithy-command-redesign/04-slice-story-into-tasks.tasks.md`
-- [x] **User Story 5 — Forge: Implement a Slice as a PR** — Terminal pipeline step; depends on cut output (`.tasks.md`). → `specs/2026-03-14-001-smithy-command-redesign/05-implement-slice-as-pr.tasks.md`
-- [x] **User Story 7 — Audit: Context-Aware Artifact Review** — Quality gate; independent of pipeline order but benefits from stable artifact conventions. Can parallelize with mark/cut/forge. → `specs/2026-03-14-001-smithy-command-redesign/07-context-aware-artifact-review.tasks.md`
-- [x] **User Story 1 — Ignite: Workshop Broad Idea into RFC** — Upper-pipeline extension; depends on core loop (mark/cut/forge) being solid first. → `specs/2026-03-14-001-smithy-command-redesign/01-workshop-idea-into-rfc.tasks.md`
-- [x] **User Story 2 — Render: Break Milestone into Features** — Depends on ignite output (`.rfc.md`). → `specs/2026-03-14-001-smithy-command-redesign/02-break-milestone-into-features.tasks.md`
-- [x] **User Story 8 — Orders: Create Tickets from Artifacts** — Productivity accelerator; depends on stable artifact conventions across all other stories. Implement last. → `specs/2026-03-14-001-smithy-command-redesign/08-create-tickets-from-artifacts.tasks.md`
+| ID  | Title                                            | Depends On         | Artifact                                                                                 |
+|-----|--------------------------------------------------|--------------------|------------------------------------------------------------------------------------------|
+| US1 | Ignite: Workshop Broad Idea into RFC             | US3, US4, US5      | `specs/2026-03-14-001-smithy-command-redesign/01-workshop-idea-into-rfc.tasks.md`        |
+| US2 | Render: Break Milestone into Features            | US1                | `specs/2026-03-14-001-smithy-command-redesign/02-break-milestone-into-features.tasks.md` |
+| US3 | Mark: Specify a Feature                          | —                  | `specs/2026-03-14-001-smithy-command-redesign/03-specify-a-feature.tasks.md`             |
+| US4 | Cut: Slice a User Story into Tasks               | US3                | `specs/2026-03-14-001-smithy-command-redesign/04-slice-story-into-tasks.tasks.md`        |
+| US5 | Forge: Implement a Slice as a PR                 | US4                | `specs/2026-03-14-001-smithy-command-redesign/05-implement-slice-as-pr.tasks.md`         |
+| US6 | Strike: Fast Track Idea to Implementation        | —                  | `specs/2026-03-14-001-smithy-command-redesign/06-fast-track-idea-to-implementation.tasks.md` |
+| US7 | Audit: Context-Aware Artifact Review             | —                  | `specs/2026-03-14-001-smithy-command-redesign/07-context-aware-artifact-review.tasks.md` |
+| US8 | Orders: Create Tickets from Artifacts            | US1, US2, US3, US4, US5, US6, US7 | `specs/2026-03-14-001-smithy-command-redesign/08-create-tickets-from-artifacts.tasks.md` |
 
 ## Requirements
 

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/01-create-smithy-issue-templates-during-init.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/01-create-smithy-issue-templates-during-init.tasks.md
@@ -59,7 +59,7 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [ ] **Slice 1** — Templates and utility must exist before the init flow can call them
-- [ ] **Slice 2** — Wires everything together into the user-facing feature; depends on Slice 1's utility functions
+| ID | Title                                                                          | Depends On | Artifact |
+|----|--------------------------------------------------------------------------------|------------|----------|
+| S1 | Default template content and provisioning utility                              | —          | —        |
+| S2 | Init flow integration, CLI flag, interactive prompts, and uninit guard         | S1         | —        |

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-smithy-templates.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-smithy-templates.tasks.md
@@ -62,7 +62,7 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [ ] **Slice 1** — establishes the template resolution algorithm, variable context definitions, and built-in default templates. Must come first because Slice 2 references these sections.
-- [ ] **Slice 2** — restructures the body construction to use the pipeline and adds tests. Depends on Slice 1's resolution phase and context tables being in place.
+| ID | Title                                                              | Depends On | Artifact |
+|----|--------------------------------------------------------------------|------------|----------|
+| S1 | Template resolution and interpolation context                     | —          | —        |
+| S2 | Restructure ticket body construction to use template pipeline     | S1         | —        |

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/03-commit-or-gitignore-smithy-dir.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/03-commit-or-gitignore-smithy-dir.tasks.md
@@ -40,6 +40,6 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [ ] **Slice 1** — This is the only slice. It depends on Story 1 (template creation) being implemented first, as the prompt is triggered by successful template creation.
+| ID | Title                                            | Depends On | Artifact |
+|----|--------------------------------------------------|------------|----------|
+| S1 | Add commit-or-gitignore prompt to init flow     | —          | —        |

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/04-orders-falls-back-to-defaults.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/04-orders-falls-back-to-defaults.tasks.md
@@ -56,7 +56,7 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [ ] **Slice 1** — Default template files must exist first so Slice 2 can reference their content inline in the prompt.
-- [ ] **Slice 2** — Adds resolution, interpolation, and fallback logic to the orders prompt, consuming Slice 1's templates.
+| ID | Title                                                            | Depends On | Artifact |
+|----|------------------------------------------------------------------|------------|----------|
+| S1 | Built-in default template files                                  | —          | —        |
+| S2 | Template resolution and interpolation in the orders prompt       | S1         | —        |

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.spec.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.spec.md
@@ -100,14 +100,14 @@ As a developer who hasn't created `.smithy/` templates, I want `smithy.orders` t
 - `.smithy/` is gitignored but the user later wants to commit it — this is a manual git operation, not smithy's responsibility.
 - `.smithy/` contains extra files beyond the 4 known templates (e.g., `README.md`, custom templates) — overwrite during init replaces only the 4 known files and leaves extras untouched.
 
-## Story Dependency Order
+## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **User Story 1 — Create `.smithy/` issue templates during init** — Foundational; templates must exist before `orders` can use them. Init is the natural setup point. → `specs/2026-03-21-002-smithy-orders-issue-templates/01-create-smithy-issue-templates-during-init.tasks.md`
-- [x] **User Story 3 — Commit-or-gitignore choice for `.smithy/`** — Setup-time decision that accompanies template creation (User Story 1). Can parallelize with User Story 1. → `specs/2026-03-21-002-smithy-orders-issue-templates/03-commit-or-gitignore-smithy-dir.tasks.md`
-- [x] **User Story 2 — Orders uses `.smithy/` templates when creating issues** — Core value proposition; depends on templates existing (User Story 1). → `specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-smithy-templates.tasks.md`
-- [x] **User Story 4 — Orders falls back to built-in defaults** — Fallback path; depends on orders integration being implemented (User Story 2) to validate the fallback is correct. → `specs/2026-03-21-002-smithy-orders-issue-templates/04-orders-falls-back-to-defaults.tasks.md`
+| ID  | Title                                                  | Depends On | Artifact                                                                                              |
+|-----|--------------------------------------------------------|------------|-------------------------------------------------------------------------------------------------------|
+| US1 | Create `.smithy/` issue templates during init          | —          | `specs/2026-03-21-002-smithy-orders-issue-templates/01-create-smithy-issue-templates-during-init.tasks.md` |
+| US2 | Orders uses `.smithy/` templates when creating issues  | US1        | `specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-smithy-templates.tasks.md`         |
+| US3 | Commit-or-gitignore choice for `.smithy/`              | —          | `specs/2026-03-21-002-smithy-orders-issue-templates/03-commit-or-gitignore-smithy-dir.tasks.md`       |
+| US4 | Orders falls back to built-in defaults                 | US2        | `specs/2026-03-21-002-smithy-orders-issue-templates/04-orders-falls-back-to-defaults.tasks.md`        |
 
 ## Requirements
 

--- a/specs/2026-04-06-003-smithy-evals-framework/01-validate-headless-execution-assumptions.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/01-validate-headless-execution-assumptions.tasks.md
@@ -46,9 +46,9 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — This is the only slice. It is the prerequisite for all other stories in the spec.
+| ID | Title                                     | Depends On | Artifact |
+|----|-------------------------------------------|------------|----------|
+| S1 | Headless Execution Validation Spike       | —          | —        |
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-06-003-smithy-evals-framework/02-reference-fixture-exists-and-is-deployable.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/02-reference-fixture-exists-and-is-deployable.tasks.md
@@ -77,10 +77,10 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — fixture source files are the foundation; the deployment test depends on them existing.
-- [x] **Slice 2** — deployment verification test; depends on Slice 1 and on `dist/cli.js` (built by the `pretest` script).
+| ID | Title                                    | Depends On | Artifact |
+|----|------------------------------------------|------------|----------|
+| S1 | Reference Fixture Source Files           | —          | —        |
+| S2 | Fixture Deployment Verification Test     | S1         | —        |
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-06-003-smithy-evals-framework/03-execute-skill-headlessly-and-capture-output.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/03-execute-skill-headlessly-and-capture-output.tasks.md
@@ -83,11 +83,11 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1: Stream Parser and Shared Types** — no upstream dependencies; must land before Slice 2 can import from it.
-- [x] **Slice 2: Runner with Fixture Management** — depends on Slice 1; delivers the core US3 capability.
-- [x] **Slice 3: Entry Point and Build Tooling** — depends on Slice 2; wires everything into a runnable CLI.
+| ID | Title                              | Depends On | Artifact |
+|----|------------------------------------|------------|----------|
+| S1 | Stream Parser and Shared Types     | —          | —        |
+| S2 | Runner with Fixture Management     | S1         | —        |
+| S3 | Entry Point and Build Tooling      | S2         | —        |
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-06-003-smithy-evals-framework/04-validate-output-structure.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/04-validate-output-structure.tasks.md
@@ -51,10 +51,10 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1: StructuralValidator and SubAgentVerifier Library** — pure module with no runtime dependencies; establishes the vitest config for all evals tests; Slice 2 imports from it.
-- [x] **Slice 2: Wire Validator into the Orchestrator** — depends on Slice 1 exports; narrow orchestrator change that delivers the user-visible outcome.
+| ID | Title                                             | Depends On | Artifact |
+|----|---------------------------------------------------|------------|----------|
+| S1 | StructuralValidator and SubAgentVerifier Library  | —          | —        |
+| S2 | Wire Validator into the Orchestrator              | S1         | —        |
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-06-003-smithy-evals-framework/05-verify-strike-end-to-end-output.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/05-verify-strike-end-to-end-output.tasks.md
@@ -62,9 +62,9 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-1. [ ] **Slice 1: Strike Scenario with Structural Expectations** — single PR-sized slice delivering the end-to-end strike eval via the existing runner + validator stack.
+| ID | Title                                          | Depends On | Artifact |
+|----|------------------------------------------------|------------|----------|
+| S1 | Strike Scenario with Structural Expectations   | —          | —        |
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.spec.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.spec.md
@@ -216,21 +216,21 @@ Plan and scout are tested **both** ways:
 - **Indirectly** via strike (US5, US6) — verifying they are dispatched as sub-agents and their output appears in strike's output.
 - **Standalone** via their own YAML eval scenarios — invoking them directly as sub-agents with their own structural expectations (e.g., `## Plan` with 4 sections for plan, `## Scout Report` with severity tables for scout). This validates their output structure independently of strike's orchestration.
 
-## Story Dependency Order
+## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **User Story 1: Validate Headless Execution Assumptions** — Must be confirmed first; the entire framework depends on `claude -p` assumptions. Blocks all other stories. → `specs/2026-04-06-003-smithy-evals-framework/01-validate-headless-execution-assumptions.tasks.md`
-- [x] **User Story 2: Reference Fixture Exists and Is Deployable** — Every eval case requires a fixture. Depends on US1 assumptions being validated. → `specs/2026-04-06-003-smithy-evals-framework/02-reference-fixture-exists-and-is-deployable.tasks.md`
-- [x] **User Story 3: Execute a Skill Headlessly and Capture Output** — Foundational runner capability; nothing else works without headless capture. Depends on US1 and US2. → `specs/2026-04-06-003-smithy-evals-framework/03-execute-skill-headlessly-and-capture-output.tasks.md`
-- [x] **User Story 4: Validate Output Structure** — Core validation logic; depends on US3 (captured output to validate). → `specs/2026-04-06-003-smithy-evals-framework/04-validate-output-structure.tasks.md`
-- [ ] **User Story 9: Eval Summary Report** — Reporting layer; depends on US3 and US4 producing results to summarize.
-- [x] **User Story 5: Verify Strike End-to-End Output** — First full eval case; depends on US3 (runner) and US4 (structural validator) being implemented. → `specs/2026-04-06-003-smithy-evals-framework/05-verify-strike-end-to-end-output.tasks.md`
-- [ ] **User Story 6: Verify Sub-Agent Invocation** — Extends US5; depends on US5 strike eval infrastructure and the stream-json parser for detecting dispatch events.
-- [ ] **User Story 7: Define Eval Scenarios Declaratively** — Maintainability improvement; depends on at least one eval case (US5) existing to migrate. Can parallelize with US5/US6.
-- [ ] **User Story 8: Fixture Contains Deliberate Inconsistencies for Scout** — Enhancement to the fixture (US2); depends on basic eval framework working (US5+). Can parallelize with US7.
-- [ ] **User Story 10: Baseline Structural Expectations** — Optional regression layer; depends on structural evals (US4, US5) being stable first.
-- [ ] **User Story 11: Cost and Time Transparency** — Developer experience enhancement; can be added any time after US9 (summary report) exists.
+| ID   | Title                                                    | Depends On      | Artifact                                                                                          |
+|------|----------------------------------------------------------|-----------------|---------------------------------------------------------------------------------------------------|
+| US1  | Validate Headless Execution Assumptions                  | —               | `specs/2026-04-06-003-smithy-evals-framework/01-validate-headless-execution-assumptions.tasks.md` |
+| US2  | Reference Fixture Exists and Is Deployable               | US1             | `specs/2026-04-06-003-smithy-evals-framework/02-reference-fixture-exists-and-is-deployable.tasks.md` |
+| US3  | Execute a Skill Headlessly and Capture Output            | US1, US2        | `specs/2026-04-06-003-smithy-evals-framework/03-execute-skill-headlessly-and-capture-output.tasks.md` |
+| US4  | Validate Output Structure                                | US3             | `specs/2026-04-06-003-smithy-evals-framework/04-validate-output-structure.tasks.md`               |
+| US5  | Verify Strike End-to-End Output                          | US3, US4        | `specs/2026-04-06-003-smithy-evals-framework/05-verify-strike-end-to-end-output.tasks.md`         |
+| US6  | Verify Sub-Agent Invocation                              | US5             | —                                                                                                 |
+| US7  | Define Eval Scenarios Declaratively                      | US5             | —                                                                                                 |
+| US8  | Fixture Contains Deliberate Inconsistencies for Scout    | US2, US5        | —                                                                                                 |
+| US9  | Eval Summary Report                                      | US3, US4        | —                                                                                                 |
+| US10 | Baseline Structural Expectations                         | US4, US5        | —                                                                                                 |
+| US11 | Cost and Time Transparency                               | US9             | —                                                                                                 |
 
 ## Requirements *(mandatory)*
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/01-updated-rfc-template-schema.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/01-updated-rfc-template-schema.tasks.md
@@ -33,6 +33,6 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — Only slice. Insert Out of Scope and Personas sections into the Phase 3 RFC template.
+| ID | Title                                                          | Depends On | Artifact |
+|----|----------------------------------------------------------------|------------|----------|
+| S1 | Insert Out of Scope and Personas into Phase 3 RFC Template    | —          | —        |

--- a/specs/2026-04-07-003-refactor-ignite-workflow/02-shared-smithy-prose-sub-agent.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/02-shared-smithy-prose-sub-agent.tasks.md
@@ -75,10 +75,10 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — creates the agent file and passes automated tests; must be merged before the orchestrator (Story 4) can reference smithy-prose in the ignite prompt
-- [x] **Slice 2** — documentation updates; depends on Slice 1 being merged so the file being documented actually exists
+| ID | Title                                            | Depends On | Artifact |
+|----|--------------------------------------------------|------------|----------|
+| S1 | Create smithy-prose Agent Definition and Tests  | —          | —        |
+| S2 | Update Documentation                             | S1         | —        |
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/03-smithy-plan-for-structured-rfc-sections.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/03-smithy-plan-for-structured-rfc-sections.tasks.md
@@ -38,9 +38,9 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — Only slice. The prompt change and test augmentation are tightly coupled (the test verifies the rendering of the prompt change) and belong in a single PR. Covers Acceptance Scenarios US3-1, US3-2, US3-3, US3-4.
+| ID | Title                                                                          | Depends On | Artifact |
+|----|--------------------------------------------------------------------------------|------------|----------|
+| S1 | Add smithy-plan Dispatch Instructions to Phase 3 (Agent-Mode Gated)           | —          | —        |
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/04-piecewise-rfc-generation.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/04-piecewise-rfc-generation.tasks.md
@@ -45,9 +45,9 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — Only slice. All tasks within the slice are ordered sequentially: RFC creation and protocol note (tasks 1–2) must precede 3a (task 3), which must precede 3b (task 4); 3e (task 5) inserts between the already-present 3d and 3f; 3g (task 6) inserts after the already-present 3f; Phase 4 update (task 7) and tests (task 8) complete the PR.
+| ID | Title                                                                         | Depends On | Artifact |
+|----|-------------------------------------------------------------------------------|------------|----------|
+| S1 | Piecewise RFC Pipeline — Full Phase 3 Orchestration + Phase 4 Update         | —          | —        |
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/06-mandatory-out-of-scope-section.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/06-mandatory-out-of-scope-section.tasks.md
@@ -63,9 +63,9 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-1. [ ] **Slice 1** — Only slice. Tasks within the slice are ordered: the 3c directive (task 1) defines the placeholder phrasing that the 3g safety net (task 2) must mirror, and the test (task 3) asserts both render after they exist.
+| ID | Title                                                                   | Depends On | Artifact |
+|----|-------------------------------------------------------------------------|------------|----------|
+| S1 | Enforce Out of Scope in 3c Dispatch and 3g Harmonize Safety Net        | —          | —        |
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/09-updated-phase-0-audit-categories.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/09-updated-phase-0-audit-categories.tasks.md
@@ -59,9 +59,9 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-1. [ ] **Slice 1** — Only slice. Tasks within the slice are ordered sequentially: update the ignite Phase 0 table first, then the shared snippet, then add the template-composition assertions that cover both surfaces.
+| ID | Title                                             | Depends On | Artifact |
+|----|---------------------------------------------------|------------|----------|
+| S1 | Align Audit Categories with New RFC Sections     | —          | —        |
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md
@@ -179,19 +179,19 @@ As a developer reviewing an existing RFC via `smithy.ignite` Phase 0, I want the
 - **Partial RFC from a different idea**: Phase 0's resume detection should verify that the RFC's Summary/Motivation are contextually related to the current idea. If unrelated, warn the user and offer to overwrite or create a new RFC.
 - **Session crash during harmonization (3g)**: If the harmonization pass crashes mid-rewrite, the RFC file may be in an inconsistent state. The next session's Phase 0 should detect the RFC and enter the review loop, where smithy-refine can identify and repair inconsistencies.
 
-## Story Dependency Order
+## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **User Story 1: Updated RFC Template Schema** — Foundational; defines the slots all other stories write into. All piecewise generation stories depend on the template having the correct sections. → `specs/2026-04-07-003-refactor-ignite-workflow/01-updated-rfc-template-schema.tasks.md`
-- [x] **User Story 2: Shared Smithy-Prose Sub-Agent** — Must exist before the piecewise pipeline can dispatch it for narrative sections (3a, 3b). → `specs/2026-04-07-003-refactor-ignite-workflow/02-shared-smithy-prose-sub-agent.tasks.md`
-- [x] **User Story 3: Smithy-Plan for Structured RFC Sections** — Defines the dispatch pattern for structured sections; required before piecewise orchestration can be wired together. Can parallelize with US2. → `specs/2026-04-07-003-refactor-ignite-workflow/03-smithy-plan-for-structured-rfc-sections.tasks.md`
-- [x] **User Story 4: Piecewise RFC Generation** — Core orchestration that wires US1+US2+US3 together. Depends on all three preceding stories. → `specs/2026-04-07-003-refactor-ignite-workflow/04-piecewise-rfc-generation.tasks.md`
-- [ ] **User Story 5: Mandatory Personas Section** — Verifies the Personas section is produced end-to-end; depends on US1 (template slot) and US2 (smithy-prose dispatch). Can be validated after US4.
-- [x] **User Story 6: Mandatory Out of Scope Section** — Verifies the Out of Scope section is produced end-to-end; depends on US1 (template slot) and US3 (smithy-plan dispatch). Can parallelize with US5. → `specs/2026-04-07-003-refactor-ignite-workflow/06-mandatory-out-of-scope-section.tasks.md`
-- [x] **User Story 9: Updated Phase 0 Audit Categories** — Updates the review loop and audit snippet; depends on US1 (new sections defined). Can be done any time after US1. → `specs/2026-04-07-003-refactor-ignite-workflow/09-updated-phase-0-audit-categories.tasks.md`
-- [ ] **User Story 7: Session Resume from Partial State** — Robustness enhancement; depends on US4 (direct-write approach) naturally leaving partial files on disk to detect.
-- [ ] **User Story 8: Cross-Session Question Deduplication** — Enhancement on top of the core pipeline; depends on US4 (sessions producing output files). Implement after core flow is solid.
+| ID  | Title                                          | Depends On   | Artifact                                                                                          |
+|-----|------------------------------------------------|--------------|---------------------------------------------------------------------------------------------------|
+| US1 | Updated RFC Template Schema                    | —            | `specs/2026-04-07-003-refactor-ignite-workflow/01-updated-rfc-template-schema.tasks.md`           |
+| US2 | Shared Smithy-Prose Sub-Agent                  | —            | `specs/2026-04-07-003-refactor-ignite-workflow/02-shared-smithy-prose-sub-agent.tasks.md`         |
+| US3 | Smithy-Plan for Structured RFC Sections        | —            | `specs/2026-04-07-003-refactor-ignite-workflow/03-smithy-plan-for-structured-rfc-sections.tasks.md` |
+| US4 | Piecewise RFC Generation                       | US1, US2, US3 | `specs/2026-04-07-003-refactor-ignite-workflow/04-piecewise-rfc-generation.tasks.md`              |
+| US5 | Mandatory Personas Section                     | US1, US2, US4 | —                                                                                                 |
+| US6 | Mandatory Out of Scope Section                 | US1, US3, US4 | `specs/2026-04-07-003-refactor-ignite-workflow/06-mandatory-out-of-scope-section.tasks.md`        |
+| US7 | Session Resume from Partial State              | US4          | —                                                                                                 |
+| US8 | Cross-Session Question Deduplication           | US4          | —                                                                                                 |
+| US9 | Updated Phase 0 Audit Categories               | US1          | `specs/2026-04-07-003-refactor-ignite-workflow/09-updated-phase-0-audit-categories.tasks.md`      |
 
 ## Requirements *(mandatory)*
 

--- a/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md
@@ -131,12 +131,10 @@ _None — all ambiguities resolved._
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — Core triage logic must exist before parent commands can render
-   the annotation. This is the foundational behavioral change.
-- [x] **Slice 2** — Depends on Slice 1's annotation format being defined. Ensures
-   annotation visibility in downstream artifacts and provides verification.
+| ID | Title                                                        | Depends On | Artifact |
+|----|--------------------------------------------------------------|------------|----------|
+| S1 | Update Triage Rules and Critical Assumption Annotation      | —          | —        |
+| S2 | Annotation Visibility in Parent Command Artifacts           | S1         | —        |
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-08-003-reduce-interaction-friction/02-track-specification-debt.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/02-track-specification-debt.tasks.md
@@ -150,13 +150,13 @@ Primary changes are in `src/templates/agent-skills/agents/smithy.clarify.prompt`
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **Slice 1** — The clarify triage engine must produce `debt_items` and `bail_out` fields before any parent command can consume them. This is the foundational change.
-- [x] **Slice 2** — Mark and cut get their debt sections and population instructions. These are the primary consumers of Slice 1's output and the most important pipeline to validate early.
-- [x] **Slice 3** — Remaining templates (strike, ignite, render) can land in parallel with or after Slice 2; they are independent of it. Recommended after Slice 2 to let the mark/cut debt section format stabilize first.
-- [x] **Slice 4** — Debt inheritance and bail-out require both Slice 1 (the `bail_out` field) and Slice 2 (the tasks template debt section structure) to be complete before wiring inheritance into cut.
-- [ ] **Slice 5** — Phase 0 resolution, audit checklists, and tests depend on all prior slices. Tests added here validate changes from Slices 1–4.
+| ID | Title                                                              | Depends On | Artifact |
+|----|--------------------------------------------------------------------|------------|----------|
+| S1 | Clarify Triage Engine — Introduce Debt Category                    | —          | —        |
+| S2 | Primary Artifact Templates — Spec and Tasks                        | S1         | —        |
+| S3 | Remaining Artifact Templates — Strike, Ignite, Render              | S1         | —        |
+| S4 | Debt Inheritance in Cut and Scope-Based Bail-Out                   | S1, S2     | —        |
+| S5 | Phase 0 Debt Resolution, Audit Checklists, and Tests               | S1, S2, S3, S4 | —      |
 
 ### Cross-Story Dependencies
 

--- a/specs/2026-04-08-003-reduce-interaction-friction/reduce-interaction-friction.spec.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/reduce-interaction-friction.spec.md
@@ -222,14 +222,14 @@ returned as a finding for the parent command to act on.
   runs non-interactively, applies changes, creates a new PR with the
   diff from the previous version.
 
-## Story Dependency Order
+## Dependency Order
 
-Recommended implementation sequence:
-
-- [x] **User Story 1: Relax Critical Decision Blocking** — Smallest, most contained change; prerequisite for one-shot mode since Critical items always blocking prevents one-shot from fully proceeding. → `specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md`
-- [x] **User Story 2: Track Specification Debt** — Foundational for one-shot mode; without it, unresolved items would be silently dropped. Depends on US1 triage matrix update. → `specs/2026-04-08-003-reduce-interaction-friction/02-track-specification-debt.tasks.md`
-- [ ] **User Story 3: One-Shot Planning Workflows** — Core friction-reduction change; depends on US1 (relaxed triage) and US2 (debt tracking) to maintain quality without gates.
-- [ ] **User Story 4: Unified Review Pattern** — Quality assurance layer for one-shot; depends on US3 (one-shot mode existing) to add the automated review before PR creation.
+| ID  | Title                               | Depends On | Artifact                                                                                  |
+|-----|-------------------------------------|------------|-------------------------------------------------------------------------------------------|
+| US1 | Relax Critical Decision Blocking    | —          | `specs/2026-04-08-003-reduce-interaction-friction/01-relax-critical-decision-blocking.tasks.md` |
+| US2 | Track Specification Debt            | US1        | `specs/2026-04-08-003-reduce-interaction-friction/02-track-specification-debt.tasks.md`   |
+| US3 | One-Shot Planning Workflows         | US1, US2   | —                                                                                         |
+| US4 | Unified Review Pattern              | US3        | —                                                                                         |
 
 ## Requirements
 


### PR DESCRIPTION
Convert `## Story Dependency Order` / `## Dependency Order` sections in all
existing `.spec.md` and `.tasks.md` files to the new canonical 4-column table
format (ID, Title, Depends On, Artifact) defined in
`src/templates/agent-skills/README.md`.

Spec files now use `US<N>` IDs with tasks-file paths in the Artifact column;
tasks files now use `S<N>` IDs with `—` in the Artifact column (slices live
inline). Legacy `- [x]` / `- [ ]` checkbox rows are removed from every
`## Dependency Order` section — task-completion checkboxes inside
`## Slice N:` bodies are unaffected.

https://claude.ai/code/session_01KtQ9kjHzCBniNhcxATrmvZ