### PR TITLE
slice-1: add status scanner type surface

### DIFF
--- a/specs/2026-04-12-004-smithy-status-skill/01-scan-artifacts-and-classify-status.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/01-scan-artifacts-and-classify-status.tasks.md
@@ -156,7 +156,7 @@
 
 Recommended implementation sequence:
 
-1. [ ] **Slice 1** — the pure parser and its type surface have no runtime prerequisites and are the import foundation every downstream slice needs.
+1. [x] **Slice 1** — the pure parser and its type surface have no runtime prerequisites and are the import foundation every downstream slice needs.
 2. [ ] **Slice 2** — the scanner consumes the parser from Slice 1 to produce a fully-classified record set; this is the first slice whose output matches the US1 acceptance contract end-to-end.
 3. [ ] **Slice 3** — the CLI subcommand composes the finished scanner, exposing US1 to end users and matching the contracts file's JSON shape.
 

--- a/specs/2026-04-12-004-smithy-status-skill/01-scan-artifacts-and-classify-status.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/01-scan-artifacts-and-classify-status.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Define status scanner types in `src/status/types.ts`**
+- [x] **Define status scanner types in `src/status/types.ts`**
 
   Create `src/status/types.ts` declaring the TypeScript entities specified in `smithy-status-skill.data-model.md`: `ArtifactType`, `Status`, `ArtifactRecord`, `DependencyRow`, `DependencyOrderTable`, `NextAction`, and `ScanSummary`. Re-export through `src/status/index.ts` so downstream modules and tests have a single import surface.
 

--- a/specs/2026-04-12-004-smithy-status-skill/01-scan-artifacts-and-classify-status.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/01-scan-artifacts-and-classify-status.tasks.md
@@ -45,7 +45,7 @@
   - Legacy checkbox section (any `- [ ]` or `- [x]` line inside `## Dependency Order` with no 4-column header) → `format: 'legacy'`, empty rows. Must distinguish cleanly from `format: 'table'` on synthetic fixtures representing both.
   - `id_prefix` is derived from `artifactType` (rfc→M, features→F, spec→US, tasks→S); a row whose actual prefix disagrees produces a warning.
 
-- [ ] **Implement `parseArtifact` in `src/status/parser.ts` covering title, slice counts, and warnings**
+- [x] **Implement `parseArtifact` in `src/status/parser.ts` covering title, slice counts, and warnings**
 
   Add `parseArtifact(filePath, content)` that extracts the artifact's title from its first H1 (handling the canonical `# Feature Specification: <Title>` prefix and arbitrary H1s, with fallback to the filename stem when absent), calls `parseDependencyTable` with an artifact type derived from the filename extension, and for `.tasks.md` files counts `completed` / `total` checkboxes found inside `## Slice N:` body sections only. Collects every non-fatal issue into `warnings[]`; never throws on malformed input.
 

--- a/specs/2026-04-12-004-smithy-status-skill/01-scan-artifacts-and-classify-status.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/01-scan-artifacts-and-classify-status.tasks.md
@@ -30,7 +30,7 @@
   - `DependencyRow` fields match `id`, `title`, `depends_on`, `artifact_path` exactly.
   - The module compiles under `npm run typecheck` with no `any` escape hatches.
 
-- [ ] **Implement pure `parseDependencyTable` in `src/status/parser.ts`**
+- [x] **Implement pure `parseDependencyTable` in `src/status/parser.ts`**
 
   Add a named export `parseDependencyTable(markdown, artifactType)` that locates the `## Dependency Order` section, parses the 4-column table with regex / string splitting (no new npm dependency), and returns a `DependencyOrderTable`. Derive `id_prefix` from `artifactType`. Normalize `—` cells to an empty `depends_on` array or `null` `artifact_path`. Validate each row's `id` against `^(M|F|US|S)[1-9][0-9]*$`. Drop dangling `depends_on` IDs (IDs that do not appear elsewhere in the same table) and append a warning describing each drop. Coerce absolute paths in the `Artifact` column to `null` with a warning. When the section is absent, return `format: 'missing'` with empty rows. When the section contains any `- [ ]` / `- [x]` line and no 4-column header, return `format: 'legacy'` with empty rows.
 

--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Public entry point for the status scanner module.
+ *
+ * Downstream modules and tests should import from `src/status/` (resolved
+ * to this file) rather than reaching into individual sub-modules, so the
+ * type surface has a single stable import path.
+ */
+
+export * from './types.js';

--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -7,4 +7,8 @@
  */
 
 export * from './types.js';
-export { parseDependencyTable, type ParsedDependencyTable } from './parser.js';
+export {
+  parseArtifact,
+  parseDependencyTable,
+  type ParsedDependencyTable,
+} from './parser.js';

--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './types.js';
+export { parseDependencyTable, type ParsedDependencyTable } from './parser.js';

--- a/src/status/parser.test.ts
+++ b/src/status/parser.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import { parseDependencyTable } from './parser.js';
+
+describe('parseDependencyTable', () => {
+  it('parses a well-formed 4-column table preserving source order', () => {
+    const markdown = `# Some Spec
+
+Preamble text.
+
+## Dependency Order
+
+| ID  | Title       | Depends On | Artifact              |
+|-----|-------------|------------|-----------------------|
+| US1 | First story | —          | specs/a/us1.tasks.md  |
+| US2 | Second story| US1        | specs/a/us2.tasks.md  |
+| US3 | Third story | —          | —                     |
+
+## Next Section
+
+trailing content
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.warnings).toEqual([]);
+    expect(result.table.format).toBe('table');
+    expect(result.table.id_prefix).toBe('US');
+    expect(result.table.rows).toHaveLength(3);
+    expect(result.table.rows[0]).toEqual({
+      id: 'US1',
+      title: 'First story',
+      depends_on: [],
+      artifact_path: 'specs/a/us1.tasks.md',
+    });
+    expect(result.table.rows[1]).toEqual({
+      id: 'US2',
+      title: 'Second story',
+      depends_on: ['US1'],
+      artifact_path: 'specs/a/us2.tasks.md',
+    });
+    expect(result.table.rows[2]).toEqual({
+      id: 'US3',
+      title: 'Third story',
+      depends_on: [],
+      artifact_path: null,
+    });
+  });
+
+  it('returns missing format when no Dependency Order section exists', () => {
+    const markdown = `# Spec
+
+Just prose, no dep order section.
+
+## Unrelated
+
+body
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.warnings).toEqual([]);
+    expect(result.table.format).toBe('missing');
+    expect(result.table.rows).toEqual([]);
+    expect(result.table.id_prefix).toBe('US');
+  });
+
+  it('detects legacy format from checkbox list under Dependency Order', () => {
+    const markdown = `# Old Spec
+
+## Dependency Order
+
+- [x] Foo
+- [ ] Bar
+- [ ] Baz
+
+## Next
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.format).toBe('legacy');
+    expect(result.table.rows).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/^format_legacy:/);
+  });
+
+  it('parses as table when checkboxes appear inside the Title column of a 4-column table', () => {
+    const markdown = `## Dependency Order
+
+| ID  | Title               | Depends On | Artifact |
+|-----|---------------------|------------|----------|
+| US1 | Handle - [x] thing  | —          | —        |
+| US2 | - [ ] Another title | —          | —        |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.format).toBe('table');
+    expect(result.table.rows).toHaveLength(2);
+    expect(result.table.rows[0]?.title).toBe('Handle - [x] thing');
+    expect(result.table.rows[1]?.title).toBe('- [ ] Another title');
+  });
+
+  it('drops dangling depends_on references with a warning', () => {
+    const markdown = `## Dependency Order
+
+| ID  | Title | Depends On | Artifact |
+|-----|-------|------------|----------|
+| US1 | Foo   | —          | —        |
+| US2 | Bar   | US9        | —        |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.format).toBe('table');
+    expect(result.table.rows).toHaveLength(2);
+    expect(result.table.rows[1]?.depends_on).toEqual([]);
+    const dangling = result.warnings.filter(w => /dangling/.test(w));
+    expect(dangling).toHaveLength(1);
+    expect(dangling[0]).toMatch(/US9/);
+  });
+
+  it('coerces absolute Artifact paths to null with a warning', () => {
+    const markdown = `## Dependency Order
+
+| ID  | Title | Depends On | Artifact         |
+|-----|-------|------------|------------------|
+| US1 | Foo   | —          | /abs/path.tasks.md |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.rows).toHaveLength(1);
+    expect(result.table.rows[0]?.artifact_path).toBeNull();
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/absolute path/);
+    expect(result.warnings[0]).toMatch(/US1/);
+  });
+
+  it('parses comma-separated depends_on into trimmed array', () => {
+    const markdown = `## Dependency Order
+
+| ID  | Title | Depends On | Artifact |
+|-----|-------|------------|----------|
+| US1 | A     | —          | —        |
+| US2 | B     | —          | —        |
+| US3 | C     | —          | —        |
+| US4 | D     | US1, US3   | —        |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.rows).toHaveLength(4);
+    expect(result.table.rows[3]?.depends_on).toEqual(['US1', 'US3']);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('drops rows whose ID fails the canonical regex and keeps following rows', () => {
+    const markdown = `## Dependency Order
+
+| ID   | Title | Depends On | Artifact |
+|------|-------|------------|----------|
+| us01 | Bad   | —          | —        |
+| US2  | Good  | —          | —        |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.rows).toHaveLength(1);
+    expect(result.table.rows[0]?.id).toBe('US2');
+    expect(result.warnings.some(w => /invalid ID/.test(w) && /us01/.test(w))).toBe(true);
+  });
+
+  it('warns when a row ID prefix disagrees with the derived id_prefix but keeps the row', () => {
+    const markdown = `## Dependency Order
+
+| ID  | Title | Depends On | Artifact |
+|-----|-------|------------|----------|
+| US1 | A     | —          | —        |
+| F1  | B     | —          | —        |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.id_prefix).toBe('US');
+    expect(result.table.rows).toHaveLength(2);
+    expect(result.table.rows.map(r => r.id)).toEqual(['US1', 'F1']);
+    expect(result.warnings.some(w => /F1/.test(w) && /prefix/i.test(w))).toBe(true);
+  });
+
+  it('handles comma-separated depends_on with some dangling IDs', () => {
+    const markdown = `## Dependency Order
+
+| ID  | Title | Depends On | Artifact |
+|-----|-------|------------|----------|
+| US1 | A     | —          | —        |
+| US2 | B     | —          | —        |
+| US3 | C     | US2, US9   | —        |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.rows[2]?.depends_on).toEqual(['US2']);
+    const dangling = result.warnings.filter(w => /dangling/.test(w));
+    expect(dangling).toHaveLength(1);
+    expect(dangling[0]).toMatch(/US9/);
+  });
+
+  it('derives id_prefix from artifactType for rfc, features, and tasks', () => {
+    const empty = `## Dependency Order
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+`;
+    expect(parseDependencyTable(empty, 'rfc').table.id_prefix).toBe('M');
+    expect(parseDependencyTable(empty, 'features').table.id_prefix).toBe('F');
+    expect(parseDependencyTable(empty, 'tasks').table.id_prefix).toBe('S');
+  });
+
+  it('returns table format with empty rows when header is present but body is empty', () => {
+    const markdown = `## Dependency Order
+
+| ID  | Title | Depends On | Artifact |
+|-----|-------|------------|----------|
+
+## Next
+
+body
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.format).toBe('table');
+    expect(result.table.rows).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/src/status/parser.test.ts
+++ b/src/status/parser.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { parseArtifact, parseDependencyTable } from './parser.js';
+// Import through the `./index.js` barrel — that is the stable public
+// surface downstream modules consume, and these tests double as an
+// assertion that the barrel re-exports the parser correctly.
+import { parseArtifact, parseDependencyTable } from './index.js';
 
 describe('parseDependencyTable', () => {
   it('parses a well-formed 4-column table preserving source order', () => {
@@ -211,6 +214,80 @@ body
     expect(result.table.format).toBe('table');
     expect(result.table.rows).toEqual([]);
     expect(result.warnings).toEqual([]);
+  });
+
+  it('drops duplicate IDs with a warning and keeps only the first occurrence', () => {
+    const markdown = `## Dependency Order
+
+| ID  | Title    | Depends On | Artifact |
+|-----|----------|------------|----------|
+| US1 | First    | —          | —        |
+| US1 | Second   | —          | —        |
+| US2 | Keeper   | US1        | —        |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.format).toBe('table');
+    expect(result.table.rows).toHaveLength(2);
+    expect(result.table.rows[0]?.title).toBe('First');
+    expect(result.table.rows[1]?.id).toBe('US2');
+    const dupWarnings = result.warnings.filter((w) => /duplicate ID/.test(w));
+    expect(dupWarnings).toHaveLength(1);
+    expect(dupWarnings[0]).toMatch(/US1/);
+    // The surviving US2 row can still reference US1 — the duplicate
+    // drop happens after the first valid US1 is already recorded.
+    expect(result.table.rows[1]?.depends_on).toEqual(['US1']);
+  });
+
+  it('parses headers whose columns are in a non-canonical order', () => {
+    const markdown = `## Dependency Order
+
+| Title | Depends On | ID  | Artifact |
+|-------|------------|-----|----------|
+| Foo   | —          | US1 | —        |
+| Bar   | US1        | US2 | specs/foo/02-bar.tasks.md |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.format).toBe('table');
+    expect(result.table.rows).toEqual([
+      { id: 'US1', title: 'Foo', depends_on: [], artifact_path: null },
+      {
+        id: 'US2',
+        title: 'Bar',
+        depends_on: ['US1'],
+        artifact_path: 'specs/foo/02-bar.tasks.md',
+      },
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('reports format: missing with a warning when the section has no recognizable table header', () => {
+    const markdown = `## Dependency Order
+
+Some prose here that is neither a table nor a checkbox list.
+
+Another paragraph.
+
+## Next
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.format).toBe('missing');
+    expect(result.table.rows).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/no 4-column table header/);
+  });
+
+  it('rejects headers that are missing one of the canonical column labels', () => {
+    // "Owner" is not a canonical label, so the header fails to match
+    // and the section is treated as structurally missing.
+    const markdown = `## Dependency Order
+
+| ID  | Title | Owner | Artifact |
+|-----|-------|-------|----------|
+| US1 | Foo   | Alice | —        |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.format).toBe('missing');
+    expect(result.warnings).toHaveLength(1);
   });
 });
 

--- a/src/status/parser.test.ts
+++ b/src/status/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseDependencyTable } from './parser.js';
+import { parseArtifact, parseDependencyTable } from './parser.js';
 
 describe('parseDependencyTable', () => {
   it('parses a well-formed 4-column table preserving source order', () => {
@@ -211,5 +211,178 @@ body
     expect(result.table.format).toBe('table');
     expect(result.table.rows).toEqual([]);
     expect(result.warnings).toEqual([]);
+  });
+});
+
+describe('parseArtifact', () => {
+  it('extracts title from a `# Feature Specification:` H1 prefix', () => {
+    const markdown = `# Feature Specification: Status Scanner
+
+Body text.
+`;
+    const record = parseArtifact('specs/foo/status.spec.md', markdown);
+    expect(record.title).toBe('Status Scanner');
+  });
+
+  it('uses the verbatim H1 text when no specification prefix is present', () => {
+    const markdown = `# Just A Title
+
+Body text.
+`;
+    const record = parseArtifact('docs/rfcs/x.rfc.md', markdown);
+    expect(record.title).toBe('Just A Title');
+  });
+
+  it('falls back to the filename stem for a tasks file with no H1', () => {
+    const record = parseArtifact('specs/foo/01-bar.tasks.md', '');
+    expect(record.title).toBe('01-bar');
+  });
+
+  it('falls back to the filename stem for a spec file with no H1', () => {
+    const record = parseArtifact('specs/foo/baz.spec.md', '');
+    expect(record.title).toBe('baz');
+  });
+
+  it('counts slice-body checkboxes from well-formed tasks files and ignores checkboxes elsewhere', () => {
+    const markdown = `# Tasks
+
+## Slice 1: Foo
+
+- [x] a
+- [x] b
+- [ ] c
+
+## Slice 2: Bar
+
+- [ ] d
+
+## Appendix
+
+- [x] ignored-in-appendix
+`;
+    const record = parseArtifact('specs/foo/tasks.tasks.md', markdown);
+    expect(record.completed).toBe(2);
+    expect(record.total).toBe(4);
+  });
+
+  it('ignores checkboxes inside a legacy Dependency Order section when counting slice body', () => {
+    const markdown = `# Legacy Tasks
+
+## Dependency Order
+
+- [x] Something
+- [ ] Another
+
+## Slice 1: Foo
+
+- [ ] a
+`;
+    const record = parseArtifact('specs/foo/legacy.tasks.md', markdown);
+    expect(record.completed).toBe(0);
+    expect(record.total).toBe(1);
+    expect(record.dependency_order.format).toBe('legacy');
+    expect(record.warnings.some((w) => /format_legacy/.test(w))).toBe(true);
+  });
+
+  it('omits completed and total for non-tasks files', () => {
+    const markdown = `# Spec
+
+## Dependency Order
+
+| ID  | Title | Depends On | Artifact |
+|-----|-------|------------|----------|
+| US1 | A     | —          | —        |
+`;
+    const record = parseArtifact('specs/foo/bar.spec.md', markdown);
+    expect(record.completed).toBeUndefined();
+    expect(record.total).toBeUndefined();
+  });
+
+  it('derives type rfc from `.rfc.md` suffix', () => {
+    const record = parseArtifact('docs/rfcs/a.rfc.md', '# A\n');
+    expect(record.type).toBe('rfc');
+  });
+
+  it('derives type features from `.features.md` suffix', () => {
+    const record = parseArtifact('specs/foo/a.features.md', '# A\n');
+    expect(record.type).toBe('features');
+  });
+
+  it('derives type spec from `.spec.md` suffix', () => {
+    const record = parseArtifact('specs/foo/a.spec.md', '# A\n');
+    expect(record.type).toBe('spec');
+  });
+
+  it('derives type tasks from `.tasks.md` suffix', () => {
+    const record = parseArtifact('specs/foo/a.tasks.md', '# A\n');
+    expect(record.type).toBe('tasks');
+  });
+
+  it('returns a record with format: missing and no warnings when no Dependency Order section exists', () => {
+    const markdown = `# A Spec
+
+Just prose.
+`;
+    const record = parseArtifact('specs/foo/a.spec.md', markdown);
+    expect(record.dependency_order.format).toBe('missing');
+    expect(record.warnings).toEqual([]);
+  });
+
+  it('returns a record with warnings for malformed but recoverable dependency order rows', () => {
+    const markdown = `# A Spec
+
+## Dependency Order
+
+| ID   | Title | Depends On | Artifact |
+|------|-------|------------|----------|
+| us01 | Bad   | —          | —        |
+| US2  | Good  | —          | —        |
+`;
+    const record = parseArtifact('specs/foo/a.spec.md', markdown);
+    expect(record.dependency_order.rows).toHaveLength(1);
+    expect(record.warnings.some((w) => /invalid ID/.test(w))).toBe(true);
+  });
+
+  // Slice 1 intentionally leaves status classification to Slice 2; every
+  // record returned here must therefore carry the `unknown` placeholder.
+  it('sets status to "unknown" as a Slice 1 placeholder (classification is Slice 2)', () => {
+    const markdown = `# A Spec
+
+## Dependency Order
+
+| ID  | Title | Depends On | Artifact |
+|-----|-------|------------|----------|
+| US1 | A     | —          | —        |
+`;
+    const record = parseArtifact('specs/foo/a.spec.md', markdown);
+    expect(record.status).toBe('unknown');
+  });
+
+  it('never throws on pathological input', () => {
+    const pathological = `###\n|||\n- [x]`;
+    expect(() => parseArtifact('specs/foo/weird.spec.md', pathological)).not.toThrow();
+    const record = parseArtifact('specs/foo/weird.spec.md', pathological);
+    expect(record).toBeDefined();
+    expect(record.type).toBe('spec');
+  });
+
+  it('counts indented checkboxes inside a slice body', () => {
+    const markdown = `## Slice 1: Foo
+
+  - [x] nested
+`;
+    const record = parseArtifact('specs/foo/a.tasks.md', markdown);
+    expect(record.completed).toBe(1);
+    expect(record.total).toBe(1);
+  });
+
+  it('parses multi-digit slice numbers', () => {
+    const markdown = `## Slice 12: Foo
+
+- [x] a
+`;
+    const record = parseArtifact('specs/foo/a.tasks.md', markdown);
+    expect(record.completed).toBe(1);
+    expect(record.total).toBe(1);
   });
 });

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -175,10 +175,11 @@ export function parseDependencyTable(
  * Parse a Smithy artifact Markdown file into an {@link ArtifactRecord}.
  *
  * Pure function — does not touch the filesystem and never throws. The
- * `filePath` argument is used only to derive the {@link ArtifactType}
- * and to compute a fallback title from the filename stem. Any non-fatal
- * issue (malformed dependency-order rows, unknown filename suffix) is
- * appended to the record's `warnings` list.
+ * `filePath` argument is used to derive the {@link ArtifactType}, to set
+ * the `path` field on the returned record, and to compute a fallback
+ * title from the filename stem. Any non-fatal issue (malformed
+ * dependency-order rows, unknown filename suffix) is appended to the
+ * record's `warnings` list.
  *
  * Status classification is deferred to Slice 2 — every record returned
  * here carries `status: 'unknown'` as a placeholder.

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -7,6 +7,7 @@
  */
 
 import type {
+  ArtifactRecord,
   ArtifactType,
   DependencyOrderTable,
   DependencyRow,
@@ -168,6 +169,155 @@ export function parseDependencyTable(
     table: { rows, id_prefix, format: 'table' },
     warnings,
   };
+}
+
+/**
+ * Parse a Smithy artifact Markdown file into an {@link ArtifactRecord}.
+ *
+ * Pure function — does not touch the filesystem and never throws. The
+ * `filePath` argument is used only to derive the {@link ArtifactType}
+ * and to compute a fallback title from the filename stem. Any non-fatal
+ * issue (malformed dependency-order rows, unknown filename suffix) is
+ * appended to the record's `warnings` list.
+ *
+ * Status classification is deferred to Slice 2 — every record returned
+ * here carries `status: 'unknown'` as a placeholder.
+ */
+export function parseArtifact(
+  filePath: string,
+  content: string,
+): ArtifactRecord {
+  const warnings: string[] = [];
+
+  // Derive ArtifactType from the filename suffix.
+  let type: ArtifactType;
+  if (filePath.endsWith('.rfc.md')) {
+    type = 'rfc';
+  } else if (filePath.endsWith('.features.md')) {
+    type = 'features';
+  } else if (filePath.endsWith('.spec.md')) {
+    type = 'spec';
+  } else if (filePath.endsWith('.tasks.md')) {
+    type = 'tasks';
+  } else {
+    type = 'spec';
+    warnings.push(
+      `artifact_type: unknown filename suffix for ${filePath} — defaulted to 'spec'`,
+    );
+  }
+
+  // Extract the title (never throw).
+  let title: string;
+  try {
+    title = extractTitle(content, filePath);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    warnings.push(`parser: unexpected error while parsing title — ${message}`);
+    title = filenameStem(filePath);
+  }
+
+  // Delegate to parseDependencyTable.
+  const depResult = parseDependencyTable(content, type);
+  warnings.push(...depResult.warnings);
+
+  const record: ArtifactRecord = {
+    type,
+    path: filePath,
+    title,
+    status: 'unknown',
+    dependency_order: depResult.table,
+    warnings,
+  };
+
+  if (type === 'tasks') {
+    try {
+      const counts = countSliceBodyCheckboxes(content);
+      record.completed = counts.completed;
+      record.total = counts.total;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      warnings.push(
+        `parser: unexpected error while counting slice checkboxes — ${message}`,
+      );
+      record.completed = 0;
+      record.total = 0;
+    }
+  }
+
+  return record;
+}
+
+/**
+ * Extract the artifact title from its first H1, handling the canonical
+ * `# Feature Specification: <Title>` prefix. Falls back to the filename
+ * stem when no H1 exists.
+ */
+function extractTitle(content: string, filePath: string): string {
+  const lines = content.split('\n');
+  for (const line of lines) {
+    if (/^#\s+/.test(line)) {
+      const raw = line.replace(/^#\s+/, '').trimEnd();
+      const specPrefix = 'Feature Specification:';
+      if (raw.startsWith(specPrefix)) {
+        return raw.slice(specPrefix.length).trim();
+      }
+      return raw.trim();
+    }
+  }
+  return filenameStem(filePath);
+}
+
+/**
+ * Strip the directory and the longest matching suffix from
+ * `{.rfc.md, .features.md, .spec.md, .tasks.md, .md}` off a path,
+ * preserving the remaining stem verbatim.
+ */
+function filenameStem(filePath: string): string {
+  const base =
+    filePath.split('/').pop() ?? filePath.split('\\').pop() ?? filePath;
+  const suffixes = ['.rfc.md', '.features.md', '.spec.md', '.tasks.md', '.md'];
+  for (const suffix of suffixes) {
+    if (base.endsWith(suffix)) {
+      return base.slice(0, base.length - suffix.length);
+    }
+  }
+  return base;
+}
+
+/**
+ * Count `- [ ]` and `- [x]` / `- [X]` items that appear only inside
+ * `## Slice <N>:` H2 body sections. Checkboxes anywhere else in the
+ * file (e.g., `## Dependency Order`, appendices) are ignored.
+ */
+function countSliceBodyCheckboxes(content: string): {
+  completed: number;
+  total: number;
+} {
+  const lines = content.split('\n');
+  const sliceHeadingRegex = /^##\s+Slice\s+\d+:/;
+  const h2Regex = /^##\s/;
+  const checkboxRegex = /^\s*-\s*\[([ xX])\]\s/;
+
+  let completed = 0;
+  let total = 0;
+  let insideSlice = false;
+
+  for (const line of lines) {
+    if (h2Regex.test(line)) {
+      insideSlice = sliceHeadingRegex.test(line);
+      continue;
+    }
+    if (!insideSlice) continue;
+    const match = checkboxRegex.exec(line);
+    if (match === null) continue;
+    total += 1;
+    const marker = match[1] ?? ' ';
+    if (marker === 'x' || marker === 'X') {
+      completed += 1;
+    }
+  }
+
+  return { completed, total };
 }
 
 /**

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -37,7 +37,9 @@ const ID_PREFIX_BY_TYPE: Record<ArtifactType, IdPrefix> = {
 const ID_REGEX = /^(M|F|US|S)[1-9][0-9]*$/;
 const EM_DASH = '—';
 
-const EXPECTED_HEADERS = ['id', 'title', 'depends on', 'artifact'];
+const EXPECTED_HEADERS = ['id', 'title', 'depends on', 'artifact'] as const;
+type ColumnName = (typeof EXPECTED_HEADERS)[number];
+type ColumnIndex = Record<ColumnName, number>;
 
 /**
  * Parse the `## Dependency Order` section of a Smithy artifact.
@@ -75,17 +77,26 @@ export function parseDependencyTable(
         warnings,
       };
     }
-    // Neither header nor checkboxes — empty table.
+    // Section exists but has no recognizable table header and no
+    // legacy checkbox rows — the required structure is missing.
+    // Emit a warning and report format as 'missing' so downstream
+    // classification treats it as a parse failure rather than an
+    // empty-but-valid table.
+    warnings.push(
+      'dependency_order: `## Dependency Order` section has no 4-column table header (expected: ID | Title | Depends On | Artifact)',
+    );
     return {
-      table: { rows: [], id_prefix, format: 'table' },
+      table: { rows: [], id_prefix, format: 'missing' },
       warnings,
     };
   }
 
+  const { dataStart, columnIndex } = headerInfo;
+
   // Parse data rows beginning after the separator line.
   const rows: DependencyRow[] = [];
   const rawRows: Array<{ cells: string[]; sourceIndex: number }> = [];
-  for (let i = headerInfo.dataStart; i < lines.length; i++) {
+  for (let i = dataStart; i < lines.length; i++) {
     const line = lines[i] ?? '';
     if (line.trim() === '') break;
     if (/^\s*##\s/.test(line)) break;
@@ -95,17 +106,22 @@ export function parseDependencyTable(
     rawRows.push({ cells, sourceIndex: rawRows.length + 1 });
   }
 
-  // First pass: validate IDs and build rows with raw depends_on lists.
+  // First pass: validate IDs, detect duplicates, and build rows with
+  // raw depends_on lists. Read cells by their header-resolved column
+  // index so tables whose columns are in the canonical order and
+  // tables whose columns are in an unusual-but-labelled order both
+  // parse correctly.
   interface PartialRow {
     row: DependencyRow;
     rawDependsOn: string[];
   }
   const partials: PartialRow[] = [];
+  const seenIds = new Set<string>();
   for (const { cells, sourceIndex } of rawRows) {
-    const id = (cells[0] ?? '').trim();
-    const title = (cells[1] ?? '').trim();
-    const dependsOnCell = (cells[2] ?? '').trim();
-    const artifactCell = (cells[3] ?? '').trim();
+    const id = (cells[columnIndex.id] ?? '').trim();
+    const title = (cells[columnIndex.title] ?? '').trim();
+    const dependsOnCell = (cells[columnIndex['depends on']] ?? '').trim();
+    const artifactCell = (cells[columnIndex.artifact] ?? '').trim();
 
     if (!ID_REGEX.test(id)) {
       warnings.push(
@@ -113,6 +129,14 @@ export function parseDependencyTable(
       );
       continue;
     }
+
+    if (seenIds.has(id)) {
+      warnings.push(
+        `dependency_order: row ${sourceIndex} has duplicate ID '${id}' — dropped`,
+      );
+      continue;
+    }
+    seenIds.add(id);
 
     const rowPrefix = id.startsWith('US') ? 'US' : (id[0] as IdPrefix);
     if (rowPrefix !== id_prefix) {
@@ -349,29 +373,56 @@ function extractDependencyOrderSection(markdown: string): string | null {
 
 /**
  * Locate a 4-column Markdown table header (ID | Title | Depends On |
- * Artifact) followed by a separator row. Returns the index of the first
- * data row, or `null` if no recognizable header/separator pair is found.
+ * Artifact) followed immediately by a separator row. Returns the
+ * index of the first data row plus a resolved {@link ColumnIndex}
+ * mapping canonical column names to the positions they occupy in the
+ * header row, or `null` if no recognizable header/separator pair is
+ * found.
+ *
+ * Header columns are matched by label name, not by position, so
+ * tables whose columns happen to be in a different order still parse
+ * correctly. A header that is missing any of the four canonical
+ * labels, or that contains duplicate labels, fails the match and the
+ * section is treated as unparseable.
  */
 function findTableHeader(
   lines: string[],
-): { dataStart: number } | null {
+): { dataStart: number; columnIndex: ColumnIndex } | null {
   for (let i = 0; i < lines.length - 1; i++) {
     const line = lines[i];
     if (line === undefined) continue;
     if (!line.includes('|')) continue;
     const cells = splitTableRow(line).map((c) => c.trim().toLowerCase());
     if (cells.length < 4) continue;
-    const matchesHeader = EXPECTED_HEADERS.every((label) =>
-      cells.includes(label),
-    );
-    if (!matchesHeader) continue;
-    // Look for the separator row on the next non-empty line.
+
+    // Resolve each canonical label to the index of the cell that
+    // contains it. A label that is missing or appears more than once
+    // causes the match to fail.
+    const resolved: Partial<ColumnIndex> = {};
+    let valid = true;
+    for (const label of EXPECTED_HEADERS) {
+      const first = cells.indexOf(label);
+      if (first === -1) {
+        valid = false;
+        break;
+      }
+      if (cells.indexOf(label, first + 1) !== -1) {
+        valid = false;
+        break;
+      }
+      resolved[label] = first;
+    }
+    if (!valid) continue;
+
     const sepIndex = i + 1;
     if (sepIndex >= lines.length) continue;
     const sepLine = lines[sepIndex];
     if (sepLine === undefined) continue;
     if (!isSeparatorRow(sepLine)) continue;
-    return { dataStart: sepIndex + 1 };
+    return {
+      dataStart: sepIndex + 1,
+      columnIndex: resolved as ColumnIndex,
+    };
   }
   return null;
 }

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -1,0 +1,258 @@
+/**
+ * Pure Markdown parser for Smithy artifact files.
+ *
+ * This module intentionally performs no filesystem I/O and no status
+ * classification. It turns Markdown text into structured records and
+ * collects non-fatal issues as warning strings for the caller to surface.
+ */
+
+import type {
+  ArtifactType,
+  DependencyOrderTable,
+  DependencyRow,
+} from './types.js';
+
+/**
+ * Result returned by {@link parseDependencyTable}.
+ *
+ * `DependencyOrderTable` itself does not carry warnings (the scanner
+ * attaches them to the owning `ArtifactRecord`), so the parser returns
+ * them alongside the table as a parallel list.
+ */
+export interface ParsedDependencyTable {
+  table: DependencyOrderTable;
+  warnings: string[];
+}
+
+type IdPrefix = DependencyOrderTable['id_prefix'];
+
+const ID_PREFIX_BY_TYPE: Record<ArtifactType, IdPrefix> = {
+  rfc: 'M',
+  features: 'F',
+  spec: 'US',
+  tasks: 'S',
+};
+
+const ID_REGEX = /^(M|F|US|S)[1-9][0-9]*$/;
+const EM_DASH = '—';
+
+const EXPECTED_HEADERS = ['id', 'title', 'depends on', 'artifact'];
+
+/**
+ * Parse the `## Dependency Order` section of a Smithy artifact.
+ *
+ * Returns a {@link DependencyOrderTable} plus a parallel `warnings` list
+ * of human-readable non-fatal issues. Never throws.
+ */
+export function parseDependencyTable(
+  markdown: string,
+  artifactType: ArtifactType,
+): ParsedDependencyTable {
+  const id_prefix = ID_PREFIX_BY_TYPE[artifactType];
+  const warnings: string[] = [];
+
+  const sectionBody = extractDependencyOrderSection(markdown);
+  if (sectionBody === null) {
+    return {
+      table: { rows: [], id_prefix, format: 'missing' },
+      warnings,
+    };
+  }
+
+  const lines = sectionBody.split('\n');
+  const headerInfo = findTableHeader(lines);
+
+  if (headerInfo === null) {
+    // No 4-column header — check for legacy checkbox format.
+    const hasCheckbox = lines.some((line) => /^\s*-\s*\[[ xX]\]/.test(line));
+    if (hasCheckbox) {
+      warnings.push(
+        'format_legacy: `## Dependency Order` uses checkbox list; expected 4-column table (ID | Title | Depends On | Artifact)',
+      );
+      return {
+        table: { rows: [], id_prefix, format: 'legacy' },
+        warnings,
+      };
+    }
+    // Neither header nor checkboxes — empty table.
+    return {
+      table: { rows: [], id_prefix, format: 'table' },
+      warnings,
+    };
+  }
+
+  // Parse data rows beginning after the separator line.
+  const rows: DependencyRow[] = [];
+  const rawRows: Array<{ cells: string[]; sourceIndex: number }> = [];
+  for (let i = headerInfo.dataStart; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    if (line.trim() === '') break;
+    if (/^\s*##\s/.test(line)) break;
+    if (!line.includes('|')) break;
+    const cells = splitTableRow(line);
+    if (cells.length < 4) continue;
+    rawRows.push({ cells, sourceIndex: rawRows.length + 1 });
+  }
+
+  // First pass: validate IDs and build rows with raw depends_on lists.
+  interface PartialRow {
+    row: DependencyRow;
+    rawDependsOn: string[];
+  }
+  const partials: PartialRow[] = [];
+  for (const { cells, sourceIndex } of rawRows) {
+    const id = (cells[0] ?? '').trim();
+    const title = (cells[1] ?? '').trim();
+    const dependsOnCell = (cells[2] ?? '').trim();
+    const artifactCell = (cells[3] ?? '').trim();
+
+    if (!ID_REGEX.test(id)) {
+      warnings.push(
+        `dependency_order: row ${sourceIndex} has invalid ID '${id}' — dropped`,
+      );
+      continue;
+    }
+
+    const rowPrefix = id.startsWith('US') ? 'US' : (id[0] as IdPrefix);
+    if (rowPrefix !== id_prefix) {
+      warnings.push(
+        `dependency_order: row ${id} has prefix '${rowPrefix}' but expected '${id_prefix}' for artifact type '${artifactType}'`,
+      );
+    }
+
+    const rawDependsOn =
+      dependsOnCell === EM_DASH || dependsOnCell === ''
+        ? []
+        : dependsOnCell
+            .split(',')
+            .map((v) => v.trim())
+            .filter((v) => v.length > 0);
+
+    let artifact_path: string | null;
+    if (artifactCell === EM_DASH || artifactCell === '') {
+      artifact_path = null;
+    } else if (isAbsolutePath(artifactCell)) {
+      warnings.push(
+        `dependency_order: row ${id} has absolute path '${artifactCell}' — coerced to null`,
+      );
+      artifact_path = null;
+    } else {
+      artifact_path = artifactCell;
+    }
+
+    partials.push({
+      row: { id, title, depends_on: [], artifact_path },
+      rawDependsOn,
+    });
+  }
+
+  // Second pass: resolve dangling depends_on references against the
+  // set of valid IDs in this table.
+  const validIds = new Set(partials.map((p) => p.row.id));
+  for (const { row, rawDependsOn } of partials) {
+    const resolved: string[] = [];
+    for (const dep of rawDependsOn) {
+      if (validIds.has(dep)) {
+        resolved.push(dep);
+      } else {
+        warnings.push(
+          `dependency_order: ${row.id} depends on dangling ID '${dep}' — dropped`,
+        );
+      }
+    }
+    row.depends_on = resolved;
+    rows.push(row);
+  }
+
+  return {
+    table: { rows, id_prefix, format: 'table' },
+    warnings,
+  };
+}
+
+/**
+ * Return the body of the `## Dependency Order` H2 section, or `null` if
+ * no such section exists. The body is everything after the heading line
+ * until the next H2 or end of file.
+ */
+function extractDependencyOrderSection(markdown: string): string | null {
+  const lines = markdown.split('\n');
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^##\s+Dependency Order\s*$/.test(lines[i] ?? '')) {
+      start = i + 1;
+      break;
+    }
+  }
+  if (start === -1) return null;
+
+  let end = lines.length;
+  for (let i = start; i < lines.length; i++) {
+    if (/^##\s/.test(lines[i] ?? '')) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join('\n');
+}
+
+/**
+ * Locate a 4-column Markdown table header (ID | Title | Depends On |
+ * Artifact) followed by a separator row. Returns the index of the first
+ * data row, or `null` if no recognizable header/separator pair is found.
+ */
+function findTableHeader(
+  lines: string[],
+): { dataStart: number } | null {
+  for (let i = 0; i < lines.length - 1; i++) {
+    const line = lines[i];
+    if (line === undefined) continue;
+    if (!line.includes('|')) continue;
+    const cells = splitTableRow(line).map((c) => c.trim().toLowerCase());
+    if (cells.length < 4) continue;
+    const matchesHeader = EXPECTED_HEADERS.every((label) =>
+      cells.includes(label),
+    );
+    if (!matchesHeader) continue;
+    // Look for the separator row on the next non-empty line.
+    const sepIndex = i + 1;
+    if (sepIndex >= lines.length) continue;
+    const sepLine = lines[sepIndex];
+    if (sepLine === undefined) continue;
+    if (!isSeparatorRow(sepLine)) continue;
+    return { dataStart: sepIndex + 1 };
+  }
+  return null;
+}
+
+/**
+ * Split a Markdown table row on `|` and drop the leading / trailing
+ * empty cells produced by the outer pipes.
+ */
+function splitTableRow(line: string): string[] {
+  const parts = line.split('|');
+  // Drop leading empty cell if the line starts with `|`.
+  if (parts.length > 0 && (parts[0] ?? '').trim() === '') parts.shift();
+  // Drop trailing empty cell if the line ends with `|`.
+  if (parts.length > 0 && (parts[parts.length - 1] ?? '').trim() === '') parts.pop();
+  return parts;
+}
+
+/**
+ * True if the line is a Markdown table separator row — every cell is
+ * a run of `-` characters, optionally prefixed/suffixed with `:` for
+ * alignment hints.
+ */
+function isSeparatorRow(line: string): boolean {
+  if (!line.includes('|')) return false;
+  const cells = splitTableRow(line).map((c) => c.trim());
+  if (cells.length === 0) return false;
+  return cells.every((c) => /^:?-{3,}:?$/.test(c));
+}
+
+/**
+ * Treat POSIX absolute paths and Windows drive-letter paths as absolute.
+ */
+function isAbsolutePath(value: string): boolean {
+  return value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value);
+}

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -20,7 +20,11 @@ export type ArtifactType = 'rfc' | 'features' | 'spec' | 'tasks';
 
 /**
  * Rolled-up lifecycle status for an artifact record. Computed freshly on
- * each scan; `unknown` always implies at least one parse-failure warning.
+ * each scan. Under the final classifier (Slice 2+), `unknown` implies at
+ * least one parse-failure warning on the record. During Slice 1 the
+ * parser uses `unknown` as a placeholder on every record it returns
+ * because classification has not yet been wired; the Slice 2 classifier
+ * overwrites it.
  */
 export type Status = 'done' | 'in-progress' | 'not-started' | 'unknown';
 
@@ -117,8 +121,11 @@ export interface ArtifactRecord {
   /** Repo-relative path to the source file. */
   path: string;
   /**
-   * Extracted from the artifact's H1 or frontmatter. Falls back to the
-   * filename stem if no title is parseable.
+   * Extracted from the artifact's first H1, handling the canonical
+   * `# Feature Specification: <Title>` prefix. Falls back to the
+   * filename stem when no H1 exists. (Frontmatter-based title
+   * extraction is deliberately not implemented — Smithy planning
+   * artifacts use an H1 by convention.)
    */
   title: string;
   /** Rolled-up status per the data-model validation rules. */

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -1,0 +1,180 @@
+/**
+ * Status scanner type surface.
+ *
+ * Entities declared here mirror `smithy-status-skill.data-model.md`. They are
+ * the in-memory record set produced by a single scan pass and consumed by the
+ * renderer, the filter, and the JSON emitter. No persistence, no schema
+ * evolution — the records exist only for the lifetime of one `smithy status`
+ * invocation.
+ *
+ * This module intentionally contains only the entities needed by User Story 1
+ * (Slice 1). Later stories (US2, US10) introduce `DependencyGraph`,
+ * `DependencyNode`, `StatusTree`, and `TreeNode`.
+ */
+
+/**
+ * The four artifact file types the scanner recognizes. Derived from the
+ * filename suffix (`.rfc.md`, `.features.md`, `.spec.md`, `.tasks.md`).
+ */
+export type ArtifactType = 'rfc' | 'features' | 'spec' | 'tasks';
+
+/**
+ * Rolled-up lifecycle status for an artifact record. Computed freshly on
+ * each scan; `unknown` always implies at least one parse-failure warning.
+ */
+export type Status = 'done' | 'in-progress' | 'not-started' | 'unknown';
+
+/**
+ * One row of an artifact's `## Dependency Order` table, parsed
+ * deterministically from its 4-column Markdown representation.
+ */
+export interface DependencyRow {
+  /**
+   * Canonical per-level ID (`M1`, `F2`, `US3`, `S4`). Matches
+   * `^(M|F|US|S)[1-9][0-9]*$`. No leading zeros. Unique within the
+   * containing `DependencyOrderTable`.
+   */
+  id: string;
+  /** Human-readable title taken verbatim from the table's Title column. */
+  title: string;
+  /**
+   * List of IDs this row depends on. Empty array when the cell is `—`.
+   * Dangling references are dropped during parse and recorded as warnings
+   * on the owning `ArtifactRecord`.
+   */
+  depends_on: string[];
+  /**
+   * Repo-relative path to the downstream artifact (file or folder), or
+   * `null` when the cell is `—`. Null signals "not yet created" — the
+   * scanner emits a virtual not-started record for the expected path.
+   */
+  artifact_path: string | null;
+}
+
+/**
+ * The full parsed `## Dependency Order` section for a single artifact.
+ *
+ * `format` distinguishes the new 4-column table from the legacy checkbox
+ * layout and from an entirely missing section. Consumers key absence off
+ * the `format` field rather than a null check, so every code path sees a
+ * concrete `DependencyOrderTable` value.
+ */
+export interface DependencyOrderTable {
+  /** Rows in the order they appear in the source Markdown. */
+  rows: DependencyRow[];
+  /**
+   * Canonical prefix used by rows in this table. Derived from the
+   * artifact's type (rfc→M, features→F, spec→US, tasks→S). A mismatch
+   * between `id_prefix` and any row's actual prefix produces a warning.
+   */
+  id_prefix: 'M' | 'F' | 'US' | 'S';
+  /**
+   * `table` for the new 4-column format, `legacy` for checkbox-based
+   * ordering, `missing` when no `## Dependency Order` section exists.
+   * `legacy` triggers a `format_legacy` warning and `unknown` status on
+   * the owning `ArtifactRecord`.
+   */
+  format: 'table' | 'legacy' | 'missing';
+}
+
+/**
+ * The suggested smithy command to run next for a non-done artifact.
+ * Populated by the deterministic rule table in the scanner.
+ */
+export interface NextAction {
+  /** The smithy command the user should run. */
+  command:
+    | 'smithy.mark'
+    | 'smithy.cut'
+    | 'smithy.forge'
+    | 'smithy.render'
+    | 'smithy.ignite'
+    | 'smithy.strike';
+  /** Positional arguments to pass (may be empty). */
+  arguments: string[];
+  /** One-line human-readable rationale. */
+  reason: string;
+  /**
+   * True when an ancestor artifact is itself not-started, meaning this
+   * suggestion was dropped from the rendered output in favor of the
+   * ancestor's suggestion. Retained in the record set for JSON consumers.
+   */
+  suppressed_by_ancestor?: boolean;
+}
+
+/**
+ * One entry per discovered artifact file, carrying everything needed to
+ * render it in the tree and to reason about its status and next action.
+ *
+ * `parent_path` distinguishes `null` (no parent — top-level RFCs and
+ * orphans) from an omitted field (unknown) per the data-model JSON
+ * guidance. `dependency_order` is always present; absence is signalled by
+ * `format: 'missing'` with `rows: []`, not by a null field.
+ */
+export interface ArtifactRecord {
+  /** Derived from filename suffix. */
+  type: ArtifactType;
+  /** Repo-relative path to the source file. */
+  path: string;
+  /**
+   * Extracted from the artifact's H1 or frontmatter. Falls back to the
+   * filename stem if no title is parseable.
+   */
+  title: string;
+  /** Rolled-up status per the data-model validation rules. */
+  status: Status;
+  /**
+   * Count of completed children. Omitted for records where counting is
+   * not meaningful.
+   */
+  completed?: number;
+  /** Total count of children. Omitted alongside `completed`. */
+  total?: number;
+  /**
+   * Repo-relative path to the parent artifact. `null` means "no parent"
+   * (top-level RFCs, orphans); an omitted field means "unknown".
+   */
+  parent_path?: string | null;
+  /**
+   * True when `parent_path` was declared by the artifact but the
+   * referenced file does not exist. Drives "Broken Links" grouping.
+   */
+  parent_missing?: boolean;
+  /**
+   * True for not-started records inferred from a parent's parsed
+   * `## Dependency Order` table but not yet present on disk. `virtual`
+   * records always have `status: 'not-started'` and their `path` is the
+   * expected path, not an existing file.
+   */
+  virtual?: boolean;
+  /**
+   * Populated by the suggestion rules; `null` for `done` records.
+   * Omitted entirely when not yet computed.
+   */
+  next_action?: NextAction | null;
+  /**
+   * Parsed `## Dependency Order` section. Always present — consumers key
+   * absence off `format: 'missing'`.
+   */
+  dependency_order: DependencyOrderTable;
+  /**
+   * Non-fatal parse issues encountered while reading the file. Empty
+   * array when clean.
+   */
+  warnings: string[];
+}
+
+/**
+ * Aggregate counts used by the summary header and the JSON output's
+ * top-level `summary` field.
+ */
+export interface ScanSummary {
+  /** E.g., `counts.spec['in-progress'] === 3`. */
+  counts: Record<ArtifactType, Record<Status, number>>;
+  /** Records with no parent (excluding top-level RFCs). */
+  orphan_count: number;
+  /** Records with `parent_missing === true`. */
+  broken_link_count: number;
+  /** Records with `status === 'unknown'`. */
+  parse_error_count: number;
+}


### PR DESCRIPTION
Define ArtifactType, Status, ArtifactRecord, DependencyRow,
DependencyOrderTable, NextAction, and ScanSummary in
src/status/types.ts. Re-export through src/status/index.ts so
downstream modules and tests have a single import surface.

Task 1 of 3 in 01-scan-artifacts-and-classify-status Slice 1.