### PR TITLE
ignite(us8): deduplicate clarification questions via .clarify-log.md

### DIFF
--- a/specs/2026-04-07-003-refactor-ignite-workflow/08-cross-session-question-deduplication.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/08-cross-session-question-deduplication.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Add clarify-log read step at the start of Phase 2**
+- [x] **Add clarify-log read step at the start of Phase 2**
 
   In `src/templates/agent-skills/commands/smithy.ignite.prompt`, insert a step at the top of Phase 2 (before the existing "Use the **smithy-clarify** sub-agent" instruction) that tells the orchestrator to look for an existing `.clarify-log.md` in the RFC folder derived in Phase 1, and if present, extract the last two `### Session YYYY-MM-DD` entries and pass them to smithy-clarify as additional context per the Clarify Log Contract Read Protocol in the contracts file.
 
@@ -28,7 +28,7 @@
   - Step instructs the orchestrator to include the dedup instruction quoted in the Read Protocol ("Do not re-ask questions already answered in this log.") when passing the log content to smithy-clarify, satisfying AS US8-2
   - Step is positioned so that smithy-clarify still receives all existing Phase 2 inputs (criteria, context, special instructions) unchanged
 
-- [ ] **Add clarify-log write step after Phase 2 completes**
+- [x] **Add clarify-log write step after Phase 2 completes**
 
   In the same prompt file, append a step at the end of Phase 2 (after smithy-clarify returns its summary, before Phase 3 begins) that tells the orchestrator to format the returned assumptions and Q&A as a new `### Session YYYY-MM-DD` entry per the Clarify Log Contract Write Format and append it to `.clarify-log.md` in the RFC folder. The step must ensure the RFC folder exists (creating it if needed) so the write succeeds even on the first session before sub-phase 3a runs, satisfying AS US8-1.
 
@@ -40,7 +40,7 @@
   - Step pulls assumptions and Q&A from the smithy-clarify return summary (not from a separate source)
   - Step is positioned after the Phase 2 dispatch instructions and before any Phase 3 content
 
-- [ ] **Assert clarify-log read and write instructions render in the claude variant**
+- [x] **Assert clarify-log read and write instructions render in the claude variant**
 
   In `src/templates.test.ts`, augment the existing `'ignite with claude variant renders competing plan dispatch'` test to add assertions that the rendered claude-variant ignite template contains identifiable markers for both the new clarify-log read step and the new clarify-log write step. Use stable phrase fragments (e.g., `.clarify-log.md`, plus a phrase distinguishing the read step from the write step) rather than exact long sentences that will drift. Confirm the existing assertions in the same test continue to pass.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -574,6 +574,26 @@ describe('getComposedTemplates', () => {
     // later RFC template code fence.
     const subPhase3gBody = ignite.slice(subphase3gIdx, phase4Idx);
     expect(subPhase3gBody).toContain('None identified at this time');
+
+    // Story 8: Phase 2 must contain both a clarify-log read step and a
+    // clarify-log write step. Bound assertions to the Phase 2 body (between
+    // `## Phase 2` and `## Phase 3`) so these never accidentally match other
+    // phases or the RFC template code fence.
+    const phase2Idx = ignite.indexOf('## Phase 2');
+    const phase3Idx = ignite.indexOf('## Phase 3', phase2Idx);
+    expect(phase2Idx).toBeGreaterThan(-1);
+    expect(phase3Idx).toBeGreaterThan(phase2Idx);
+    const phase2Block = ignite.slice(phase2Idx, phase3Idx);
+    // Filename appears at least twice — once for the read step, once for
+    // the write step.
+    const clarifyLogOccurrences = phase2Block.split('.clarify-log.md').length - 1;
+    expect(clarifyLogOccurrences).toBeGreaterThanOrEqual(2);
+    // Read-step marker: the no-re-ask instruction quoted from the Clarify
+    // Log Read Protocol. This phrase is unique to the read step.
+    expect(phase2Block).toContain('Do not re-ask questions already answered in this log.');
+    // Write-step marker: language about appending a new session entry.
+    // Distinct from any read-step phrasing.
+    expect(phase2Block.toLowerCase()).toMatch(/append[^.]*new session/);
   });
 
   it('ignite default does not contain competing plan dispatch', () => {

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -133,6 +133,29 @@ Present the reconciled plan to the user as:
 
 ## Phase 2: Clarify
 
+### Read Prior Clarify Log
+
+Before dispatching smithy-clarify, check whether a `.clarify-log.md` file
+already exists at the RFC folder derived in Phase 1 — i.e.
+`docs/rfcs/<YYYY>-<NNN>-<slug>/.clarify-log.md`, using the exact folder path
+resolved during intake (never a hard-coded path).
+
+- If the file does not exist, **skip this step silently** and proceed to the
+  dispatch below. This is the first-session case — there is nothing to read
+  and no warning or error should be produced.
+- If the file exists, read it and extract only the **last two**
+  `### Session YYYY-MM-DD` entries (not the full history). This follows the
+  Clarify Log **Read Protocol** defined in the contracts file
+  (`refactor-ignite-workflow.contracts.md`, "Clarify Log Contract"), which
+  caps the log slice at two sessions to limit context usage.
+- When dispatching smithy-clarify in the next step, pass the extracted
+  sessions as additional context alongside the existing criteria, context,
+  and special instructions — do not drop or replace any of the existing
+  inputs — and include the quoted instruction from the Read Protocol:
+  *"Do not re-ask questions already answered in this log."*
+
+### Dispatch smithy-clarify
+
 Use the **smithy-clarify** sub-agent. Pass it:
 
 - **Criteria**:
@@ -146,6 +169,28 @@ Use the **smithy-clarify** sub-agent. Pass it:
 - **Special instructions**: if the idea is already well-specified (e.g., from a
   detailed PRD), expect more assumptions and fewer questions. Never skip
   clarification entirely.
+
+### Append New Clarify Log Session
+
+After smithy-clarify returns its summary of assumptions and Q&A, and before
+Phase 3 begins, persist the results to `.clarify-log.md` so future sessions
+on this RFC folder can deduplicate against them:
+
+1. Ensure the RFC folder `docs/rfcs/<YYYY>-<NNN>-<slug>/` exists. If it does
+   not yet exist, **create it now** so the write succeeds even on the first
+   session — sub-phase 3a may not have run yet, so the orchestrator cannot
+   assume the folder is already on disk.
+2. Format the returned assumptions and Q&A as a new
+   `### Session YYYY-MM-DD` entry using today's date, conforming to the
+   Clarify Log **Write Format** defined in the contracts file
+   (`refactor-ignite-workflow.contracts.md`, "Clarify Log Contract"). Do not
+   restate the format here — follow the contract. Pull the assumptions and
+   Q&A from smithy-clarify's return summary, not from any other source.
+3. **Append** the new session entry to
+   `docs/rfcs/<YYYY>-<NNN>-<slug>/.clarify-log.md`. The log is append-only
+   per the data model's validation rule — never overwrite prior sessions,
+   and never modify existing `### Session YYYY-MM-DD` entries. If the file
+   does not yet exist, create it with the new entry as its first session.
 
 ---
 

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -136,22 +136,20 @@ Present the reconciled plan to the user as:
 ### Read Prior Clarify Log
 
 Before dispatching smithy-clarify, check whether a `.clarify-log.md` file
-already exists at the RFC folder derived in Phase 1 — i.e.
-`docs/rfcs/<YYYY>-<NNN>-<slug>/.clarify-log.md`, using the exact folder path
-resolved during intake (never a hard-coded path).
+already exists at the RFC folder derived in Phase 1 — for example,
+`docs/rfcs/<YYYY>-<NNN>-<slug>/.clarify-log.md` — using the exact folder
+path resolved during intake, not a hard-coded location.
 
 - If the file does not exist, **skip this step silently** and proceed to the
   dispatch below. This is the first-session case — there is nothing to read
   and no warning or error should be produced.
 - If the file exists, read it and extract only the **last two**
-  `### Session YYYY-MM-DD` entries (not the full history). This follows the
-  Clarify Log **Read Protocol** defined in the contracts file
-  (`refactor-ignite-workflow.contracts.md`, "Clarify Log Contract"), which
-  caps the log slice at two sessions to limit context usage.
+  `### Session YYYY-MM-DD` entries (not the full history). Capping the log
+  slice at two sessions keeps context usage bounded as the log grows.
 - When dispatching smithy-clarify in the next step, pass the extracted
   sessions as additional context alongside the existing criteria, context,
   and special instructions — do not drop or replace any of the existing
-  inputs — and include the quoted instruction from the Read Protocol:
+  inputs — and include this exact instruction:
   *"Do not re-ask questions already answered in this log."*
 
 ### Dispatch smithy-clarify
@@ -181,16 +179,30 @@ on this RFC folder can deduplicate against them:
    session — sub-phase 3a may not have run yet, so the orchestrator cannot
    assume the folder is already on disk.
 2. Format the returned assumptions and Q&A as a new
-   `### Session YYYY-MM-DD` entry using today's date, conforming to the
-   Clarify Log **Write Format** defined in the contracts file
-   (`refactor-ignite-workflow.contracts.md`, "Clarify Log Contract"). Do not
-   restate the format here — follow the contract. Pull the assumptions and
-   Q&A from smithy-clarify's return summary, not from any other source.
+   `### Session YYYY-MM-DD` entry using today's date, following exactly this
+   structure:
+
+   ```
+   ### Session YYYY-MM-DD
+
+   **Assumptions**:
+   - <assumption 1>
+   - <assumption 2>
+
+   **Questions & Answers**:
+   - Q: <question> → A: <answer>
+   - Q: <question> → A: <answer>
+   ```
+
+   Pull the assumptions and Q&A from smithy-clarify's return summary, not
+   from any other source. Omit either the `**Assumptions**` or
+   `**Questions & Answers**` block if smithy-clarify returned nothing for
+   that category, but always include the `### Session YYYY-MM-DD` heading.
 3. **Append** the new session entry to
-   `docs/rfcs/<YYYY>-<NNN>-<slug>/.clarify-log.md`. The log is append-only
-   per the data model's validation rule — never overwrite prior sessions,
-   and never modify existing `### Session YYYY-MM-DD` entries. If the file
-   does not yet exist, create it with the new entry as its first session.
+   `docs/rfcs/<YYYY>-<NNN>-<slug>/.clarify-log.md`. The log is append-only —
+   never overwrite prior sessions, and never modify existing
+   `### Session YYYY-MM-DD` entries. If the file does not yet exist, create
+   it with the new entry as its first session.
 
 ---
 


### PR DESCRIPTION
Wire cross-session question deduplication into Phase 2 of the ignite
orchestrator. Before dispatching smithy-clarify, read the last two
sessions from `.clarify-log.md` in the Phase 1-derived RFC folder (if
present) and pass them as additional context with the no-re-ask
instruction from the Clarify Log Read Protocol. After smithy-clarify
returns, ensure the RFC folder exists and append a new dated session
entry with the returned assumptions and Q&A per the Write Format.

Augment the claude-variant ignite template test to assert both the read
and write instructions render, bounded to the Phase 2 body.

Addresses FR-009, FR-010 (US8-1, US8-2, US8-3) from
specs/2026-04-07-003-refactor-ignite-workflow.

https://claude.ai/code/session_01XUHpVBQjYmhNZ2gYQvQKcL