### PR TITLE
mark: remove STOP gates and create PR in one-shot mode (Slice 3 T1)

### DIFF
--- a/specs/2026-04-08-003-reduce-interaction-friction/03-one-shot-planning-workflows.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/03-one-shot-planning-workflows.tasks.md
@@ -162,7 +162,7 @@ non-interactive sub-agents.
 
 ### Tasks
 
-- [ ] **Remove mark's intermediate STOP gates and add PR creation**
+- [x] **Remove mark's intermediate STOP gates and add PR creation**
 
   In `src/templates/agent-skills/commands/smithy.mark.prompt`, delete the
   Phase 6 "Review & approve" STOP and the Phase 0c refinement STOP. After

--- a/specs/2026-04-08-003-reduce-interaction-friction/03-one-shot-planning-workflows.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/03-one-shot-planning-workflows.tasks.md
@@ -180,7 +180,7 @@ non-interactive sub-agents.
   - Phase 0 review loop ends by committing refinements, creating a PR, and
     rendering one-shot output
 
-- [ ] **Remove cut's intermediate STOP gates and add PR creation**
+- [x] **Remove cut's intermediate STOP gates and add PR creation**
 
   In `src/templates/agent-skills/commands/smithy.cut.prompt`, delete the
   Phase 5 "Review tasks" STOP and the Phase 0c refinement STOP. Add a PR

--- a/specs/2026-04-08-003-reduce-interaction-friction/03-one-shot-planning-workflows.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/03-one-shot-planning-workflows.tasks.md
@@ -197,7 +197,7 @@ non-interactive sub-agents.
   - Existing bail-out behavior from Story 2 is preserved (clarify bail-out
     still short-circuits before PR creation)
 
-- [ ] **Assert mark and cut render the one-shot output contract**
+- [x] **Assert mark and cut render the one-shot output contract**
 
   Add Tier 2 assertions in `src/templates.test.ts` verifying that the
   composed `smithy.mark.md` and `smithy.cut.md` templates contain the

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -405,6 +405,99 @@ describe('getComposedTemplates', () => {
     expect(refine).toContain('summary');
   });
 
+  // Story 3 Slice 3: mark and cut must render the shared one-shot output
+  // snippet as their terminal contract, reference the forge `gh pr create`
+  // pattern after artifact write-out, and carry no STOP-gate language from
+  // the removed intermediate approval stops.
+
+  it('mark template resolves the one-shot-output partial', () => {
+    const mark = composed.commands.get('smithy.mark.md')!;
+    expect(mark).toBeDefined();
+    // Unresolved partial references must not leak through composition.
+    expect(mark).not.toContain('{{>one-shot-output}}');
+    // The snippet's H2 title is unique — if present, the partial resolved.
+    expect(mark).toContain('## One-Shot Output');
+  });
+
+  it('mark template contains all four one-shot output section headers', () => {
+    const mark = composed.commands.get('smithy.mark.md')!;
+    expect(mark).toContain('## Summary');
+    expect(mark).toContain('## Assumptions');
+    expect(mark).toContain('## Specification Debt');
+    expect(mark).toContain('## PR');
+  });
+
+  it('mark template references PR creation after artifact write in Phase 6', () => {
+    const mark = composed.commands.get('smithy.mark.md')!;
+    expect(mark).toContain('gh pr create');
+    // Scope to Phase 6 so we measure the write → PR ordering inside the
+    // Write & PR phase, not across the file (Phase 0c also references
+    // `gh pr create` for the refinement-diff PR path).
+    const phase6Idx = mark.indexOf('## Phase 6:');
+    expect(phase6Idx).toBeGreaterThan(-1);
+    const phase6 =
+      mark.slice(phase6Idx, mark.indexOf('## Phase 0:', phase6Idx));
+    const writeIdx = phase6.indexOf('Create the spec folder and write');
+    const prIdx = phase6.indexOf('gh pr create');
+    expect(writeIdx).toBeGreaterThan(-1);
+    expect(prIdx).toBeGreaterThan(writeIdx);
+  });
+
+  it('mark template contains no intermediate STOP-gate language', () => {
+    const mark = composed.commands.get('smithy.mark.md')!;
+    // Intermediate approval STOPs must be gone. The Phase 2 clarify bail-out
+    // path (`Stop and wait for the user to provide expanded information`)
+    // is intentional and preserved from Story 2 — it only runs when clarify
+    // returns `bail_out: true` and the pipeline short-circuits before any
+    // files are written.
+    expect(mark).not.toMatch(/STOP and ask/i);
+    expect(mark).not.toMatch(/STOP after/i);
+  });
+
+  it('cut template resolves the one-shot-output partial', () => {
+    const cut = composed.commands.get('smithy.cut.md')!;
+    expect(cut).toBeDefined();
+    expect(cut).not.toContain('{{>one-shot-output}}');
+    expect(cut).toContain('## One-Shot Output');
+  });
+
+  it('cut template contains all four one-shot output section headers', () => {
+    const cut = composed.commands.get('smithy.cut.md')!;
+    expect(cut).toContain('## Summary');
+    expect(cut).toContain('## Assumptions');
+    expect(cut).toContain('## Specification Debt');
+    expect(cut).toContain('## PR');
+  });
+
+  it('cut template references PR creation after artifact write in Phase 5', () => {
+    const cut = composed.commands.get('smithy.cut.md')!;
+    expect(cut).toContain('gh pr create');
+    // Scope to Phase 5 so we measure the write → PR ordering inside the
+    // Write & PR phase, not across the file (Phase 0c is earlier in the
+    // file and also references `gh pr create` for the refinement-diff PR
+    // path).
+    const phase5Idx = cut.indexOf('## Phase 5:');
+    expect(phase5Idx).toBeGreaterThan(-1);
+    const phase5 = cut.slice(phase5Idx);
+    const writeIdx = phase5.indexOf(
+      'Write the file to `specs/<folder>/<NN>-<story-slug>.tasks.md`',
+    );
+    const prIdx = phase5.indexOf('gh pr create');
+    expect(writeIdx).toBeGreaterThan(-1);
+    expect(prIdx).toBeGreaterThan(writeIdx);
+  });
+
+  it('cut template contains no intermediate STOP-gate language', () => {
+    const cut = composed.commands.get('smithy.cut.md')!;
+    // Intermediate approval STOPs must be gone. The Phase 3 clarify bail-out
+    // path (`Stop and wait for the user to provide expanded information`)
+    // is intentional and preserved from Story 2 — it only runs when clarify
+    // returns `bail_out: true` and the pipeline short-circuits before the
+    // tasks file is written.
+    expect(cut).not.toMatch(/STOP and ask/i);
+    expect(cut).not.toMatch(/STOP after/i);
+  });
+
   it('mark template contains ## Specification Debt between ## Assumptions and ## Out of Scope', () => {
     const mark = composed.commands.get('smithy.mark.md')!;
     expect(mark).toBeDefined();

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -980,8 +980,17 @@ describe('getComposedTemplates', () => {
     // fallback.
     expect(cut).not.toContain('## Story Dependency Order');
 
-    const cutMarkdownMatch = cut.match(/```markdown\r?\n([\s\S]*?)\r?\n```/);
-    expect(cutMarkdownMatch).not.toBeNull();
+    // Cut contains more than one ```markdown fence now: Phase 0c and Phase 5
+    // render the shared one-shot-output snippet, which itself embeds a
+    // markdown fence. Pick the fence that actually defines the tasks file
+    // structure — i.e. the one containing `## Dependency Order`.
+    const cutMarkdownBlocks = [
+      ...cut.matchAll(/```markdown\r?\n([\s\S]*?)\r?\n```/g),
+    ];
+    const cutMarkdownMatch = cutMarkdownBlocks.find((m) =>
+      m[1]!.includes('## Dependency Order'),
+    );
+    expect(cutMarkdownMatch).toBeDefined();
     const cutMarkdownBlock = cutMarkdownMatch![1]!;
     expect(cutMarkdownBlock).not.toContain('## Story Dependency Order');
     expect(cutMarkdownBlock).toContain('## Dependency Order');

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -507,6 +507,14 @@ have a tasks file yet".
 One-shot mode: do **not** stop to ask the user to review or approve the tasks
 file. The file is on disk and the PR is the review surface.
 
+**Branch check**: before committing, verify the current branch is NOT the
+repository's default branch. Discover the default branch dynamically (e.g.
+`git symbolic-ref refs/remotes/origin/HEAD`) rather than assuming `main`.
+If HEAD is on the default branch, stop with an error telling the user to
+re-run cut from the spec folder's feature branch (the one `smithy.mark`
+created) — pushing planning commits to the default branch and calling
+`gh pr create` with `head == base` will fail and pollute history.
+
 1. Stage and commit both the new `.tasks.md` file and the spec's
    `## Dependency Order` write-back on the current branch.
 2. Push the branch to `origin`.

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -62,6 +62,14 @@ One-shot mode: do **not** stop to ask the user to review or approve the
 refinements. The refinement diff is the review surface and the one-shot PR
 below is how the user sees it.
 
+**No-op check**: if refine returned an empty `refinements` list and no new
+`debt_items`, and `git status --porcelain` reports a clean worktree, this
+pass had nothing to change. Skip the commit, push, and PR-creation steps
+below. Render the one-shot output snippet with an explicit "no-op" note in
+`## Summary` ("Artifacts produced: 0 files — refine found no changes") and
+reuse the branch's existing PR URL if one exists (fall back to "No PR —
+nothing to change" otherwise). Do not fail with "nothing to commit".
+
 1. Stage and commit the refinement diff on the current branch. The commit
    message should describe the refinements applied (e.g.,
    `cut refine: split Slice 2; resolve SD-001`).

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -66,12 +66,17 @@ below is how the user sees it.
    message should describe the refinements applied (e.g.,
    `cut refine: split Slice 2; resolve SD-001`).
 2. Push the branch to `origin`.
-3. Create a pull request using the same `gh pr create` pattern that
-   `smithy.forge` uses:
-   - **Title**: `Refine <user story title> tasks` — under 70 characters.
-   - **Body**: the refine summary, a list of refinements applied, and any
-     debt items resolved or introduced by this pass.
-4. Capture the resulting PR URL for the one-shot output snippet.
+3. Check whether the current branch already has an open pull request (for
+   example with `gh pr view --json url` or by querying by head branch).
+   - If a PR already exists for this branch, capture and reuse that PR URL
+     for the one-shot output snippet — do **not** run `gh pr create`
+     again, and do **not** treat the existing PR as a failure.
+   - If no PR exists, create one using the same `gh pr create` pattern
+     that `smithy.forge` uses:
+     - **Title**: `Refine <user story title> tasks` — under 70 characters.
+     - **Body**: the refine summary, a list of refinements applied, and any
+       debt items resolved or introduced by this pass.
+4. Capture the resulting or existing PR URL for the one-shot output snippet.
 
 If `gh pr create` fails, fall through to the PR-creation-failure branch of
 the one-shot output snippet so the user sees exactly what changed and what

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -55,9 +55,34 @@ Use the **smithy-refine** sub-agent. Pass it:
 ### 0c. Apply Refinements
 
 After the sub-agent returns its summary, update the existing tasks file on disk
-to incorporate the refinements. Present a summary of what changed — do not dump
-the full file contents into the terminal. **STOP and ask** the user to review
-the updated file at its path and let you know if further changes are needed.
+to incorporate the refinements. Do not dump the full file contents into the
+terminal.
+
+One-shot mode: do **not** stop to ask the user to review or approve the
+refinements. The refinement diff is the review surface and the one-shot PR
+below is how the user sees it.
+
+1. Stage and commit the refinement diff on the current branch. The commit
+   message should describe the refinements applied (e.g.,
+   `cut refine: split Slice 2; resolve SD-001`).
+2. Push the branch to `origin`.
+3. Create a pull request using the same `gh pr create` pattern that
+   `smithy.forge` uses:
+   - **Title**: `Refine <user story title> tasks` — under 70 characters.
+   - **Body**: the refine summary, a list of refinements applied, and any
+     debt items resolved or introduced by this pass.
+4. Capture the resulting PR URL for the one-shot output snippet.
+
+If `gh pr create` fails, fall through to the PR-creation-failure branch of
+the one-shot output snippet so the user sees exactly what changed and what
+went wrong.
+
+Render the shared one-shot output snippet as the terminal output, populating
+Summary (the refined tasks file and its slice count), Assumptions (from
+refine's findings), Specification Debt (from refine's `debt_items`, including
+inherited debt carried forward from the spec), and PR (the captured URL).
+
+{{>one-shot-output}}
 
 **Resolving specification debt**: When the refine sub-agent identifies debt
 items that can now be resolved based on new information or user answers,
@@ -415,7 +440,7 @@ existing code to find the right implementation pattern.
 
 ---
 
-## Phase 5: Write & Review
+## Phase 5: Write & PR
 
 Write the file to `specs/<folder>/<NN>-<story-slug>.tasks.md` (where `<NN>` is
 the zero-padded user story number).
@@ -466,21 +491,44 @@ Write-back procedure:
 The `Artifact` cell is the single source of truth for "does this user story
 have a tasks file yet".
 
-Then present a summary to the user:
+### Commit and create the PR
 
-1. Show a summary:
-   - Number of slices with their titles.
-   - Which FRs and acceptance scenarios each slice addresses.
-   - The recommended implementation order.
-   - Estimated complexity per slice (small / medium / large).
-2. Highlight any risks, open questions, or tradeoffs in the slicing.
-3. **Do NOT dump the full file contents into the terminal.** The file is on
-   disk — the user can review it in their editor.
-4. **STOP and ask**: "Review the tasks at `<path>` and let me know if you'd
-   like changes, or approve to finalize."
+One-shot mode: do **not** stop to ask the user to review or approve the tasks
+file. The file is on disk and the PR is the review surface.
 
-If the user requests changes, incorporate them, update the file on disk, and
-ask again.
+1. Stage and commit both the new `.tasks.md` file and the spec's
+   `## Dependency Order` write-back on the current branch.
+2. Push the branch to `origin`.
+3. Create a pull request using the same `gh pr create` pattern that
+   `smithy.forge` uses:
+   - **Title**: the user story title, under 70 characters, plain descriptive
+     text (no FR numbers, no bracketed tags).
+   - **Body**: a short summary with the tasks file path, the slice count and
+     titles, the FRs and acceptance scenarios each slice addresses, the
+     recommended implementation order, any tradeoffs noted, and a one-line
+     pointer to `smithy.forge` as the next step.
+4. Capture the resulting PR URL for the one-shot output snippet.
+
+If `gh pr create` fails (network error, auth failure, missing upstream,
+etc.), do **not** roll back the written files — they stay on disk. Fall
+through to the PR-creation-failure branch of the one-shot output snippet
+below so the user sees exactly what was produced and what went wrong.
+
+The bail-out behavior from Phase 3 is preserved: if clarify returned
+`bail_out: true`, the pipeline short-circuits before writing the tasks file
+and before this commit-and-PR step. The one-shot output snippet renders its
+Bail-Out branch instead of the full contract.
+
+### Render the one-shot output contract
+
+Render the shared one-shot output snippet as the terminal output for this
+run. Populate every placeholder from captured run data — the tasks file
+path, the branch name, the slice count, the full `assumptions` and
+`debt_items` arrays returned by clarify (including debt inherited from the
+spec), and the PR URL from the previous step. Do NOT dump the full file
+contents into the terminal; the snippet is the contract.
+
+{{>one-shot-output}}
 
 ---
 

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -82,10 +82,16 @@ If `gh pr create` fails, fall through to the PR-creation-failure branch of
 the one-shot output snippet so the user sees exactly what changed and what
 went wrong.
 
-Render the shared one-shot output snippet as the terminal output, populating
-Summary (the refined tasks file and its slice count), Assumptions (from
-refine's findings), Specification Debt (from refine's `debt_items`, including
-inherited debt carried forward from the spec), and PR (the captured URL).
+Render the shared one-shot output snippet as the terminal output, mapping
+refine-run data onto the snippet's canonical sections: in `## Summary`, use
+the spec folder for `<path>`, the current branch for `<branch>`, and list
+the refined tasks file (plus any spec write-back) under "Artifacts
+produced". Follow the snippet's relabeling guidance to report the slice
+count in place of the default "User stories" bullet. Populate Assumptions
+(from refine's findings), Specification Debt (from refine's `debt_items`,
+including inherited debt carried forward from the spec), and PR (the
+captured URL). Do not invent new placeholders or reinterpret existing
+ones.
 
 {{>one-shot-output}}
 
@@ -527,11 +533,17 @@ Bail-Out branch instead of the full contract.
 ### Render the one-shot output contract
 
 Render the shared one-shot output snippet as the terminal output for this
-run. Populate every placeholder from captured run data — the tasks file
-path, the branch name, the slice count, the full `assumptions` and
-`debt_items` arrays returned by clarify (including debt inherited from the
-spec), and the PR URL from the previous step. Do NOT dump the full file
-contents into the terminal; the snippet is the contract.
+run. Map captured run data onto the snippet's canonical sections: in
+`## Summary`, use the spec folder for `<path>`, the current branch name
+for `<branch>`, and list the tasks file (plus the spec write-back) under
+"Artifacts produced". Follow the snippet's relabeling guidance to report
+the slice count in place of the default "User stories" bullet. Populate
+Assumptions and Specification Debt from the full `assumptions` and
+`debt_items` arrays returned by clarify (including debt inherited from
+the spec), and substitute the PR URL from the previous step into the
+`## PR` section. Do not invent new placeholders or reinterpret existing
+ones. Do NOT dump the full file contents into the terminal; the snippet
+is the contract.
 
 {{>one-shot-output}}
 

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -565,12 +565,17 @@ below is how the user sees it.
    applied (e.g., `mark refine: resolve SD-003; add US4 priority
    justification`).
 2. Push the branch to `origin`.
-3. Create a pull request using the same `gh pr create` pattern that
-   `smithy.forge` uses:
-   - **Title**: `Refine <feature title>` — under 70 characters, plain text.
-   - **Body**: the refine summary, a list of refinements applied, and any
-     debt items resolved or introduced by this pass.
-4. Capture the resulting PR URL for the one-shot output snippet.
+3. Check whether the current branch already has an open pull request (for
+   example with `gh pr view --json url` or by querying by head branch).
+   - If a PR already exists for this branch, capture and reuse that PR URL
+     for the one-shot output snippet — do **not** run `gh pr create`
+     again, and do **not** treat the existing PR as a failure.
+   - If no PR exists, create one using the same `gh pr create` pattern
+     that `smithy.forge` uses:
+     - **Title**: `Refine <feature title>` — under 70 characters, plain text.
+     - **Body**: the refine summary, a list of refinements applied, and any
+       debt items resolved or introduced by this pass.
+4. Capture the resulting or existing PR URL for the one-shot output snippet.
 
 If `gh pr create` fails, fall through to the PR-creation-failure branch of
 the one-shot output snippet so the user sees exactly what changed and what

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -434,7 +434,7 @@ Existing contracts remain unchanged.
 
 ---
 
-## Phase 6: Write & Review
+## Phase 6: Write & PR
 
 Create the spec folder and write all three files to disk first.
 
@@ -484,21 +484,40 @@ Write-back procedure:
 The `Artifact` cell is the single source of truth for "does this feature
 have a spec yet".
 
-Then present a summary to the user:
+### Commit and create the PR
 
-1. Show a summary of what was produced:
-   - Spec folder path and branch name.
-   - Number of user stories with their titles and priorities.
-   - Key entities from the data model (if any).
-   - Contracts/interfaces identified (if any).
-2. Highlight any remaining risks or open questions.
-3. **Do NOT dump the full file contents into the terminal.** The files are on
-   disk — the user can review them in their editor.
-4. **STOP and ask**: "Review the files at `<path>` and let me know if you'd like
-   changes, or approve to finalize."
+One-shot mode: do **not** stop to ask the user to review or approve the
+artifacts. The files are on disk and the PR is the review surface.
 
-If the user requests changes, incorporate them, update the files on disk, and
-ask again.
+1. Stage and commit all written files on the current branch:
+   - the three spec artifacts in the new spec folder
+   - the updated `.features.md` (if this run performed a feature-map
+     write-back)
+2. Push the branch to `origin`.
+3. Create a pull request using the same `gh pr create` pattern that
+   `smithy.forge` uses:
+   - **Title**: the feature title, under 70 characters, plain descriptive text
+     (no FR numbers, no bracketed tags).
+   - **Body**: a short summary with the spec folder path, the user story list
+     with priorities, key entities (if any), contracts/interfaces identified
+     (if any), and a one-line pointer to `smithy.cut` as the next step.
+4. Capture the resulting PR URL for the one-shot output snippet.
+
+If `gh pr create` fails (network error, auth failure, missing upstream,
+etc.), do **not** roll back the written files — they stay on disk. Fall
+through to the PR-creation-failure branch of the one-shot output snippet
+below so the user sees exactly what was produced and what went wrong.
+
+### Render the one-shot output contract
+
+Render the shared one-shot output snippet as the terminal output for this
+run. Populate every placeholder from captured run data — the spec folder
+path, the branch name, the artifact list, the user story / FR counts, the
+full `assumptions` and `debt_items` arrays returned by clarify, and the PR
+URL from the previous step. Do NOT dump the full file contents into the
+terminal; the snippet is the contract.
+
+{{>one-shot-output}}
 
 ---
 
@@ -534,10 +553,35 @@ Use the **smithy-refine** sub-agent. Pass it:
 ### 0c. Apply Refinements
 
 After the sub-agent returns its summary, update the existing spec, data-model,
-and/or contracts files on disk to incorporate the refinements. Present a summary
-of what changed — do not dump the full file contents into the terminal. **STOP
-and ask** the user to review the updated files at their paths and let you know
-if further changes are needed.
+and/or contracts files on disk to incorporate the refinements. Do not dump the
+full file contents into the terminal.
+
+One-shot mode: do **not** stop to ask the user to review or approve the
+refinements. The refinement diff is the review surface, and the one-shot PR
+below is how the user sees it.
+
+1. Stage and commit the refinement diff on the current branch (the spec
+   folder's branch). The commit message should describe the refinements
+   applied (e.g., `mark refine: resolve SD-003; add US4 priority
+   justification`).
+2. Push the branch to `origin`.
+3. Create a pull request using the same `gh pr create` pattern that
+   `smithy.forge` uses:
+   - **Title**: `Refine <feature title>` — under 70 characters, plain text.
+   - **Body**: the refine summary, a list of refinements applied, and any
+     debt items resolved or introduced by this pass.
+4. Capture the resulting PR URL for the one-shot output snippet.
+
+If `gh pr create` fails, fall through to the PR-creation-failure branch of
+the one-shot output snippet so the user sees exactly what changed and what
+went wrong.
+
+Render the shared one-shot output snippet as the terminal output, populating
+Summary (note that "Artifacts produced" describes the refinement diff, not a
+first-pass run), Assumptions (from refine's returned findings), Specification
+Debt (from refine's `debt_items`), and PR (the captured URL).
+
+{{>one-shot-output}}
 
 **Resolving specification debt**: When the refine sub-agent identifies debt
 items that can now be resolved based on new information or user answers,

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -560,6 +560,14 @@ One-shot mode: do **not** stop to ask the user to review or approve the
 refinements. The refinement diff is the review surface, and the one-shot PR
 below is how the user sees it.
 
+**No-op check**: if refine returned an empty `refinements` list and no new
+`debt_items`, and `git status --porcelain` reports a clean worktree, this
+pass had nothing to change. Skip the commit, push, and PR-creation steps
+below. Render the one-shot output snippet with an explicit "no-op" note in
+`## Summary` ("Artifacts produced: 0 files — refine found no changes") and
+reuse the branch's existing PR URL if one exists (fall back to "No PR —
+nothing to change" otherwise). Do not fail with "nothing to commit".
+
 1. Stage and commit the refinement diff on the current branch (the spec
    folder's branch). The commit message should describe the refinements
    applied (e.g., `mark refine: resolve SD-003; add US4 priority


### PR DESCRIPTION
Phase 6 and Phase 0c no longer stop to ask the user to review or approve
the produced artifacts. Mark now commits the spec folder (plus feature-map
write-back), creates a PR via the same `gh pr create` pattern used by
smithy.forge, and renders the shared `{{>one-shot-output}}` snippet as the
terminal contract. The Phase 0 refine loop follows the same sequence for
refinement diffs.

Refs: specs/2026-04-08-003-reduce-interaction-friction/03-one-shot-planning-workflows.tasks.md