### PR TITLE
Enforce mandatory Personas section in ignite pipeline

### DIFF
--- a/specs/2026-04-07-003-refactor-ignite-workflow/05-mandatory-personas-section.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/05-mandatory-personas-section.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Tighten sub-phase 3b dispatch to enforce persona forwarding**
+- [x] **Tighten sub-phase 3b dispatch to enforce persona forwarding**
 
   In `src/templates/agent-skills/commands/smithy.ignite.prompt`, update the Sub-phase 3b block inside `{{#ifAgent}}` so the orchestrator explicitly requires personas surfaced during Phase 2 clarification to appear in the drafted section. Satisfies AS US5-3.
 
@@ -27,7 +27,7 @@
   - 3b instructs the orchestrator to halt with a diagnostic pointing at the clarification record if smithy-prose returns empty or placeholder content for Personas
   - Non-agent (`{{else}}`) path and other sub-phases remain unchanged
 
-- [ ] **Add explicit Personas verification and repair to sub-phase 3g harmonize**
+- [x] **Add explicit Personas verification and repair to sub-phase 3g harmonize**
 
   In the same file, extend the Sub-phase 3g harmonize block so the coherence pass names `## Personas` as a mandatory section and repairs it if missing or empty. Satisfies AS US5-1 and US5-2 at the harmonize boundary.
 
@@ -38,7 +38,7 @@
   - Generic present/non-empty verification for unaffected sections is preserved
   - Non-agent path is unchanged
 
-- [ ] **Lock Personas enforcement with ignite template tests**
+- [x] **Lock Personas enforcement with ignite template tests**
 
   Extend `src/templates.test.ts` to verify that the ignite claude-variant rendered output encodes both the 3b dispatch enforcement and the 3g harmonize verification for Personas. Covers AS US5-1, US5-2, US5-3 at the template-composition level.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -512,6 +512,30 @@ describe('getComposedTemplates', () => {
     expect(ignite).toContain('smithy-prose');
     // Phase 4 agent path must NOT contain the unconditional file-write instruction
     expect(ignite).not.toContain('Write the RFC to');
+
+    // Story 5: Sub-phase 3b enforces mandatory personas via tone_directives
+    // and halts on empty/placeholder sub-agent output.
+    const subphase3bIdx = ignite.indexOf('Sub-phase 3b');
+    const subphase3cIdx = ignite.indexOf('Sub-phase 3c');
+    expect(subphase3bIdx).toBeGreaterThan(-1);
+    expect(subphase3cIdx).toBeGreaterThan(subphase3bIdx);
+    const subphase3bBlock = ignite.slice(subphase3bIdx, subphase3cIdx);
+    expect(subphase3bBlock).toContain('tone_directives');
+    expect(subphase3bBlock.toLowerCase()).toContain('mandatory');
+    expect(subphase3bBlock.toLowerCase()).toContain('halt');
+    expect(subphase3bBlock).toContain('clarification');
+
+    // Story 5: Sub-phase 3g harmonize verifies `## Personas` as a mandatory
+    // section and repairs it via smithy-prose if missing or empty.
+    const subphase3gIdx = ignite.indexOf('Sub-phase 3g');
+    expect(subphase3gIdx).toBeGreaterThan(-1);
+    const subphase3gBlock = ignite.slice(subphase3gIdx);
+    expect(subphase3gBlock).toContain('## Personas');
+    expect(subphase3gBlock.toLowerCase()).toContain('mandatory');
+    expect(subphase3gBlock).toContain('Out of Scope');
+    expect(subphase3gBlock).toContain('Proposal');
+    expect(subphase3gBlock).toContain('smithy-prose');
+    expect(subphase3gBlock.toLowerCase()).toMatch(/repair|re-dispatch/);
   });
 
   it('ignite default does not contain competing plan dispatch', () => {

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -526,16 +526,24 @@ describe('getComposedTemplates', () => {
     expect(subphase3bBlock).toContain('clarification');
 
     // Story 5: Sub-phase 3g harmonize verifies `## Personas` as a mandatory
-    // section and repairs it via smithy-prose if missing or empty.
+    // section and repairs it via smithy-prose if missing, empty, or
+    // misplaced. Bound the slice to the `## Phase 4` heading so the
+    // assertions only match content inside the 3g block itself — not the
+    // later RFC template code fence which also mentions `## Personas`,
+    // `Out of Scope`, and `Proposal`.
     const subphase3gIdx = ignite.indexOf('Sub-phase 3g');
     expect(subphase3gIdx).toBeGreaterThan(-1);
-    const subphase3gBlock = ignite.slice(subphase3gIdx);
+    const phase4Idx = ignite.indexOf('## Phase 4', subphase3gIdx);
+    expect(phase4Idx).toBeGreaterThan(subphase3gIdx);
+    const subphase3gBlock = ignite.slice(subphase3gIdx, phase4Idx);
     expect(subphase3gBlock).toContain('## Personas');
     expect(subphase3gBlock.toLowerCase()).toContain('mandatory');
     expect(subphase3gBlock).toContain('Out of Scope');
     expect(subphase3gBlock).toContain('Proposal');
     expect(subphase3gBlock).toContain('smithy-prose');
     expect(subphase3gBlock.toLowerCase()).toMatch(/repair|re-dispatch/);
+    // Repair dispatch must include idea_description (smithy-prose contract)
+    expect(subphase3gBlock).toContain('idea_description');
   });
 
   it('ignite default does not contain competing plan dispatch', () => {

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -272,7 +272,20 @@ This sub-phase is orchestrator-inline — no sub-agent dispatch.
    - Fix cross-references between sections (e.g., a Milestone referencing a Goal
      by name, a Proposal referencing a Persona).
    - Verify that every expected RFC template section is present and non-empty.
-3. Rewrite the file in place with the harmonized content.
+   - **`## Personas` is a mandatory verified section.** Explicitly check that
+     the harmonized RFC contains a non-empty `## Personas` section positioned
+     after `## Out of Scope` and before `## Proposal`, and that it lists at
+     least one named persona with a description (not placeholder text such as
+     the template's `<Persona 1 ...>` literal).
+3. **Personas repair.** If the `## Personas` section is missing, empty, or
+   contains only placeholder content after the coherence pass, re-dispatch
+   **smithy-prose** with `section_assignment` = "Personas", the accumulating
+   RFC content, and the Phase 2 `clarify_output`, then re-append (or splice)
+   the returned Personas section at the canonical position (after Out of Scope,
+   before Proposal) before finalizing the file. Re-run the mandatory-section
+   verification after repair; if Personas is still missing or empty, halt the
+   pipeline with a diagnostic pointing at the Phase 2 clarification record.
+4. Rewrite the file in place with the harmonized content.
 
 Confirm the harmonize step completed before proceeding to Phase 4.
 

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -264,27 +264,55 @@ Append the returned content to the RFC file.
 
 ### Sub-phase 3g: Harmonize
 
-This sub-phase is orchestrator-inline — no sub-agent dispatch.
+This sub-phase is primarily orchestrator-inline. The only exception is the
+Personas repair branch in step 3 below, which may conditionally re-dispatch
+**smithy-prose** when the coherence pass detects that the `## Personas`
+section is missing, empty, or placeholder-only. No other sub-agents are
+dispatched in 3g.
 
 1. Read the complete `<slug>.rfc.md` from disk.
 2. Perform a coherence pass:
    - Smooth tone across sections written by different sub-agents.
    - Fix cross-references between sections (e.g., a Milestone referencing a Goal
      by name, a Proposal referencing a Persona).
+   - **Reorder sections to match the RFC template structure** (Summary →
+     Motivation / Problem Statement → Goals → Out of Scope → Personas →
+     Proposal → Design Considerations → Decisions → Open Questions →
+     Specification Debt → Milestones → Dependency Order). This reordering is
+     required because sub-phase 3b appends Personas before sub-phase 3c
+     appends Out of Scope, so a correctly drafted Personas section will be
+     misplaced in the accumulating file and MUST be moved into canonical
+     position here.
    - Verify that every expected RFC template section is present and non-empty.
    - **`## Personas` is a mandatory verified section.** Explicitly check that
      the harmonized RFC contains a non-empty `## Personas` section positioned
      after `## Out of Scope` and before `## Proposal`, and that it lists at
      least one named persona with a description (not placeholder text such as
-     the template's `<Persona 1 ...>` literal).
-3. **Personas repair.** If the `## Personas` section is missing, empty, or
-   contains only placeholder content after the coherence pass, re-dispatch
-   **smithy-prose** with `section_assignment` = "Personas", the accumulating
-   RFC content, and the Phase 2 `clarify_output`, then re-append (or splice)
-   the returned Personas section at the canonical position (after Out of Scope,
-   before Proposal) before finalizing the file. Re-run the mandatory-section
-   verification after repair; if Personas is still missing or empty, halt the
-   pipeline with a diagnostic pointing at the Phase 2 clarification record.
+     the template's `<Persona 1 ...>` literal). Treat any of the following as
+     a failure that triggers the Personas repair branch in step 3: missing
+     section, empty section, placeholder-only content, or a non-empty
+     Personas section that remains outside the canonical position after the
+     reorder step above.
+3. **Personas repair.** If the Personas verification above fails for any
+   reason (missing, empty, placeholder-only, or still misplaced after
+   reorder), re-dispatch **smithy-prose** with:
+   - `section_assignment` = "Personas"
+   - `idea_description` = the user's original idea description or PRD content
+     from intake (same value passed to sub-phase 3b; required by the
+     smithy-prose contract)
+   - `clarify_output` = the Phase 2 clarification Q&A and assumptions
+   - `rfc_file_path` = the path to the accumulating `<slug>.rfc.md`
+   - `tone_directives` = "Personas named or described during Phase 2
+     clarification are mandatory. Do not return placeholder or empty content."
+
+   When smithy-prose returns, **replace** any existing `## Personas` section
+   in the RFC file with the returned content in place — do not append a
+   second Personas section. If no `## Personas` heading exists, splice the
+   returned section in at the canonical position (after `## Out of Scope`
+   and before `## Proposal`). Re-run the mandatory-section verification from
+   step 2 after repair; if Personas is still missing, empty, or misplaced,
+   halt the pipeline with a diagnostic pointing at the Phase 2 clarification
+   record.
 4. Rewrite the file in place with the harmonized content.
 
 Confirm the harmonize step completed before proceeding to Phase 4.

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -201,8 +201,15 @@ Dispatch **smithy-prose** with:
 - **idea_description**: the user's idea description or PRD content from intake
 - **clarify_output**: the Q&A and assumptions from Phase 2 clarification
 - **rfc_file_path**: the path to the accumulating `<slug>.rfc.md` (which at this point contains the header plus Summary and Motivation)
+- **tone_directives**: "Personas named or described during Phase 2 clarification are mandatory — every persona surfaced there MUST appear in the drafted `## Personas` section with a role and a description of how this RFC benefits them. Do not return placeholder or empty content."
 
-After smithy-prose returns, append the returned content to the RFC file.
+After smithy-prose returns, verify that the returned content contains a
+non-empty `## Personas` section with at least one named persona. If the
+sub-agent returns empty output, placeholder content (e.g., the template's
+`<Persona 1 ...>` literal), or a response missing the `## Personas` heading,
+**halt the pipeline** with a diagnostic that points at the Phase 2
+clarification record so the user can confirm which personas were identified
+before retrying. Otherwise, append the returned content to the RFC file.
 
 ### Sub-phase 3c: Goals + Out of Scope
 


### PR DESCRIPTION
## Source

- Spec: `specs/2026-04-07-003-refactor-ignite-workflow/refactor-ignite-workflow.spec.md`
- Tasks: `specs/2026-04-07-003-refactor-ignite-workflow/05-mandatory-personas-section.tasks.md`

## Slice

**Slice 1: Enforce Personas Section End-to-End** — Harden the piecewise RFC pipeline so that personas identified during Phase 2 clarification always reach the final RFC's `## Personas` section. Enforcement at sub-phase 3b, verification and repair at sub-phase 3g, and template tests locking both.

## Addresses

- **FR-005** — mandatory `## Personas` section in the RFC template schema (positioning requirement)
- **FR-007b** — smithy-prose dispatch for narrative sections including Personas
- **US5-1** — final RFC contains a non-empty `## Personas` section listing stakeholders
- **US5-2** — personas drafted in 3b reach the final harmonized RFC
- **US5-3** — personas from Phase 2 clarification are never silently dropped between clarification and drafting

## Tasks completed

- [x] Tighten sub-phase 3b dispatch to enforce persona forwarding
- [x] Add explicit Personas verification and repair to sub-phase 3g harmonize
- [x] Lock Personas enforcement with ignite template tests

### Change summary

**`src/templates/agent-skills/commands/smithy.ignite.prompt`** (inside `{{#ifAgent}}` only):
- Sub-phase 3b now passes a `tone_directives` value declaring that personas named during Phase 2 clarification are mandatory, and instructs the orchestrator to halt with a diagnostic pointing at the clarification record if smithy-prose returns empty or placeholder Personas content.
- Sub-phase 3g's harmonize coherence pass now names `## Personas` as a mandatory verified section (positioned after Out of Scope, before Proposal) and re-dispatches smithy-prose with the accumulating RFC and the Phase 2 `clarify_output` to repair a missing, empty, or placeholder Personas section before finalizing. Post-repair verification halts with a diagnostic if still empty.
- Generic present/non-empty verification for other sections is preserved; the non-agent (`{{else}}`) path is unchanged.

**`src/templates.test.ts`**: Extended the existing `ignite with claude variant renders competing plan dispatch` test to assert the 3b block references `tone_directives`, `mandatory`, `halt`, and `clarification`, and that the 3g block names `## Personas` as a verified section positioned relative to Out of Scope / Proposal with repair via smithy-prose. The default (non-agent) ignite variant test continues to assert the absence of agent-path content.

## Review

Self-reviewed — no findings. Changes are scoped to the already-agent-gated `{{#ifAgent}}` block in the ignite prompt plus assertions in the existing template test. No new files, no behavioral changes to the non-agent path, no changes to other sub-phases or commands.

## Validation

All commands run against HEAD after the three task commits:

- `npm run typecheck` — clean (no output)
- `npm run build` — success (`dist/cli.js` built)
- `npm test` — **215/215 passing** across 8 test files, including the extended `ignite with claude variant renders competing plan dispatch` test and the unchanged `ignite default does not contain competing plan dispatch` test.

https://claude.ai/code/session_01XPyNi6iqzJRYyGLNsyVepL