### PR TITLE
slice-1: add shared one-shot-output snippet for planning commands

### DIFF
--- a/specs/2026-04-08-003-reduce-interaction-friction/03-one-shot-planning-workflows.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/03-one-shot-planning-workflows.tasks.md
@@ -24,7 +24,7 @@ depends on snippet rendering, so this PR delivers visible content (the snippet
 
 ### Tasks
 
-- [ ] **Create the `one-shot-output` snippet file**
+- [x] **Create the `one-shot-output` snippet file**
 
   Add `src/templates/agent-skills/snippets/one-shot-output.md` containing the
   Markdown block defined in the contracts (`## Summary`, `## Assumptions`,
@@ -39,7 +39,7 @@ depends on snippet rendering, so this PR delivers visible content (the snippet
   - Includes a bail-out fallback note (contracts Error Conditions)
   - File has no YAML frontmatter (snippets are raw Markdown per snippets README)
 
-- [ ] **Register the snippet in the snippets README table**
+- [x] **Register the snippet in the snippets README table**
 
   Add a row to `src/templates/agent-skills/snippets/README.md` documenting
   the new snippet and listing the consumers the remaining slices will wire it
@@ -50,7 +50,7 @@ depends on snippet rendering, so this PR delivers visible content (the snippet
   - Alphabetical or logical placement within the existing table
   - No deployment metadata changes (snippet is not deployed standalone)
 
-- [ ] **Assert the snippet composes into every planning command**
+- [x] **Assert the snippet composes into every planning command**
 
   Add Tier 2 assertions in `src/templates.test.ts` that verify the snippet
   is resolvable and that it will be referenced from each planning command

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -101,7 +101,7 @@ describe('resolveSnippets', () => {
 describe('loadSnippets', () => {
   it('loads all snippet files', () => {
     const snippets = loadSnippets();
-    expect(snippets.size).toBe(11);
+    expect(snippets.size).toBe(12);
 
     const expectedFiles = [
       'audit-checklist-rfc.md',
@@ -115,6 +115,7 @@ describe('loadSnippets', () => {
       'guidance-shell.md',
       'tdd-protocol.md',
       'review-protocol.md',
+      'one-shot-output.md',
     ];
     for (const file of expectedFiles) {
       expect(snippets.has(file)).toBe(true);
@@ -135,6 +136,76 @@ describe('loadSnippets', () => {
     expect(snippets.get('competing-lenses-decomposition.md')).toContain('Competing Slice Lenses');
     expect(snippets.get('competing-lenses-implementation.md')).toContain('Competing Plan Lenses');
     expect(snippets.get('competing-lenses-scoping.md')).toContain('Competing Plan Lenses');
+  });
+});
+
+describe('one-shot-output snippet', () => {
+  // Story 3 Slice 1: the shared one-shot output snippet is the single source
+  // of truth for the terminal output format every planning command must
+  // render when running one-shot. These assertions lock down the snippet's
+  // contract so any regression (deleted file, renamed file, dropped header,
+  // missing error fallback) fails the test suite immediately.
+
+  it('snippet file is loadable as a partial via loadSnippets', () => {
+    const snippets = loadSnippets();
+    expect(snippets.has('one-shot-output.md')).toBe(true);
+    const content = snippets.get('one-shot-output.md')!;
+    expect(content.length).toBeGreaterThan(0);
+  });
+
+  it('snippet has no YAML frontmatter (raw Markdown per snippets README)', () => {
+    const snippets = loadSnippets();
+    const content = snippets.get('one-shot-output.md')!;
+    expect(content).not.toMatch(/^---\s*\n/);
+  });
+
+  it('snippet contains the four required section headers in contract order', () => {
+    const snippets = loadSnippets();
+    const content = snippets.get('one-shot-output.md')!;
+
+    const summaryIdx = content.indexOf('## Summary');
+    const assumptionsIdx = content.indexOf('## Assumptions');
+    const debtIdx = content.indexOf('## Specification Debt');
+    const prIdx = content.indexOf('## PR');
+
+    expect(summaryIdx).toBeGreaterThan(-1);
+    expect(assumptionsIdx).toBeGreaterThan(summaryIdx);
+    expect(debtIdx).toBeGreaterThan(assumptionsIdx);
+    expect(prIdx).toBeGreaterThan(debtIdx);
+  });
+
+  it('snippet includes PR-creation-failure fallback guidance', () => {
+    const snippets = loadSnippets();
+    const content = snippets.get('one-shot-output.md')!;
+    expect(content).toMatch(/PR creation fail/i);
+    expect(content.toLowerCase()).toContain('artifacts are on disk');
+  });
+
+  it('snippet includes bail-out fallback guidance', () => {
+    const snippets = loadSnippets();
+    const content = snippets.get('one-shot-output.md')!;
+    expect(content).toMatch(/bail[- ]out/i);
+    expect(content).toContain('## Bail-Out');
+  });
+
+  it('snippet composes into any template via the {{>one-shot-output}} partial', async () => {
+    // Prove the snippet is resolvable by the same partial machinery that
+    // every planning command will use once subsequent slices wire it in.
+    // If the snippet is deleted or renamed, this fails because the renderer
+    // has no partial to substitute.
+    const snippets = loadSnippets();
+    const partials: Record<string, string> = {};
+    for (const [filename, content] of snippets) {
+      partials[filename.replace(/\.md$/, '')] = content;
+    }
+    const renderer = new Dotprompt({ partials });
+    const host = '# Host Template\n\n{{>one-shot-output}}\n';
+    const result = await resolveSnippets(host, renderer);
+    expect(result).toContain('## Summary');
+    expect(result).toContain('## Assumptions');
+    expect(result).toContain('## Specification Debt');
+    expect(result).toContain('## PR');
+    expect(result).not.toContain('{{>one-shot-output}}');
   });
 });
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -196,7 +196,10 @@ describe('one-shot-output snippet', () => {
     const snippets = loadSnippets();
     const partials: Record<string, string> = {};
     for (const [filename, content] of snippets) {
-      partials[filename.replace(/\.md$/, '')] = content;
+      // Mirror the trailing-whitespace normalization applied by
+      // buildPartialsMap in templates.ts so this test reflects runtime
+      // partial-composition behavior rather than diverging from it.
+      partials[filename.replace(/\.md$/, '')] = content.trimEnd();
     }
     const renderer = new Dotprompt({ partials });
     const host = '# Host Template\n\n{{>one-shot-output}}\n';

--- a/src/templates/agent-skills/snippets/README.md
+++ b/src/templates/agent-skills/snippets/README.md
@@ -25,6 +25,7 @@ its contents. The snippet file itself is never deployed.
 | `competing-lenses-decomposition.md` | Competing slice lenses for decomposition planning | smithy.cut |
 | `competing-lenses-implementation.md` | Competing plan lenses for implementation planning | smithy.strike, smithy.ignite, smithy.render, smithy.mark |
 | `competing-lenses-scoping.md` | Competing plan lenses for scoping | smithy.strike, smithy.ignite, smithy.render, smithy.mark |
+| `one-shot-output.md` | Standardized terminal output format for one-shot planning runs (Summary → Assumptions → Specification Debt → PR), with PR-failure and bail-out fallbacks | smithy.strike, smithy.ignite, smithy.mark, smithy.render, smithy.cut |
 
 ## Conventions
 

--- a/src/templates/agent-skills/snippets/one-shot-output.md
+++ b/src/templates/agent-skills/snippets/one-shot-output.md
@@ -1,0 +1,106 @@
+## One-Shot Output
+
+Render this block verbatim as the terminal output of a one-shot planning
+command run. Replace each placeholder with the value captured during the run
+— do **not** reword the section headers, and do **not** drop sections. The
+format is the contract that lets developers scan every planning command's
+output the same way.
+
+```markdown
+## Summary
+
+- **Spec folder**: `<path>`
+- **Branch**: `<branch>`
+- **Artifacts produced**: <count> files (<list>)
+- **User stories**: <count> (P1: <n>, P2: <n>, P3: <n>)
+- **Functional requirements**: <count>
+
+## Assumptions
+
+- <assumption 1>
+- <assumption 2> [Critical Assumption]
+- ...
+
+(If clarify returned zero assumptions, write: `None — the feature description
+was unambiguous.`)
+
+## Specification Debt
+
+<count> items deferred — see `## Specification Debt` in the artifact.
+
+- <debt item 1 description> [Impact: <level>]
+- <debt item 2 description> [Impact: <level>]
+- ...
+
+(If clarify returned zero debt items, write: `None — no specification debt
+was recorded.`)
+
+## PR
+
+<PR link>
+```
+
+### Placeholder Guidance
+
+- **Spec folder**: absolute-or-repo-relative path to the folder containing the
+  artifacts produced by the run (e.g. `specs/2026-04-08-003-reduce-interaction-friction/`).
+  For RFC-only runs (ignite without a downstream spec folder), use the RFC
+  file's parent directory.
+- **Branch**: the feature branch the command pushed the PR from.
+- **Artifacts produced**: file count and comma-separated list of basenames
+  (e.g. `3 files (reduce-interaction-friction.spec.md, …data-model.md,
+  …contracts.md)`).
+- **User stories / Functional requirements**: counts lifted from the spec.
+  For commands that don't produce a spec directly (ignite → RFC, render →
+  feature map), substitute the next-level-down counts — milestones, features,
+  etc. — and relabel the bullet accordingly.
+- **Assumptions**: copy each item from the clarify return's `assumptions`
+  array. Preserve the `[Critical Assumption]` annotation on any item whose
+  severity was Critical.
+- **Specification Debt**: copy each item from the clarify return's
+  `debt_items` array, including its Impact level. The leading count MUST
+  match the number of bullets rendered.
+- **PR**: the `gh pr create` URL captured after the artifact write-out step.
+
+### Error Fallbacks
+
+Two edge cases change the output shape. Follow these rules rather than
+attempting to render the full format above:
+
+- **PR creation failure**: if `gh pr create` fails (network error, auth
+  failure, missing upstream, etc.), still render the `## Summary`,
+  `## Assumptions`, and `## Specification Debt` sections from the captured
+  run data, then replace the `## PR` section with:
+
+  ```markdown
+  ## PR
+
+  PR creation failed — artifacts are on disk at `<spec folder>`. Re-run `gh
+  pr create` manually, or retry the command. Error: <error message>.
+  ```
+
+  Never silently drop the PR section; the developer needs to see that PR
+  creation was attempted and failed.
+
+- **Bail-out**: if the run short-circuited because clarify returned
+  `bail_out: true`, no artifacts were written and there is no PR. Skip the
+  full format above and render only:
+
+  ```markdown
+  ## Bail-Out
+
+  The feature description has too much specification debt to produce a
+  meaningful artifact. No files were written and no PR was created.
+
+  ### Why
+
+  <clarify's bail_out_summary>
+
+  ### What's needed
+
+  <clarify's debt summary — the specific information required to proceed>
+  ```
+
+  Do not emit `## Summary`, `## Assumptions`, `## Specification Debt`, or
+  `## PR` in the bail-out case. The bail-out summary replaces the whole
+  block.


### PR DESCRIPTION
Introduces src/templates/agent-skills/snippets/one-shot-output.md — the
Story 3 Slice 1 foundation snippet that defines the standardized terminal
output contract (Summary → Assumptions → Specification Debt → PR) for
one-shot planning runs. Registers it in the snippets README and adds Tier 2
assertions that lock down the four required headers, the PR-failure and
bail-out fallbacks, and that the snippet is composable as a
{{>one-shot-output}} partial — so any regression (deleted file, renamed
file, dropped header, missing fallback) fails the test suite.

Addresses FR-016; Acceptance Scenario 3.6.

https://claude.ai/code/session_018tGJpF7P3W5UFuZ1yoF3tu