### PR TITLE
slice-2: add pure classifyRecord for status rollup

### DIFF
--- a/specs/2026-04-12-004-smithy-status-skill/01-scan-artifacts-and-classify-status.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/01-scan-artifacts-and-classify-status.tasks.md
@@ -71,7 +71,7 @@
 
 ### Tasks
 
-- [ ] **Implement pure `classifyRecord` in `src/status/classifier.ts`**
+- [x] **Implement pure `classifyRecord` in `src/status/classifier.ts`**
 
   Add a pure function `classifyRecord(record, resolvedChildren)` that returns a `Status` derived from the record's type per the data-model validation rules. For `tasks` records, derive status from `completed` / `total`: `completed === total && total > 0` → `done`; `0 < completed < total` → `in-progress`; `total === 0` or `completed === 0` → `not-started`. For parent record types (`spec`, `features`, `rfc`), roll up the resolved children per the data model: every row `done` → `done`; any child `in-progress` or a mix of `done` and not-done rows → `in-progress`; every row `not-started` (or the row's `Artifact` is `—`) → `not-started`. A record carrying any parse-failure warning that prevents classification (missing required `## Dependency Order` section for a parent type, or `format: 'legacy'`) must resolve to `unknown`. Virtual records always resolve to `not-started`.
 

--- a/specs/2026-04-12-004-smithy-status-skill/01-scan-artifacts-and-classify-status.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/01-scan-artifacts-and-classify-status.tasks.md
@@ -85,7 +85,7 @@
   - Implementation is a pure function: same input always produces same output, no filesystem access, no I/O.
   - Unit tests exercise every branch with synthetic `ArtifactRecord` inputs in memory.
 
-- [ ] **Implement `scan(root)` in `src/status/scanner.ts` with discovery, parent resolution, virtual emission, and leaf-to-root classification**
+- [x] **Implement `scan(root)` in `src/status/scanner.ts` with discovery, parent resolution, virtual emission, and leaf-to-root classification**
 
   Add `scan(root)` that walks `specs/`, `docs/rfcs/`, and `specs/strikes/` under `root` using `node:fs` (no new dependencies; mirror the recursive-walk pattern already in `src/utils.ts`). Discover files by extension suffix (`.rfc.md`, `.features.md`, `.spec.md`, `.tasks.md`). Do not follow symlinks that resolve outside `root`. For each discovered file, call `parseArtifact` to build a partial record. Then, in a second pass, resolve `parent_path` for every record by scanning each candidate parent's `dependency_order.rows` for a row whose `artifact_path` resolves to the child's repo-relative `path` after normalization. Resolution rules match the data model's lineage: an RFC milestone row points at a `.features.md` file (exact match); a feature-map feature row points at a **spec folder**, and resolution locates the `.spec.md` file inside that folder by the naming convention (`<folder>/<slug>.spec.md`); a spec user-story row points at a `.tasks.md` file (exact match). Exact matches and folder-to-spec matches are both valid — no directory-structure heuristics beyond the documented lineage are permitted. Set `parent_missing: true` on records whose declared parent path cannot be resolved to an existing file. For every parent row whose `artifact_path` is `null` or resolves to a file that does not exist on disk, emit a virtual `ArtifactRecord` with `virtual: true`, `status: 'not-started'`, and the row's declared or naming-convention-expected path. On a virtual / real collision at the same path, the real record wins and the virtual is discarded. Finally, classify records leaf-to-root (tasks first, then spec, then features, then rfc) so every parent sees already-classified children when `classifyRecord` runs. Individual file read or parse failures produce a record with `status: 'unknown'` and a descriptive warning — scanning continues without aborting.
 
@@ -157,7 +157,7 @@
 Recommended implementation sequence:
 
 1. [x] **Slice 1** — the pure parser and its type surface have no runtime prerequisites and are the import foundation every downstream slice needs.
-2. [ ] **Slice 2** — the scanner consumes the parser from Slice 1 to produce a fully-classified record set; this is the first slice whose output matches the US1 acceptance contract end-to-end.
+2. [x] **Slice 2** — the scanner consumes the parser from Slice 1 to produce a fully-classified record set; this is the first slice whose output matches the US1 acceptance contract end-to-end.
 3. [ ] **Slice 3** — the CLI subcommand composes the finished scanner, exposing US1 to end users and matching the contracts file's JSON shape.
 
 ### Cross-Story Dependencies

--- a/src/status/classifier.test.ts
+++ b/src/status/classifier.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from 'vitest';
+// Import through the `./index.js` barrel — that is the stable public
+// surface downstream modules consume, and these tests double as an
+// assertion that the barrel re-exports the classifier correctly.
+import {
+  classifyRecord,
+  type ArtifactRecord,
+  type ArtifactType,
+  type DependencyOrderTable,
+  type DependencyRow,
+  type Status,
+} from './index.js';
+
+/**
+ * Build a synthetic `ArtifactRecord` with enough fields populated to
+ * exercise the classifier. Tests that need to tweak individual fields
+ * pass them in via `overrides`.
+ */
+function makeRecord(overrides: Partial<ArtifactRecord> = {}): ArtifactRecord {
+  const type: ArtifactType = overrides.type ?? 'spec';
+  const idPrefix: DependencyOrderTable['id_prefix'] =
+    type === 'rfc'
+      ? 'M'
+      : type === 'features'
+        ? 'F'
+        : type === 'spec'
+          ? 'US'
+          : 'S';
+  const dependency_order: DependencyOrderTable = overrides.dependency_order ?? {
+    rows: [],
+    id_prefix: idPrefix,
+    format: 'table',
+  };
+  return {
+    type,
+    path: overrides.path ?? `specs/sample.${type === 'tasks' ? 'tasks' : type}.md`,
+    title: overrides.title ?? 'Sample',
+    status: overrides.status ?? 'unknown',
+    dependency_order,
+    warnings: overrides.warnings ?? [],
+    ...overrides,
+  };
+}
+
+function makeRow(
+  id: string,
+  artifact_path: string | null = null,
+): DependencyRow {
+  return { id, title: `Row ${id}`, depends_on: [], artifact_path };
+}
+
+function makeChild(status: Status, type: ArtifactType = 'tasks'): ArtifactRecord {
+  return makeRecord({ type, status });
+}
+
+describe('classifyRecord — tasks records', () => {
+  it('returns in-progress when some but not all checkboxes are ticked', () => {
+    const record = makeRecord({ type: 'tasks', completed: 3, total: 6 });
+    expect(classifyRecord(record, [])).toBe('in-progress');
+  });
+
+  it('returns done when every checkbox is ticked and total is positive', () => {
+    const record = makeRecord({ type: 'tasks', completed: 6, total: 6 });
+    expect(classifyRecord(record, [])).toBe('done');
+  });
+
+  it('returns not-started when completed is zero and total is positive', () => {
+    const record = makeRecord({ type: 'tasks', completed: 0, total: 6 });
+    expect(classifyRecord(record, [])).toBe('not-started');
+  });
+
+  it('returns not-started when total is zero', () => {
+    const record = makeRecord({ type: 'tasks', completed: 0, total: 0 });
+    expect(classifyRecord(record, [])).toBe('not-started');
+  });
+
+  it('returns not-started for the edge case where completed > 0 but total is zero', () => {
+    // Structural guard — the parser should never produce this state, but
+    // classifyRecord must still resolve deterministically.
+    const record = makeRecord({ type: 'tasks', completed: 5, total: 0 });
+    expect(classifyRecord(record, [])).toBe('not-started');
+  });
+
+  it('ignores resolvedChildren entirely for tasks records', () => {
+    const record = makeRecord({ type: 'tasks', completed: 3, total: 6 });
+    const bogusChildren = [makeChild('done'), makeChild('done')];
+    expect(classifyRecord(record, bogusChildren)).toBe('in-progress');
+  });
+});
+
+describe('classifyRecord — parent records (rollup)', () => {
+  it('returns in-progress for a spec with two done tasks and one virtual not-started child (AS 1.1)', () => {
+    const parent = makeRecord({
+      type: 'spec',
+      dependency_order: {
+        rows: [
+          makeRow('US1', 'specs/x/01.tasks.md'),
+          makeRow('US2', 'specs/x/02.tasks.md'),
+          makeRow('US3', null),
+        ],
+        id_prefix: 'US',
+        format: 'table',
+      },
+    });
+    const children: ArtifactRecord[] = [
+      makeChild('done'),
+      makeChild('done'),
+      makeRecord({ type: 'tasks', status: 'not-started', virtual: true }),
+    ];
+    expect(classifyRecord(parent, children)).toBe('in-progress');
+  });
+
+  it('returns done for a spec where every child is done', () => {
+    const parent = makeRecord({
+      type: 'spec',
+      dependency_order: {
+        rows: [makeRow('US1'), makeRow('US2')],
+        id_prefix: 'US',
+        format: 'table',
+      },
+    });
+    expect(
+      classifyRecord(parent, [makeChild('done'), makeChild('done')]),
+    ).toBe('done');
+  });
+
+  it('returns done for a features record where every child is done', () => {
+    const parent = makeRecord({
+      type: 'features',
+      dependency_order: {
+        rows: [makeRow('F1'), makeRow('F2')],
+        id_prefix: 'F',
+        format: 'table',
+      },
+    });
+    expect(
+      classifyRecord(parent, [
+        makeChild('done', 'spec'),
+        makeChild('done', 'spec'),
+      ]),
+    ).toBe('done');
+  });
+
+  it('returns done for an rfc record where every child is done', () => {
+    const parent = makeRecord({
+      type: 'rfc',
+      dependency_order: {
+        rows: [makeRow('M1'), makeRow('M2')],
+        id_prefix: 'M',
+        format: 'table',
+      },
+    });
+    expect(
+      classifyRecord(parent, [
+        makeChild('done', 'features'),
+        makeChild('done', 'features'),
+      ]),
+    ).toBe('done');
+  });
+
+  it('returns not-started for a spec where every child is not-started', () => {
+    const parent = makeRecord({
+      type: 'spec',
+      dependency_order: {
+        rows: [makeRow('US1'), makeRow('US2')],
+        id_prefix: 'US',
+        format: 'table',
+      },
+    });
+    expect(
+      classifyRecord(parent, [
+        makeChild('not-started'),
+        makeChild('not-started'),
+      ]),
+    ).toBe('not-started');
+  });
+
+  it('returns not-started for a features record where every child is not-started', () => {
+    const parent = makeRecord({
+      type: 'features',
+      dependency_order: {
+        rows: [makeRow('F1'), makeRow('F2')],
+        id_prefix: 'F',
+        format: 'table',
+      },
+    });
+    expect(
+      classifyRecord(parent, [
+        makeChild('not-started', 'spec'),
+        makeChild('not-started', 'spec'),
+      ]),
+    ).toBe('not-started');
+  });
+
+  it('returns not-started for an rfc record where every child is not-started', () => {
+    const parent = makeRecord({
+      type: 'rfc',
+      dependency_order: {
+        rows: [makeRow('M1'), makeRow('M2')],
+        id_prefix: 'M',
+        format: 'table',
+      },
+    });
+    expect(
+      classifyRecord(parent, [
+        makeChild('not-started', 'features'),
+        makeChild('not-started', 'features'),
+      ]),
+    ).toBe('not-started');
+  });
+
+  it('returns in-progress for a parent with an explicit in-progress child', () => {
+    const parent = makeRecord({
+      type: 'spec',
+      dependency_order: {
+        rows: [makeRow('US1'), makeRow('US2')],
+        id_prefix: 'US',
+        format: 'table',
+      },
+    });
+    expect(
+      classifyRecord(parent, [makeChild('in-progress'), makeChild('done')]),
+    ).toBe('in-progress');
+  });
+
+  it('falls through to in-progress when at least one child has unknown status', () => {
+    // Documented behavior: any child whose status is `unknown` prevents a
+    // clean done / not-started verdict, so the parent resolves to
+    // in-progress. The parent itself remains classifiable because its
+    // own dependency_order parsed cleanly; only its child is impaired.
+    const parent = makeRecord({
+      type: 'spec',
+      dependency_order: {
+        rows: [makeRow('US1'), makeRow('US2')],
+        id_prefix: 'US',
+        format: 'table',
+      },
+    });
+    expect(
+      classifyRecord(parent, [makeChild('done'), makeChild('unknown')]),
+    ).toBe('in-progress');
+  });
+
+  it('returns not-started for a parent with zero resolved children (empty rows, format=table)', () => {
+    const parent = makeRecord({
+      type: 'spec',
+      dependency_order: { rows: [], id_prefix: 'US', format: 'table' },
+    });
+    expect(classifyRecord(parent, [])).toBe('not-started');
+  });
+});
+
+describe('classifyRecord — parse failures on parent records', () => {
+  it('returns unknown when dependency_order.format is legacy, ignoring children', () => {
+    const parent = makeRecord({
+      type: 'spec',
+      dependency_order: { rows: [], id_prefix: 'US', format: 'legacy' },
+    });
+    const allDone = [makeChild('done'), makeChild('done')];
+    expect(classifyRecord(parent, allDone)).toBe('unknown');
+  });
+
+  it('returns unknown when dependency_order.format is missing, ignoring children', () => {
+    const parent = makeRecord({
+      type: 'features',
+      dependency_order: { rows: [], id_prefix: 'F', format: 'missing' },
+    });
+    const allDone = [makeChild('done', 'spec'), makeChild('done', 'spec')];
+    expect(classifyRecord(parent, allDone)).toBe('unknown');
+  });
+
+  it('returns unknown for an rfc with legacy format regardless of children', () => {
+    const parent = makeRecord({
+      type: 'rfc',
+      dependency_order: { rows: [], id_prefix: 'M', format: 'legacy' },
+    });
+    expect(classifyRecord(parent, [makeChild('done', 'features')])).toBe(
+      'unknown',
+    );
+  });
+});
+
+describe('classifyRecord — virtual records', () => {
+  it('always returns not-started for a virtual tasks record regardless of completed/total', () => {
+    const record = makeRecord({
+      type: 'tasks',
+      virtual: true,
+      completed: 6,
+      total: 6,
+    });
+    expect(classifyRecord(record, [])).toBe('not-started');
+  });
+
+  it('always returns not-started for a virtual spec record regardless of dependency_order', () => {
+    const record = makeRecord({
+      type: 'spec',
+      virtual: true,
+      dependency_order: {
+        rows: [makeRow('US1')],
+        id_prefix: 'US',
+        format: 'table',
+      },
+    });
+    expect(classifyRecord(record, [makeChild('done')])).toBe('not-started');
+  });
+
+  it('returns not-started for a virtual parent whose format would otherwise yield unknown', () => {
+    const record = makeRecord({
+      type: 'features',
+      virtual: true,
+      dependency_order: { rows: [], id_prefix: 'F', format: 'legacy' },
+    });
+    expect(classifyRecord(record, [])).toBe('not-started');
+  });
+});

--- a/src/status/classifier.ts
+++ b/src/status/classifier.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure status classifier for Smithy artifact records.
+ *
+ * This module contains a single pure function, `classifyRecord`, that
+ * derives a final {@link Status} from an already-parsed {@link ArtifactRecord}
+ * and its already-classified children. It performs no filesystem I/O,
+ * no network calls, and no parsing — every input required to make a
+ * decision must be supplied by the caller. The scanner (Slice 2)
+ * orchestrates discovery and child resolution on top of this function,
+ * calling it leaf-to-root so each invocation sees finalized child
+ * statuses.
+ *
+ * The classification rules mirror the validation rules in
+ * `smithy-status-skill.data-model.md`.
+ */
+
+import type { ArtifactRecord, Status } from './types.js';
+
+/**
+ * Derive the finalized {@link Status} for a single {@link ArtifactRecord}.
+ *
+ * Rules:
+ *
+ * 1. A record with `virtual === true` always resolves to `'not-started'`
+ *    regardless of type, children, or dependency_order.
+ * 2. A `tasks` record derives its status from `completed` / `total`:
+ *    - `completed === total && total > 0` → `'done'`
+ *    - `0 < completed < total` → `'in-progress'`
+ *    - otherwise (`total === 0` or `completed === 0`) → `'not-started'`
+ *    For tasks records, `resolvedChildren` is ignored.
+ * 3. A parent record (`spec`, `features`, `rfc`) rolls up from its
+ *    `resolvedChildren`:
+ *    - If `dependency_order.format` is `'legacy'` or `'missing'`, the
+ *      record resolves to `'unknown'`. Children are ignored in this
+ *      case — a parse-failure on the parent's own dependency order
+ *      blocks rollup entirely.
+ *    - Otherwise, with `format === 'table'`:
+ *      - Zero resolved children → `'not-started'`.
+ *      - Every child `'done'` → `'done'`.
+ *      - Every child `'not-started'` → `'not-started'`.
+ *      - Any other combination (any `'in-progress'`, any mix of `'done'`
+ *        and non-`'done'`, any `'unknown'`) → `'in-progress'`.
+ *
+ * This function is pure: same inputs always produce the same output.
+ *
+ * @param record           The record whose status should be derived.
+ * @param resolvedChildren Children whose `status` has already been
+ *                         finalized, in the same order as the parent's
+ *                         `dependency_order.rows`. For `tasks` records
+ *                         this argument is ignored and may be an empty
+ *                         array.
+ */
+export function classifyRecord(
+  record: ArtifactRecord,
+  resolvedChildren: ArtifactRecord[],
+): Status {
+  // Rule 1: virtual records are always not-started.
+  if (record.virtual === true) {
+    return 'not-started';
+  }
+
+  // Rule 2: tasks records derive status from checkbox counts alone.
+  if (record.type === 'tasks') {
+    const completed = record.completed ?? 0;
+    const total = record.total ?? 0;
+    if (total > 0 && completed === total) return 'done';
+    if (completed > 0 && completed < total) return 'in-progress';
+    return 'not-started';
+  }
+
+  // Rule 3: parent records (spec / features / rfc).
+  const format = record.dependency_order.format;
+  if (format === 'legacy' || format === 'missing') {
+    return 'unknown';
+  }
+
+  // format === 'table' from here on.
+  if (resolvedChildren.length === 0) {
+    return 'not-started';
+  }
+
+  let allDone = true;
+  let allNotStarted = true;
+  for (const child of resolvedChildren) {
+    if (child.status !== 'done') allDone = false;
+    if (child.status !== 'not-started') allNotStarted = false;
+  }
+
+  if (allDone) return 'done';
+  if (allNotStarted) return 'not-started';
+  return 'in-progress';
+}

--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -12,3 +12,4 @@ export {
   parseDependencyTable,
   type ParsedDependencyTable,
 } from './parser.js';
+export { classifyRecord } from './classifier.js';

--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -13,3 +13,4 @@ export {
   type ParsedDependencyTable,
 } from './parser.js';
 export { classifyRecord } from './classifier.js';
+export { scan } from './scanner.js';

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -205,8 +205,9 @@ export function parseDependencyTable(
  * dependency-order rows, unknown filename suffix) is appended to the
  * record's `warnings` list.
  *
- * Status classification is deferred to Slice 2 — every record returned
- * here carries `status: 'unknown'` as a placeholder.
+ * Status classification is performed by `classifyRecord` in the scanner
+ * (`src/status/scanner.ts`). Every record returned here carries
+ * `status: 'unknown'` as a placeholder until the scanner resolves it.
  */
 export function parseArtifact(
   filePath: string,

--- a/src/status/scanner.test.ts
+++ b/src/status/scanner.test.ts
@@ -371,6 +371,33 @@ ${TABLE_HEADER}
     expect(withThatPath[0]?.status).toBe('done');
   });
 
+  it('feature-map folder match requires the canonical <leaf>.spec.md filename', () => {
+    // The feature map points at `specs/feature-a/`. Inside that folder
+    // there is a non-canonical `notes.spec.md`. The scanner must NOT
+    // bind the feature row to it (binding would depend on readdirSync
+    // order). Instead it emits a virtual record at the folder path.
+    write(
+      'specs/feature-a/feature-a.features.md',
+      `# Feature Map\n\n## Dependency Order\n\n${TABLE_HEADER}\n| F1 | First | — | specs/feature-a/ |\n`,
+    );
+    write(
+      'specs/feature-a/notes.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | One | — | — |\n`,
+    );
+    const records = scan(root);
+    const notes = byPath(records, 'specs/feature-a/notes.spec.md');
+    expect(notes).toBeDefined();
+    // notes.spec.md was discovered as a real record but NOT linked to
+    // the feature map (its parent_path stays unset).
+    expect(notes?.parent_path).toBeUndefined();
+    // A virtual spec record for the folder placeholder is emitted.
+    const virt = records.find(
+      (r) => r.type === 'spec' && r.virtual === true && r.path === 'specs/feature-a/',
+    );
+    expect(virt).toBeDefined();
+    expect(virt?.parent_path).toBe('specs/feature-a/feature-a.features.md');
+  });
+
   it('legacy-format artifact yields a spec record with status=unknown', () => {
     write(
       'specs/feature-a/feature-a.spec.md',

--- a/src/status/scanner.test.ts
+++ b/src/status/scanner.test.ts
@@ -398,6 +398,35 @@ ${TABLE_HEADER}
     expect(virt?.parent_path).toBe('specs/feature-a/feature-a.features.md');
   });
 
+  it('parent_path collision: a child claimed by two parents keeps the first and warns', () => {
+    // Two specs both list the same tasks file in their dep-order
+    // tables. The child must keep the first parent_path and append a
+    // warning naming the second parent.
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec A\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | One | — | specs/shared/01-only.tasks.md |\n`,
+    );
+    write(
+      'specs/feature-b/feature-b.spec.md',
+      `# Spec B\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | One | — | specs/shared/01-only.tasks.md |\n`,
+    );
+    write(
+      'specs/shared/01-only.tasks.md',
+      `# Tasks\n\n## Slice 1: Only\n\n- [x] Done\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    const records = scan(root);
+    const child = byPath(records, 'specs/shared/01-only.tasks.md');
+    expect(child).toBeDefined();
+    // Whichever spec was iterated first wins; both specs are valid
+    // first-parents so accept either.
+    expect(child?.parent_path === 'specs/feature-a/feature-a.spec.md' ||
+      child?.parent_path === 'specs/feature-b/feature-b.spec.md').toBe(true);
+    const collisionWarnings = child?.warnings.filter((w) =>
+      w.startsWith('parent_collision:'),
+    );
+    expect(collisionWarnings).toHaveLength(1);
+  });
+
   it('legacy-format artifact yields a spec record with status=unknown', () => {
     write(
       'specs/feature-a/feature-a.spec.md',

--- a/src/status/scanner.test.ts
+++ b/src/status/scanner.test.ts
@@ -164,6 +164,32 @@ ${TABLE_HEADER}
     expect(virt?.parent_path).toBe('specs/feature-a/feature-a.spec.md');
   });
 
+  it('spec — row virtual placeholder uses zero-padded NN-<slug>.tasks.md convention', () => {
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US3 | Third story | — | — |\n`,
+    );
+    const records = scan(root);
+    const virt = records.find(
+      (r) => r.type === 'tasks' && r.virtual === true,
+    );
+    expect(virt).toBeDefined();
+    expect(virt?.path).toBe('specs/feature-a/03-third-story.tasks.md');
+  });
+
+  it('rfc — row virtual placeholder uses zero-padded NN-<slug>.features.md convention', () => {
+    write(
+      'docs/rfcs/demo.rfc.md',
+      `# RFC\n\n## Dependency Order\n\n${TABLE_HEADER}\n| M2 | Second milestone | — | — |\n`,
+    );
+    const records = scan(root);
+    const virt = records.find(
+      (r) => r.type === 'features' && r.virtual === true,
+    );
+    expect(virt).toBeDefined();
+    expect(virt?.path).toBe('docs/rfcs/02-second-milestone.features.md');
+  });
+
   it('AS 1.5: feature-map row with — yields a virtual spec record at the slug placeholder path', () => {
     write(
       'specs/feature-a/feature-a.features.md',

--- a/src/status/scanner.test.ts
+++ b/src/status/scanner.test.ts
@@ -201,6 +201,35 @@ ${TABLE_HEADER}
     expect(good?.status).not.toBe('unknown');
   });
 
+  it('terminates on a symlink directory cycle inside root', () => {
+    // A symlink that points back at one of its ancestors inside `root`
+    // would cause an unbounded recursive walk if the walker did not
+    // track visited canonical directories. The scan must terminate
+    // and still discover the real artifact alongside the cycle.
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | One | — | — |\n`,
+    );
+    try {
+      // `specs/feature-a/loop` -> `specs/feature-a` (parent dir).
+      symlinkSync(
+        join(root, 'specs', 'feature-a'),
+        join(root, 'specs', 'feature-a', 'loop'),
+        'dir',
+      );
+    } catch {
+      return; // Platform without symlink support — skip.
+    }
+    const records = scan(root);
+    expect(
+      records.some((r) => r.path === 'specs/feature-a/feature-a.spec.md'),
+    ).toBe(true);
+    // No record should be discovered under the looping symlink path.
+    expect(
+      records.some((r) => r.path.startsWith('specs/feature-a/loop/')),
+    ).toBe(false);
+  });
+
   it('does not follow symlinks whose real path escapes root', () => {
     // Create an external directory with an artifact and symlink it
     // inside root. The symlink target is outside root, so the walker

--- a/src/status/scanner.test.ts
+++ b/src/status/scanner.test.ts
@@ -6,7 +6,7 @@ import {
   writeFileSync,
   symlinkSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { scan } from './index.js';
@@ -34,7 +34,7 @@ afterEach(() => {
 
 function write(relPath: string, contents: string): void {
   const abs = join(root, relPath);
-  mkdirSync(abs.substring(0, abs.lastIndexOf('/')), { recursive: true });
+  mkdirSync(dirname(abs), { recursive: true });
   writeFileSync(abs, contents);
 }
 

--- a/src/status/scanner.test.ts
+++ b/src/status/scanner.test.ts
@@ -1,0 +1,330 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  symlinkSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { scan } from './index.js';
+import type { ArtifactRecord } from './index.js';
+
+/**
+ * Integration tests for `scan(root)`. Each test builds a fresh synthetic
+ * repository layout under `os.tmpdir()`, invokes the scanner, and asserts
+ * on the returned `ArtifactRecord[]`. Per SD-003 resolution, real on-disk
+ * temp directories are used (not an in-memory filesystem mock) to exercise
+ * the recursive-walk path.
+ */
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'smithy-scan-'));
+});
+
+afterEach(() => {
+  if (root) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function write(relPath: string, contents: string): void {
+  const abs = join(root, relPath);
+  mkdirSync(abs.substring(0, abs.lastIndexOf('/')), { recursive: true });
+  writeFileSync(abs, contents);
+}
+
+function byPath(records: ArtifactRecord[], path: string): ArtifactRecord | undefined {
+  return records.find((r) => r.path === path);
+}
+
+const TABLE_HEADER =
+  '| ID | Title | Depends On | Artifact |\n|----|-------|------------|----------|';
+
+describe('scan', () => {
+  it('returns an empty array for a completely empty root', () => {
+    const records = scan(root);
+    expect(records).toEqual([]);
+  });
+
+  it('tolerates missing top-level scan directories', () => {
+    // Only specs/ exists; docs/rfcs/ and specs/strikes/ are absent.
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | specs/feature-a/01-first.tasks.md |\n`,
+    );
+    write(
+      'specs/feature-a/01-first.tasks.md',
+      `# Tasks\n\n## Slice 1: First\n\n- [x] Task one\n- [x] Task two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | First | — | — |\n`,
+    );
+    const records = scan(root);
+    expect(records.length).toBeGreaterThan(0);
+    expect(records.some((r) => r.type === 'spec')).toBe(true);
+    expect(records.some((r) => r.type === 'tasks')).toBe(true);
+  });
+
+  it('discovers artifacts across specs/, docs/rfcs/, and specs/strikes/', () => {
+    write(
+      'docs/rfcs/demo.rfc.md',
+      `# RFC\n\n## Dependency Order\n\n${TABLE_HEADER}\n| M1 | First milestone | — | — |\n`,
+    );
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+    write(
+      'specs/strikes/2026-04-12-001-demo/demo.tasks.md',
+      `# Strike Tasks\n\n## Slice 1: Only\n\n- [ ] Task\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    const records = scan(root);
+    expect(records.some((r) => r.path === 'docs/rfcs/demo.rfc.md')).toBe(true);
+    expect(
+      records.some((r) => r.path === 'specs/feature-a/feature-a.spec.md'),
+    ).toBe(true);
+    expect(
+      records.some(
+        (r) => r.path === 'specs/strikes/2026-04-12-001-demo/demo.tasks.md',
+      ),
+    ).toBe(true);
+  });
+
+  it('ignores unrelated .md files like README.md and notes.md', () => {
+    write('specs/README.md', '# Readme\nnot an artifact');
+    write('specs/feature-a/notes.md', 'just notes');
+    write('docs/rfcs/README.md', '# Readme');
+    const records = scan(root);
+    expect(records).toEqual([]);
+  });
+
+  it('AS 1.1: spec with two done tasks children and one — row', () => {
+    // Spec references two existing tasks files (both fully checked)
+    // and one — row which must emit a virtual not-started tasks record.
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Feature Specification: Feature A
+
+## Dependency Order
+
+${TABLE_HEADER}
+| US1 | First story  | — | specs/feature-a/01-first.tasks.md  |
+| US2 | Second story | — | specs/feature-a/02-second.tasks.md |
+| US3 | Third story  | — | —                                   |
+`,
+    );
+    write(
+      'specs/feature-a/01-first.tasks.md',
+      `# Tasks\n\n## Slice 1: Only\n\n- [x] One\n- [x] Two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    write(
+      'specs/feature-a/02-second.tasks.md',
+      `# Tasks\n\n## Slice 1: Only\n\n- [x] One\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+
+    const records = scan(root);
+
+    const spec = byPath(records, 'specs/feature-a/feature-a.spec.md');
+    expect(spec).toBeDefined();
+    expect(spec?.status).toBe('in-progress');
+
+    const t1 = byPath(records, 'specs/feature-a/01-first.tasks.md');
+    const t2 = byPath(records, 'specs/feature-a/02-second.tasks.md');
+    expect(t1?.status).toBe('done');
+    expect(t2?.status).toBe('done');
+    expect(t1?.virtual).toBeUndefined();
+    expect(t2?.virtual).toBeUndefined();
+    expect(t1?.parent_path).toBe('specs/feature-a/feature-a.spec.md');
+    expect(t2?.parent_path).toBe('specs/feature-a/feature-a.spec.md');
+
+    // Exactly one virtual tasks record for the US3 — row.
+    const virtualTasks = records.filter(
+      (r) => r.type === 'tasks' && r.virtual === true,
+    );
+    expect(virtualTasks).toHaveLength(1);
+    expect(virtualTasks[0]?.status).toBe('not-started');
+    expect(virtualTasks[0]?.parent_path).toBe(
+      'specs/feature-a/feature-a.spec.md',
+    );
+  });
+
+  it('AS 1.4: spec row points at a tasks file not on disk → virtual record', () => {
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Missing | — | specs/feature-a/01-foo.tasks.md |\n`,
+    );
+    const records = scan(root);
+    const virt = byPath(records, 'specs/feature-a/01-foo.tasks.md');
+    expect(virt).toBeDefined();
+    expect(virt?.virtual).toBe(true);
+    expect(virt?.type).toBe('tasks');
+    expect(virt?.status).toBe('not-started');
+    expect(virt?.parent_path).toBe('specs/feature-a/feature-a.spec.md');
+  });
+
+  it('AS 1.5: feature-map row with — yields a virtual spec record at the slug placeholder path', () => {
+    write(
+      'specs/feature-a/feature-a.features.md',
+      `# Feature Map\n\n## Dependency Order\n\n${TABLE_HEADER}\n| F3 | Webhooks | — | — |\n`,
+    );
+    const records = scan(root);
+    const virt = records.find(
+      (r) => r.type === 'spec' && r.virtual === true && r.title === 'Webhooks',
+    );
+    expect(virt).toBeDefined();
+    // SD-001 placeholder: `specs/<slug>/`
+    expect(virt?.path).toBe('specs/webhooks/');
+    expect(virt?.status).toBe('not-started');
+    expect(virt?.parent_path).toBe('specs/feature-a/feature-a.features.md');
+  });
+
+  it('AS 1.6: a malformed artifact (no Dependency Order section in a spec) classifies as unknown without aborting', () => {
+    // No Dependency Order section at all — for a parent type this
+    // resolves to 'unknown' via the classifier.
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      '# Spec\n\nJust prose, no dep order section.\n',
+    );
+    // Well-formed tasks file elsewhere to confirm the scan continues.
+    write(
+      'specs/feature-b/feature-b.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | OK | — | — |\n`,
+    );
+    const records = scan(root);
+    const bad = byPath(records, 'specs/feature-a/feature-a.spec.md');
+    expect(bad).toBeDefined();
+    expect(bad?.status).toBe('unknown');
+    const good = byPath(records, 'specs/feature-b/feature-b.spec.md');
+    expect(good).toBeDefined();
+    expect(good?.status).not.toBe('unknown');
+  });
+
+  it('does not follow symlinks whose real path escapes root', () => {
+    // Create an external directory with an artifact and symlink it
+    // inside root. The symlink target is outside root, so the walker
+    // must skip it.
+    const outside = mkdtempSync(join(tmpdir(), 'smithy-scan-outside-'));
+    try {
+      write(
+        'specs/feature-a/feature-a.spec.md',
+        `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Here | — | — |\n`,
+      );
+      mkdirSync(join(outside, 'hidden'), { recursive: true });
+      writeFileSync(
+        join(outside, 'hidden', 'escaped.spec.md'),
+        `# Escaped\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Escaped | — | — |\n`,
+      );
+      try {
+        symlinkSync(outside, join(root, 'specs', 'linkout'), 'dir');
+      } catch {
+        // Platforms that do not allow symlink creation skip the assertion.
+        return;
+      }
+      const records = scan(root);
+      // The in-root spec must be found.
+      expect(
+        records.some((r) => r.path === 'specs/feature-a/feature-a.spec.md'),
+      ).toBe(true);
+      // The escaped file must NOT be discovered.
+      expect(
+        records.some((r) => r.path.includes('escaped.spec.md')),
+      ).toBe(false);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('leaf-to-root classification: fully-done chain rolls up to done at the rfc', () => {
+    write(
+      'docs/rfcs/demo.rfc.md',
+      `# RFC\n\n## Dependency Order\n\n${TABLE_HEADER}\n| M1 | Only | — | specs/feature-a/feature-a.features.md |\n`,
+    );
+    write(
+      'specs/feature-a/feature-a.features.md',
+      `# Feature Map\n\n## Dependency Order\n\n${TABLE_HEADER}\n| F1 | Only | — | specs/feature-a/ |\n`,
+    );
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Only | — | specs/feature-a/01-only.tasks.md |\n`,
+    );
+    write(
+      'specs/feature-a/01-only.tasks.md',
+      `# Tasks\n\n## Slice 1: Only\n\n- [x] Done one\n- [x] Done two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    const records = scan(root);
+    expect(byPath(records, 'docs/rfcs/demo.rfc.md')?.status).toBe('done');
+    expect(
+      byPath(records, 'specs/feature-a/feature-a.features.md')?.status,
+    ).toBe('done');
+    expect(
+      byPath(records, 'specs/feature-a/feature-a.spec.md')?.status,
+    ).toBe('done');
+    expect(
+      byPath(records, 'specs/feature-a/01-only.tasks.md')?.status,
+    ).toBe('done');
+  });
+
+  it('leaf-to-root classification: in-progress chain rolls up as in-progress', () => {
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | One | — | specs/feature-a/01-a.tasks.md |\n| US2 | Two | — | specs/feature-a/02-b.tasks.md |\n`,
+    );
+    write(
+      'specs/feature-a/01-a.tasks.md',
+      `# Tasks\n\n## Slice 1: Only\n\n- [x] Done\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    write(
+      'specs/feature-a/02-b.tasks.md',
+      `# Tasks\n\n## Slice 1: Only\n\n- [ ] Pending\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    const records = scan(root);
+    expect(
+      byPath(records, 'specs/feature-a/feature-a.spec.md')?.status,
+    ).toBe('in-progress');
+  });
+
+  it('leaf-to-root classification: not-started chain rolls up as not-started', () => {
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | One | — | — |\n`,
+    );
+    const records = scan(root);
+    expect(
+      byPath(records, 'specs/feature-a/feature-a.spec.md')?.status,
+    ).toBe('not-started');
+  });
+
+  it('virtual/real collision: a real file at the expected virtual path wins', () => {
+    // A spec row declares an artifact path that resolves to a real
+    // tasks file — the scanner must NOT also emit a virtual duplicate.
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Only | — | specs/feature-a/01-only.tasks.md |\n`,
+    );
+    write(
+      'specs/feature-a/01-only.tasks.md',
+      `# Tasks\n\n## Slice 1: Only\n\n- [x] Done\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    const records = scan(root);
+    const withThatPath = records.filter(
+      (r) => r.path === 'specs/feature-a/01-only.tasks.md',
+    );
+    expect(withThatPath).toHaveLength(1);
+    expect(withThatPath[0]?.virtual).toBeUndefined();
+    expect(withThatPath[0]?.status).toBe('done');
+  });
+
+  it('legacy-format artifact yields a spec record with status=unknown', () => {
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n- [x] US1: First story\n- [ ] US2: Second story\n`,
+    );
+    const records = scan(root);
+    const spec = byPath(records, 'specs/feature-a/feature-a.spec.md');
+    expect(spec).toBeDefined();
+    expect(spec?.status).toBe('unknown');
+    expect(spec?.dependency_order.format).toBe('legacy');
+  });
+});

--- a/src/status/scanner.ts
+++ b/src/status/scanner.ts
@@ -304,10 +304,16 @@ function resolveChildForRow(
       if (row.artifact_path !== null) {
         return { path: normalizePath(row.artifact_path), type };
       }
+      // Repo convention: `<NN>-<milestone-slug>.features.md` (see
+      // existing render output examples like `01-milestone-1.features.md`).
+      // Derive the NN from the row id (M1 → 01) so virtual placeholder
+      // paths collide with real `smithy.render` output and the real
+      // record wins on the next scan.
       const parentDir = repoDirname(parent.path);
+      const nn = paddedNumberFromId(row.id);
       const placeholder = repoJoin(
         parentDir,
-        `${slugify(row.title)}.features.md`,
+        `${nn}-${slugify(row.title)}.features.md`,
       );
       return { path: placeholder, type };
     }
@@ -340,13 +346,14 @@ function resolveChildForRow(
         return { path: normalizePath(row.artifact_path), type };
       }
       // Placeholder for a spec `—` row. Smithy tasks files use the
-      // convention `NN-<slug>.tasks.md` inside the spec folder, but we
-      // only have the row ID (`US1`, `US2`, ...) so we lower-case that
-      // as the numeric substitute.
+      // convention `<NN>-<story-slug>.tasks.md` inside the spec folder
+      // (see `smithy.cut` output). Derive NN from the row id (US1 → 01)
+      // so virtual placeholders match the eventual real path and the
+      // real record wins on the next scan.
       const parentDir = repoDirname(parent.path);
-      const idLower = row.id.toLowerCase();
+      const nn = paddedNumberFromId(row.id);
       return {
-        path: repoJoin(parentDir, `${idLower}-${slugify(row.title)}.tasks.md`),
+        path: repoJoin(parentDir, `${nn}-${slugify(row.title)}.tasks.md`),
         type,
       };
     }
@@ -439,6 +446,20 @@ function slugify(title: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Extract the numeric portion of a canonical row id (`M1`, `F2`, `US3`,
+ * `S10`) and zero-pad it to two digits. Used to build placeholder
+ * virtual paths that match the `<NN>-<slug>` filename convention emitted
+ * by `smithy.render` and `smithy.cut`. Falls back to the lower-cased id
+ * itself if the id has no trailing digits, so malformed ids never
+ * crash placeholder generation.
+ */
+function paddedNumberFromId(id: string): string {
+  const digits = id.match(/[0-9]+$/)?.[0];
+  if (digits === undefined) return id.toLowerCase();
+  return digits.padStart(2, '0');
 }
 
 function idPrefixForType(type: ArtifactType): DependencyOrderTable['id_prefix'] {

--- a/src/status/scanner.ts
+++ b/src/status/scanner.ts
@@ -121,10 +121,24 @@ export function scan(root: string): ArtifactRecord[] {
 
       let child = records.get(resolution.path);
       if (child !== undefined) {
-        // Real or previously-emitted virtual already occupies this path —
-        // real records always win because Phase 1 populated them before
-        // any virtual could be inserted.
-        child.parent_path = parent.path;
+        // Real or previously-emitted virtual already occupies this
+        // path — real records always win because Phase 1 populated
+        // them before any virtual could be inserted.
+        if (
+          child.parent_path !== undefined &&
+          child.parent_path !== null &&
+          child.parent_path !== parent.path
+        ) {
+          // Another parent already claimed this child. Keep the
+          // first parent (deterministic: parents are iterated in
+          // discovery order) and surface a warning on the child so
+          // downstream renderers can flag the conflict.
+          child.warnings.push(
+            `parent_collision: also referenced by ${parent.path}`,
+          );
+        } else {
+          child.parent_path = parent.path;
+        }
       } else {
         child = makeVirtualRecord(resolution.path, resolution.type, row, parent);
         records.set(resolution.path, child);

--- a/src/status/scanner.ts
+++ b/src/status/scanner.ts
@@ -79,6 +79,12 @@ export function scan(root: string): ArtifactRecord[] {
   }
 
   const records = new Map<string, ArtifactRecord>();
+  // Canonical real paths of every directory the walker has descended
+  // into. Used to break symlink cycles (e.g., `specs/a/link -> ..`)
+  // and to avoid revisiting the same physical directory reached via
+  // two different scan roots (e.g., `specs/strikes/` reached via both
+  // `specs/` and `specs/strikes/`).
+  const visitedDirs = new Set<string>();
 
   // Phase 1: discover + parse.
   for (const scanRoot of SCAN_ROOTS) {
@@ -90,7 +96,16 @@ export function scan(root: string): ArtifactRecord[] {
       continue;
     }
     if (!stat.isDirectory()) continue;
-    walkDir(startDir, realRoot, records);
+    let realStart: string;
+    try {
+      realStart = fs.realpathSync(startDir);
+    } catch {
+      continue;
+    }
+    if (!isWithinRoot(realStart, realRoot)) continue;
+    if (visitedDirs.has(realStart)) continue;
+    visitedDirs.add(realStart);
+    walkDir(startDir, realRoot, records, visitedDirs);
   }
 
   // Phase 2: resolve parent/child linkage and emit virtual records.
@@ -141,13 +156,15 @@ export function scan(root: string): ArtifactRecord[] {
 
 /**
  * Recursively walk `dir`, resolving each entry through `realpath` and
- * skipping anything whose real path escapes `realRoot`. Parses every
+ * skipping anything whose real path escapes `realRoot` or that has
+ * already been visited (which breaks symlink cycles). Parses every
  * discovered artifact file into `records`.
  */
 function walkDir(
   dir: string,
   realRoot: string,
   records: Map<string, ArtifactRecord>,
+  visitedDirs: Set<string>,
 ): void {
   let entries: string[];
   try {
@@ -174,7 +191,12 @@ function walkDir(
     }
 
     if (stat.isDirectory()) {
-      walkDir(abs, realRoot, records);
+      // Guard against directory cycles introduced by symlinks (and
+      // duplicate descents from overlapping scan roots) by tracking
+      // canonical real paths we have already walked.
+      if (visitedDirs.has(realAbs)) continue;
+      visitedDirs.add(realAbs);
+      walkDir(abs, realRoot, records, visitedDirs);
     } else if (stat.isFile()) {
       handleFile(abs, realRoot, records);
     }

--- a/src/status/scanner.ts
+++ b/src/status/scanner.ts
@@ -1,0 +1,444 @@
+/**
+ * Filesystem scanner for Smithy artifact files.
+ *
+ * `scan(root)` is the single entry point that turns a working directory
+ * into a fully-classified `ArtifactRecord[]` matching the data-model
+ * contract in `smithy-status-skill.data-model.md`. It proceeds in three
+ * phases:
+ *
+ *   1. **Discovery / parse** — walk `specs/`, `docs/rfcs/`, and
+ *      `specs/strikes/` under `root`, collect files by suffix
+ *      (`.rfc.md`, `.features.md`, `.spec.md`, `.tasks.md`), read their
+ *      contents, and call {@link parseArtifact} for each. Symlinks whose
+ *      real path escapes `root` are silently skipped.
+ *
+ *   2. **Resolution + virtual emission** — walk every real parent
+ *      record's `dependency_order.rows`, match each row to an existing
+ *      child record per the data-model lineage (RFC → features file,
+ *      feature row → spec folder → spec file, spec row → tasks file).
+ *      Rows whose `artifact_path` is `—` or points at a file not present
+ *      on disk produce a virtual `ArtifactRecord` with `virtual: true`,
+ *      `status: 'not-started'`, and a naming-convention-derived path. On
+ *      a virtual/real collision at the same path, the real record wins
+ *      and the virtual is discarded.
+ *
+ *   3. **Classification** — call {@link classifyRecord} leaf-to-root
+ *      (`tasks` → `spec` → `features` → `rfc`) so every parent sees its
+ *      children's finalized `status` when it is classified. Records that
+ *      carry a `read_error:` warning from Phase 1 are preserved as
+ *      `status: 'unknown'` and are not re-classified.
+ *
+ * The scanner performs no network I/O and never throws on an individual
+ * artifact failure. Per-file errors are surfaced as warnings on the
+ * affected record and scanning continues.
+ *
+ * Notes on unresolved specification debt:
+ * - SD-001: Feature-map virtual spec placeholders use `specs/<slug>/` —
+ *   the canonical `YYYY-MM-DD-NNN-<slug>` prefix cannot be derived from
+ *   a feature row alone, so the slug is a best-effort placeholder.
+ * - SD-002: `parent_missing` is not populated in this slice — real
+ *   records never set `parent_path` to a non-existent file because
+ *   linkage is established exclusively from existing parents' dep-order
+ *   rows. The field remains available for future heuristics.
+ * - SD-003: Integration tests use real on-disk temp directories under
+ *   `os.tmpdir()` to exercise the recursive walk path.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { classifyRecord } from './classifier.js';
+import { parseArtifact } from './parser.js';
+import type {
+  ArtifactRecord,
+  ArtifactType,
+  DependencyOrderTable,
+  DependencyRow,
+} from './types.js';
+
+const SCAN_ROOTS = ['specs', 'docs/rfcs', 'specs/strikes'] as const;
+
+const SUFFIX_TYPES: Array<readonly [string, ArtifactType]> = [
+  ['.rfc.md', 'rfc'],
+  ['.features.md', 'features'],
+  ['.spec.md', 'spec'],
+  ['.tasks.md', 'tasks'],
+];
+
+/**
+ * Walk the repo under `root`, build `ArtifactRecord` entries for every
+ * discovered Smithy artifact file, and return the fully-classified
+ * record set. See the module-level JSDoc for the three-phase flow.
+ */
+export function scan(root: string): ArtifactRecord[] {
+  let realRoot: string;
+  try {
+    realRoot = fs.realpathSync(root);
+  } catch {
+    return [];
+  }
+
+  const records = new Map<string, ArtifactRecord>();
+
+  // Phase 1: discover + parse.
+  for (const scanRoot of SCAN_ROOTS) {
+    const startDir = path.join(realRoot, scanRoot);
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(startDir);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+    walkDir(startDir, realRoot, records);
+  }
+
+  // Phase 2: resolve parent/child linkage and emit virtual records.
+  const childrenByParent = new Map<string, ArtifactRecord[]>();
+  const parentsSnapshot = Array.from(records.values()).filter(
+    (r) => r.type !== 'tasks' && r.virtual !== true,
+  );
+  for (const parent of parentsSnapshot) {
+    const kids: ArtifactRecord[] = [];
+    for (const row of parent.dependency_order.rows) {
+      const resolution = resolveChildForRow(parent, row, records);
+      if (resolution === null) continue;
+
+      let child = records.get(resolution.path);
+      if (child !== undefined) {
+        // Real or previously-emitted virtual already occupies this path —
+        // real records always win because Phase 1 populated them before
+        // any virtual could be inserted.
+        child.parent_path = parent.path;
+      } else {
+        child = makeVirtualRecord(resolution.path, resolution.type, row, parent);
+        records.set(resolution.path, child);
+      }
+      kids.push(child);
+    }
+    childrenByParent.set(parent.path, kids);
+  }
+
+  // Phase 3: classify leaf-to-root. `classifyRecord` is pure; all we do
+  // here is order the calls so every parent sees its already-finalized
+  // children.
+  const classificationOrder: ArtifactType[] = ['tasks', 'spec', 'features', 'rfc'];
+  for (const type of classificationOrder) {
+    for (const record of records.values()) {
+      if (record.type !== type) continue;
+      if (hasReadError(record)) continue;
+      const kids = childrenByParent.get(record.path) ?? [];
+      record.status = classifyRecord(record, kids);
+    }
+  }
+
+  return Array.from(records.values());
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 helpers: walk + parse
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively walk `dir`, resolving each entry through `realpath` and
+ * skipping anything whose real path escapes `realRoot`. Parses every
+ * discovered artifact file into `records`.
+ */
+function walkDir(
+  dir: string,
+  realRoot: string,
+  records: Map<string, ArtifactRecord>,
+): void {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return;
+  }
+
+  for (const name of entries) {
+    const abs = path.join(dir, name);
+    let realAbs: string;
+    try {
+      realAbs = fs.realpathSync(abs);
+    } catch {
+      continue;
+    }
+    if (!isWithinRoot(realAbs, realRoot)) continue;
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(realAbs);
+    } catch {
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      walkDir(abs, realRoot, records);
+    } else if (stat.isFile()) {
+      handleFile(abs, realRoot, records);
+    }
+  }
+}
+
+function isWithinRoot(candidate: string, realRoot: string): boolean {
+  if (candidate === realRoot) return true;
+  return candidate.startsWith(realRoot + path.sep);
+}
+
+/**
+ * Parse a single discovered file into an `ArtifactRecord` and insert it
+ * into `records` keyed by repo-relative path. Read errors produce an
+ * `unknown`-status record with a `read_error:` warning so the scan can
+ * continue.
+ */
+function handleFile(
+  abs: string,
+  realRoot: string,
+  records: Map<string, ArtifactRecord>,
+): void {
+  const rel = toRepoRelative(abs, realRoot);
+  const type = detectTypeFromSuffix(rel);
+  if (type === null) return;
+
+  // Same file visited via two scan roots (e.g., `specs/strikes/` lives
+  // inside `specs/`): the first insert wins and subsequent visits are
+  // no-ops. This keeps the returned record set free of duplicates.
+  if (records.has(rel)) return;
+
+  let content: string;
+  try {
+    content = fs.readFileSync(abs, 'utf8');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    records.set(rel, buildReadErrorRecord(rel, type, message));
+    return;
+  }
+
+  const record = parseArtifact(rel, content);
+  records.set(rel, record);
+}
+
+function detectTypeFromSuffix(relPath: string): ArtifactType | null {
+  for (const [suffix, type] of SUFFIX_TYPES) {
+    if (relPath.endsWith(suffix)) return type;
+  }
+  return null;
+}
+
+function buildReadErrorRecord(
+  relPath: string,
+  type: ArtifactType,
+  message: string,
+): ArtifactRecord {
+  return {
+    type,
+    path: relPath,
+    title: filenameStem(relPath),
+    status: 'unknown',
+    dependency_order: {
+      rows: [],
+      id_prefix: idPrefixForType(type),
+      format: 'missing',
+    },
+    warnings: [`read_error: ${message}`],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 helpers: parent/child resolution + virtual emission
+// ---------------------------------------------------------------------------
+
+interface ChildResolution {
+  /** Repo-relative path where the child (real or virtual) lives. */
+  path: string;
+  /** Expected artifact type for the child row. */
+  type: ArtifactType;
+}
+
+/**
+ * Resolve a single dep-order row on `parent` to the repo-relative path
+ * where its child record should live, per the data-model lineage rules.
+ *
+ * - RFC rows (`M`): child is a `.features.md` file — direct path match
+ *   or a slug placeholder when the cell is `—`.
+ * - Feature-map rows (`F`): child is a `.spec.md` file. The cell may
+ *   point at either a spec folder or a spec file; folder cells are
+ *   resolved by scanning the already-discovered record set for a
+ *   `.spec.md` under the folder prefix.
+ * - Spec rows (`US`): child is a `.tasks.md` file — direct path match
+ *   or a naming-convention placeholder when the cell is `—`.
+ * - Tasks rows (`S`): never reached because tasks records are filtered
+ *   out of the parent set.
+ */
+function resolveChildForRow(
+  parent: ArtifactRecord,
+  row: DependencyRow,
+  records: Map<string, ArtifactRecord>,
+): ChildResolution | null {
+  switch (parent.type) {
+    case 'rfc': {
+      const type: ArtifactType = 'features';
+      if (row.artifact_path !== null) {
+        return { path: normalizePath(row.artifact_path), type };
+      }
+      const parentDir = repoDirname(parent.path);
+      const placeholder = repoJoin(
+        parentDir,
+        `${slugify(row.title)}.features.md`,
+      );
+      return { path: placeholder, type };
+    }
+    case 'features': {
+      const type: ArtifactType = 'spec';
+      if (row.artifact_path !== null) {
+        const raw = normalizePath(row.artifact_path);
+        if (raw.endsWith('.spec.md')) {
+          return { path: raw, type };
+        }
+        // Treat as a spec folder — search the record set for a
+        // `.spec.md` that lives inside that folder.
+        const folder = raw.endsWith('/') ? raw : `${raw}/`;
+        const match = findSpecInFolder(folder, records);
+        if (match !== null) {
+          return { path: match, type };
+        }
+        // No discovered spec in the folder — emit a virtual record
+        // keyed by the folder path itself. This matches the feature
+        // row's declared intent without inventing a canonical file
+        // name that does not yet exist.
+        return { path: folder, type };
+      }
+      // SD-001 placeholder for a feature-map `—` row: `specs/<slug>/`.
+      return { path: `specs/${slugify(row.title)}/`, type };
+    }
+    case 'spec': {
+      const type: ArtifactType = 'tasks';
+      if (row.artifact_path !== null) {
+        return { path: normalizePath(row.artifact_path), type };
+      }
+      // Placeholder for a spec `—` row. Smithy tasks files use the
+      // convention `NN-<slug>.tasks.md` inside the spec folder, but we
+      // only have the row ID (`US1`, `US2`, ...) so we lower-case that
+      // as the numeric substitute.
+      const parentDir = repoDirname(parent.path);
+      const idLower = row.id.toLowerCase();
+      return {
+        path: repoJoin(parentDir, `${idLower}-${slugify(row.title)}.tasks.md`),
+        type,
+      };
+    }
+    case 'tasks':
+      return null;
+  }
+}
+
+function findSpecInFolder(
+  folder: string,
+  records: Map<string, ArtifactRecord>,
+): string | null {
+  const folderLeaf = folder.replace(/\/+$/, '').split('/').pop() ?? '';
+  let fallback: string | null = null;
+  let canonical: string | null = null;
+  for (const [p, rec] of records) {
+    if (rec.type !== 'spec') continue;
+    if (!p.startsWith(folder)) continue;
+    if (!p.endsWith('.spec.md')) continue;
+    // Reject nested sub-folder matches: only direct children of the
+    // folder are considered. A spec at `specs/a/b.spec.md` must not
+    // match a folder query for `specs/`.
+    const tail = p.slice(folder.length);
+    if (tail.includes('/')) continue;
+    if (fallback === null) fallback = p;
+    const base = tail;
+    if (base === `${folderLeaf}.spec.md`) {
+      canonical = p;
+    }
+  }
+  return canonical ?? fallback;
+}
+
+function makeVirtualRecord(
+  p: string,
+  type: ArtifactType,
+  row: DependencyRow,
+  parent: ArtifactRecord,
+): ArtifactRecord {
+  return {
+    type,
+    path: p,
+    title: row.title,
+    status: 'not-started',
+    parent_path: parent.path,
+    virtual: true,
+    dependency_order: {
+      rows: [],
+      id_prefix: idPrefixForType(type),
+      format: 'missing',
+    },
+    warnings: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3 helpers
+// ---------------------------------------------------------------------------
+
+function hasReadError(record: ArtifactRecord): boolean {
+  return record.warnings.some((w) => w.startsWith('read_error:'));
+}
+
+// ---------------------------------------------------------------------------
+// Path + string helpers
+// ---------------------------------------------------------------------------
+
+function toRepoRelative(abs: string, realRoot: string): string {
+  const rel = path.relative(realRoot, abs);
+  return rel.split(path.sep).join('/');
+}
+
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, '/');
+}
+
+function repoDirname(relPath: string): string {
+  const idx = relPath.lastIndexOf('/');
+  if (idx < 0) return '';
+  return relPath.slice(0, idx);
+}
+
+function repoJoin(dir: string, name: string): string {
+  if (dir === '') return name;
+  return `${dir}/${name}`;
+}
+
+function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function idPrefixForType(type: ArtifactType): DependencyOrderTable['id_prefix'] {
+  switch (type) {
+    case 'rfc':
+      return 'M';
+    case 'features':
+      return 'F';
+    case 'spec':
+      return 'US';
+    case 'tasks':
+      return 'S';
+  }
+}
+
+function filenameStem(relPath: string): string {
+  const base = relPath.split('/').pop() ?? relPath;
+  for (const [suffix] of SUFFIX_TYPES) {
+    if (base.endsWith(suffix)) {
+      return base.slice(0, base.length - suffix.length);
+    }
+  }
+  if (base.endsWith('.md')) return base.slice(0, -3);
+  return base;
+}

--- a/src/status/scanner.ts
+++ b/src/status/scanner.ts
@@ -362,13 +362,21 @@ function resolveChildForRow(
   }
 }
 
+/**
+ * Look up the canonical `<folder-leaf>.spec.md` file inside `folder`
+ * within the already-discovered record set. Only the canonical filename
+ * is accepted; if the folder contains a non-canonical `.spec.md` (or
+ * several), this returns `null` and the scanner emits a virtual record
+ * at the folder path instead. Falling back to "first .spec.md found"
+ * would make parent linkage depend on `readdirSync` order, which is not
+ * stable across filesystems.
+ */
 function findSpecInFolder(
   folder: string,
   records: Map<string, ArtifactRecord>,
 ): string | null {
   const folderLeaf = folder.replace(/\/+$/, '').split('/').pop() ?? '';
-  let fallback: string | null = null;
-  let canonical: string | null = null;
+  const canonicalBase = `${folderLeaf}.spec.md`;
   for (const [p, rec] of records) {
     if (rec.type !== 'spec') continue;
     if (!p.startsWith(folder)) continue;
@@ -378,13 +386,11 @@ function findSpecInFolder(
     // match a folder query for `specs/`.
     const tail = p.slice(folder.length);
     if (tail.includes('/')) continue;
-    if (fallback === null) fallback = p;
-    const base = tail;
-    if (base === `${folderLeaf}.spec.md`) {
-      canonical = p;
+    if (tail === canonicalBase) {
+      return p;
     }
   }
-  return canonical ?? fallback;
+  return null;
 }
 
 function makeVirtualRecord(


### PR DESCRIPTION
Implements Task 1 of Slice 2: a pure function that derives the final
Status for an ArtifactRecord from its own fields plus its already
classified children. Tasks records roll up from completed/total; parent
records (spec, features, rfc) roll up from child statuses; a parent with
a legacy or missing dependency_order format resolves to unknown; virtual
records always resolve to not-started.

https://claude.ai/code/session_01RepuQtAB9yy11LEVZ7Kg4c