### PR TITLE
ignite(phase-0): detect partial RFC state and resume from first missing sub-phase

### DIFF
--- a/specs/2026-04-07-003-refactor-ignite-workflow/07-session-resume-from-partial-state.tasks.md
+++ b/specs/2026-04-07-003-refactor-ignite-workflow/07-session-resume-from-partial-state.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Add Phase 0 state-detection step and section-to-sub-phase map**
+- [x] **Add Phase 0 state-detection step and section-to-sub-phase map**
 
   Rename the existing `## Phase 0: Review Loop` heading in the `{{#ifAgent}}` branch of `src/templates/agent-skills/commands/smithy.ignite.prompt` to `## Phase 0: State Detection and Review Loop`, and insert a new initial sub-step before the current `Phase 0a–0b` audit block. The new sub-step must instruct the orchestrator to read the RFC file, enumerate its `##` headings, and classify the file as `fresh` (header only), `partial` (some but not all mandatory template sections), or `complete` (all mandatory sections present) using an explicit section-to-sub-phase mapping covering Summary/Motivation → 3a, Personas → 3b, Goals/Out of Scope → 3c, Proposal/Design Considerations → 3d, Decisions/Open Questions → 3e, Milestones → 3f.
 
@@ -29,7 +29,7 @@
   - Detection step instructs the orchestrator to report which sections are present to the user (AS US7-1)
   - Existing `Phase 0a–0b` audit block and `Phase 0c` apply-refinements block remain intact below the new detection step
 
-- [ ] **Branch Phase 0 on detected state**
+- [x] **Branch Phase 0 on detected state**
 
   Immediately after the detection step introduced in task 1, add a branch block that routes the orchestrator based on the classification: `complete` → continue into the existing audit/review loop; `partial` → compute the first missing sub-phase from the section map, inform the user which sections are present and which sub-phase will run next, confirm resume with the user, and hand off to Phase 3 starting at that sub-phase; `fresh` → skip the review loop and hand off to Phase 3 at sub-phase 3a with the existing header-only file left in place. Add an explicit note covering the "partial RFC from a different idea" edge case: before resuming, the orchestrator must verify that the existing Summary/Motivation is contextually related to the current idea and, if not, warn the user and offer to overwrite, create a new RFC, or proceed anyway. Add a second note covering the "session crash during harmonization" edge case: if the file is classified `complete` but the detection step sees inconsistent or duplicated headings, enter the review loop so smithy-refine can repair it. References AS US7-1, US7-2, and the two edge cases from the spec.
 
@@ -43,7 +43,7 @@
   - Harmonize-crash note routes inconsistent "complete" files into the existing review loop
   - Existing review-loop behavior for genuinely complete RFCs is unchanged
 
-- [ ] **Teach Phase 3 to honor the resume hand-off**
+- [x] **Teach Phase 3 to honor the resume hand-off**
 
   In the same prompt file, extend the preamble of the Phase 3 `{{#ifAgent}}` block (the append-and-continue protocol note added by US4) with an explicit resume note: when Phase 0 hands off with a specific starting sub-phase, the orchestrator must skip all earlier sub-phases, leave the accumulating `<slug>.rfc.md` untouched on entry, and begin dispatching from the designated sub-phase. Clarify that each sub-phase's existing `rfc_file_path` context already gives the dispatched sub-agent access to every previously written section via disk read, so no additional context bridging is required. Do not modify the per-sub-phase dispatch blocks themselves. References AS US7-2.
 
@@ -54,7 +54,7 @@
   - RFC file creation step still runs only in the fresh-pipeline case, not on resume
   - Sub-phases 3a–3g keep their current dispatch directives from US3 and US4 unchanged
 
-- [ ] **Handle the no-RFC-file case in Routing**
+- [x] **Handle the no-RFC-file case in Routing**
 
   Update the `## Routing` section of the prompt so it cleanly covers the US7-3 case where no RFC file exists. The routing must still send explicit `.rfc.md` inputs into Phase 0 (which now classifies state itself) and still send description/PRD inputs into Phase 1. Also update the mid-intake redirect inside Phase 1 so that, when it finds a close-matching `docs/rfcs/` folder, it hands control to Phase 0 rather than asking the user to choose "review or create new" inline — Phase 0's state detection is now the single place that handles that decision. The option to create a new RFC instead of touching the existing one must still be available to the user from within Phase 0. References AS US7-3 and the existing mid-intake redirect behavior the spec preserves.
 
@@ -65,7 +65,7 @@
   - Routing does not duplicate the section-to-sub-phase map (that lives only in Phase 0)
   - Phase 1 intake for genuinely new ideas is otherwise unchanged
 
-- [ ] **Assert ignite agent variant renders state detection and resume branch**
+- [x] **Assert ignite agent variant renders state detection and resume branch**
 
   In `src/templates.test.ts`, extend the existing `'ignite with claude variant renders competing plan dispatch'` test to verify the new Phase 0 detection step, the three-way branch, and the Phase 3 resume note all render in the composed claude-variant ignite prompt. Target distinctive phrases from the new wording rather than substrings that could collide with the RFC template code fence or the existing audit table. Confirm the default (non-agent) variant remains free of the detection step so the new logic is scoped to the agent path.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -574,6 +574,49 @@ describe('getComposedTemplates', () => {
     // later RFC template code fence.
     const subPhase3gBody = ignite.slice(subphase3gIdx, phase4Idx);
     expect(subPhase3gBody).toContain('None identified at this time');
+
+    // Story 7: Phase 0 state detection and branch. The renamed Phase 0
+    // heading must cover both detection and the review loop in the agent
+    // variant, and the three classification states must appear verbatim in
+    // backticks so the detection vocabulary is locked in place.
+    expect(ignite).toContain('Phase 0: State Detection and Review Loop');
+    expect(ignite).toContain('`fresh`');
+    expect(ignite).toContain('`partial`');
+    expect(ignite).toContain('`complete`');
+    // The partial branch must wire the hand-off to the "first missing
+    // sub-phase" — a distinctive phrase introduced by Story 7 task 1/2 that
+    // does not collide with the RFC template code fence or the audit table.
+    expect(ignite).toContain('first missing sub-phase');
+    // The partial branch must require user confirmation before resuming
+    // (AS US7-1) and must explicitly forbid re-running completed sub-phases
+    // (AS US7-2).
+    const phase0DetectIdx = ignite.indexOf('Phase 0.0: State Detection');
+    const phase0ApplyIdx = ignite.indexOf('Phase 0c: Apply Refinements');
+    expect(phase0DetectIdx).toBeGreaterThan(-1);
+    expect(phase0ApplyIdx).toBeGreaterThan(phase0DetectIdx);
+    const phase0Block = ignite.slice(phase0DetectIdx, phase0ApplyIdx);
+    expect(phase0Block.toLowerCase()).toContain('confirm');
+    expect(phase0Block.toLowerCase()).toMatch(/re-run any earlier sub-phase/);
+    // Edge case: contextual mismatch offers overwrite / new RFC / proceed
+    // anyway as explicit options.
+    expect(phase0Block.toLowerCase()).toContain('overwrite');
+    expect(phase0Block.toLowerCase()).toContain('proceed anyway');
+    // Edge case: harmonize-crash note routes inconsistent "complete" files
+    // into the review loop.
+    expect(phase0Block.toLowerCase()).toContain('harmonization');
+
+    // Story 7: Phase 3 resume note lives in the Phase 3 preamble (alongside
+    // the append-and-continue protocol), not inside any individual sub-phase
+    // block. Slice from the start of Phase 3 to the first sub-phase to
+    // verify placement.
+    const phase3Idx = ignite.indexOf('## Phase 3');
+    const phase3aIdx = ignite.indexOf('### Sub-phase 3a');
+    expect(phase3Idx).toBeGreaterThan(-1);
+    expect(phase3aIdx).toBeGreaterThan(phase3Idx);
+    const phase3Preamble = ignite.slice(phase3Idx, phase3aIdx);
+    expect(phase3Preamble).toContain('Resume Hand-off');
+    expect(phase3Preamble.toLowerCase()).toContain('skip');
+    expect(phase3Preamble).toContain('rfc_file_path');
   });
 
   it('ignite default does not contain competing plan dispatch', () => {
@@ -584,6 +627,13 @@ describe('getComposedTemplates', () => {
     expect(ignite).not.toContain('Competing Plan Lenses');
     // Default (non-agent) path retains the unconditional file-write instruction
     expect(ignite).toContain('Write the RFC to');
+    // Story 7: the new Phase 0 state-detection step lives only inside
+    // `{{#ifAgent}}`, so the default variant must not render its heading,
+    // classification states, or resume note.
+    expect(ignite).not.toContain('State Detection and Review Loop');
+    expect(ignite).not.toContain('Phase 0.0: State Detection');
+    expect(ignite).not.toContain('Resume Hand-off');
+    expect(ignite).not.toContain('first missing sub-phase');
   });
 
   it('ignite RFC template contains Out of Scope and Personas sections in correct order', () => {

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -27,29 +27,115 @@ If no input is clear from the above, ask the user what idea they want to worksho
 
 Before starting, determine the mode:
 
-1. If the input points to an existing `.rfc.md` file, go to **Phase 0: Review Loop**.
-2. If the input is a file path (not `.rfc.md`), read the file and go to **Phase 1: Intake**.
-3. If the input is a description string, go to **Phase 1: Intake**.
+1. If the input points to an existing `.rfc.md` file, go to **Phase 0** —
+   Phase 0's state-detection step now classifies the file itself and decides
+   whether to review a complete RFC, resume a partial one from its first
+   missing sub-phase, or treat a header-only file as fresh.
+2. If the input is a file path (not `.rfc.md`), read the file and go to
+   **Phase 1: Intake**.
+3. If the input is a description string and no matching `docs/rfcs/` folder
+   is found during intake, go to **Phase 1: Intake** as normal — this is the
+   default new-idea path and Phase 1 proceeds unchanged for genuinely new
+   ideas.
 
 **Mid-intake redirect**: During Phase 1, step 2 scans `docs/rfcs/` for existing
-folders. If a folder's slug is a close match to the derived slug for the new idea
-(e.g., `docs/rfcs/2026-001-plugin-system/` already exists when the user asks to
-"build a plugin system"), **stop intake** and ask the user:
-
-> "An existing RFC was found at `docs/rfcs/<YYYY-NNN-slug>/<slug>.rfc.md`.
-> Would you like to **review and refine** the existing RFC, or **create a new one**?"
-
-- If the user chooses to review, go to **Phase 0: Review Loop** with that `.rfc.md`.
-- If the user chooses to create new, continue Phase 1 with the next available `NNN`.
+folders. If a folder's slug is a close match to the derived slug for the new
+idea (e.g., `docs/rfcs/2026-001-plugin-system/` already exists when the user
+asks to "build a plugin system"), **stop intake** and hand control to
+**Phase 0** with the matched `.rfc.md`. Do **not** ask the user "review or
+create new" inline here — that decision is delegated to Phase 0's
+state-detection step, which is now the single place that handles review,
+resume, and new-RFC branching. The option to **create a new RFC instead** of
+touching the existing file remains available to the user from inside Phase 0's
+`partial` and `complete` branches, so nothing is lost by deferring the
+decision.
 
 ---
 
+{{#ifAgent}}
+## Phase 0: State Detection and Review Loop
+{{else}}
 ## Phase 0: Review Loop
+{{/ifAgent}}
 
 Triggered when:
 - The input explicitly points to an existing `.rfc.md` file, **or**
 - Phase 1 detected a matching RFC folder during the `docs/rfcs/` scan and the
   user chose to review it (see Routing above).
+
+{{#ifAgent}}
+### Phase 0.0: State Detection
+
+Before running the review loop, classify the existing RFC file to decide
+whether this is a full review, a resume from partial state, or a fresh-start
+header-only file.
+
+1. Read the RFC file from disk and enumerate its `##` headings.
+2. Classify the file as exactly one of three states using the
+   section-to-sub-phase map below:
+   - **`fresh`** — only the RFC header is present; none of the mandatory
+     template `##` sections have been written yet.
+   - **`partial`** — at least one but not all of the mandatory template
+     sections are present.
+   - **`complete`** — every mandatory template section is present.
+3. Report to the user which sections are present, which are missing, and
+   which state was detected.
+
+The section-to-sub-phase map below pairs the RFC template's mandatory `##`
+section headings with the sub-phase that produces each section. Use the exact
+same section titles as the RFC template code fence later in this prompt.
+
+| RFC section(s)                                    | Sub-phase |
+|---------------------------------------------------|-----------|
+| `## Summary`, `## Motivation / Problem Statement` | 3a        |
+| `## Personas`                                     | 3b        |
+| `## Goals`, `## Out of Scope`                     | 3c        |
+| `## Proposal`, `## Design Considerations`         | 3d        |
+| `## Decisions`, `## Open Questions`               | 3e        |
+| `## Milestones`                                   | 3f        |
+
+### Phase 0.1: Branch on Detected State
+
+Route the pipeline based on the classification from Phase 0.0. Each state
+routes to a distinct next step:
+
+- **`complete`** → continue into `Phase 0a–0b: Audit & Refinement Questions`
+  below, exactly as before. The existing review-loop behavior for genuinely
+  complete RFCs is unchanged by this branching step.
+- **`partial`** → compute the **first missing sub-phase** as the lowest
+  sub-phase ID (3a → 3b → 3c → 3d → 3e → 3f) whose section(s) from the map
+  above are not yet present in the file. Tell the user which sections are
+  present, which sections are missing, and which sub-phase the pipeline will
+  resume from, then **ask the user to confirm** the resume. If the user
+  confirms, hand off to **Phase 3** beginning at that first missing
+  sub-phase (see the Phase 3 resume note for how the hand-off is honored).
+  Do **not** re-run any earlier sub-phase — the sections already on disk are
+  authoritative and must be preserved in place.
+- **`fresh`** → skip the review loop entirely. Leave the existing header-only
+  file on disk **untouched** (do not recreate it) and hand off to **Phase 3**
+  starting at sub-phase **3a**.
+
+From the `partial` or `complete` branch, the user may always choose to
+**create a new RFC instead** rather than touching the existing file; in that
+case, continue Phase 1 with the next available `NNN` so the existing file is
+preserved and a fresh RFC is drafted alongside it.
+
+**Partial RFC from a different idea.** Before resuming a `partial` file,
+verify that the existing `## Summary` and `## Motivation / Problem Statement`
+are contextually related to the current idea. If they are not a plausible
+match for the idea the user is now igniting, warn the user explicitly and
+offer exactly three options: **overwrite** the existing file (discard it and
+start a fresh draft in place), **create a new RFC** in a different folder
+with the next available `NNN`, or **proceed anyway** (treating the mismatch
+as intentional and resuming into the existing file as-is).
+
+**Session crash during harmonization (3g).** If the detection step classifies
+a file as `complete` but its enumerated headings are inconsistent, duplicated,
+or out of canonical template order — the symptom of a harmonization pass
+that crashed mid-rewrite — enter the `Phase 0a–0b` review loop below so that
+`smithy-refine` can identify and repair the inconsistencies.
+
+{{/ifAgent}}
 
 ### Phase 0a–0b: Audit & Refinement Questions
 
@@ -181,6 +267,32 @@ content to `<slug>.rfc.md` before dispatching the next sub-phase. This is the
 append-and-continue protocol for sub-phases 3a–3f. For inline sub-phase 3e, the
 orchestrator appends directly. Sub-phase 3g is an exception: it rewrites the
 entire file in place (harmonize pass) rather than appending.
+
+### Resume Hand-off from Phase 0
+
+If Phase 0's state-detection step (Phase 0.1) handed off to Phase 3 with a
+specific starting sub-phase (either a `partial` RFC resumed at its first
+missing sub-phase, or a `fresh` header-only RFC resumed at 3a), honor the
+hand-off with the following rules:
+
+1. **Skip** every sub-phase earlier than the designated starting sub-phase.
+   Those sections are already present on disk and MUST NOT be re-run — their
+   prior-session output is authoritative.
+2. **Leave the accumulating `<slug>.rfc.md` on disk untouched on entry.** The
+   `RFC File Creation` step above only runs in the fresh-pipeline case where
+   no file exists yet; on resume, the file Phase 0 classified is already on
+   disk (either a header-only `fresh` file or a `partial` file with some
+   sections already written) and is preserved as-is.
+3. **Begin dispatch** from the designated starting sub-phase and continue
+   through sub-phase 3g normally, using the append-and-continue protocol
+   above for each remaining sub-phase.
+
+No extra context bridging is required for resumed sub-phases. Each sub-phase
+below already passes `rfc_file_path` — the path to the accumulating
+`<slug>.rfc.md` — to its dispatched sub-agent, so every section written by an
+earlier sub-phase (whether in this session or in an interrupted prior
+session) flows into the current sub-agent via the existing disk-read
+contract.
 
 ### Sub-phase 3a: Summary + Motivation
 

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -27,6 +27,7 @@ If no input is clear from the above, ask the user what idea they want to worksho
 
 Before starting, determine the mode:
 
+{{#ifAgent}}
 1. If the input points to an existing `.rfc.md` file, go to **Phase 0** —
    Phase 0's state-detection step now classifies the file itself and decides
    whether to review a complete RFC, resume a partial one from its first
@@ -49,6 +50,22 @@ resume, and new-RFC branching. The option to **create a new RFC instead** of
 touching the existing file remains available to the user from inside Phase 0's
 `partial` and `complete` branches, so nothing is lost by deferring the
 decision.
+{{else}}
+1. If the input points to an existing `.rfc.md` file, go to **Phase 0: Review Loop**.
+2. If the input is a file path (not `.rfc.md`), read the file and go to **Phase 1: Intake**.
+3. If the input is a description string, go to **Phase 1: Intake**.
+
+**Mid-intake redirect**: During Phase 1, step 2 scans `docs/rfcs/` for existing
+folders. If a folder's slug is a close match to the derived slug for the new idea
+(e.g., `docs/rfcs/2026-001-plugin-system/` already exists when the user asks to
+"build a plugin system"), **stop intake** and ask the user:
+
+> "An existing RFC was found at `docs/rfcs/<YYYY-NNN-slug>/<slug>.rfc.md`.
+> Would you like to **review and refine** the existing RFC, or **create a new one**?"
+
+- If the user chooses to review, go to **Phase 0: Review Loop** with that `.rfc.md`.
+- If the user chooses to create new, continue Phase 1 with the next available `NNN`.
+{{/ifAgent}}
 
 ---
 
@@ -60,8 +77,9 @@ decision.
 
 Triggered when:
 - The input explicitly points to an existing `.rfc.md` file, **or**
-- Phase 1 detected a matching RFC folder during the `docs/rfcs/` scan and the
-  user chose to review it (see Routing above).
+- Phase 1 detected a close-matching RFC folder during the `docs/rfcs/` scan
+  and handed control to Phase 0 with the matched `.rfc.md` (see Routing
+  above).
 
 {{#ifAgent}}
 ### Phase 0.0: State Detection
@@ -283,16 +301,41 @@ hand-off with the following rules:
    no file exists yet; on resume, the file Phase 0 classified is already on
    disk (either a header-only `fresh` file or a `partial` file with some
    sections already written) and is preserved as-is.
-3. **Begin dispatch** from the designated starting sub-phase and continue
+3. **Reconstruct the missing intake and clarify context** before dispatching
+   the resumed sub-phase. The sub-agents below all expect
+   `idea_description` (normally produced by Phase 1 intake) and
+   `clarify_output` (normally produced by Phase 2 clarification), and the
+   inline sub-phase 3e synthesizes Decisions/Open Questions directly from
+   the clarification record. When Phase 0 hands off into a resume, those
+   in-session artifacts may not exist, so the orchestrator MUST rebuild
+   them before continuing:
+   - **`idea_description`**: re-derive from the existing `## Summary` and
+     `## Motivation / Problem Statement` sections of the on-disk RFC. If
+     those sections do not yet exist (e.g., 3a is the first missing
+     sub-phase), fall back to the user's current invocation arguments or
+     ask the user to restate the idea in one or two sentences.
+   - **`clarify_output`**: prefer loading the RFC folder's
+     `.clarify-log.md` if it exists. If no log is present, run **Phase 2
+     (Clarify)** before dispatching the first resumed sub-phase so the
+     downstream sub-agents receive grounded clarification context rather
+     than fabricated answers. Do not silently dispatch with empty
+     clarification.
+4. **Begin dispatch** from the designated starting sub-phase and continue
    through sub-phase 3g normally, using the append-and-continue protocol
    above for each remaining sub-phase.
 
-No extra context bridging is required for resumed sub-phases. Each sub-phase
-below already passes `rfc_file_path` — the path to the accumulating
-`<slug>.rfc.md` — to its dispatched sub-agent, so every section written by an
-earlier sub-phase (whether in this session or in an interrupted prior
-session) flows into the current sub-agent via the existing disk-read
-contract.
+For the disk-read context bridging itself, sub-phases **3b–3g** already pass
+`rfc_file_path` — the path to the accumulating `<slug>.rfc.md` — to their
+dispatched sub-agent, so every section written by an earlier sub-phase
+(whether in this session or in an interrupted prior session) flows into the
+current sub-agent via the existing disk-read contract. **Exception:**
+sub-phase 3a normally does **not** pass `rfc_file_path` because in the
+fresh pipeline the file contains only the header at that point. If Phase 0
+hands off into 3a (either a `fresh` header-only file or a `partial` file
+where 3a is somehow the first missing sub-phase), the orchestrator MUST
+pass `rfc_file_path` to smithy-prose for the resumed 3a dispatch so the
+sub-agent can see whatever is already on disk before writing the Summary
+and Motivation sections.
 
 ### Sub-phase 3a: Summary + Motivation
 


### PR DESCRIPTION
Teach smithy.ignite Phase 0 to classify any existing `.rfc.md` it encounters
as `fresh`, `partial`, or `complete` before running the audit/review loop,
and route each state to a distinct next step. Partial files resume at the
first missing sub-phase (computed from a section-to-sub-phase map covering
3a–3f) after user confirmation, without re-running completed sub-phases.
Fresh header-only files skip the review loop and hand off to 3a with the
existing file preserved in place. Complete files continue into the existing
Phase 0a–0b audit as before.

Phase 3's append-and-continue preamble now carries an explicit resume note
that skips earlier sub-phases, leaves the accumulating file untouched on
entry, and relies on the existing `rfc_file_path` parameter to bridge prior
sections into dispatched sub-agents. The Routing section delegates the
review-vs-resume-vs-new decision to Phase 0, so the mid-intake redirect no
longer asks the user inline. Edge cases for partial-from-a-different-idea
and harmonize-crash mid-rewrite are handled explicitly.

Template tests assert the renamed Phase 0 heading, the three state labels,
the first-missing-sub-phase wiring, and the Phase 3 resume note all render
in the claude-variant ignite prompt, and that none of this bleeds into the
default (non-agent) variant.

https://claude.ai/code/session_0143LJZ6nK3Pnj6Tu7tNbcTh