### PR TITLE
slice-5: convert ignite and render to one-shot execution

### DIFF
--- a/specs/2026-04-08-003-reduce-interaction-friction/03-one-shot-planning-workflows.tasks.md
+++ b/specs/2026-04-08-003-reduce-interaction-friction/03-one-shot-planning-workflows.tasks.md
@@ -302,7 +302,7 @@ commands), SC-001
 
 ### Tasks
 
-- [ ] **Remove ignite's Phase 4 STOPs and add PR creation**
+- [x] **Remove ignite's Phase 4 STOPs and add PR creation**
 
   In `src/templates/agent-skills/commands/smithy.ignite.prompt`, delete
   both Phase 4 "Review RFC" STOPs (agent and non-agent branches). After
@@ -317,7 +317,7 @@ commands), SC-001
   - Phase 0 Review Loop ends non-interactively and creates a PR with the
     refinement diff
 
-- [ ] **Remove render's STOP gates and add PR creation**
+- [x] **Remove render's STOP gates and add PR creation**
 
   In `src/templates/agent-skills/commands/smithy.render.prompt`, delete the
   Phase 0c refinement STOP, the Phase 1 target-confirmation STOP, and the
@@ -332,7 +332,7 @@ commands), SC-001
   - Phase 0 Review Loop ends non-interactively and creates a PR with the
     refinement diff
 
-- [ ] **Assert ignite and render render the one-shot output contract**
+- [x] **Assert ignite and render render the one-shot output contract**
 
   Add Tier 2 assertions in `src/templates.test.ts` verifying that the
   composed `smithy.ignite.md` and `smithy.render.md` templates contain the

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1056,6 +1056,91 @@ describe('getComposedTemplates', () => {
     expect(depSection).not.toContain('- [x]');
   });
 
+  // Story 3 Slice 5: ignite and smithy.render are now one-shot. Each must
+  // include the shared one-shot-output snippet content, reference PR
+  // creation after writing the artifact, and carry no STOP-gate language.
+  // The cross-command assertion below iterates over the set of planning
+  // commands that have been converted to one-shot so a regression
+  // reintroducing a STOP in any of them fails the test suite. The list will
+  // grow as slices 3 (mark, cut) and 4 (strike) land.
+
+  it('ignite template renders the one-shot output headers after conversion', () => {
+    const ignite = composed.commands.get('smithy.ignite.md')!;
+    expect(ignite).toBeDefined();
+    // The one-shot-output snippet drops `## Summary`, `## Assumptions`,
+    // `## Specification Debt`, and `## PR` sections into the composed
+    // template. `## Summary` already appears in the RFC template code
+    // fence, so assert on the three unique headers plus the bail-out
+    // fallback that only the snippet produces.
+    expect(ignite).toContain('## Assumptions');
+    expect(ignite).toContain('## Specification Debt');
+    expect(ignite).toContain('## PR');
+    expect(ignite).toContain('## Bail-Out');
+  });
+
+  it('ignite template references PR creation after artifact write-out', () => {
+    const ignite = composed.commands.get('smithy.ignite.md')!;
+    expect(ignite).toBeDefined();
+    expect(ignite).toMatch(/gh pr create/);
+    // Phase 4 is the write-and-create-PR phase after the conversion.
+    expect(ignite).toContain('Phase 4: Write & Create PR');
+    // The legacy review-loop heading is gone.
+    expect(ignite).not.toContain('## Phase 4: Write & Review');
+  });
+
+  it('ignite template is non-interactive: no STOP-gate language', () => {
+    const ignite = composed.commands.get('smithy.ignite.md')!;
+    expect(ignite).toBeDefined();
+    expect(ignite).not.toMatch(/STOP and wait/i);
+    expect(ignite).not.toMatch(/STOP and ask/i);
+  });
+
+  it('render template renders the one-shot output headers after conversion', () => {
+    const render = composed.commands.get('smithy.render.md')!;
+    expect(render).toBeDefined();
+    // `## Summary` does not appear in render's feature-map template code
+    // fence, so the snippet's `## Summary` header is the only source.
+    expect(render).toContain('## Summary');
+    expect(render).toContain('## Assumptions');
+    expect(render).toContain('## Specification Debt');
+    expect(render).toContain('## PR');
+    expect(render).toContain('## Bail-Out');
+  });
+
+  it('render template references PR creation after artifact write-out', () => {
+    const render = composed.commands.get('smithy.render.md')!;
+    expect(render).toBeDefined();
+    expect(render).toMatch(/gh pr create/);
+    // Phase 4 is the write-and-create-PR phase after the conversion.
+    expect(render).toContain('Phase 4: Write & Create PR');
+    // The legacy review-loop heading is gone.
+    expect(render).not.toContain('## Phase 4: Write & Review');
+  });
+
+  it('render template is non-interactive: no STOP-gate language', () => {
+    const render = composed.commands.get('smithy.render.md')!;
+    expect(render).toBeDefined();
+    expect(render).not.toMatch(/STOP and wait/i);
+    expect(render).not.toMatch(/STOP and ask/i);
+  });
+
+  it('converted planning commands have no STOP-gate language', () => {
+    // Cross-command invariant for the planning commands already converted
+    // to one-shot in story 03. The list grows as slices 3 and 4 land
+    // (strike, mark, cut). A regression reintroducing "STOP and ask" or
+    // "STOP and wait" in any converted planning command fails here.
+    const convertedPlanningCommands = [
+      'smithy.ignite.md',
+      'smithy.render.md',
+    ];
+    for (const name of convertedPlanningCommands) {
+      const tpl = composed.commands.get(name);
+      expect(tpl, `${name} should be in the composed commands map`).toBeDefined();
+      expect(tpl!, `${name} should not contain "STOP and ask"`).not.toMatch(/STOP and ask/i);
+      expect(tpl!, `${name} should not contain "STOP and wait"`).not.toMatch(/STOP and wait/i);
+    }
+  });
+
   it('variant does not change the number of template keys', async () => {
     const claudeComposed = await getComposedTemplates('claude');
     expect([...composed.commands.keys()].sort()).toEqual([...claudeComposed.commands.keys()].sort());

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1067,11 +1067,14 @@ describe('getComposedTemplates', () => {
   it('ignite template renders the one-shot output headers after conversion', () => {
     const ignite = composed.commands.get('smithy.ignite.md')!;
     expect(ignite).toBeDefined();
-    // The one-shot-output snippet drops `## Summary`, `## Assumptions`,
-    // `## Specification Debt`, and `## PR` sections into the composed
-    // template. `## Summary` already appears in the RFC template code
-    // fence, so assert on the three unique headers plus the bail-out
-    // fallback that only the snippet produces.
+    // The one-shot-output snippet adds `## Summary`, `## Assumptions`,
+    // `## Specification Debt`, and `## PR` sections to the composed
+    // template. `## Summary` and `## Specification Debt` already appear
+    // elsewhere in the ignite template (in the RFC template code fence),
+    // so their presence here does not prove the snippet was inlined.
+    // The unique indicators of the inlined snippet are `## PR` and
+    // `## Bail-Out` (only the snippet produces those); the other two
+    // assertions guard against accidental removal of either copy.
     expect(ignite).toContain('## Assumptions');
     expect(ignite).toContain('## Specification Debt');
     expect(ignite).toContain('## PR');

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -654,10 +654,15 @@ and file write — proceed directly to commit and PR:
    - **Body**: the one-shot output snippet content (rendered below) plus a
      relative link to the RFC file.
 3. Render the one-shot output snippet as the terminal contract. For an
-   RFC-only run, use the RFC folder as the spec folder, substitute milestone
-   counts where the snippet asks for user stories / functional requirements,
-   and copy the clarify return's `assumptions` and `debt_items` into the
-   Assumptions and Specification Debt sections.
+   RFC-only run, use the RFC folder as the spec folder and substitute
+   milestone counts where the snippet asks for user stories / functional
+   requirements. Copy the clarify return's `assumptions` into the
+   snippet's `## Assumptions` section (the snippet / PR body is the only
+   Assumptions surface — the RFC artifact itself has no `## Assumptions`
+   section). Write `debt_items` into **both** the RFC's
+   `## Specification Debt` table **and** the snippet's
+   `## Specification Debt` summary so the PR body and the artifact stay
+   in sync.
 
 {{else}}
 1. Create the folder `docs/rfcs/<YYYY>-<NNN>-<slug>/` if it doesn't exist.
@@ -668,18 +673,19 @@ and file write — proceed directly to commit and PR:
    - **Body**: the one-shot output snippet content (rendered below) plus a
      relative link to the RFC file.
 5. Render the one-shot output snippet as the terminal contract. For an
-   RFC-only run, use the RFC folder as the spec folder, substitute milestone
-   counts where the snippet asks for user stories / functional requirements,
-   and copy the clarify return's `assumptions` and `debt_items` into the
-   Assumptions and Specification Debt sections.
+   RFC-only run, use the RFC folder as the spec folder and substitute
+   milestone counts where the snippet asks for user stories / functional
+   requirements. Copy the clarify return's `assumptions` into the
+   snippet's `## Assumptions` section (the snippet / PR body is the only
+   Assumptions surface — the RFC artifact itself has no `## Assumptions`
+   section). Write `debt_items` into **both** the RFC's
+   `## Specification Debt` table **and** the snippet's
+   `## Specification Debt` summary so the PR body and the artifact stay
+   in sync.
 
 {{/ifAgent}}
 
 {{>one-shot-output}}
-
-After the snippet is rendered, suggest the next step as a non-interactive
-hint in the terminal output: "Ready for `smithy.render` to break a milestone
-into features." Do not block on confirmation.
 
 ---
 

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -1,6 +1,6 @@
 ---
 name: smithy-ignite
-description: "Ignite a broad idea into a structured RFC with milestones. Workshop through clarifying questions, then produce a reviewable RFC in docs/rfcs/."
+description: "Ignite a broad idea into a structured RFC with milestones one-shot. Runs clarify, drafts the RFC, creates a PR, and renders a standardized terminal summary without intermediate approval gates."
 ---
 # smithy-ignite
 
@@ -178,9 +178,19 @@ Use the **smithy-refine** sub-agent. Pass it:
 ### Phase 0c: Apply Refinements
 
 After the sub-agent returns its summary:
-1. Update the existing RFC to incorporate the refinements.
-2. Present the changes for user approval before writing.
-3. If approved, write the updated RFC to the same file path.
+1. Apply the refinements from smithy-refine directly to the RFC file in place
+   — refine is non-interactive and returns high-confidence refinements ready
+   to apply. Do not pause for user approval before writing.
+2. Route any low-confidence findings returned in `debt_items` into the RFC's
+   `## Specification Debt` section.
+3. Commit the refinement diff and create a PR for the refinement using the
+   forge `gh pr create` pattern (the same pattern Phase 4 uses below).
+4. Render the one-shot output block (the format defined in the
+   `one-shot-output` shared snippet, inlined into Phase 4 below) as the
+   terminal contract for the refinement pass, treating the refinement diff
+   as the artifact produced. Do **not** pause for user approval of the
+   refinement diff before creating the PR — Phase 0 is non-interactive like
+   the first-pass flow.
 
 ---
 
@@ -626,52 +636,64 @@ Recommended implementation sequence:
 | M2 | <Title> | — | — |
 ```
 
-## Phase 4: Write & Review
+## Phase 4: Write & Create PR
+
+Ignite runs one-shot: after the RFC is on disk, commit it, create a PR for
+the RFC artifact, and render the one-shot output snippet as the terminal
+contract. Do **not** pause for user approval of the RFC before creating the
+PR — the snippet's PR link is the handoff point, not an interactive gate.
 
 {{#ifAgent}}
 Phase 3 already created the RFC folder, wrote the file piecewise through
 sub-phases 3a–3f, and harmonized it in sub-phase 3g. Skip folder creation
-and file write — proceed directly to review:
+and file write — proceed directly to commit and PR:
 
-1. Present a **summary** of the harmonized RFC — title, milestone count and
-   titles, key decisions.
-2. Point the user to the file on disk:
-   `docs/rfcs/<YYYY>-<NNN>-<slug>/<slug>.rfc.md`.
-3. **Do NOT dump the full RFC contents into the terminal.** The file is on
-   disk — the user can review it in their editor.
-4. **STOP and ask**: "Review the RFC at `<path>` and let me know if you'd like
-   changes, or approve to move on."
-
-If the user wants changes, incorporate them by updating the existing file in
-place (do not rewrite from scratch). Ask again after each round of changes.
-Once approved, suggest the next step: "Ready for `smithy.render` to break a
-milestone into features."
+1. Commit the RFC file on the feature branch.
+2. Create a PR for the RFC artifact using the forge `gh pr create` pattern:
+   - **Title**: the RFC title, under 70 characters, descriptive text only.
+   - **Body**: the one-shot output snippet content (rendered below) plus a
+     relative link to the RFC file.
+3. Render the one-shot output snippet as the terminal contract. For an
+   RFC-only run, use the RFC folder as the spec folder, substitute milestone
+   counts where the snippet asks for user stories / functional requirements,
+   and copy the clarify return's `assumptions` and `debt_items` into the
+   Assumptions and Specification Debt sections.
 
 {{else}}
 1. Create the folder `docs/rfcs/<YYYY>-<NNN>-<slug>/` if it doesn't exist.
 2. Write the RFC to `docs/rfcs/<YYYY>-<NNN>-<slug>/<slug>.rfc.md`.
-3. Present a **summary** of the draft — title, problem statement, milestone
-   count and titles, key decisions.
-4. **Do NOT dump the full RFC contents into the terminal.** The file is on
-   disk — the user can review it in their editor.
-5. **STOP and ask**: "Review the RFC at `<path>` and let me know if you'd like
-   changes, or approve to move on."
-
-If the user wants changes, incorporate them, update the file on disk, and ask
-again. Once approved, suggest the next step: "Ready for `smithy.render` to
-break a milestone into features."
+3. Commit the RFC file on the feature branch.
+4. Create a PR for the RFC artifact using the forge `gh pr create` pattern:
+   - **Title**: the RFC title, under 70 characters, descriptive text only.
+   - **Body**: the one-shot output snippet content (rendered below) plus a
+     relative link to the RFC file.
+5. Render the one-shot output snippet as the terminal contract. For an
+   RFC-only run, use the RFC folder as the spec folder, substitute milestone
+   counts where the snippet asks for user stories / functional requirements,
+   and copy the clarify return's `assumptions` and `debt_items` into the
+   Assumptions and Specification Debt sections.
 
 {{/ifAgent}}
+
+{{>one-shot-output}}
+
+After the snippet is rendered, suggest the next step as a non-interactive
+hint in the terminal output: "Ready for `smithy.render` to break a milestone
+into features." Do not block on confirmation.
 
 ---
 
 ## Rules
 
 - **DO NOT** write code or implementation details. RFCs are "WHAT not HOW".
-- **DO NOT** skip clarification. Always ask at least one question, even for well-specified ideas.
-- **DO** write the RFC file to disk before asking for review — do not dump
+- **DO NOT** skip clarification. Always run smithy-clarify — it is
+  non-interactive and returns assumptions and debt items directly.
+- **DO NOT** stop for user approval before creating the RFC PR. Ignite is
+  one-shot: Phase 4 writes the RFC, creates the PR, and renders the one-shot
+  output snippet without an intermediate approval gate.
+- **DO** write the RFC file to disk before creating the PR — do not dump
   the full contents into the terminal.
 - **DO** maintain a "WHAT not HOW" tone throughout.
 - **DO** ensure milestones are clearly delineated with distinct scope and success criteria.
-- **DO** challenge assumptions and surface risks during clarification.
+- **DO** surface risks during clarification via the clarify return.
 - **DO** keep the RFC concise — a good RFC is a starting point, not a final design.

--- a/src/templates/agent-skills/commands/smithy.render.prompt
+++ b/src/templates/agent-skills/commands/smithy.render.prompt
@@ -118,8 +118,10 @@ Parse the input and prepare the target:
 
 1. **Read the RFC file.** Parse the Milestones section to extract all milestones
    (each `### Milestone N: <Title>` heading).
-2. **Validate the target milestone.** If a milestone number was specified, confirm
-   it exists. If auto-selected, proceed with that choice (step 5 will confirm).
+2. **Validate the target milestone.** If a milestone number was specified,
+   verify it exists in the RFC and abort with a clear error if it does not.
+   If auto-selected, proceed with that choice without asking — render is
+   one-shot and Step 5 only reports the target, it does not re-confirm it.
 3. **Derive the slug.** Create a kebab-case slug from the milestone title
    (e.g., "Core Pipeline Commands" → `core-pipeline-commands`).
 4. **Derive the filename.** `<NN>-<milestone-slug>.features.md` where `<NN>` is the
@@ -294,16 +296,17 @@ the PR.
    - **Body**: the one-shot output snippet content (rendered below) plus a
      relative link to the feature map file.
 4. Render the one-shot output snippet as the terminal contract. For a
-   feature-map run, use the RFC folder as the spec folder, substitute
+   feature-map run, use the RFC folder as the spec folder and substitute
    feature counts where the snippet asks for user stories / functional
-   requirements, and copy the clarify return's `assumptions` and
-   `debt_items` into the Assumptions and Specification Debt sections.
+   requirements. Copy the clarify return's `assumptions` into the
+   snippet's `## Assumptions` section (the snippet / PR body is the only
+   Assumptions surface — the feature map artifact has no `## Assumptions`
+   section). Write `debt_items` into **both** the feature map's
+   `## Specification Debt` table **and** the snippet's
+   `## Specification Debt` summary so the PR body and the artifact stay
+   in sync.
 
 {{>one-shot-output}}
-
-After the snippet is rendered, suggest the next step as a non-interactive
-hint in the terminal output: "Ready for `smithy.mark` to specify each
-feature." Do not block on confirmation.
 
 ---
 

--- a/src/templates/agent-skills/commands/smithy.render.prompt
+++ b/src/templates/agent-skills/commands/smithy.render.prompt
@@ -1,6 +1,6 @@
 ---
 name: smithy-render
-description: "Break an RFC milestone into a feature map through interactive clarification. Produces a structured list of discrete, user-facing features."
+description: "Break an RFC milestone into a feature map one-shot. Runs clarify, drafts the map, creates a PR, and renders a standardized terminal summary without intermediate approval gates."
 ---
 # smithy-render
 
@@ -66,7 +66,8 @@ Before auditing, locate the source RFC and the specific milestone the map covers
 3. **Read the matched RFC milestone section** so it is available as the baseline
    for the audit scan.
 4. If neither the header nor the fallback resolves a valid RFC and milestone,
-   stop and ask the user to provide the RFC path and milestone number.
+   abort with an error message instructing the user to re-invoke render with
+   an explicit RFC path and milestone number.
 
 ### Phase 0a–0b: Audit & Refinement Questions
 
@@ -94,16 +95,20 @@ Use the **smithy-refine** sub-agent. Pass it:
 
 After the sub-agent returns its summary:
 
-1. Incorporate the user's answers into an **updated feature map**.
-2. Overwrite the existing `.features.md` with the updated version.
-3. Present a **summary** of what changed (features added, removed, merged,
-   re-scoped, or reworded). **Do NOT dump the full file contents into the
-   terminal** — the file is on disk for the user to review.
-4. **STOP and ask**: "Review the updated map at `<path>` and let me know if
-   you'd like changes, or approve to move on."
-
-If the user requests changes, incorporate them, update the file on disk, and
-ask again. Once approved, confirm the file path and suggest next steps.
+1. Apply the refinements from smithy-refine directly to the `.features.md`
+   file in place — refine is non-interactive and returns high-confidence
+   refinements ready to apply. Do not pause for user approval before
+   writing.
+2. Route any low-confidence findings returned in `debt_items` into the
+   feature map's `## Specification Debt` section.
+3. Commit the refinement diff and create a PR for the refinement using the
+   forge `gh pr create` pattern (the same pattern Phase 4 uses below).
+4. Render the one-shot output block (the format defined in the
+   `one-shot-output` shared snippet, inlined into Phase 4 below) as the
+   terminal contract for the refinement pass, using the feature map as the
+   artifact produced. Do **not** pause for user approval of the refinement
+   diff before creating the PR — Phase 0 is non-interactive like the
+   first-pass flow.
 
 ---
 
@@ -119,12 +124,11 @@ Parse the input and prepare the target:
    (e.g., "Core Pipeline Commands" → `core-pipeline-commands`).
 4. **Derive the filename.** `<NN>-<milestone-slug>.features.md` where `<NN>` is the
    two-digit zero-padded milestone number (e.g., `01-`, `02-`, ... `09-`, `10-`).
-5. **Confirm the target with the user:**
+5. **Report the target** to the terminal so the developer can see what
+   render picked (do not block on confirmation — render is one-shot):
    - RFC path
    - Milestone number and title
    - Derived filename
-
-**STOP and wait** for the user to confirm before proceeding.
 
 ---
 
@@ -273,27 +277,45 @@ Direction must be either `depends on` or `depended upon by`.
 _If no cross-milestone dependencies exist, state "None — this milestone is self-contained."_
 ```
 
-## Phase 4: Write & Review
+## Phase 4: Write & Create PR
+
+Render runs one-shot: after the feature map is on disk, commit it, create a
+PR for the feature map artifact, and render the one-shot output snippet as
+the terminal contract. Do **not** pause for user approval before creating
+the PR.
 
 1. Write the feature map to the RFC folder as `<NN>-<milestone-slug>.features.md`,
    co-located with the source RFC.
-2. Present a **summary** of the draft — feature count, feature titles, and key
-   scope boundaries. **Do NOT dump the full file contents into the terminal** —
-   the file is on disk for the user to review.
-3. **STOP and ask**: "Review the feature map at `<path>` and let me know if
-   you'd like changes, or approve to move on."
+2. Commit the feature map file on the feature branch.
+3. Create a PR for the feature map artifact using the forge `gh pr create`
+   pattern:
+   - **Title**: `Feature Map: <Milestone Title>`, under 70 characters,
+     descriptive text only.
+   - **Body**: the one-shot output snippet content (rendered below) plus a
+     relative link to the feature map file.
+4. Render the one-shot output snippet as the terminal contract. For a
+   feature-map run, use the RFC folder as the spec folder, substitute
+   feature counts where the snippet asks for user stories / functional
+   requirements, and copy the clarify return's `assumptions` and
+   `debt_items` into the Assumptions and Specification Debt sections.
 
-If the user wants changes, incorporate them, update the file on disk, and ask
-again. Once approved, suggest the next step:
-> "Ready for `smithy.mark` to specify each feature."
+{{>one-shot-output}}
+
+After the snippet is rendered, suggest the next step as a non-interactive
+hint in the terminal output: "Ready for `smithy.mark` to specify each
+feature." Do not block on confirmation.
 
 ---
 
 ## Rules
 
 - **DO NOT** write code or implementation details. Feature maps are "WHAT not HOW".
-- **DO NOT** skip clarification. Always ask at least one question, even for well-defined milestones.
-- **DO** write the feature map file to disk before asking for review — do not
+- **DO NOT** skip clarification. Always run smithy-clarify — it is
+  non-interactive and returns assumptions and debt items directly.
+- **DO NOT** stop for user approval before creating the feature map PR.
+  Render is one-shot: Phase 4 writes the map, creates the PR, and renders
+  the one-shot output snippet without an intermediate approval gate.
+- **DO** write the feature map file to disk before creating the PR — do not
   dump the full contents into the terminal.
 - **DO NOT** treat render as an entry point — it requires an existing RFC from `smithy.ignite`. If the user provides a description instead of a file path, redirect them to ignite.
 - **DO** ensure each feature is a discrete unit of user-facing functionality.


### PR DESCRIPTION
Remove every STOP gate from smithy.ignite and smithy.render and replace
the review-loop approval phases with one-shot PR creation plus the shared
one-shot-output snippet.

- ignite Phase 4: drop the "STOP and ask review the RFC" gates on both
  variants, add commit + gh pr create + {{>one-shot-output}} rendering,
  and rename the phase to "Write & Create PR".
- ignite Phase 0c: drop the "present changes for user approval" gate;
  refinements now land directly, commit, create a PR, and reference the
  Phase 4 one-shot output block. The partial is only inlined once (in
  Phase 4) so the RFC template markdown code fence remains the first
  code fence in the composed template.
- render Phase 4: drop the "STOP and ask review the feature map" gate,
  add commit + gh pr create + {{>one-shot-output}} rendering, and rename
  the phase to "Write & Create PR".
- render Phase 1: drop the "STOP and wait for the user to confirm"
  target-confirmation gate; render reports the target and proceeds.
- render Phase 0c: drop the "STOP and ask review the updated map" gate;
  refinements now land directly, commit, create a PR, and reference the
  Phase 4 one-shot output block.
- render Phase 0 source-context fallback: reword the "stop and ask the
  user" abort to "abort with an error message", which keeps the
  semantics but removes STOP-gate language the Tier 2 guard looks for.
- Frontmatter descriptions, Rules sections, and any "stop and wait" /
  "stop and ask" prose across both prompts are reworded to match the
  one-shot contract.
- templates.test.ts Tier 2 assertions verify that the composed ignite
  and render templates contain the snippet's one-shot output headers,
  reference gh pr create, and carry no "STOP and ask" / "STOP and wait"
  language. A cross-command assertion iterates over the set of planning
  commands already converted to one-shot (ignite, render) so a
  regression reintroducing a STOP in either fails the suite; the list
  will grow as slices 3 (mark, cut) and 4 (strike) land.
- Mark slice 5 tasks complete in the tasks file.

Addresses FR-011, FR-016, SC-001 (ignite and render portion) and
Acceptance Scenario 3.1. Completes story 03 slice 5 from
specs/2026-04-08-003-reduce-interaction-friction/.

https://claude.ai/code/session_01CHoTMUd3QCg7xwMQ67d8iy