### PR TITLE
strike: remove Phase 3 Refine iteration for one-shot flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Smithy is a CLI tool that bootstraps AI-assisted development workflows across mu
 
 Smithy provides a collection of workflow prompts, each for a different stage/style of development:
 
-- **smithy.strike** — The lightweight "just do it" command. Interactive planning + implementation in one session. This is the starting point we're actively developing. Has `command: true` so it deploys as a Claude Code slash command (`/smithy.strike`).
+- **smithy.strike** — The lightweight "just do it" command. One-shot: explore, plan, write a `.strike.md` document, and create a PR in a single pass — no intermediate approval stops. This is the starting point we're actively developing. Has `command: true` so it deploys as a Claude Code slash command (`/smithy.strike`).
 - **smithy.spark** — Optional upstream entry point. Turns a raw idea into a ~1 page PRD (problem statement, proposed solution, alternatives / build-vs-buy) at `docs/prds/<YYYY>-<NNN>-<slug>.prd.md`. One-shot by default. The PRD can then feed `smithy.ignite`.
 - **smithy.ignite** — Full pipeline kickoff for larger features (RFC, design, etc.). Accepts a PRD file path as input to workshop into an RFC.
 - **smithy.forge** — Implementation executor that works from task specs

--- a/specs/2026-04-08-003-reduce-interaction-friction/03-one-shot-planning-workflows.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/03-one-shot-planning-workflows.tasks.md
@@ -234,7 +234,7 @@ and 2.
 
 ### Tasks
 
-- [ ] **Remove strike's Phase 3 Refine iteration**
+- [x] **Remove strike's Phase 3 Refine iteration**
 
   In `src/templates/agent-skills/commands/smithy.strike.prompt`, delete
   Phase 3 (Refine) in its entirety. Phase 2's reconciled plan and clarify
@@ -249,7 +249,7 @@ and 2.
     remains in the strike prompt
   - Subsequent phase numbering or references are updated for consistency
 
-- [ ] **Remove strike's Phase 5 STOP and add one-shot PR creation**
+- [x] **Remove strike's Phase 5 STOP and add one-shot PR creation**
 
   Replace the Phase 5 "Ready to forge, or want to refine the plan?" STOP
   with a non-interactive sequence: write the strike document, create a PR
@@ -264,7 +264,7 @@ and 2.
   - The "forge handoff" is reduced to a suggestion in the terminal output,
     not an interactive branching gate
 
-- [ ] **Assert strike runs one-shot with no Refine phase**
+- [x] **Assert strike runs one-shot with no Refine phase**
 
   Add Tier 2 assertions in `src/templates.test.ts` verifying that the
   composed `smithy.strike.md` template has no Phase 3 Refine section, no

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -450,6 +450,57 @@ describe('getComposedTemplates', () => {
     expect(debtIdx).toBeLessThan(singleSliceIdx);
   });
 
+  // Story 3 Slice 4: strike runs one-shot — no Phase 3 Refine iteration,
+  // no Phase 5 STOP gate, creates a PR after writing the strike document,
+  // and renders the shared one-shot output snippet as the terminal contract.
+  it('strike template has no Phase 3 Refine heading', () => {
+    const strike = composed.commands.get('smithy.strike.md')!;
+    expect(strike).toBeDefined();
+    // The old Phase 3 was "## Phase 3: Refine" — Slice 4 removed it. The
+    // renumbered Phase 3 is now "Strike Document". Assert the Refine
+    // heading is gone and that the stale "keep iterating until the user
+    // gives explicit approval" language is gone with it.
+    expect(strike).not.toMatch(/##\s+Phase\s+3:\s*Refine/i);
+    expect(strike).not.toMatch(/Keep iterating until the user gives explicit approval/i);
+  });
+
+  it('strike template contains no STOP-gate language', () => {
+    const strike = composed.commands.get('smithy.strike.md')!;
+    expect(strike).toBeDefined();
+    // The old Phase 5 STOP ("Ready to forge, or want to refine the plan?")
+    // is replaced with non-interactive PR creation.
+    expect(strike).not.toMatch(/STOP and ask/i);
+    expect(strike).not.toMatch(/STOP and wait/i);
+    expect(strike).not.toMatch(/Ready to forge, or want to refine the plan\?/i);
+  });
+
+  it('strike template references PR creation after artifact write', () => {
+    const strike = composed.commands.get('smithy.strike.md')!;
+    expect(strike).toBeDefined();
+    expect(strike).toMatch(/gh pr create/i);
+    // PR creation must come after the Strike Document phase so the
+    // artifact is on disk before the PR is opened.
+    const strikeDocIdx = strike.indexOf('## Phase 3: Strike Document');
+    const prIdx = strike.search(/gh pr create/i);
+    expect(strikeDocIdx).toBeGreaterThan(-1);
+    expect(prIdx).toBeGreaterThan(strikeDocIdx);
+  });
+
+  it('strike template includes all four one-shot output headers', () => {
+    const strike = composed.commands.get('smithy.strike.md')!;
+    expect(strike).toBeDefined();
+    // These headers come from the {{>one-shot-output}} partial. ## Summary
+    // and ## Specification Debt also appear in the strike document
+    // markdown template, but ## Assumptions and ## PR are unique to the
+    // snippet, so their presence proves the partial composed in.
+    expect(strike).toContain('## Summary');
+    expect(strike).toContain('## Assumptions');
+    expect(strike).toContain('## Specification Debt');
+    expect(strike).toContain('## PR');
+    // Partials must be resolved — no leftover Handlebars syntax.
+    expect(strike).not.toContain('{{>one-shot-output}}');
+  });
+
   it('ignite template contains ## Specification Debt between ## Open Questions and ## Milestones', () => {
     const ignite = composed.commands.get('smithy.ignite.md')!;
     expect(ignite).toBeDefined();
@@ -485,7 +536,7 @@ describe('getComposedTemplates', () => {
     expect(debtIdx).toBeLessThan(crossMilestoneIdx);
   });
 
-  it('command templates without partials are returned as-is', () => {
+  it('strike template has all partial references resolved', () => {
     const strike = composed.commands.get('smithy.strike.md')!;
     expect(strike).toBeDefined();
     expect(strike.length).toBeGreaterThan(0);

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -639,6 +639,47 @@ describe('getComposedTemplates', () => {
     expect(strike).not.toContain('{{');
   });
 
+  // Story 3 Slice 4: the claude variant of strike renders the {{#ifAgent}}
+  // branch, which is the code path actually deployed to Claude Code. The
+  // default-variant assertions above are not enough to catch a regression
+  // that reintroduces interactivity, drops PR creation, or breaks the
+  // one-shot output snippet only inside the agent branch.
+  it('strike claude variant has no Phase 3 Refine heading and no STOP-gate language', async () => {
+    const claudeComposed = await getComposedTemplates('claude');
+    const strike = claudeComposed.commands.get('smithy.strike.md')!;
+    expect(strike).toBeDefined();
+    expect(strike).not.toMatch(/##\s+Phase\s+3:\s*Refine/i);
+    expect(strike).not.toMatch(/Keep iterating until the user gives explicit approval/i);
+    expect(strike).not.toMatch(/STOP and ask/i);
+    expect(strike).not.toMatch(/STOP and wait/i);
+    expect(strike).not.toMatch(/Ready to forge, or want to refine the plan\?/i);
+    // The {{#ifAgent}} branch previously asked the agent to "Let the
+    // user decide" on unresolved conflicts. Slice 4 removed that gate.
+    expect(strike).not.toMatch(/Let the user decide/i);
+  });
+
+  it('strike claude variant references PR creation after the strike document phase', async () => {
+    const claudeComposed = await getComposedTemplates('claude');
+    const strike = claudeComposed.commands.get('smithy.strike.md')!;
+    expect(strike).toBeDefined();
+    expect(strike).toMatch(/gh pr create/i);
+    const strikeDocIdx = strike.indexOf('## Phase 3: Strike Document');
+    const prIdx = strike.search(/gh pr create/i);
+    expect(strikeDocIdx).toBeGreaterThan(-1);
+    expect(prIdx).toBeGreaterThan(strikeDocIdx);
+  });
+
+  it('strike claude variant includes all four one-shot output headers', async () => {
+    const claudeComposed = await getComposedTemplates('claude');
+    const strike = claudeComposed.commands.get('smithy.strike.md')!;
+    expect(strike).toBeDefined();
+    expect(strike).toContain('## Summary');
+    expect(strike).toContain('## Assumptions');
+    expect(strike).toContain('## Specification Debt');
+    expect(strike).toContain('## PR');
+    expect(strike).not.toContain('{{>one-shot-output}}');
+  });
+
   it('strike default does not contain competing plan dispatch', () => {
     const strike = composed.commands.get('smithy.strike.md')!;
     expect(strike).toBeDefined();

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -36,8 +36,10 @@ the next:
 ignite (RFC) → render (feature map) → mark (spec) → cut (tasks) → forge (implementation)
 ```
 
-`strike` is a lightweight shortcut that combines planning + implementation in
-one session, bypassing the full pipeline.
+`strike` is a lightweight one-shot shortcut that goes from feature description
+to a `.strike.md` document and PR in a single pass, bypassing the full pipeline.
+Implementation still happens in forge — strike produces the planning document
+and the PR that forge then consumes.
 
 ## Artifact Hierarchy and Dependency Order Format
 

--- a/src/templates/agent-skills/commands/README.md
+++ b/src/templates/agent-skills/commands/README.md
@@ -10,7 +10,7 @@ Deployed to:
 
 | Command | Purpose | Sub-Agents Used |
 |---------|---------|-----------------|
-| `smithy.strike` | Lightweight planning + implementation in one session | clarify, plan, reconcile |
+| `smithy.strike` | Lightweight one-shot planning — explore, write `.strike.md`, create PR | clarify, plan, reconcile |
 | `smithy.ignite` | Workshop an idea into an RFC with milestones | clarify, refine, plan, reconcile |
 | `smithy.render` | Break an RFC milestone into a feature map | clarify, refine, **scout** |
 | `smithy.mark` | Transform a feature into a spec with user stories | clarify, refine, **scout** |

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -68,8 +68,13 @@ Then capture for the strike document:
 
 After capturing the plan, use the **smithy-clarify** sub-agent. Pass it:
    - **Criteria**: Scope, Edge Cases, Preferences, Architecture Fit, Testing Strategy
-   - **Context**: this is a strike document; include the feature description and
-     the relevant file paths you discovered during exploration.
+   - **Context**: this is a strike document; include the feature description,
+     the relevant file paths you discovered during exploration, and the
+     captured plan: summary, approach, and risks. If the reconciled plan
+     contains conflicts, include both the conflicting options and the
+     reconciler's recommended resolution as part of the context so clarify
+     can evaluate Architecture Fit and Testing Strategy against the
+     proposed approach.
 
 Clarify is non-interactive and returns `assumptions`, `debt_items`,
 `bail_out`, and `bail_out_summary` directly. Do not ask the user any

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -1,12 +1,14 @@
 ---
 name: smithy-strike
-description: "Strike while the iron is hot. Explore, plan interactively, and produce a strike document — then hand off to forge for implementation."
+description: "Strike while the iron is hot. Explore, plan, and produce a strike document in one shot — creates a PR and suggests forge for implementation."
 ---
 # smithy-strike
 
-You are the **smithy-strike agent**. You help developers go from idea to a complete
-strike document in a single interactive session. You explore the codebase, propose an
-approach, iterate with the user, and produce a `.strike.md` ready for implementation.
+You are the **smithy-strike agent**. You help developers go from idea to a
+complete strike document in a single one-shot session. You explore the
+codebase, propose an approach, produce a `.strike.md` ready for
+implementation, and create a PR for it — all without stopping for user
+approval. The shared one-shot output format is the terminal contract.
 
 ## Input
 
@@ -57,37 +59,39 @@ Present the reconciled plan to the user as:
    recommendation. Let the user decide.
 
 {{else}}
-Then present to the user:
+Then capture for the strike document:
 
 1. **Summary** — What you understand the feature to be.
 2. **Approach** — What files you'd change, what you'd add, and why.
 3. **Risks** — Anything that could go wrong or get complicated.
 {{/ifAgent}}
 
-After presenting the plan, use the **smithy-clarify** sub-agent. Pass it:
+After capturing the plan, use the **smithy-clarify** sub-agent. Pass it:
    - **Criteria**: Scope, Edge Cases, Preferences, Architecture Fit, Testing Strategy
    - **Context**: this is a strike document; include the feature description and
      the relevant file paths you discovered during exploration.
 
+Clarify is non-interactive and returns `assumptions`, `debt_items`,
+`bail_out`, and `bail_out_summary` directly. Do not ask the user any
+follow-up questions. The reconciled plan, the clarify result, and the file
+paths you discovered flow directly into Phase 3 as the approved inputs for
+writing the strike document — there is no separate approval step.
+
+**Bail-out check**: if clarify returns `bail_out: true`, skip Phase 3 and
+Phase 4 entirely. Render only the `## Bail-Out` fallback from the
+`{{>one-shot-output}}` snippet using clarify's `bail_out_summary` and debt
+summary, and stop. No strike document is written and no PR is created.
+
 ---
 
-## Phase 3: Refine
-
-Incorporate the user's feedback into your approach. If anything is still unclear, ask follow-up questions.
-
-**Keep iterating until the user gives explicit approval** (e.g., "looks good", "go", "ship it", "approved", "do it").
-
-Do not proceed to implementation without clear approval.
-
----
-
-## Phase 4: Strike Document
+## Phase 3: Strike Document
 
 **Title conventions**: Before writing, read the `smithy.titles` prompt for
 canonical title formats and check for repo-level overrides in the project's
 CLAUDE.md. Apply those conventions to all headings in this artifact.
 
-Once approved, write a single strike document to `specs/strikes/YYYY-MM-DD-<slug>.strike.md` with this format:
+Write a single strike document to `specs/strikes/YYYY-MM-DD-<slug>.strike.md`
+with this format:
 
 ```markdown
 # Strike: <Title>
@@ -131,7 +135,7 @@ Once approved, write a single strike document to `specs/strikes/YYYY-MM-DD-<slug
 
 ## Decisions
 
-<Important decisions and tradeoffs made during the interactive planning phase.>
+<Important decisions and tradeoffs made during the planning phase.>
 
 ## Specification Debt
 
@@ -165,20 +169,45 @@ Create the `specs/strikes/` directory if it doesn't exist.
 
 ---
 
-## Phase 5: Review & Handoff
+## Phase 4: PR Creation & One-Shot Output
 
-After writing the strike document, present a summary to the user:
+After writing the strike document, commit it, push the strike branch, and
+create a PR — do not stop for user approval. The forge handoff is a
+suggestion in the terminal output, not an interactive branching gate.
 
-1. **Show the strike summary** — Goal, Requirements (count), Tasks (count), and the Validation Plan.
-2. **STOP and ask**: "Ready to forge, or want to refine the plan?"
-3. **If refine**: incorporate feedback, update the `.strike.md`, and ask again.
-4. **If forge**: tell the agent to proceed as the **smithy-forge** agent, passing the `.strike.md` file path as input. Follow the instructions in the `smithy.forge` prompt from this point forward, using the strike document as the input file.
+1. **Commit the strike document** on the `strike/<slug>` branch with a
+   message referencing the strike goal.
+2. **Push the branch** with `git push -u origin strike/<slug>`.
+3. **Create the PR** using the same `gh pr create` pattern as
+   `smithy-forge`:
+   - **Title**: the strike goal, concise and under 70 characters.
+   - **Body**: include the strike summary, goal, link to the
+     `.strike.md` file, and the one-shot output content produced below.
+4. **Render the one-shot output** as the terminal output of this run using
+   the shared snippet below. Populate the placeholders from the strike run
+   data: `Spec folder` = `specs/strikes/`, `Branch` = `strike/<slug>`,
+   `Artifacts produced` = the single `.strike.md` file, and substitute
+   `User stories` / `Functional requirements` with the strike's requirement
+   and task counts per the snippet's placeholder guidance. Copy
+   `assumptions` and `debt_items` from clarify's return.
+5. **Suggest forge as the next step** inside the terminal output — do not
+   block on approval. A developer can invoke `smithy-forge` with the
+   strike file path when they are ready.
+
+If `gh pr create` fails, follow the snippet's PR-creation-failure fallback:
+still render the Summary, Assumptions, and Specification Debt sections, and
+replace the `## PR` section with the failure note so the developer knows
+the artifact is on disk and can retry manually.
+
+{{>one-shot-output}}
 
 ---
 
 ## Rules
 
 - **No GitHub issues, milestones, or RFCs.** This is a lightweight workflow.
-- **Do not skip the interactive phase.** Always explore, propose, and get approval before implementing.
+- **Run one-shot.** Do not stop for user approval between phases — explore,
+  plan, write the strike document, and create a PR in a single pass. The
+  terminal output follows the shared one-shot format.
 - **If scope grows too large** (more than ~5 tasks or touches many subsystems), tell the user this feature may be better suited for `smithy-ignite` and the full pipeline.
 - **Keep commits atomic.** Each commit should represent a logical, working change.

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -193,17 +193,24 @@ suggestion in the terminal output, not an interactive branching gate.
    `smithy-forge`:
    - **Title**: the strike goal, concise and under 70 characters.
    - **Body**: include the strike summary, goal, link to the
-     `.strike.md` file, and the one-shot output content produced below.
-4. **Render the one-shot output** as the terminal output of this run using
-   the shared snippet below. Populate the placeholders from the strike run
-   data: `Spec folder` = `specs/strikes/`, `Branch` = `strike/<slug>`,
-   `Artifacts produced` = the single `.strike.md` file, and substitute
-   `User stories` / `Functional requirements` with the strike's requirement
-   and task counts per the snippet's placeholder guidance. Copy
-   `assumptions` and `debt_items` from clarify's return.
-5. **Suggest forge as the next step** inside the terminal output — do not
-   block on approval. A developer can invoke `smithy-forge` with the
-   strike file path when they are ready.
+     `.strike.md` file, and the one-shot output content produced below
+     **excluding the `## PR` section**, since the PR URL is only known
+     after `gh pr create` succeeds. Populate the other sections
+     (`## Summary`, `## Assumptions`, `## Specification Debt`) from the
+     run data captured during Phase 2 and Phase 3.
+4. **Capture the PR URL** returned by `gh pr create`.
+5. **Render the full one-shot output** as the terminal output of this
+   run using the shared snippet below. Populate the placeholders from
+   the strike run data: `Spec folder` = `specs/strikes/`, `Branch` =
+   `strike/<slug>`, `Artifacts produced` = the single `.strike.md`
+   file, and substitute `User stories` / `Functional requirements`
+   with the strike's requirement and task counts per the snippet's
+   placeholder guidance. Populate the `## PR` section with the URL
+   captured in the previous step, and copy `assumptions` and
+   `debt_items` from clarify's return.
+6. **Suggest forge as the next step** inside the terminal output — do
+   not block on approval. A developer can invoke `smithy-forge` with
+   the strike file path when they are ready.
 
 If `gh pr create` fails, follow the snippet's PR-creation-failure fallback:
 still render the Summary, Assumptions, and Specification Debt sections, and

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -78,9 +78,10 @@ paths you discovered flow directly into Phase 3 as the approved inputs for
 writing the strike document — there is no separate approval step.
 
 **Bail-out check**: if clarify returns `bail_out: true`, skip Phase 3 and
-Phase 4 entirely. Render only the `## Bail-Out` fallback from the
-`{{>one-shot-output}}` snippet using clarify's `bail_out_summary` and debt
-summary, and stop. No strike document is written and no PR is created.
+Phase 4 entirely. Render only the `## Bail-Out` fallback from the shared
+one-shot output snippet (see Phase 4) using clarify's `bail_out_summary`
+and debt summary, and stop. No strike document is written and no PR is
+created.
 
 ---
 

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -89,8 +89,9 @@ writing the strike document — there is no separate approval step.
 **Bail-out check**: if clarify returns `bail_out: true`, skip Phase 3 and
 Phase 4 entirely. Render only the `## Bail-Out` fallback from the shared
 one-shot output snippet (see Phase 4) using clarify's `bail_out_summary`
-and debt summary, and stop. No strike document is written and no PR is
-created.
+for the `### Why` section and a bulleted summary derived from clarify's
+returned `debt_items` for the `### What's needed` section, then stop. No
+strike document is written and no PR is created.
 
 ---
 

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -47,16 +47,20 @@ Pass each smithy-plan sub-agent:
 - **Codebase file paths**: the relevant files you discovered during exploration
 - **Additional planning directives**: the lens directive from the competing-lenses section above (each run gets a different directive)
 
-Present the reconciled plan to the user as:
+Capture the reconciled plan as:
 
 1. **Summary** — What you understand the feature to be.
 2. **Approach** — The reconciled approach (file changes, rationale). Note any
    items annotated with `[via <lens>]` — these are unique perspectives from
    individual focus lenses.
 3. **Risks** — The reconciled risk assessment.
-4. **Conflicts** — If the reconciled plan contains unresolved conflicts between
-   approaches, present them with both options and the reconciler's
-   recommendation. Let the user decide.
+4. **Conflicts** — If the reconciled plan contains unresolved conflicts
+   between approaches, adopt the reconciler's recommendation as the
+   chosen path. Do not stop to ask the user. Record the rejected
+   alternative and the tradeoff in the strike document's `## Decisions`
+   section, and if the conflict cannot be confidently resolved, route it
+   into the `## Specification Debt` table instead. Strike is one-shot —
+   there is no interactive decision point.
 
 {{else}}
 Then capture for the strike document:


### PR DESCRIPTION
Delete strike's Refine phase and replace its interactive approval flow
with a direct transition from Phase 2 (Explore & Propose) to Phase 3
(Strike Document). Update Phase 2 so the reconciled plan and clarify
output implicitly approve the inputs for writing the strike document,
and add a bail-out check that short-circuits before artifact write-out
when clarify returns bail_out: true.