### PR TITLE
Add Claude Code session-title hook for /smithy.* commands

### DIFF
--- a/src/agents/claude.test.ts
+++ b/src/agents/claude.test.ts
@@ -2,7 +2,18 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { buildClaudeAllowList, buildClaudeDenyList, deploy, removeLegacy, writePermissions, resolveSettingsPath } from './claude.js';
+import {
+  buildClaudeAllowList,
+  buildClaudeDenyList,
+  deploy,
+  deploySessionTitleHookScript,
+  removeLegacy,
+  removeSessionTitleHook,
+  resolveSettingsPath,
+  SESSION_TITLE_HOOK_FILENAME,
+  writePermissions,
+  writeSessionTitleHook,
+} from './claude.js';
 import { getComposedTemplates, getTemplateFilesByCategory } from '../templates.js';
 import { writeManifest, readManifest, removeStaleFiles } from '../manifest.js';
 
@@ -639,5 +650,200 @@ describe('writePermissions', () => {
     expect(config.permissions.deny).toContain('Bash(git branch -D *)');
     // Custom key should be preserved
     expect(config.permissions.someCustomFlag).toBe(true);
+  });
+});
+
+describe('deploySessionTitleHookScript', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-claude-test-'));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('copies the hook script to .claude/hooks/ and makes it executable', () => {
+    const rel = deploySessionTitleHookScript(tmpDir);
+    const dest = path.join(tmpDir, rel);
+    expect(fs.existsSync(dest)).toBe(true);
+    expect(rel).toBe(path.join('.claude', 'hooks', SESSION_TITLE_HOOK_FILENAME));
+    const stat = fs.statSync(dest);
+    expect(stat.mode & 0o111).toBeGreaterThan(0);
+    // Script content must include the deriveTitle export so the hook actually works
+    const body = fs.readFileSync(dest, 'utf8');
+    expect(body).toContain('export function deriveTitle');
+  });
+
+  it('writes to homedir when location is "user"', () => {
+    const fakeHome = path.join(tmpDir, 'fakehome');
+    fs.mkdirSync(fakeHome, { recursive: true });
+    vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+
+    const rel = deploySessionTitleHookScript(tmpDir, 'user');
+    expect(fs.existsSync(path.join(fakeHome, rel))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'hooks'))).toBe(false);
+  });
+});
+
+describe('writeSessionTitleHook', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-claude-test-'));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates settings.json with a UserPromptSubmit hook entry', () => {
+    writeSessionTitleHook(tmpDir, 'repo');
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    expect(fs.existsSync(settingsPath)).toBe(true);
+
+    const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    const ups = config.hooks.UserPromptSubmit;
+    expect(Array.isArray(ups)).toBe(true);
+    expect(ups.length).toBe(1);
+    expect(ups[0].hooks[0].type).toBe('command');
+    expect(ups[0].hooks[0].command).toContain(SESSION_TITLE_HOOK_FILENAME);
+    expect(ups[0].hooks[0].command).toContain('$CLAUDE_PROJECT_DIR');
+  });
+
+  it('preserves existing permissions and unrelated keys', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    const settingsPath = path.join(claudeDir, 'settings.json');
+    fs.writeFileSync(settingsPath, JSON.stringify({
+      model: 'claude-sonnet-4-6',
+      permissions: { allow: ['Bash(echo)'], deny: [] },
+    }));
+
+    writeSessionTitleHook(tmpDir, 'repo');
+
+    const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    expect(config.model).toBe('claude-sonnet-4-6');
+    expect(config.permissions.allow).toContain('Bash(echo)');
+    expect(config.hooks.UserPromptSubmit).toBeDefined();
+  });
+
+  it('preserves unrelated UserPromptSubmit hooks from other tools', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    const settingsPath = path.join(claudeDir, 'settings.json');
+    fs.writeFileSync(settingsPath, JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: '/path/to/other-tool.sh' }] },
+        ],
+      },
+    }));
+
+    writeSessionTitleHook(tmpDir, 'repo');
+
+    const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    const ups = config.hooks.UserPromptSubmit;
+    expect(ups.length).toBe(2);
+    expect(ups[0].hooks[0].command).toBe('/path/to/other-tool.sh');
+    expect(ups[1].hooks[0].command).toContain(SESSION_TITLE_HOOK_FILENAME);
+  });
+
+  it('is idempotent — second call does not duplicate the entry', () => {
+    writeSessionTitleHook(tmpDir, 'repo');
+    writeSessionTitleHook(tmpDir, 'repo');
+
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    const ups = config.hooks.UserPromptSubmit;
+    const smithyEntries = ups.filter((e: { hooks?: { command?: string }[] }) =>
+      e.hooks?.some(h => h.command?.includes(SESSION_TITLE_HOOK_FILENAME)),
+    );
+    expect(smithyEntries.length).toBe(1);
+  });
+
+  it('handles malformed existing settings.json gracefully', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(path.join(claudeDir, 'settings.json'), 'not valid json{{{');
+
+    writeSessionTitleHook(tmpDir, 'repo');
+
+    const config = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf8'));
+    expect(config.hooks.UserPromptSubmit[0].hooks[0].command).toContain(SESSION_TITLE_HOOK_FILENAME);
+  });
+});
+
+describe('removeSessionTitleHook', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-claude-test-'));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('removes the smithy hook entry while leaving permissions intact', () => {
+    writePermissions(tmpDir, 'repo');
+    writeSessionTitleHook(tmpDir, 'repo');
+
+    removeSessionTitleHook(tmpDir, 'repo');
+
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    expect(config.permissions.allow).toContain('Bash(git status)');
+    expect(config.hooks).toBeUndefined();
+  });
+
+  it('preserves unrelated UserPromptSubmit hooks from other tools', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: '/path/to/other-tool.sh' }] },
+        ],
+      },
+    }));
+    writeSessionTitleHook(tmpDir, 'repo');
+
+    removeSessionTitleHook(tmpDir, 'repo');
+
+    const config = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf8'));
+    expect(config.hooks.UserPromptSubmit).toBeDefined();
+    expect(config.hooks.UserPromptSubmit.length).toBe(1);
+    expect(config.hooks.UserPromptSubmit[0].hooks[0].command).toBe('/path/to/other-tool.sh');
+  });
+
+  it('deletes settings.json when nothing else remains', () => {
+    writeSessionTitleHook(tmpDir, 'repo');
+    removeSessionTitleHook(tmpDir, 'repo');
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(false);
+  });
+
+  it('is a no-op when settings.json does not exist', () => {
+    expect(() => removeSessionTitleHook(tmpDir, 'repo')).not.toThrow();
+  });
+
+  it('is a no-op when there is no UserPromptSubmit section', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({
+      permissions: { allow: ['Bash(echo)'], deny: [] },
+    }));
+
+    removeSessionTitleHook(tmpDir, 'repo');
+
+    const config = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf8'));
+    expect(config.permissions.allow).toContain('Bash(echo)');
   });
 });

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -4,8 +4,16 @@ import path from 'path';
 import picocolors from 'picocolors';
 import { getComposedTemplates, getTemplateFilesByCategory, stripFrontmatter } from '../templates.js';
 import { flattenPermissions, claudeToolPermissions, denyPermissions, type LanguageToolchain } from '../permissions.js';
-import { removeIfExists } from '../utils.js';
+import { hooksTemplateDir, removeIfExists } from '../utils.js';
 import type { PermissionLevel, DeployablePermissionLevel, DeployLocation } from '../interactive.js';
+
+/** Filename of the deployed Claude Code session-title hook script. */
+export const SESSION_TITLE_HOOK_FILENAME = 'smithy-session-title.mjs';
+/** Relative deploy path under the Claude base directory. */
+export const SESSION_TITLE_HOOK_RELPATH = `.claude/hooks/${SESSION_TITLE_HOOK_FILENAME}`;
+/** The shell command registered in settings.json to invoke the hook. */
+export const SESSION_TITLE_HOOK_COMMAND =
+  `node "$CLAUDE_PROJECT_DIR/.claude/hooks/${SESSION_TITLE_HOOK_FILENAME}"`;
 
 /**
  * Deploy Claude templates. Returns the list of deployed file paths (relative to baseDir).
@@ -77,6 +85,21 @@ export async function deploy(targetDir: string, permissionLevel: PermissionLevel
   }
 
   return deployedFiles;
+}
+
+/**
+ * Copy the session-title hook script into `<baseDir>/.claude/hooks/` and return
+ * the relative path so the manifest can track it like any other artifact.
+ */
+export function deploySessionTitleHookScript(targetDir: string, location: DeployLocation = 'repo'): string {
+  const baseDir = location === 'user' ? os.homedir() : targetDir;
+  const hooksDir = path.join(baseDir, '.claude', 'hooks');
+  if (!fs.existsSync(hooksDir)) fs.mkdirSync(hooksDir, { recursive: true });
+  const src = path.join(hooksTemplateDir, SESSION_TITLE_HOOK_FILENAME);
+  const dest = path.join(hooksDir, SESSION_TITLE_HOOK_FILENAME);
+  fs.copyFileSync(src, dest);
+  fs.chmodSync(dest, 0o755);
+  return path.relative(baseDir, dest);
 }
 
 /**
@@ -167,4 +190,118 @@ export function writePermissions(targetDir: string, level: DeployablePermissionL
 
   fs.writeFileSync(settingsPath, JSON.stringify(config, null, 2));
   console.log(picocolors.blue(`  Added default permissions to ${settingsPath}`));
+}
+
+// ----- Session-title hook -----
+
+interface HookCommand {
+  type?: string;
+  command?: string;
+}
+
+interface HookEntry {
+  matcher?: string;
+  hooks?: HookCommand[];
+}
+
+interface SettingsWithHooks {
+  hooks?: Record<string, HookEntry[]>;
+  [key: string]: unknown;
+}
+
+/**
+ * Read settings.json (or return an empty object). Tolerant of malformed JSON —
+ * mirrors the behavior of `writePermissions`.
+ */
+function readSettings(settingsPath: string): SettingsWithHooks {
+  if (!fs.existsSync(settingsPath)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as SettingsWithHooks;
+  } catch {
+    return {};
+  }
+}
+
+function isSessionTitleHookCommand(cmd: HookCommand | undefined): boolean {
+  return !!cmd && typeof cmd.command === 'string' && cmd.command.includes(SESSION_TITLE_HOOK_FILENAME);
+}
+
+/**
+ * Merge the smithy session-title UserPromptSubmit hook into settings.json.
+ * Idempotent: a second call leaves the file unchanged.
+ */
+export function writeSessionTitleHook(targetDir: string, level: DeployablePermissionLevel): void {
+  const settingsPath = resolveSettingsPath(targetDir, level);
+  const settingsDir = path.dirname(settingsPath);
+  if (!fs.existsSync(settingsDir)) fs.mkdirSync(settingsDir, { recursive: true });
+
+  const settings = readSettings(settingsPath);
+  const hooks = (settings.hooks ?? {}) as Record<string, HookEntry[]>;
+  const ups = Array.isArray(hooks.UserPromptSubmit) ? hooks.UserPromptSubmit : [];
+
+  // Idempotent: bail if our hook command is already registered anywhere in UserPromptSubmit
+  const alreadyRegistered = ups.some(entry =>
+    Array.isArray(entry.hooks) && entry.hooks.some(isSessionTitleHookCommand),
+  );
+
+  if (!alreadyRegistered) {
+    ups.push({
+      hooks: [{ type: 'command', command: SESSION_TITLE_HOOK_COMMAND }],
+    });
+  }
+
+  const next: SettingsWithHooks = {
+    ...settings,
+    hooks: { ...hooks, UserPromptSubmit: ups },
+  };
+
+  fs.writeFileSync(settingsPath, JSON.stringify(next, null, 2));
+  if (!alreadyRegistered) {
+    console.log(picocolors.blue(`  Added session-title hook to ${settingsPath}`));
+  }
+}
+
+/**
+ * Remove the smithy session-title UserPromptSubmit hook entry from settings.json.
+ * Preserves any unrelated hooks. If settings.json ends up empty, deletes it.
+ */
+export function removeSessionTitleHook(targetDir: string, level: DeployablePermissionLevel): void {
+  const settingsPath = resolveSettingsPath(targetDir, level);
+  if (!fs.existsSync(settingsPath)) return;
+
+  const settings = readSettings(settingsPath);
+  const hooks = settings.hooks;
+  if (!hooks || !Array.isArray(hooks.UserPromptSubmit)) {
+    return;
+  }
+
+  const filteredEntries: HookEntry[] = [];
+  for (const entry of hooks.UserPromptSubmit) {
+    const cmds = Array.isArray(entry.hooks) ? entry.hooks.filter(c => !isSessionTitleHookCommand(c)) : [];
+    if (cmds.length > 0) {
+      filteredEntries.push({ ...entry, hooks: cmds });
+    }
+  }
+
+  const nextHooks: Record<string, HookEntry[]> = { ...hooks };
+  if (filteredEntries.length > 0) {
+    nextHooks.UserPromptSubmit = filteredEntries;
+  } else {
+    delete nextHooks.UserPromptSubmit;
+  }
+
+  const next: SettingsWithHooks = { ...settings };
+  if (Object.keys(nextHooks).length > 0) {
+    next.hooks = nextHooks;
+  } else {
+    delete next.hooks;
+  }
+
+  // If nothing is left, remove the settings file entirely.
+  if (Object.keys(next).length === 0) {
+    removeIfExists(settingsPath);
+    return;
+  }
+
+  fs.writeFileSync(settingsPath, JSON.stringify(next, null, 2));
 }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -87,13 +87,38 @@ describe('CLI init --yes (non-interactive)', () => {
   });
 
   it('skips permissions with --no-permissions', () => {
-    execFileSync('node', [CLI, 'init', '-a', 'claude', '--no-permissions', '-y'], {
+    // Also pass --no-session-titles so settings.json is not created at all.
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '--no-permissions', '--no-session-titles', '-y'], {
       encoding: 'utf-8',
       cwd: tmpDir,
     });
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'prompts'))).toBe(true);
-    // No permissions file when --no-permissions
+    // No settings file when both permissions and session-titles are disabled
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(false);
+  });
+
+  it('deploys session-title hook by default', () => {
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'hooks', 'smithy-session-title.mjs'))).toBe(true);
+    const config = JSON.parse(fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf8'));
+    expect(config.hooks.UserPromptSubmit[0].hooks[0].command).toContain('smithy-session-title.mjs');
+  });
+
+  it('skips session-title hook with --no-session-titles', () => {
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '--no-session-titles', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'hooks'))).toBe(false);
+    // settings.json may exist for permissions, but it must not contain our hook
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    if (fs.existsSync(settingsPath)) {
+      const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      expect(config.hooks).toBeUndefined();
+    }
   });
 
   it('rejects invalid agent names', () => {
@@ -187,6 +212,26 @@ describe('CLI uninit --yes (non-interactive)', () => {
 
     // settings.json should still exist after uninit
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(true);
+  });
+
+  it('removes the session-title hook script and its settings.json entry on uninit', () => {
+    // beforeEach already ran `init -y` which deploys the hook by default
+    const hookScript = path.join(tmpDir, '.claude', 'hooks', 'smithy-session-title.mjs');
+    expect(fs.existsSync(hookScript)).toBe(true);
+    const beforeConfig = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf8'),
+    );
+    expect(beforeConfig.hooks?.UserPromptSubmit).toBeDefined();
+
+    execFileSync('node', [CLI, 'uninit', '-y'], { encoding: 'utf-8', cwd: tmpDir });
+
+    expect(fs.existsSync(hookScript)).toBe(false);
+    // settings.json is preserved (still has permissions) but hook entry is gone
+    const afterConfig = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf8'),
+    );
+    expect(afterConfig.hooks).toBeUndefined();
+    expect(afterConfig.permissions).toBeDefined();
   });
 
   it('preserves user-created files in .claude/prompts/', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,7 @@ program
   .option('--no-permissions', 'Skip permissions setup')
   .option('--issue-templates', 'Install Smithy issue templates')
   .option('--no-issue-templates', 'Skip issue templates')
+  .option('--no-session-titles', 'Skip the Claude Code session-title hook')
   .option('--toolchains <list>', 'Comma-separated language toolchains to include in permissions (node,java,rust,python)')
   .option('-d, --target-dir <path>', 'Target directory')
   .option('-y, --yes', 'Accept defaults for unset options (non-interactive)')

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -28,6 +28,12 @@ export interface InitOptions {
   location?: DeployLocation;
   permissions?: boolean;
   issueTemplates?: boolean;
+  /**
+   * When true (default), deploys the Claude Code session-title UserPromptSubmit
+   * hook so `/smithy.<cmd>` invocations get a meaningful session title.
+   * Set to false (via `--no-session-titles`) to skip.
+   */
+  sessionTitles?: boolean;
   languages?: LanguageToolchain[] | undefined;
   targetDir?: string;
   yes?: boolean;
@@ -87,6 +93,9 @@ export async function initAction(opts: InitOptions = {}): Promise<void> {
     }
   }
 
+  // 5b. Session-title hook (Claude only). Default on; opt out via --no-session-titles.
+  const deploySessionTitles = opts.sessionTitles ?? true;
+
   // 6. Issue templates — y/n at the selected deploy location
   let deployIssueTemplates: boolean;
   if (opts.issueTemplates !== undefined) {
@@ -121,6 +130,11 @@ export async function initAction(opts: InitOptions = {}): Promise<void> {
       if (deployPermissions) {
         claude.writePermissions(targetDir, deployLocation, languages);
       }
+      if (deploySessionTitles) {
+        const hookRel = claude.deploySessionTitleHookScript(targetDir, deployLocation);
+        deployedFiles['claude'].push(hookRel);
+        claude.writeSessionTitleHook(targetDir, deployLocation);
+      }
     } else if (a === 'codex') {
       deployedFiles['codex'] = await codex.deploy(targetDir, deployPermissions && deployLocation === 'repo');
     }
@@ -140,6 +154,7 @@ export async function initAction(opts: InitOptions = {}): Promise<void> {
     agents: [...agentsToSetup],
     permissions: deployPermissions,
     issueTemplates: deployIssueTemplates,
+    sessionTitles: deploySessionTitles,
     languages,
     files: deployedFiles,
   });

--- a/src/commands/uninit.ts
+++ b/src/commands/uninit.ts
@@ -74,6 +74,13 @@ export async function uninitAction(opts: UninitOptions = {}): Promise<void> {
   // Step 1: Remove manifest-tracked files for each selected location
   for (const { location, hasManifest } of targets) {
     if (hasManifest) {
+      // If a session-title hook was deployed, strip its entry from settings.json
+      // before removing the manifest. The hook script file itself is removed by
+      // removeManifestFiles since it's tracked in `files['claude']`.
+      const manifest = location === 'repo' ? repoManifest : userManifest;
+      if (manifest?.sessionTitles) {
+        claude.removeSessionTitleHook(targetDir, location);
+      }
       removedCount += removeManifestFiles(targetDir, location);
     }
   }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -86,6 +86,7 @@ async function redeployFromManifest(
     location: manifest.deployLocation,
     permissions: manifest.permissions,
     issueTemplates: manifest.issueTemplates,
+    sessionTitles: manifest.sessionTitles ?? true,
     languages: validatedLanguages(manifest.languages),
     targetDir,
     yes: true,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -17,6 +17,8 @@ export interface SmithyManifest {
   agents: string[];
   permissions: boolean;
   issueTemplates: boolean;
+  /** Whether the Claude Code session-title UserPromptSubmit hook was deployed. */
+  sessionTitles?: boolean;
   languages?: string[] | undefined;
   files: Record<string, string[]>;  // agent name → relative file paths
 }
@@ -91,6 +93,7 @@ export interface WriteManifestOptions {
   agents: string[];
   permissions: boolean;
   issueTemplates: boolean;
+  sessionTitles?: boolean;
   languages?: string[] | undefined;
   files: Record<string, string[]>;
 }
@@ -109,6 +112,7 @@ export function writeManifest(opts: WriteManifestOptions): void {
     agents: opts.agents,
     permissions: opts.permissions,
     issueTemplates: opts.issueTemplates,
+    ...(opts.sessionTitles !== undefined ? { sessionTitles: opts.sessionTitles } : {}),
     ...(opts.languages !== undefined ? { languages: opts.languages } : {}),
     files: opts.files,
   };

--- a/src/session-title-hook.test.ts
+++ b/src/session-title-hook.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error - .mjs import has no type declarations
+import { deriveTitle } from './templates/hooks/smithy-session-title.mjs';
+
+describe('deriveTitle', () => {
+  it('derives "Evals cut 03" from a smithy.cut spec-folder + story number', () => {
+    expect(deriveTitle('/smithy.cut specs/2026-03-14-001-evals 3')).toBe('Evals cut 03');
+  });
+
+  it('derives "Runner forge 03 02" from a smithy.forge tasks-file path + slice number', () => {
+    expect(
+      deriveTitle('/smithy.forge specs/2026-03-14-001-evals/03-runner.tasks.md 2'),
+    ).toBe('Runner forge 03 02');
+  });
+
+  it('derives "Add strike" from a smithy.strike with a quoted feature description', () => {
+    expect(deriveTitle('/smithy.strike "add verbose flag"')).toBe('Add strike');
+  });
+
+  it('falls back to "Smithy <cmd>" when there are no arguments', () => {
+    expect(deriveTitle('/smithy.orders')).toBe('Smithy orders');
+  });
+
+  it('returns null for non-smithy prompts', () => {
+    expect(deriveTitle('not a smithy command')).toBeNull();
+    expect(deriveTitle('/some-other-command run')).toBeNull();
+    expect(deriveTitle('')).toBeNull();
+  });
+
+  it('returns null for non-string input', () => {
+    expect(deriveTitle(undefined)).toBeNull();
+    expect(deriveTitle(null)).toBeNull();
+    expect(deriveTitle(42)).toBeNull();
+  });
+
+  it('handles a strike file path', () => {
+    expect(deriveTitle('/smithy.forge feature.strike.md')).toBe('Feature forge');
+  });
+
+  it('handles a bare slug + cut story number', () => {
+    expect(deriveTitle('/smithy.cut foo 7')).toBe('Foo cut 07');
+  });
+
+  it('handles a bare slice number for forge with no path', () => {
+    // No slug recoverable, falls back to Smithy; sliceNum is the trailing 2.
+    expect(deriveTitle('/smithy.forge 2')).toBe('Smithy forge 02');
+  });
+
+  it('uses branch fallback when no slug is in the prompt', () => {
+    expect(deriveTitle('/smithy.audit', { branch: 'feature/evals-runner' })).toBe(
+      'Runner audit',
+    );
+  });
+
+  it('zero-pads single-digit story numbers', () => {
+    expect(deriveTitle('/smithy.cut specs/2026-03-14-001-evals 1')).toBe('Evals cut 01');
+  });
+
+  it('handles two-digit story and slice numbers', () => {
+    expect(
+      deriveTitle('/smithy.forge specs/2026-03-14-001-evals/12-runner.tasks.md 11'),
+    ).toBe('Runner forge 12 11');
+  });
+
+  it('is case-insensitive on the smithy prefix', () => {
+    expect(deriveTitle('/SMITHY.cut specs/2026-03-14-001-evals 3')).toBe('Evals cut 03');
+  });
+
+  it('only takes the first dash-segment of the slug for the display', () => {
+    expect(
+      deriveTitle('/smithy.cut specs/2026-03-14-001-evals-framework 3'),
+    ).toBe('Evals cut 03');
+  });
+
+  it('does not extract a sliceNum for non-forge commands', () => {
+    // smithy.strike with a trailing number — the number should NOT become a
+    // story or slice ID (only cut consumes trailing ints, only forge keeps
+    // them as slice IDs). The slug fallback treats "build" as the first word.
+    expect(deriveTitle('/smithy.strike build 5')).toBe('Build strike');
+  });
+});

--- a/src/templates/hooks/smithy-session-title.mjs
+++ b/src/templates/hooks/smithy-session-title.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// Smithy session-title hook for Claude Code.
+//
+// Wired into .claude/settings.json as a UserPromptSubmit hook by `smithy init`.
+// On every user prompt that starts with `/smithy.<cmd>`, derive a short session
+// title (slug + command + IDs) and emit it as `sessionTitle`. For non-smithy
+// prompts, exits silently. Any error path also exits silently so this hook
+// never blocks a user prompt.
+
+import { pathToFileURL } from 'node:url';
+
+const SMITHY_PREFIX = /^\/smithy\.([a-z][a-z0-9-]*)\b/i;
+
+function capitalize(s) {
+  if (!s) return '';
+  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+}
+
+function pad2(n) {
+  const s = String(n);
+  return s.length === 1 ? '0' + s : s;
+}
+
+// Try to extract slug + numeric IDs from the argument string of a smithy command.
+function parseArgs(cmd, rest) {
+  let slug;
+  let storyNum;
+  let sliceNum;
+
+  // Tasks file pattern: <NN>-<slug>.tasks.md (anywhere in path)
+  const tasksMatch = rest.match(/(?:^|[\s/])(\d{1,3})-([a-z0-9][a-z0-9-]*)\.tasks\.md\b/i);
+  if (tasksMatch) {
+    storyNum = pad2(parseInt(tasksMatch[1], 10));
+    slug = tasksMatch[2];
+  }
+
+  // Strike file pattern: <slug>.strike.md
+  if (!slug) {
+    const strikeMatch = rest.match(/(?:^|[\s/])([a-z0-9][a-z0-9-]*)\.strike\.md\b/i);
+    if (strikeMatch) {
+      slug = strikeMatch[1];
+    }
+  }
+
+  // Spec folder pattern: specs/<YYYY>-<MM>-<DD>-<NNN>-<slug>
+  if (!slug) {
+    const specMatch = rest.match(/specs?\/\d{4}-\d{2}-\d{2}-\d{3}-([a-z0-9][a-z0-9-]*)/i);
+    if (specMatch) {
+      slug = specMatch[1];
+    }
+  }
+
+  // Quoted-string fallback: first quoted run, take its first word
+  if (!slug) {
+    const quoted = rest.match(/["']([^"']+)["']/);
+    if (quoted) {
+      const firstQuotedWord = quoted[1].trim().split(/\s+/)[0];
+      if (firstQuotedWord) slug = firstQuotedWord;
+    }
+  }
+
+  // First non-flag, non-numeric token fallback
+  if (!slug) {
+    const firstWord = rest.trim().split(/\s+/)[0];
+    if (firstWord && !firstWord.startsWith('-') && /[a-z]/i.test(firstWord)) {
+      const last = firstWord.split('/').filter(Boolean).pop() || firstWord;
+      slug = last.replace(/\.[^.]+$/, '').replace(/^\d+-/, '');
+    }
+  }
+
+  // Trailing bare integer: slice number for forge, story number for cut
+  const trailingInt = rest.match(/(?:^|\s)(\d{1,3})\s*$/);
+  if (trailingInt) {
+    const n = pad2(parseInt(trailingInt[1], 10));
+    if (cmd === 'forge') {
+      sliceNum = n;
+    } else if (cmd === 'cut' && !storyNum) {
+      storyNum = n;
+    }
+  }
+
+  return { slug, storyNum, sliceNum };
+}
+
+/**
+ * Derive a Claude Code session title from a user prompt.
+ * Returns null if the prompt is not a `/smithy.<cmd>` invocation.
+ *
+ * @param {string} prompt
+ * @param {{ branch?: string }} [options]
+ * @returns {string | null}
+ */
+export function deriveTitle(prompt, options = {}) {
+  if (typeof prompt !== 'string') return null;
+  const trimmed = prompt.trim();
+  const match = trimmed.match(SMITHY_PREFIX);
+  if (!match) return null;
+
+  const cmd = match[1].toLowerCase();
+  const rest = trimmed.slice(match[0].length).trim();
+
+  const { slug, storyNum, sliceNum } = parseArgs(cmd, rest);
+
+  // Build the display slug: take the first dash/space-separated segment, capitalize.
+  let display = '';
+  if (slug) {
+    display = capitalize(slug.split(/[-\s]/)[0]);
+  }
+  if (!display && options.branch) {
+    const branchTail = options.branch.split(/[/_-]/).pop() || '';
+    display = capitalize(branchTail);
+  }
+  if (!display) {
+    display = 'Smithy';
+  }
+
+  const numbers = [storyNum, sliceNum].filter(Boolean).join(' ');
+  return [display, cmd, numbers].filter(Boolean).join(' ');
+}
+
+// --- main: read stdin JSON, emit sessionTitle if applicable ---
+async function main() {
+  let raw = '';
+  try {
+    for await (const chunk of process.stdin) {
+      raw += chunk;
+    }
+    if (!raw.trim()) return;
+    const data = JSON.parse(raw);
+    const title = deriveTitle(data.prompt);
+    if (!title) return;
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'UserPromptSubmit',
+        sessionTitle: title,
+      },
+    }));
+  } catch {
+    // Silent — never block a user prompt.
+  }
+}
+
+// Run main only when executed directly (not when imported by tests).
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  await main();
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,7 @@ export const promptsTemplateDir = path.join(agentSkillsDir, 'prompts');
 export const agentsTemplateDir = path.join(agentSkillsDir, 'agents');
 export const snippetsTemplateDir = path.join(agentSkillsDir, 'snippets');
 export const skillsTemplateDir = path.join(agentSkillsDir, 'skills');
+export const hooksTemplateDir = path.join(templatesBaseDir, 'hooks');
 export const issueTemplatesSrcDir = path.join(templatesBaseDir, 'issues');
 
 /**


### PR DESCRIPTION
Smithy slash commands now hint a meaningful Claude Code session title via
a UserPromptSubmit hook. `smithy init` deploys the hook script to
.claude/hooks/smithy-session-title.mjs and registers it in settings.json
by default; pass --no-session-titles to opt out. uninit cleans both the
script and the hook entry while preserving permissions.

The hook derives titles like "Evals cut 03" or "Runner forge 03 02" from
the smithy command + its arguments (spec folder slug, tasks file slug,
strike file slug, or quoted feature description) plus story/slice IDs.