### PR TITLE
Ship pure EvalReport library (US9 Slice 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ Smithy has three testing tiers, each tested differently:
 
 1. **CLI behavior** (Tier 1) — init/uninit/update flows, option parsing, file deployment, idempotency. Covered by `npm test` (automated, CI) and interactive terminal tests (H1-H4).
 2. **Agent-skill file validation** (Tier 2) — template composition, partial resolution, frontmatter, agent variants, file categorization. Covered by `npm test` (automated, CI) and agent-session tests (A1-A6).
-3. **Agent-skill execution behavior** (Tier 3) — skills produce correct output when invoked by an AI agent, sub-agents are dispatched, output structure matches expectations. Covered by evals framework (`npm run eval`, local on-demand, not CI). **Status: runner, entry point, and structural validator implemented (stream parser, runner, `validateStructure`, `verifySubAgents`, `npm run eval` and `npm run test:evals` wired); YAML scenario loading pending.**
+3. **Agent-skill execution behavior** (Tier 3) — skills produce correct output when invoked by an AI agent, sub-agents are dispatched, output structure matches expectations. Covered by evals framework (`npm run eval`, local on-demand, not CI). **Status: runner, entry point, structural validator, and report library implemented (stream parser, runner, `validateStructure`, `verifySubAgents`, `scenarioRunToResult`, `buildReport`, `formatReport`, `npm run eval` and `npm run test:evals` wired); YAML scenario loading and orchestrator wiring of the report library (US9 Slice 2) pending.**
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for test file details. Agent and human test cases are in **[tests/](tests/)**: [tests/Agent.tests.md](tests/Agent.tests.md) (A-series), [tests/Manual.tests.md](tests/Manual.tests.md) (H-series).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,10 +53,12 @@ The evals framework (under `evals/`) — implemented:
 - Runs locally on demand (`npm run eval`), not in CI, due to LLM cost
 - Structural output validation (`validateStructure` — required headings, patterns, tables, forbidden patterns)
 - Sub-agent invocation verification (`verifySubAgents` — pattern matching against extracted text and dispatch events)
+- Eval summary report library (`scenarioRunToResult`, `buildReport`, `formatReport`, `EvalReport` — pure, fully unit-tested)
 - Dedicated evals test suite runnable via `npm run test:evals` (independent of `npm test`)
 
 Pending:
 - YAML-defined scenario loading (`evals/cases/`)
+- Orchestrator wiring of the report library into `run-evals.ts` (US9 Slice 2)
 
 See **[specs/2026-04-06-003-smithy-evals-framework/](specs/2026-04-06-003-smithy-evals-framework/)** for the feature specification.
 

--- a/evals/lib/report.test.ts
+++ b/evals/lib/report.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { scenarioRunToResult } from './report.js';
+import { scenarioRunToResult, buildReport } from './report.js';
 import type {
   CheckResult,
+  EvalResult,
   EvalScenario,
   RunOutput,
 } from './types.js';
@@ -268,6 +269,167 @@ describe('scenarioRunToResult', () => {
       scenarioRunToResult(scenario, output, [passingCheck]);
       expect(JSON.stringify(scenario)).toBe(scenarioBefore);
       expect(JSON.stringify(output)).toBe(outputBefore);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildReport
+// ---------------------------------------------------------------------------
+
+function makeResult(overrides: Partial<EvalResult> = {}): EvalResult {
+  return {
+    scenario_name: 'sample',
+    status: 'pass',
+    extracted_text: '## Plan\n\nDetails.',
+    duration_ms: 100,
+    structural_checks: [passingCheck],
+    ...overrides,
+  };
+}
+
+describe('buildReport', () => {
+  // -----------------------------------------------------------------------
+  // Aggregate counts and overall status
+  // -----------------------------------------------------------------------
+  describe('aggregate counts and overall status', () => {
+    it('returns overall_status pass with all-pass results (3 cases)', () => {
+      const results: EvalResult[] = [
+        makeResult({ scenario_name: 'a' }),
+        makeResult({ scenario_name: 'b' }),
+        makeResult({ scenario_name: 'c' }),
+      ];
+      const report = buildReport(results, 5000);
+
+      expect(report.overall_status).toBe('pass');
+      expect(report.total_cases).toBe(3);
+      expect(report.passed).toBe(3);
+      expect(report.failed).toBe(0);
+    });
+
+    it('returns overall_status fail with 2 pass + 1 fail', () => {
+      const results: EvalResult[] = [
+        makeResult({ scenario_name: 'a', status: 'pass' }),
+        makeResult({ scenario_name: 'b', status: 'pass' }),
+        makeResult({ scenario_name: 'c', status: 'fail' }),
+      ];
+      const report = buildReport(results, 7500);
+
+      expect(report.overall_status).toBe('fail');
+      expect(report.total_cases).toBe(3);
+      expect(report.passed).toBe(2);
+      expect(report.failed).toBe(1);
+    });
+
+    it('counts timeout and error as failed (1 pass + 1 timeout + 1 error)', () => {
+      const results: EvalResult[] = [
+        makeResult({ scenario_name: 'a', status: 'pass' }),
+        makeResult({
+          scenario_name: 'b',
+          status: 'timeout',
+          error: 'timed out',
+        }),
+        makeResult({
+          scenario_name: 'c',
+          status: 'error',
+          error: 'exit 1',
+        }),
+      ];
+      const report = buildReport(results, 12000);
+
+      expect(report.overall_status).toBe('fail');
+      expect(report.total_cases).toBe(3);
+      expect(report.passed).toBe(1);
+      expect(report.failed).toBe(2);
+    });
+
+    it('returns a well-formed empty report for zero-length results', () => {
+      const report = buildReport([], 0);
+
+      expect(report.overall_status).toBe('pass');
+      expect(report.total_cases).toBe(0);
+      expect(report.passed).toBe(0);
+      expect(report.failed).toBe(0);
+      expect(report.results).toEqual([]);
+      expect(report.total_duration_ms).toBe(0);
+      expect(typeof report.timestamp).toBe('string');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Field passthrough and shape
+  // -----------------------------------------------------------------------
+  describe('field passthrough', () => {
+    it('total_duration_ms equals the passed-in argument', () => {
+      const report = buildReport([makeResult()], 9876);
+      expect(report.total_duration_ms).toBe(9876);
+    });
+
+    it('results field contains every input result in order', () => {
+      const results: EvalResult[] = [
+        makeResult({ scenario_name: 'first' }),
+        makeResult({ scenario_name: 'second' }),
+        makeResult({ scenario_name: 'third' }),
+      ];
+      const report = buildReport(results, 100);
+
+      expect(report.results).toHaveLength(3);
+      expect(report.results[0]?.scenario_name).toBe('first');
+      expect(report.results[1]?.scenario_name).toBe('second');
+      expect(report.results[2]?.scenario_name).toBe('third');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Timestamp
+  // -----------------------------------------------------------------------
+  describe('timestamp', () => {
+    it('returns a valid ISO 8601 timestamp string', () => {
+      const report = buildReport([makeResult()], 100);
+
+      expect(typeof report.timestamp).toBe('string');
+      // ISO 8601 with milliseconds and Z suffix, as produced by toISOString()
+      expect(report.timestamp).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+      expect(Number.isNaN(Date.parse(report.timestamp))).toBe(false);
+    });
+
+    it('sets timestamp at call time (within a small window of now)', () => {
+      const before = Date.now();
+      const report = buildReport([makeResult()], 100);
+      const after = Date.now();
+
+      const ts = Date.parse(report.timestamp);
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Purity
+  // -----------------------------------------------------------------------
+  describe('purity', () => {
+    it('does not mutate the input results array', () => {
+      const results: EvalResult[] = [
+        makeResult({ scenario_name: 'a' }),
+        makeResult({ scenario_name: 'b', status: 'fail' }),
+      ];
+      const before = JSON.stringify(results);
+      buildReport(results, 1000);
+      expect(JSON.stringify(results)).toBe(before);
+    });
+
+    it('does not throw when called with a frozen results array', () => {
+      const results: EvalResult[] = Object.freeze([
+        makeResult({ scenario_name: 'a' }),
+        makeResult({ scenario_name: 'b' }),
+      ]) as EvalResult[];
+
+      expect(() => buildReport(results, 500)).not.toThrow();
+      const report = buildReport(results, 500);
+      expect(report.total_cases).toBe(2);
+      expect(report.passed).toBe(2);
     });
   });
 });

--- a/evals/lib/report.test.ts
+++ b/evals/lib/report.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from 'vitest';
+import { scenarioRunToResult } from './report.js';
+import type {
+  CheckResult,
+  EvalScenario,
+  RunOutput,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeScenario(overrides: Partial<EvalScenario> = {}): EvalScenario {
+  return {
+    name: 'sample-scenario',
+    skill: '/smithy.strike',
+    prompt: 'do a thing',
+    structural_expectations: {
+      required_headings: ['## Plan'],
+    },
+    ...overrides,
+  };
+}
+
+function makeOutput(overrides: Partial<RunOutput> = {}): RunOutput {
+  return {
+    extracted_text: '## Plan\n\nDetails here.',
+    stream_events: [],
+    duration_ms: 1234,
+    exit_code: 0,
+    timed_out: false,
+    ...overrides,
+  };
+}
+
+const passingCheck: CheckResult = {
+  check_name: "has '## Plan' heading",
+  passed: true,
+  actual: 'found',
+};
+
+const failingCheck: CheckResult = {
+  check_name: "has '## Summary' heading",
+  passed: false,
+  actual: 'not found',
+};
+
+// ---------------------------------------------------------------------------
+// scenarioRunToResult
+// ---------------------------------------------------------------------------
+
+describe('scenarioRunToResult', () => {
+  // -----------------------------------------------------------------------
+  // Status: pass
+  // -----------------------------------------------------------------------
+  describe('pass status', () => {
+    it('returns pass when output is clean and all structural checks pass', () => {
+      const scenario = makeScenario();
+      const output = makeOutput();
+      const result = scenarioRunToResult(scenario, output, [passingCheck]);
+
+      expect(result.status).toBe('pass');
+      expect(result.error).toBeUndefined();
+    });
+
+    it('omits sub_agent_checks when not provided', () => {
+      const scenario = makeScenario();
+      const output = makeOutput();
+      const result = scenarioRunToResult(scenario, output, [passingCheck]);
+
+      expect('sub_agent_checks' in result).toBe(false);
+    });
+
+    it('omits sub_agent_checks when provided as an empty array', () => {
+      const scenario = makeScenario();
+      const output = makeOutput();
+      const result = scenarioRunToResult(scenario, output, [passingCheck], []);
+
+      expect('sub_agent_checks' in result).toBe(false);
+    });
+
+    it('returns pass when both structural and sub-agent checks pass', () => {
+      const scenario = makeScenario();
+      const output = makeOutput();
+      const subAgentCheck: CheckResult = {
+        check_name: 'smithy-plan evidence present',
+        passed: true,
+        actual: 'matched in extracted text',
+      };
+      const result = scenarioRunToResult(
+        scenario,
+        output,
+        [passingCheck],
+        [subAgentCheck],
+      );
+
+      expect(result.status).toBe('pass');
+      expect(result.sub_agent_checks).toEqual([subAgentCheck]);
+      expect(result.error).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Status: fail
+  // -----------------------------------------------------------------------
+  describe('fail status', () => {
+    it('returns fail when at least one structural check fails', () => {
+      const scenario = makeScenario();
+      const output = makeOutput();
+      const result = scenarioRunToResult(scenario, output, [
+        passingCheck,
+        failingCheck,
+      ]);
+
+      expect(result.status).toBe('fail');
+      expect(result.error).toBeUndefined();
+    });
+
+    it('returns fail when at least one sub-agent check fails', () => {
+      const scenario = makeScenario();
+      const output = makeOutput();
+      const failingSubAgent: CheckResult = {
+        check_name: 'smithy-plan evidence present',
+        passed: false,
+        actual: 'no match found',
+      };
+      const result = scenarioRunToResult(
+        scenario,
+        output,
+        [passingCheck],
+        [failingSubAgent],
+      );
+
+      expect(result.status).toBe('fail');
+      expect(result.error).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Status: error
+  // -----------------------------------------------------------------------
+  describe('error status', () => {
+    it('returns error when exit_code is non-zero', () => {
+      const scenario = makeScenario();
+      const output = makeOutput({ exit_code: 1 });
+      const result = scenarioRunToResult(scenario, output, [passingCheck]);
+
+      expect(result.status).toBe('error');
+      expect(result.error).toBeDefined();
+      expect(typeof result.error).toBe('string');
+      expect(result.error!.length).toBeGreaterThan(0);
+    });
+
+    it('error status takes precedence over failing checks', () => {
+      const scenario = makeScenario();
+      const output = makeOutput({ exit_code: 2 });
+      const result = scenarioRunToResult(scenario, output, [failingCheck]);
+
+      expect(result.status).toBe('error');
+      expect(result.error).toBeDefined();
+    });
+
+    it('includes the exit code in the error message', () => {
+      const scenario = makeScenario();
+      const output = makeOutput({ exit_code: 42 });
+      const result = scenarioRunToResult(scenario, output, [passingCheck]);
+
+      expect(result.error).toContain('42');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Status: timeout
+  // -----------------------------------------------------------------------
+  describe('timeout status', () => {
+    it('returns timeout when timed_out is true', () => {
+      const scenario = makeScenario();
+      const output = makeOutput({ timed_out: true });
+      const result = scenarioRunToResult(scenario, output, [passingCheck]);
+
+      expect(result.status).toBe('timeout');
+      expect(result.error).toBeDefined();
+      expect(typeof result.error).toBe('string');
+      expect(result.error!.length).toBeGreaterThan(0);
+    });
+
+    it('timeout takes precedence over non-zero exit_code AND failing checks', () => {
+      const scenario = makeScenario();
+      const output = makeOutput({ timed_out: true, exit_code: 137 });
+      const result = scenarioRunToResult(scenario, output, [failingCheck]);
+
+      expect(result.status).toBe('timeout');
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Field population
+  // -----------------------------------------------------------------------
+  describe('field population', () => {
+    it('populates scenario_name from scenario.name', () => {
+      const scenario = makeScenario({ name: 'my-special-case' });
+      const output = makeOutput();
+      const result = scenarioRunToResult(scenario, output, [passingCheck]);
+
+      expect(result.scenario_name).toBe('my-special-case');
+    });
+
+    it('populates extracted_text from output.extracted_text', () => {
+      const scenario = makeScenario();
+      const output = makeOutput({ extracted_text: 'unique extracted body' });
+      const result = scenarioRunToResult(scenario, output, [passingCheck]);
+
+      expect(result.extracted_text).toBe('unique extracted body');
+    });
+
+    it('populates duration_ms from output.duration_ms', () => {
+      const scenario = makeScenario();
+      const output = makeOutput({ duration_ms: 9876 });
+      const result = scenarioRunToResult(scenario, output, [passingCheck]);
+
+      expect(result.duration_ms).toBe(9876);
+    });
+
+    it('populates structural_checks from the input array', () => {
+      const scenario = makeScenario();
+      const output = makeOutput();
+      const checks = [passingCheck, failingCheck];
+      const result = scenarioRunToResult(scenario, output, checks);
+
+      expect(result.structural_checks).toEqual(checks);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Purity
+  // -----------------------------------------------------------------------
+  describe('purity', () => {
+    it('does not mutate the structural_checks input array', () => {
+      const scenario = makeScenario();
+      const output = makeOutput();
+      const checks: CheckResult[] = [passingCheck];
+      const before = JSON.stringify(checks);
+      scenarioRunToResult(scenario, output, checks);
+      expect(JSON.stringify(checks)).toBe(before);
+    });
+
+    it('does not mutate the sub_agent_checks input array', () => {
+      const scenario = makeScenario();
+      const output = makeOutput();
+      const subChecks: CheckResult[] = [
+        {
+          check_name: 'smithy-plan evidence present',
+          passed: true,
+          actual: 'matched',
+        },
+      ];
+      const before = JSON.stringify(subChecks);
+      scenarioRunToResult(scenario, output, [passingCheck], subChecks);
+      expect(JSON.stringify(subChecks)).toBe(before);
+    });
+
+    it('does not mutate the scenario or output inputs', () => {
+      const scenario = makeScenario();
+      const output = makeOutput({ exit_code: 1 });
+      const scenarioBefore = JSON.stringify(scenario);
+      const outputBefore = JSON.stringify(output);
+      scenarioRunToResult(scenario, output, [passingCheck]);
+      expect(JSON.stringify(scenario)).toBe(scenarioBefore);
+      expect(JSON.stringify(output)).toBe(outputBefore);
+    });
+  });
+});

--- a/evals/lib/report.test.ts
+++ b/evals/lib/report.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { scenarioRunToResult, buildReport } from './report.js';
+import { describe, it, expect, vi } from 'vitest';
+import { scenarioRunToResult, buildReport, formatReport } from './report.js';
 import type {
   CheckResult,
   EvalResult,
@@ -430,6 +430,209 @@ describe('buildReport', () => {
       const report = buildReport(results, 500);
       expect(report.total_cases).toBe(2);
       expect(report.passed).toBe(2);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatReport
+// ---------------------------------------------------------------------------
+
+describe('formatReport', () => {
+  // -----------------------------------------------------------------------
+  // Return type and side effects
+  // -----------------------------------------------------------------------
+  describe('return type and side effects', () => {
+    it('returns a string', () => {
+      const report = buildReport([makeResult()], 100);
+      const out = formatReport(report);
+
+      expect(typeof out).toBe('string');
+    });
+
+    it('does not call console.log', () => {
+      const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        const report = buildReport(
+          [
+            makeResult({ scenario_name: 'a' }),
+            makeResult({ scenario_name: 'b', status: 'fail' }),
+          ],
+          200,
+        );
+        formatReport(report);
+        expect(spy).not.toHaveBeenCalled();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // All-pass report (AS 9.1)
+  // -----------------------------------------------------------------------
+  describe('all-pass report', () => {
+    it('renders each scenario_name with a PASS token and final PASS line with total count', () => {
+      const results: EvalResult[] = [
+        makeResult({ scenario_name: 'alpha' }),
+        makeResult({ scenario_name: 'beta' }),
+        makeResult({ scenario_name: 'gamma' }),
+      ];
+      const report = buildReport(results, 1500);
+      const out = formatReport(report);
+      const lines = out.split('\n');
+
+      // Each scenario has a line with its name and a PASS token
+      for (const name of ['alpha', 'beta', 'gamma']) {
+        const line = lines.find((l) => l.includes(name));
+        expect(line, `expected line for ${name}`).toBeDefined();
+        expect(line!).toMatch(/\bPASS\b/);
+        expect(line!).not.toMatch(/\b(FAIL|TIMEOUT|ERROR)\b/);
+      }
+
+      // Final aggregate line carries PASS and total count
+      const finalLine = lines[lines.length - 1] ?? '';
+      expect(finalLine).toMatch(/\bPASS\b/);
+      expect(finalLine).toContain('3');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Mixed pass/fail report (AS 9.2)
+  // -----------------------------------------------------------------------
+  describe('mixed 2-pass / 1-fail report', () => {
+    it('renders each scenario_name; both PASS and FAIL tokens appear; final line is FAIL', () => {
+      const results: EvalResult[] = [
+        makeResult({ scenario_name: 'alpha', status: 'pass' }),
+        makeResult({ scenario_name: 'beta', status: 'pass' }),
+        makeResult({ scenario_name: 'gamma', status: 'fail' }),
+      ];
+      const report = buildReport(results, 2500);
+      const out = formatReport(report);
+      const lines = out.split('\n');
+
+      const alphaLine = lines.find((l) => l.includes('alpha'));
+      const betaLine = lines.find((l) => l.includes('beta'));
+      const gammaLine = lines.find((l) => l.includes('gamma'));
+
+      expect(alphaLine).toBeDefined();
+      expect(betaLine).toBeDefined();
+      expect(gammaLine).toBeDefined();
+
+      expect(alphaLine!).toMatch(/\bPASS\b/);
+      expect(betaLine!).toMatch(/\bPASS\b/);
+      expect(gammaLine!).toMatch(/\bFAIL\b/);
+      expect(gammaLine!).not.toMatch(/\b(PASS|TIMEOUT|ERROR)\b/);
+
+      const finalLine = lines[lines.length - 1] ?? '';
+      expect(finalLine).toMatch(/\bFAIL\b/);
+      expect(finalLine).toContain('3');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Timeout-included report (AS 9.3)
+  // -----------------------------------------------------------------------
+  describe('timeout-included report', () => {
+    it('renders TIMEOUT as a distinct token, not FAIL or ERROR', () => {
+      const results: EvalResult[] = [
+        makeResult({ scenario_name: 'happy', status: 'pass' }),
+        makeResult({
+          scenario_name: 'slow-poke',
+          status: 'timeout',
+          error: 'timed out after 60000ms',
+        }),
+      ];
+      const report = buildReport(results, 60500);
+      const out = formatReport(report);
+      const lines = out.split('\n');
+
+      const timeoutLine = lines.find((l) => l.includes('slow-poke'));
+      expect(timeoutLine).toBeDefined();
+      expect(timeoutLine!).toMatch(/\bTIMEOUT\b/);
+      expect(timeoutLine!).not.toMatch(/\b(FAIL|ERROR|PASS)\b/);
+
+      const happyLine = lines.find((l) => l.includes('happy'));
+      expect(happyLine).toBeDefined();
+      expect(happyLine!).toMatch(/\bPASS\b/);
+
+      const finalLine = lines[lines.length - 1] ?? '';
+      expect(finalLine).toMatch(/\bFAIL\b/);
+      expect(finalLine).toContain('2');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Error-included report
+  // -----------------------------------------------------------------------
+  describe('error-included report', () => {
+    it('renders ERROR as a distinct token, not FAIL or TIMEOUT', () => {
+      const results: EvalResult[] = [
+        makeResult({ scenario_name: 'ok', status: 'pass' }),
+        makeResult({
+          scenario_name: 'crashy',
+          status: 'error',
+          error: 'claude CLI exited with non-zero status code 1',
+        }),
+      ];
+      const report = buildReport(results, 1200);
+      const out = formatReport(report);
+      const lines = out.split('\n');
+
+      const errorLine = lines.find((l) => l.includes('crashy'));
+      expect(errorLine).toBeDefined();
+      expect(errorLine!).toMatch(/\bERROR\b/);
+      expect(errorLine!).not.toMatch(/\b(FAIL|TIMEOUT|PASS)\b/);
+
+      const finalLine = lines[lines.length - 1] ?? '';
+      expect(finalLine).toMatch(/\bFAIL\b/);
+      expect(finalLine).toContain('2');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Determinism
+  // -----------------------------------------------------------------------
+  describe('determinism', () => {
+    it('returns the identical string when called twice on the same report', () => {
+      const results: EvalResult[] = [
+        makeResult({ scenario_name: 'a', status: 'pass' }),
+        makeResult({ scenario_name: 'b', status: 'fail' }),
+        makeResult({
+          scenario_name: 'c',
+          status: 'timeout',
+          error: 'timed out',
+        }),
+        makeResult({
+          scenario_name: 'd',
+          status: 'error',
+          error: 'exit 1',
+        }),
+      ];
+      const report = buildReport(results, 9000);
+
+      const first = formatReport(report);
+      const second = formatReport(report);
+
+      expect(first).toBe(second);
+    });
+
+    it('renders results in input order', () => {
+      const results: EvalResult[] = [
+        makeResult({ scenario_name: 'first-name' }),
+        makeResult({ scenario_name: 'second-name' }),
+        makeResult({ scenario_name: 'third-name' }),
+      ];
+      const report = buildReport(results, 300);
+      const out = formatReport(report);
+
+      const firstIdx = out.indexOf('first-name');
+      const secondIdx = out.indexOf('second-name');
+      const thirdIdx = out.indexOf('third-name');
+
+      expect(firstIdx).toBeGreaterThanOrEqual(0);
+      expect(secondIdx).toBeGreaterThan(firstIdx);
+      expect(thirdIdx).toBeGreaterThan(secondIdx);
     });
   });
 });

--- a/evals/lib/report.ts
+++ b/evals/lib/report.ts
@@ -1,0 +1,77 @@
+/**
+ * Eval summary report library.
+ *
+ * Pure, dependency-free helpers that derive per-scenario `EvalResult`s from
+ * runner output, aggregate them into an `EvalReport`, and render the report
+ * to a stdout-ready string.
+ *
+ * No I/O, no console output, no process control — everything is exercised
+ * via unit tests in `report.test.ts`. The orchestrator (`run-evals.ts`)
+ * imports these functions in Slice 2.
+ *
+ * Implements FR-009; backs Acceptance Scenarios 9.1, 9.2, 9.3.
+ */
+
+import type {
+  CheckResult,
+  EvalResult,
+  EvalScenario,
+  RunOutput,
+} from './types.js';
+
+/**
+ * Assemble an `EvalResult` from the scenario, runner output, and the
+ * computed structural / sub-agent check arrays.
+ *
+ * Status precedence (AS 9.3):
+ *   1. `output.timed_out === true`              → `'timeout'`
+ *   2. `output.exit_code !== 0`                 → `'error'`
+ *   3. any failing structural / sub-agent check → `'fail'`
+ *   4. otherwise                                → `'pass'`
+ *
+ * The function is pure: it does not mutate any of its inputs and performs
+ * no I/O. `sub_agent_checks` is omitted from the returned object when the
+ * caller passes `undefined` or an empty array. The `error` field is only
+ * populated for `'timeout'` and `'error'` statuses.
+ */
+export function scenarioRunToResult(
+  scenario: EvalScenario,
+  output: RunOutput,
+  structuralChecks: CheckResult[],
+  subAgentChecks?: CheckResult[],
+): EvalResult {
+  let status: EvalResult['status'];
+  let error: string | undefined;
+
+  if (output.timed_out) {
+    status = 'timeout';
+    error = `Scenario timed out after ${output.duration_ms}ms`;
+  } else if (output.exit_code !== 0) {
+    status = 'error';
+    error = `claude CLI exited with non-zero status code ${output.exit_code}`;
+  } else {
+    const structuralFailed = structuralChecks.some((c) => !c.passed);
+    const subAgentFailed = subAgentChecks
+      ? subAgentChecks.some((c) => !c.passed)
+      : false;
+    status = structuralFailed || subAgentFailed ? 'fail' : 'pass';
+  }
+
+  const result: EvalResult = {
+    scenario_name: scenario.name,
+    status,
+    extracted_text: output.extracted_text,
+    duration_ms: output.duration_ms,
+    structural_checks: structuralChecks,
+  };
+
+  if (subAgentChecks && subAgentChecks.length > 0) {
+    result.sub_agent_checks = subAgentChecks;
+  }
+
+  if (error !== undefined) {
+    result.error = error;
+  }
+
+  return result;
+}

--- a/evals/lib/report.ts
+++ b/evals/lib/report.ts
@@ -115,3 +115,62 @@ export function buildReport(
     total_duration_ms: totalDurationMs,
   };
 }
+
+/**
+ * Map an `EvalResult` status to its uppercase display token.
+ *
+ * The four tokens are intentionally distinct strings so that callers can
+ * use word-boundary matching to tell `TIMEOUT` and `ERROR` apart from
+ * `FAIL` (AS 9.3).
+ */
+function statusToken(status: EvalResult['status']): string {
+  switch (status) {
+    case 'pass':
+      return 'PASS';
+    case 'fail':
+      return 'FAIL';
+    case 'timeout':
+      return 'TIMEOUT';
+    case 'error':
+      return 'ERROR';
+  }
+}
+
+/**
+ * Render an `EvalReport` to a deterministic, multi-line, stdout-ready
+ * string.
+ *
+ * Output shape:
+ *
+ *     Eval Summary
+ *       [PASS] strike-health-check
+ *       [FAIL] plan-standalone
+ *       [TIMEOUT] scout-standalone
+ *       [ERROR] clarify-standalone
+ *
+ *     Result: FAIL (1/4 passed, 4 total)
+ *
+ * The function is pure: no I/O, no `console.log`, no mutation of `report`.
+ * Per-case lines are emitted in `report.results` order so the output is
+ * stable across calls — making snapshot-style assertions feasible. The four
+ * status tokens (`PASS`, `FAIL`, `TIMEOUT`, `ERROR`) are distinct strings,
+ * so word-boundary matchers can distinguish a timeout case from a fail
+ * case (AS 9.3). The final aggregate line carries the overall result
+ * (`PASS` or `FAIL`) plus the total case count (AS 9.1, 9.2).
+ */
+export function formatReport(report: EvalReport): string {
+  const lines: string[] = ['Eval Summary'];
+
+  for (const result of report.results) {
+    const token = statusToken(result.status);
+    lines.push(`  [${token}] ${result.scenario_name}`);
+  }
+
+  const overallToken = report.overall_status === 'pass' ? 'PASS' : 'FAIL';
+  lines.push('');
+  lines.push(
+    `Result: ${overallToken} (${report.passed}/${report.total_cases} passed, ${report.total_cases} total)`,
+  );
+
+  return lines.join('\n');
+}

--- a/evals/lib/report.ts
+++ b/evals/lib/report.ts
@@ -14,6 +14,7 @@
 
 import type {
   CheckResult,
+  EvalReport,
   EvalResult,
   EvalScenario,
   RunOutput,
@@ -74,4 +75,43 @@ export function scenarioRunToResult(
   }
 
   return result;
+}
+
+/**
+ * Aggregate an array of `EvalResult`s into a single `EvalReport`.
+ *
+ * Tallies `passed` as `status === 'pass'` and `failed` as every non-`pass`
+ * status (including `fail`, `timeout`, and `error`). `overall_status` is
+ * `'pass'` only when every result passed; an empty `results` array yields a
+ * well-formed empty report with `overall_status: 'pass'` and zero counts.
+ *
+ * The function is pure: it does not mutate `results` and performs no I/O.
+ * `timestamp` is set to the current wall-clock time (ISO 8601) at call time;
+ * `total_duration_ms` is passed through unchanged from the caller.
+ *
+ * Backs Acceptance Scenarios 9.1 and 9.2.
+ */
+export function buildReport(
+  results: EvalResult[],
+  totalDurationMs: number,
+): EvalReport {
+  let passed = 0;
+  for (const result of results) {
+    if (result.status === 'pass') {
+      passed += 1;
+    }
+  }
+  const failed = results.length - passed;
+  const overall_status: EvalReport['overall_status'] =
+    failed === 0 ? 'pass' : 'fail';
+
+  return {
+    timestamp: new Date().toISOString(),
+    total_cases: results.length,
+    passed,
+    failed,
+    overall_status,
+    results: results.slice(),
+    total_duration_ms: totalDurationMs,
+  };
 }

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -141,3 +141,33 @@ export interface EvalResult {
   sub_agent_checks?: CheckResult[] | undefined;
   error?: string | undefined;
 }
+
+// ---------------------------------------------------------------------------
+// Aggregate report (across all scenarios in a single run)
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregate summary across all scenarios in a single eval run.
+ *
+ * Mirrors the EvalReport entity in the data model (§4). Produced by
+ * `buildReport` in `evals/lib/report.ts` and rendered to stdout by
+ * `formatReport`. `overall_status` is `'pass'` only when every result in
+ * `results` has status `'pass'`; any `fail`/`timeout`/`error` case flips it
+ * to `'fail'`.
+ */
+export interface EvalReport {
+  /** ISO 8601 timestamp marking when the run started (or was reported). */
+  timestamp: string;
+  /** Number of scenarios executed in this run. */
+  total_cases: number;
+  /** Count of scenarios with status `pass`. */
+  passed: number;
+  /** Count of scenarios with status `fail`, `timeout`, or `error`. */
+  failed: number;
+  /** `pass` only if every result passed; `fail` if any case did not. */
+  overall_status: 'pass' | 'fail';
+  /** Per-case results, in execution order. */
+  results: EvalResult[];
+  /** Total wall-clock time for the entire run, in milliseconds. */
+  total_duration_ms: number;
+}

--- a/specs/2026-04-06-003-smithy-evals-framework/09-eval-summary-report.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/09-eval-summary-report.tasks.md
@@ -40,7 +40,7 @@
   - `error` field is populated with a descriptive message on `timeout`/`error` status and absent on `pass`/`fail`
   - All imports (`EvalScenario`, `RunOutput`, `CheckResult`, `EvalResult`) come from `./types.js`
 
-- [ ] **Implement `buildReport` aggregator over `EvalResult[]`**
+- [x] **Implement `buildReport` aggregator over `EvalResult[]`**
 
   Add a pure `buildReport(results: EvalResult[], totalDurationMs: number): EvalReport` function to `evals/lib/report.ts` that tallies per-status counts and assembles a complete `EvalReport`. Accepting an array today — even a one-element one — preserves the US7 contract where YAML loading will pass N scenarios without further changes to the report API (AS 9.1, 9.2).
 

--- a/specs/2026-04-06-003-smithy-evals-framework/09-eval-summary-report.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/09-eval-summary-report.tasks.md
@@ -52,7 +52,7 @@
   - `total_duration_ms` equals the passed-in argument
   - Zero-length `results` input returns a well-formed empty report with `overall_status: 'pass'` and zero counts
 
-- [ ] **Implement `formatReport` pure string formatter**
+- [x] **Implement `formatReport` pure string formatter**
 
   Add a pure `formatReport(report: EvalReport): string` function to `evals/lib/report.ts` returning a multi-line stdout-ready summary. Each per-case line carries the scenario name and a status label; timeout cases display a distinct `TIMEOUT` token (AS 9.3), error cases a distinct `ERROR` token, and the final aggregate line shows `PASS` or `FAIL` with the total case count (AS 9.1, 9.2).
 

--- a/specs/2026-04-06-003-smithy-evals-framework/09-eval-summary-report.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/09-eval-summary-report.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Declare `EvalReport` aggregate type in `types.ts`**
+- [x] **Declare `EvalReport` aggregate type in `types.ts`**
 
   Add an `EvalReport` interface to `evals/lib/types.ts` matching the data model entity. It must expose enough shape for `buildReport` and `formatReport` to satisfy AS 9.1 and 9.2 — an ISO 8601 timestamp, total/passed/failed counts, overall status, the underlying `EvalResult[]`, and total wall-clock duration in milliseconds.
 

--- a/specs/2026-04-06-003-smithy-evals-framework/09-eval-summary-report.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/09-eval-summary-report.tasks.md
@@ -28,7 +28,7 @@
   - No runtime logic introduced; existing exports unchanged
   - Type is importable from `./types.js` by both `report.ts` and `run-evals.ts`
 
-- [ ] **Implement `scenarioRunToResult` status-derivation helper**
+- [x] **Implement `scenarioRunToResult` status-derivation helper**
 
   Create `evals/lib/report.ts` and export a pure function that assembles an `EvalResult` from a `RunOutput`, the scenario, and the computed check arrays. Status precedence (required by AS 9.3): `timed_out` → `timeout`; otherwise non-zero `exit_code` → `error`; otherwise any failing check → `fail`; otherwise `pass`.
 


### PR DESCRIPTION
## Source

- Spec: [`specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.spec.md`](specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.spec.md) — User Story 9
- Tasks: [`specs/2026-04-06-003-smithy-evals-framework/09-eval-summary-report.tasks.md`](specs/2026-04-06-003-smithy-evals-framework/09-eval-summary-report.tasks.md)
- Data model: [`smithy-evals-framework.data-model.md`](specs/2026-04-06-003-smithy-evals-framework/smithy-evals-framework.data-model.md) §4 `EvalReport`

## Slice

**Slice 1 of 2** — *Report Library — Types, Status Derivation, Aggregation, Formatting*

**Goal**: Ship a pure, fully unit-testable `evals/lib/report.ts` module plus the `EvalReport` type declaration in `evals/lib/types.ts`. The module exports `scenarioRunToResult` (status precedence), `buildReport` (aggregation over `EvalResult[]`), and `formatReport` (stdout string rendering). No orchestrator changes — Slice 2 will wire `formatReport` into `run-evals.ts`.

## Addresses

- **FR-009** — Summary report to stdout with per-case pass/fail status and overall result
- **AS 9.1** — all-pass report prints overall `PASS` with total count
- **AS 9.2** — mixed 2-pass/1-fail report prints each case + overall `FAIL`
- **AS 9.3** — timeout case surfaces a distinct `TIMEOUT` token (not conflated with `FAIL`)

## Tasks completed

- [x] Declare `EvalReport` aggregate type in `evals/lib/types.ts`
- [x] Implement `scenarioRunToResult` pure status-derivation helper (precedence `timeout > error > fail > pass`)
- [x] Implement `buildReport(results, totalDurationMs): EvalReport` aggregator
- [x] Implement `formatReport(report): string` pure string formatter

## What's in the diff

- **`evals/lib/types.ts`** — new `EvalReport` interface matching the data-model entity (`timestamp`, `total_cases`, `passed`, `failed`, `overall_status: 'pass' | 'fail'`, `results: EvalResult[]`, `total_duration_ms`).
- **`evals/lib/report.ts`** — new module with three pure exports:
  - `scenarioRunToResult(scenario, output, structuralChecks, subAgentChecks?)` — derives the final `EvalResult` status with strict precedence `timeout > error > fail > pass`. `sub_agent_checks` is omitted from the result when the argument is `undefined` or empty. `error` is populated only on `timeout`/`error`.
  - `buildReport(results, totalDurationMs)` — tallies `passed`/`failed` (everything non-`pass` counts as failed), assembles ISO-8601 `timestamp`, returns `overall_status: 'pass'` iff every result is `'pass'` (vacuously true for empty input).
  - `formatReport(report)` — deterministic multi-line string. Per-case lines use four distinct tokens (`PASS`/`FAIL`/`TIMEOUT`/`ERROR`); final line carries overall result + total count. No `console.log`, no mutation.
- **`evals/lib/report.test.ts`** — 37 new unit tests covering status precedence, the `sub_agent_checks`-absent-vs-empty distinction, the zero-length vacuous-pass case, token distinctness via word boundaries, purity (frozen input arrays), and determinism.
- **`CLAUDE.md` / `CONTRIBUTING.md`** — maid commit updating the evals-framework "implemented" blurbs to mention the report library.
- **Tasks file** — four Slice 1 checkboxes flipped to `[x]`.

## Review

Ran via `smithy-review`. **No review findings** — implementation matches spec, data model, and tasks acceptance criteria:

- Status precedence in `scenarioRunToResult` exactly matches AS 9.3 (`timeout > error > fail > pass`).
- `sub_agent_checks` omission uses a strict `'key' in obj` guard, not truthiness — covered by tests.
- `buildReport` treats `timeout`/`error` as `failed` (verified by 1-pass + 1-timeout + 1-error test).
- Empty-results case returns `overall_status: 'pass'` with zero counts.
- Four `formatReport` tokens are whole-word distinct; tests use `\bTIMEOUT\b` matchers and explicit `not.toMatch(/\b(FAIL|ERROR|PASS)\b/)` on the TIMEOUT line to prevent false positives.
- Purity: all three functions construct fresh objects; `buildReport` defensively copies `results`; `formatReport` is verified via `vi.spyOn(console, 'log')`.
- Style matches the existing `evals/lib/` modules (`.js` import extensions, JSDoc header with spec reference, type-only imports).
- `run-evals.ts` is deliberately untouched — correctly deferred to Slice 2.

No auto-fixes were needed. No escalations.

## Documentation

Maid scan flagged two stale facts and noted one deferred cleanup:

- **Auto-fixed**: `CLAUDE.md` line 114 — evals-status blurb now mentions `scenarioRunToResult` / `buildReport` / `formatReport` and notes orchestrator wiring is pending as Slice 2. Committed as `f9b4c0b`.
- **Auto-fixed**: `CONTRIBUTING.md` lines 51–60 — implemented list now includes the report library; pending list now mentions Slice 2 wiring. Committed as `f9b4c0b`.
- **Flagged for Slice 2**: `evals/run-evals.ts` line 10 has a `US9 will extend the result summary...` comment that remains accurate now but will become stale once Slice 2 lands. Slice 2 PR should clean it up — left alone here per scope.

No other artifact drift. `EvalReport` in `types.ts` lines up 1:1 with the data-model §4 entity.

## Validation

All run locally against HEAD (`f9b4c0b`, includes maid auto-fix commits):

| Command | Result |
|---|---|
| `npm run typecheck` | clean |
| `npm run build` | success (tsup, 45.85 KB) |
| `npm run test:evals` | 85/85 passed across 5 files (37 new in `report.test.ts`) |
| `npm test` | 289/289 passed across 11 files |

`npm run eval` is unchanged in behavior this slice — the library is unwired until Slice 2.

## What's next

- **Slice 2** of the same tasks file wires `scenarioRunToResult` / `buildReport` / `formatReport` into `evals/run-evals.ts`, replacing the current `Result: PASS/FAIL` line with `console.log(formatReport(report))` while preserving existing per-check inline output. That PR will be small and additive on top of this one.