### PR TITLE
slice-3: wire smithy status subcommand to scanner

### DIFF
--- a/specs/2026-04-12-004-smithy-status-skill/01-scan-artifacts-and-classify-status.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/01-scan-artifacts-and-classify-status.tasks.md
@@ -118,7 +118,7 @@
 
 ### Tasks
 
-- [ ] **Create `src/commands/status.ts`, register `smithy status` in `src/cli.ts`, and add an integration test**
+- [x] **Create `src/commands/status.ts`, register `smithy status` in `src/cli.ts`, and add an integration test**
 
   Create `src/commands/status.ts` exporting a `statusAction(opts)` function that composes the scanner: call `scan(opts.root ?? process.cwd())`, derive a `ScanSummary` from the returned records, and emit either (a) a contract-shaped JSON object with `summary`, `records`, and empty-stub `tree` / `graph` keys when `--format json` is passed, or (b) a minimal flat text listing (one line per record showing type, path, title, status) otherwise. Handle the three error conditions from the contracts table: `--root` pointing at a nonexistent path exits with code 2 and a stderr message; an empty repo (no discovered artifacts) exits 0 with the friendly hint pointing at `smithy.ignite` / `smithy.mark`; individual artifact parse failures are surfaced in the record set with `status: 'unknown'` without aborting. Register the subcommand in `src/cli.ts` using Commander, mirroring the existing `init` / `update` registration pattern. Declare option stubs for `--status`, `--type`, `--all`, `--graph`, and `--no-color` so downstream stories can wire them without re-touching the entry file — this slice does not need to make them functional beyond Commander parsing. Add an integration test in `src/cli.test.ts` that drives the built CLI against a synthetic temp-dir fixture and asserts (at minimum) the JSON output shape, the empty-repo hint exit path, and the nonexistent-`--root` error exit.
 
@@ -158,7 +158,7 @@ Recommended implementation sequence:
 
 1. [x] **Slice 1** — the pure parser and its type surface have no runtime prerequisites and are the import foundation every downstream slice needs.
 2. [x] **Slice 2** — the scanner consumes the parser from Slice 1 to produce a fully-classified record set; this is the first slice whose output matches the US1 acceptance contract end-to-end.
-3. [ ] **Slice 3** — the CLI subcommand composes the finished scanner, exposing US1 to end users and matching the contracts file's JSON shape.
+3. [x] **Slice 3** — the CLI subcommand composes the finished scanner, exposing US1 to end users and matching the contracts file's JSON shape.
 
 ### Cross-Story Dependencies
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -557,7 +557,7 @@ describe('CLI status', () => {
     expect(result.stderr).toContain('does not exist');
   });
 
-  it('emits a minimal flat text listing by default', () => {
+  it('emits a minimal flat text listing in type/path/title/status column order', () => {
     write(
       'specs/feature-a/feature-a.spec.md',
       `# Feature Specification: Feature A\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
@@ -567,9 +567,57 @@ describe('CLI status', () => {
       encoding: 'utf-8',
     });
 
-    // Flat listing: one line per record mentioning the path.
-    expect(output).toContain('specs/feature-a/feature-a.spec.md');
-    expect(output).toContain('spec');
+    // Flat listing: one line per record. Column order is type, path,
+    // title, status per the Slice 3 task spec.
+    const line = output
+      .split('\n')
+      .find((l) => l.includes('specs/feature-a/feature-a.spec.md'));
+    expect(line).toBeDefined();
+    const cols = (line ?? '').split('\t');
+    expect(cols[0]).toBe('spec');
+    expect(cols[1]).toBe('specs/feature-a/feature-a.spec.md');
+    expect(cols[2]).toBe('Feature A');
+    expect(cols[3]).toBe('not-started');
+  });
+
+  it('emits a valid (empty) JSON payload for an empty repo in --format json mode', () => {
+    const output = execFileSync('node', [CLI, 'status', '--format', 'json', '--root', tmpDir], {
+      encoding: 'utf-8',
+    });
+    // Must be parseable as JSON — machine consumers parse stdout
+    // unconditionally in JSON mode.
+    const payload = JSON.parse(output) as {
+      summary: { parse_error_count: number };
+      records: unknown[];
+      tree: { roots: unknown[] };
+      graph: { nodes: unknown; layers: unknown[] };
+    };
+    expect(payload.records).toEqual([]);
+    expect(payload.summary.parse_error_count).toBe(0);
+    expect(payload.tree.roots).toEqual([]);
+    expect(payload.graph.layers).toEqual([]);
+  });
+
+  it('exits 2 with a stderr message on an invalid --status value', () => {
+    const result = spawnSync(
+      'node',
+      [CLI, 'status', '--root', tmpDir, '--status', 'bogus'],
+      { encoding: 'utf-8' },
+    );
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('invalid --status');
+    expect(result.stderr).toContain('done');
+  });
+
+  it('exits 2 with a stderr message on an invalid --type value', () => {
+    const result = spawnSync(
+      'node',
+      [CLI, 'status', '--root', tmpDir, '--type', 'bogus'],
+      { encoding: 'utf-8' },
+    );
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('invalid --type');
+    expect(result.stderr).toContain('rfc');
   });
 
   it('surfaces individual parse failures as records with status unknown and exits 0', () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -446,3 +446,177 @@ describe('CLI init lifecycle and idempotency', () => {
     expect(fs.existsSync(customFile)).toBe(true);
   });
 });
+
+describe('CLI status', () => {
+  let tmpDir: string;
+
+  const TABLE_HEADER =
+    '| ID | Title | Depends On | Artifact |\n|----|-------|------------|----------|';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-status-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function write(relPath: string, contents: string): void {
+    const abs = path.join(tmpDir, relPath);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, contents);
+  }
+
+  it('shows the subcommand and all options in --help', () => {
+    const output = execFileSync('node', [CLI, 'status', '--help'], {
+      encoding: 'utf-8',
+    });
+    expect(output).toContain('status');
+    expect(output).toContain('--root');
+    expect(output).toContain('--format');
+    expect(output).toContain('--status');
+    expect(output).toContain('--type');
+    expect(output).toContain('--all');
+    expect(output).toContain('--graph');
+    expect(output).toContain('--no-color');
+  });
+
+  it('emits contract-shaped JSON with records, summary, tree, graph', () => {
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Feature Specification: Feature A\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story One | — | specs/feature-a/01-first.tasks.md |\n`,
+    );
+    write(
+      'specs/feature-a/01-first.tasks.md',
+      `# Tasks\n\n## Slice 1: First\n\n- [x] Task one\n- [x] Task two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | First | — | — |\n`,
+    );
+
+    const output = execFileSync('node', [CLI, 'status', '--format', 'json', '--root', tmpDir], {
+      encoding: 'utf-8',
+    });
+
+    const payload = JSON.parse(output) as {
+      summary: {
+        counts: Record<'rfc' | 'features' | 'spec' | 'tasks', Record<string, number>>;
+        orphan_count: number;
+        broken_link_count: number;
+        parse_error_count: number;
+      };
+      records: Array<{
+        type: string;
+        path: string;
+        title: string;
+        status: string;
+        dependency_order: { rows: unknown[]; id_prefix: string; format: string };
+      }>;
+      tree: { roots: unknown[] };
+      graph: { nodes: unknown; layers: unknown[]; cycles: unknown[]; dangling_refs: unknown[] };
+    };
+
+    // Top-level shape matches the contracts.
+    expect(payload).toHaveProperty('summary');
+    expect(payload).toHaveProperty('records');
+    expect(payload).toHaveProperty('tree');
+    expect(payload).toHaveProperty('graph');
+
+    // Records embed the parsed dependency_order sub-object.
+    const specRecord = payload.records.find((r) => r.type === 'spec');
+    expect(specRecord).toBeDefined();
+    expect(specRecord?.dependency_order.format).toBe('table');
+    expect(specRecord?.dependency_order.id_prefix).toBe('US');
+
+    // Tasks record classifies as done (2/2 checkboxes in slice body).
+    const tasksRecord = payload.records.find((r) => r.type === 'tasks');
+    expect(tasksRecord).toBeDefined();
+    expect(tasksRecord?.status).toBe('done');
+
+    // Spec rolls up to done because its only child is done.
+    expect(specRecord?.status).toBe('done');
+
+    // Summary counts match the records.
+    expect(payload.summary.counts.spec.done).toBe(1);
+    expect(payload.summary.counts.tasks.done).toBe(1);
+    expect(payload.summary.parse_error_count).toBe(0);
+  });
+
+  it('exits 0 with a friendly hint on an empty repo', () => {
+    const result = spawnSync('node', [CLI, 'status', '--root', tmpDir], {
+      encoding: 'utf-8',
+    });
+    expect(result.status).toBe(0);
+    const output = result.stdout + result.stderr;
+    expect(output).toMatch(/smithy\.ignite|smithy\.mark/);
+  });
+
+  it('exits 2 with a stderr message when --root points to a nonexistent path', () => {
+    const missing = path.join(tmpDir, 'does-not-exist');
+    const result = spawnSync('node', [CLI, 'status', '--root', missing], {
+      encoding: 'utf-8',
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('does not exist');
+  });
+
+  it('emits a minimal flat text listing by default', () => {
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Feature Specification: Feature A\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+
+    const output = execFileSync('node', [CLI, 'status', '--root', tmpDir], {
+      encoding: 'utf-8',
+    });
+
+    // Flat listing: one line per record mentioning the path.
+    expect(output).toContain('specs/feature-a/feature-a.spec.md');
+    expect(output).toContain('spec');
+  });
+
+  it('surfaces individual parse failures as records with status unknown and exits 0', () => {
+    // A parent-type artifact whose `## Dependency Order` section uses
+    // the legacy checkbox format triggers the `unknown` classifier
+    // branch AND emits a `format_legacy` warning (SD-002 rule).
+    write(
+      'specs/broken/broken.spec.md',
+      '# Broken\n\n## Dependency Order\n\n- [ ] US1 Story One → specs/broken/01-story.tasks.md\n- [ ] US2 Story Two → specs/broken/02-story.tasks.md\n',
+    );
+
+    const result = spawnSync('node', [CLI, 'status', '--format', 'json', '--root', tmpDir], {
+      encoding: 'utf-8',
+    });
+    expect(result.status).toBe(0);
+
+    const payload = JSON.parse(result.stdout) as {
+      records: Array<{ status: string; warnings: string[] }>;
+      summary: { parse_error_count: number };
+    };
+    const unknownRecord = payload.records.find((r) => r.status === 'unknown');
+    expect(unknownRecord).toBeDefined();
+    expect(unknownRecord?.warnings.length).toBeGreaterThan(0);
+    expect(payload.summary.parse_error_count).toBeGreaterThan(0);
+  });
+
+  it('accepts all downstream option stubs without error', () => {
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+
+    const result = spawnSync(
+      'node',
+      [
+        CLI,
+        'status',
+        '--root', tmpDir,
+        '--status', 'in-progress',
+        '--type', 'spec',
+        '--all',
+        '--graph',
+        '--no-color',
+      ],
+      { encoding: 'utf-8' },
+    );
+    // Commander should not reject any of these stubs.
+    expect(result.status).toBe(0);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,14 +80,14 @@ program
   // Option stubs wired for downstream stories (US2, US3, US6). Commander
   // parses them so `smithy status --help` advertises the full surface,
   // but their behavioral effect is out of scope for US1 Slice 3.
-  .addOption(
-    new Option('--status <state>', 'Filter by status (stub — wired in US6)')
-      .choices(['done', 'in-progress', 'not-started', 'unknown']),
-  )
-  .addOption(
-    new Option('--type <artifact-type>', 'Filter by artifact type (stub — wired in US6)')
-      .choices(['rfc', 'features', 'spec', 'tasks']),
-  )
+  //
+  // `--status` and `--type` deliberately do NOT use Commander
+  // `.choices()` because Commander's invalid-choice handler exits with
+  // code 1, while the contracts mandate exit code 2 for invalid values
+  // on these two flags. `statusAction` validates them manually and
+  // sets `process.exitCode = 2`.
+  .option('--status <state>', 'Filter by status: done|in-progress|not-started|unknown (stub — wired in US6)')
+  .option('--type <artifact-type>', 'Filter by artifact type: rfc|features|spec|tasks (stub — wired in US6)')
   .option('--all', 'Disable collapsing of done subtrees (stub — wired in US3)')
   .option('--graph', 'Render the cross-artifact dependency graph (stub — wired in US2/US10)')
   .option('--no-color', 'Suppress ANSI color output (stub — no colored text yet)')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { initAction, type InitOptions } from './commands/init.js';
 import { toolchains, type LanguageToolchain } from './permissions.js';
 import { uninitAction } from './commands/uninit.js';
 import { updateAction } from './commands/update.js';
+import { statusAction, type StatusOptions } from './commands/status.js';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json') as { version: string };
@@ -66,5 +67,33 @@ program
   .option('-d, --target-dir <path>', 'Target directory')
   .option('-y, --yes', 'Accept defaults (non-interactive)')
   .action(updateAction);
+
+program
+  .command('status')
+  .description('Scan the repository and report the status of Smithy artifacts')
+  .option('--root <path>', 'Directory to scan (defaults to current working directory)')
+  .addOption(
+    new Option('--format <format>', 'Output format')
+      .choices(['text', 'json'])
+      .default('text'),
+  )
+  // Option stubs wired for downstream stories (US2, US3, US6). Commander
+  // parses them so `smithy status --help` advertises the full surface,
+  // but their behavioral effect is out of scope for US1 Slice 3.
+  .addOption(
+    new Option('--status <state>', 'Filter by status (stub — wired in US6)')
+      .choices(['done', 'in-progress', 'not-started', 'unknown']),
+  )
+  .addOption(
+    new Option('--type <artifact-type>', 'Filter by artifact type (stub — wired in US6)')
+      .choices(['rfc', 'features', 'spec', 'tasks']),
+  )
+  .option('--all', 'Disable collapsing of done subtrees (stub — wired in US3)')
+  .option('--graph', 'Render the cross-artifact dependency graph (stub — wired in US2/US10)')
+  .option('--no-color', 'Suppress ANSI color output (stub — no colored text yet)')
+  .action((opts: Record<string, unknown>) => {
+    const statusOpts: StatusOptions = { ...opts } as StatusOptions;
+    return statusAction(statusOpts);
+  });
 
 program.parse(process.argv);

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,0 +1,200 @@
+/**
+ * `smithy status` subcommand — thin CLI wiring around the status scanner.
+ *
+ * This module composes the pieces already built in Slices 1 and 2:
+ *
+ *   1. Resolve `--root` (defaults to `process.cwd()`).
+ *   2. Hard-fail with exit 2 if the resolved path does not exist or is not
+ *      a directory, matching the "non-existent `--root`" row of the
+ *      contracts error table.
+ *   3. Call {@link scan} to build the fully-classified `ArtifactRecord[]`.
+ *   4. Derive a {@link ScanSummary} from the records.
+ *   5. Emit either contract-shaped JSON (`--format json`) or a minimal
+ *      flat text listing (default). Rendering the hierarchical tree and
+ *      the graph is owned by downstream stories (US2, US10); this slice
+ *      ships stub values (`tree: { roots: [] }`, `graph: { ... }`) in
+ *      the JSON payload so consumers can depend on the top-level shape
+ *      today.
+ *   6. On an empty repo (no discovered artifacts), print a friendly hint
+ *      pointing at `smithy.ignite` / `smithy.mark` and exit 0 — the
+ *      contracts treat this as "not an error".
+ *
+ * Option stubs for `--status`, `--type`, `--all`, `--graph`, and
+ * `--no-color` are accepted but intentionally have no behavioral effect
+ * in this slice. Downstream stories (US2, US3, US6) wire them.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { scan } from '../status/index.js';
+import type {
+  ArtifactRecord,
+  ArtifactType,
+  ScanSummary,
+  Status,
+} from '../status/index.js';
+
+/**
+ * CLI options accepted by `smithy status`. Fields map 1:1 to the
+ * Commander options registered in `src/cli.ts`. All fields are optional
+ * because Commander omits unspecified flags entirely.
+ */
+export interface StatusOptions {
+  /** Directory to scan. Defaults to `process.cwd()`. */
+  root?: string;
+  /** Output format. Defaults to `text`. */
+  format?: 'text' | 'json';
+  /** Stub: filter by status. Parsed but not wired (US6). */
+  status?: Status;
+  /** Stub: filter by artifact type. Parsed but not wired (US6). */
+  type?: ArtifactType;
+  /** Stub: disable done-subtree collapsing. Parsed but not wired (US3). */
+  all?: boolean;
+  /** Stub: render the cross-artifact graph. Parsed but not wired (US2/US10). */
+  graph?: boolean;
+  /**
+   * Stub: suppress ANSI colors. Parsed but not wired — no text rendering
+   * in this slice uses color yet.
+   */
+  color?: boolean;
+}
+
+/**
+ * Contract-shaped JSON payload emitted by `--format json`. `tree` and
+ * `graph` are stubbed with empty containers in this slice; their real
+ * population is owned by US2 (tree) and US10 (graph). The stub keys are
+ * emitted unconditionally so consumers can depend on the top-level shape
+ * from US1 onward.
+ */
+interface StatusJsonPayload {
+  summary: ScanSummary;
+  records: ArtifactRecord[];
+  tree: { roots: [] };
+  graph: {
+    nodes: Record<string, never>;
+    layers: [];
+    cycles: [];
+    dangling_refs: [];
+  };
+}
+
+/**
+ * Entry point for the `smithy status` subcommand. Delegates to
+ * {@link scan} and emits either JSON (`--format json`) or a minimal flat
+ * text listing. Sets `process.exitCode` on error conditions so Commander
+ * does not have to know about them.
+ */
+export function statusAction(opts: StatusOptions = {}): void {
+  const rawRoot = opts.root ?? process.cwd();
+  const resolvedRoot = path.resolve(rawRoot);
+
+  // Error condition: `--root` points to a nonexistent path.
+  // Hard fail with exit 2 and a stderr message per the contracts.
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(resolvedRoot);
+  } catch {
+    process.stderr.write(
+      `smithy status: --root path does not exist: ${rawRoot}\n`,
+    );
+    process.exitCode = 2;
+    return;
+  }
+  if (!stat.isDirectory()) {
+    process.stderr.write(
+      `smithy status: --root path is not a directory: ${rawRoot}\n`,
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  const records = scan(resolvedRoot);
+
+  // Empty repo: friendly hint, exit 0. Not an error.
+  if (records.length === 0) {
+    console.log(
+      'No Smithy artifacts found. Run `smithy.ignite` or `smithy.mark` to create one.',
+    );
+    return;
+  }
+
+  const summary = summarize(records);
+
+  if (opts.format === 'json') {
+    const payload: StatusJsonPayload = {
+      summary,
+      records,
+      tree: { roots: [] },
+      graph: {
+        nodes: {},
+        layers: [],
+        cycles: [],
+        dangling_refs: [],
+      },
+    };
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  // Default text output: minimal flat listing. Hierarchical rendering
+  // is owned by US2; this slice ships a placeholder so humans get
+  // something legible and CI can parse it line-by-line.
+  for (const record of records) {
+    console.log(
+      `${record.type}\t${record.status}\t${record.path}\t${record.title}`,
+    );
+  }
+}
+
+/**
+ * Aggregate an `ArtifactRecord[]` into the `ScanSummary` shape expected
+ * by the data-model contract. Pure function so it can be unit-tested
+ * independently if needed later.
+ *
+ * Orphan definition per the data model: a record with no parent (`null`
+ * or omitted `parent_path`) that is NOT a top-level RFC — RFCs are
+ * roots, not orphans. Virtual records are not orphans either: they are
+ * always emitted as children of a real parent and therefore always have
+ * a non-null `parent_path`.
+ */
+function summarize(records: ArtifactRecord[]): ScanSummary {
+  const counts = emptyCounts();
+  let orphan_count = 0;
+  let broken_link_count = 0;
+  let parse_error_count = 0;
+
+  for (const record of records) {
+    counts[record.type][record.status] += 1;
+    if (record.status === 'unknown') parse_error_count += 1;
+    if (record.parent_missing === true) broken_link_count += 1;
+
+    const hasParent =
+      record.parent_path !== undefined && record.parent_path !== null;
+    if (!hasParent && record.type !== 'rfc') {
+      orphan_count += 1;
+    }
+  }
+
+  return {
+    counts,
+    orphan_count,
+    broken_link_count,
+    parse_error_count,
+  };
+}
+
+function emptyCounts(): ScanSummary['counts'] {
+  const emptyStatusCounts = (): Record<Status, number> => ({
+    done: 0,
+    'in-progress': 0,
+    'not-started': 0,
+    unknown: 0,
+  });
+  return {
+    rfc: emptyStatusCounts(),
+    features: emptyStatusCounts(),
+    spec: emptyStatusCounts(),
+    tasks: emptyStatusCounts(),
+  };
+}

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -37,8 +37,11 @@ import type {
 
 /**
  * CLI options accepted by `smithy status`. Fields map 1:1 to the
- * Commander options registered in `src/cli.ts`. All fields are optional
- * because Commander omits unspecified flags entirely.
+ * Commander options registered in `src/cli.ts`. Properties are marked
+ * optional because this action accepts partially populated option
+ * objects; when invoked via Commander, some options may still be
+ * present with default values (e.g. `--format` defaults to `'text'`,
+ * `--no-color` produces `color: true`) rather than being omitted.
  */
 export interface StatusOptions {
   /** Directory to scan. Defaults to `process.cwd()`. */
@@ -85,19 +88,67 @@ interface StatusJsonPayload {
  * text listing. Sets `process.exitCode` on error conditions so Commander
  * does not have to know about them.
  */
+const VALID_STATUSES: readonly Status[] = [
+  'done',
+  'in-progress',
+  'not-started',
+  'unknown',
+];
+
+const VALID_TYPES: readonly ArtifactType[] = [
+  'rfc',
+  'features',
+  'spec',
+  'tasks',
+];
+
 export function statusAction(opts: StatusOptions = {}): void {
+  // Error condition: invalid `--status` or `--type` value.
+  // Validated here (not via Commander `.choices()`) because the
+  // contracts mandate exit code 2 for these errors, while Commander's
+  // built-in invalid-choice handler exits with code 1.
+  if (opts.status !== undefined && !VALID_STATUSES.includes(opts.status)) {
+    process.stderr.write(
+      `smithy status: invalid --status value '${opts.status}'. Valid values: ${VALID_STATUSES.join(', ')}\n`,
+    );
+    process.exitCode = 2;
+    return;
+  }
+  if (opts.type !== undefined && !VALID_TYPES.includes(opts.type)) {
+    process.stderr.write(
+      `smithy status: invalid --type value '${opts.type}'. Valid values: ${VALID_TYPES.join(', ')}\n`,
+    );
+    process.exitCode = 2;
+    return;
+  }
+
   const rawRoot = opts.root ?? process.cwd();
   const resolvedRoot = path.resolve(rawRoot);
 
-  // Error condition: `--root` points to a nonexistent path.
+  // Error condition: `--root` cannot be inspected.
   // Hard fail with exit 2 and a stderr message per the contracts.
+  // Distinguish ENOENT (the contract's "non-existent path" case) from
+  // permission and other I/O failures so the message stays accurate.
   let stat: fs.Stats;
   try {
     stat = fs.statSync(resolvedRoot);
-  } catch {
-    process.stderr.write(
-      `smithy status: --root path does not exist: ${rawRoot}\n`,
-    );
+  } catch (error: unknown) {
+    const errorCode =
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      typeof (error as { code?: unknown }).code === 'string'
+        ? (error as { code: string }).code
+        : undefined;
+
+    const message =
+      errorCode === 'ENOENT'
+        ? `smithy status: --root path does not exist: ${rawRoot}\n`
+        : errorCode === 'EACCES' || errorCode === 'EPERM'
+          ? `smithy status: cannot access --root path: ${rawRoot}\n`
+          : `smithy status: failed to inspect --root path: ${rawRoot}\n`;
+
+    process.stderr.write(message);
     process.exitCode = 2;
     return;
   }
@@ -110,17 +161,12 @@ export function statusAction(opts: StatusOptions = {}): void {
   }
 
   const records = scan(resolvedRoot);
-
-  // Empty repo: friendly hint, exit 0. Not an error.
-  if (records.length === 0) {
-    console.log(
-      'No Smithy artifacts found. Run `smithy.ignite` or `smithy.mark` to create one.',
-    );
-    return;
-  }
-
   const summary = summarize(records);
 
+  // JSON mode: always emit a valid JSON payload, even on an empty
+  // repo. Machine consumers (CI, the smithy.status agent skill) parse
+  // stdout as JSON unconditionally, so a plain-text empty-repo hint
+  // would break them.
   if (opts.format === 'json') {
     const payload: StatusJsonPayload = {
       summary,
@@ -137,12 +183,21 @@ export function statusAction(opts: StatusOptions = {}): void {
     return;
   }
 
+  // Text mode, empty repo: friendly hint, exit 0. Not an error.
+  if (records.length === 0) {
+    console.log(
+      'No Smithy artifacts found. Run `smithy.ignite` or `smithy.mark` to create one.',
+    );
+    return;
+  }
+
   // Default text output: minimal flat listing. Hierarchical rendering
   // is owned by US2; this slice ships a placeholder so humans get
-  // something legible and CI can parse it line-by-line.
+  // something legible and CI can parse it line-by-line. Column order
+  // matches the Slice 3 task spec: type, path, title, status.
   for (const record of records) {
     console.log(
-      `${record.type}\t${record.status}\t${record.path}\t${record.title}`,
+      `${record.type}\t${record.path}\t${record.title}\t${record.status}`,
     );
   }
 }


### PR DESCRIPTION
Register `smithy status` with Commander, delegate to scan(), and emit
contract-shaped JSON via --format json or a minimal flat text listing
otherwise. Handles the three contract error conditions:
nonexistent --root exits 2 with a stderr message, empty repos exit 0
with a friendly smithy.ignite / smithy.mark hint, and per-artifact
parse failures surface as status: unknown records without aborting.

Option stubs for --status, --type, --all, --graph, and --no-color are
parsed by Commander so downstream stories (US2, US3, US6) can wire
their behavior without re-touching the CLI entry point.

Integration tests in src/cli.test.ts drive the built CLI against
synthetic temp-dir fixtures and cover the JSON shape, empty-repo hint,
nonexistent-root exit, text listing, unknown-status surfacing, and
option-stub acceptance.