### PR TITLE
forge(us7): text-mode roll-up header + AS 7.2 counts guard

### DIFF
--- a/specs/2026-04-12-004-smithy-status-skill/07-summary-roll-up-header.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/07-summary-roll-up-header.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Render per-type summary header above text-mode listing**
+- [x] **Render per-type summary header above text-mode listing**
 
   Add a pure `formatSummaryHeader(summary: ScanSummary): string` helper co-located with `summarize()` in `src/commands/status.ts`, and invoke it from the text-mode path of `statusAction` after the empty-repo early-return and before the flat records loop. The header must render AS 7.1 verbatim from `ScanSummary.counts` without touching `ArtifactRecord[]` or coupling to any future tree renderer.
 
@@ -31,7 +31,7 @@
   - An integration test under the `CLI status` describe block in `src/cli.test.ts` exercises a fixture containing records of multiple types and asserts the header appears above the flat listing with the four type labels present (references AS 7.1 by ID).
   - The existing empty-repo integration test remains green without modification.
 
-- [ ] **Guard AS 7.2 with a full per-type JSON counts assertion**
+- [x] **Guard AS 7.2 with a full per-type JSON counts assertion**
 
   Extend the existing `--format json` integration test in `src/cli.test.ts` so its fixture contains at least one record of each artifact type and the assertions cover every key under `payload.summary.counts`. This task touches no production source — it locks down AS 7.2's current (already-correct) behavior as US7's acceptance boundary.
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -526,7 +526,21 @@ describe('CLI status', () => {
     expect(output).toContain('--no-color');
   });
 
-  it('emits contract-shaped JSON with records, summary, tree, graph', () => {
+  it('emits contract-shaped JSON with records, summary, tree, graph, and full per-type counts (AS 7.2)', () => {
+    // Fixture stitches one record of every artifact type — rfc,
+    // features, spec, tasks — through the canonical lineage so every
+    // `counts[type][status]` slot in `payload.summary.counts` is
+    // observable. AS 7.2 guards the JSON `summary` key: this slice
+    // does not change its shape, only locks it down with a full
+    // per-type regression assertion.
+    write(
+      'docs/rfcs/example.rfc.md',
+      `# RFC: Example\n\n## Dependency Order\n\n${TABLE_HEADER}\n| M1 | Milestone One | — | docs/rfcs/01-milestone-one.features.md |\n`,
+    );
+    write(
+      'docs/rfcs/01-milestone-one.features.md',
+      `# Feature Map\n\n## Dependency Order\n\n${TABLE_HEADER}\n| F1 | Feature A | — | specs/feature-a |\n`,
+    );
     write(
       'specs/feature-a/feature-a.spec.md',
       `# Feature Specification: Feature A\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story One | — | specs/feature-a/01-first.tasks.md |\n`,
@@ -542,7 +556,10 @@ describe('CLI status', () => {
 
     const payload = JSON.parse(output) as {
       summary: {
-        counts: Record<'rfc' | 'features' | 'spec' | 'tasks', Record<string, number>>;
+        counts: Record<
+          'rfc' | 'features' | 'spec' | 'tasks',
+          Record<'done' | 'in-progress' | 'not-started' | 'unknown', number>
+        >;
         orphan_count: number;
         broken_link_count: number;
         parse_error_count: number;
@@ -578,10 +595,76 @@ describe('CLI status', () => {
     // Spec rolls up to done because its only child is done.
     expect(specRecord?.status).toBe('done');
 
-    // Summary counts match the records.
+    // AS 7.2: `summary.counts` exposes every artifact type key, and
+    // each per-type object carries the four status fields defined on
+    // the data-model `ScanSummary` entity (done, in-progress,
+    // not-started, unknown). Every record of the fixture rolls up to
+    // `done`, so the other slots assert zero — locking down the
+    // shape, not just the two types spot-checked previously.
+    const STATUS_KEYS: Array<'done' | 'in-progress' | 'not-started' | 'unknown'> = [
+      'done',
+      'in-progress',
+      'not-started',
+      'unknown',
+    ];
+    for (const type of ['rfc', 'features', 'spec', 'tasks'] as const) {
+      expect(payload.summary.counts).toHaveProperty(type);
+      for (const status of STATUS_KEYS) {
+        expect(payload.summary.counts[type]).toHaveProperty(status);
+        expect(typeof payload.summary.counts[type][status]).toBe('number');
+      }
+    }
+    expect(payload.summary.counts.rfc.done).toBe(1);
+    expect(payload.summary.counts.features.done).toBe(1);
     expect(payload.summary.counts.spec.done).toBe(1);
     expect(payload.summary.counts.tasks.done).toBe(1);
     expect(payload.summary.parse_error_count).toBe(0);
+  });
+
+  it('text mode prints a per-type summary header above the flat listing (AS 7.1)', () => {
+    // Fixture exercises multiple artifact types so the header has real
+    // counts to render: one RFC, one features file, one spec, and one
+    // tasks file stitched through the canonical lineage. AS 7.1 is the
+    // header-format acceptance scenario from US7 of the spec.
+    write(
+      'docs/rfcs/example.rfc.md',
+      `# RFC: Example\n\n## Dependency Order\n\n${TABLE_HEADER}\n| M1 | Milestone One | — | docs/rfcs/01-milestone-one.features.md |\n`,
+    );
+    write(
+      'docs/rfcs/01-milestone-one.features.md',
+      `# Feature Map\n\n## Dependency Order\n\n${TABLE_HEADER}\n| F1 | Feature A | — | specs/feature-a |\n`,
+    );
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Feature Specification: Feature A\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story One | — | specs/feature-a/01-first.tasks.md |\n`,
+    );
+    write(
+      'specs/feature-a/01-first.tasks.md',
+      `# Tasks\n\n## Slice 1: First\n\n- [x] Task one\n- [x] Task two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | First | — | — |\n`,
+    );
+
+    const output = execFileSync('node', [CLI, 'status', '--root', tmpDir], {
+      encoding: 'utf-8',
+    });
+
+    const lines = output.split('\n');
+    const headerLine = lines[0] ?? '';
+    // All four plural type labels appear in the canonical order.
+    expect(headerLine).toMatch(
+      /RFCs:.*·\s*Features:.*·\s*Specs:.*·\s*Tasks:/,
+    );
+    // Header precedes the flat listing. The first record line comes
+    // after the header line (AS 7.1: header "above" the listing).
+    const firstRecordLineIndex = lines.findIndex((l) =>
+      l.includes('specs/feature-a/feature-a.spec.md'),
+    );
+    expect(firstRecordLineIndex).toBeGreaterThan(0);
+    // Header segments use the stable "N done / N in-progress / N not-started"
+    // shape — status segments whose count is zero are suppressed, and a
+    // type with every count zero still renders with a "0 done" placeholder
+    // (SD-011). Only done / in-progress / not-started appear — `unknown`
+    // is intentionally omitted per FR-016 / SD-012.
+    expect(headerLine).not.toMatch(/unknown/);
   });
 
   it('exits 0 with a friendly hint on an empty repo', () => {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -9,8 +9,9 @@
  *      contracts error table.
  *   3. Call {@link scan} to build the fully-classified `ArtifactRecord[]`.
  *   4. Derive a {@link ScanSummary} from the records.
- *   5. Emit either contract-shaped JSON (`--format json`) or a minimal
- *      flat text listing (default). Rendering the hierarchical tree and
+ *   5. Emit either contract-shaped JSON (`--format json`) or a per-type
+ *      roll-up summary header followed by a flat text listing (default).
+ *      Rendering the hierarchical tree and
  *      the graph is owned by downstream stories (US2, US10); this slice
  *      ships stub values (`tree: { roots: [] }`, `graph: { ... }`) in
  *      the JSON payload so consumers can depend on the top-level shape
@@ -84,9 +85,10 @@ interface StatusJsonPayload {
 
 /**
  * Entry point for the `smithy status` subcommand. Delegates to
- * {@link scan} and emits either JSON (`--format json`) or a minimal flat
- * text listing. Sets `process.exitCode` on error conditions so Commander
- * does not have to know about them.
+ * {@link scan} and emits either JSON (`--format json`) or a per-type
+ * roll-up summary header followed by a flat text listing (text mode).
+ * Sets `process.exitCode` on error conditions so Commander does not
+ * have to know about them.
  */
 const VALID_STATUSES: readonly Status[] = [
   'done',
@@ -191,6 +193,13 @@ export function statusAction(opts: StatusOptions = {}): void {
     return;
   }
 
+  // US7 Slice 1: per-type roll-up header printed above the flat
+  // listing whenever the scan finds at least one artifact. Kept pure
+  // and derived from the already-computed `ScanSummary` so the future
+  // US2 tree renderer can keep, move, or wrap the call site without
+  // touching the helper.
+  console.log(formatSummaryHeader(summary));
+
   // Default text output: minimal flat listing. Hierarchical rendering
   // is owned by US2; this slice ships a placeholder so humans get
   // something legible and CI can parse it line-by-line. Column order
@@ -237,6 +246,51 @@ function summarize(records: ArtifactRecord[]): ScanSummary {
     broken_link_count,
     parse_error_count,
   };
+}
+
+/**
+ * Render the per-type roll-up header printed above the text-mode flat
+ * listing (US7 Slice 1, AS 7.1). A pure function of {@link ScanSummary}
+ * so the caller can be moved or wrapped later (e.g., by the US2 tree
+ * renderer) without touching this helper.
+ *
+ * Format (SD-010 / SD-011 / SD-012):
+ * - Single line with plural type labels in the canonical order
+ *   `RFCs`, `Features`, `Specs`, `Tasks` regardless of count.
+ * - Types are joined by ` · ` (U+00B7, one space either side).
+ * - Within a type, status segments use ` / ` as the separator and
+ *   appear in the fixed order `done`, `in-progress`, `not-started`.
+ * - Segments whose count is zero are suppressed when at least one
+ *   sibling segment is non-zero, so sparse types stay compact.
+ * - A type whose counts are all zero still appears with a stable
+ *   `0 done` placeholder to preserve the four-type column structure.
+ * - `unknown` counts and the `orphan_count` / `broken_link_count` /
+ *   `parse_error_count` summary fields are intentionally omitted —
+ *   FR-016 enumerates only done / in-progress / not-started.
+ */
+export function formatSummaryHeader(summary: ScanSummary): string {
+  const TYPE_ORDER: Array<{ type: ArtifactType; label: string }> = [
+    { type: 'rfc', label: 'RFCs' },
+    { type: 'features', label: 'Features' },
+    { type: 'spec', label: 'Specs' },
+    { type: 'tasks', label: 'Tasks' },
+  ];
+  const STATUS_ORDER: Array<Exclude<Status, 'unknown'>> = [
+    'done',
+    'in-progress',
+    'not-started',
+  ];
+
+  const segments = TYPE_ORDER.map(({ type, label }) => {
+    const counts = summary.counts[type];
+    const parts = STATUS_ORDER.filter((s) => counts[s] > 0).map(
+      (s) => `${counts[s]} ${s}`,
+    );
+    const body = parts.length > 0 ? parts.join(' / ') : '0 done';
+    return `${label}: ${body}`;
+  });
+
+  return segments.join(' · ');
 }
 
 function emptyCounts(): ScanSummary['counts'] {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -268,7 +268,7 @@ function summarize(records: ArtifactRecord[]): ScanSummary {
  *   `parse_error_count` summary fields are intentionally omitted —
  *   FR-016 enumerates only done / in-progress / not-started.
  */
-export function formatSummaryHeader(summary: ScanSummary): string {
+function formatSummaryHeader(summary: ScanSummary): string {
   const TYPE_ORDER: Array<{ type: ArtifactType; label: string }> = [
     { type: 'rfc', label: 'RFCs' },
     { type: 'features', label: 'Features' },


### PR DESCRIPTION
Slice 1 of US7 Summary Roll-up Header. Adds a pure
formatSummaryHeader(ScanSummary) helper co-located with summarize() in
src/commands/status.ts and wires it into the text-mode path after the
empty-repo early-return. The header renders plural type labels
(RFCs / Features / Specs / Tasks) in canonical order joined by " · ",
with in-type segments " / "-joined and zero segments suppressed unless
every count for a type is zero (in which case a stable "0 done"
placeholder preserves the four-type structure). Per SD-012, unknown /
orphan / broken / parse-error fields are intentionally omitted from
the header.

ScanSummary, summarize(), and the --format json payload are
unmodified. The existing JSON integration test is extended into an
AS 7.2 regression guard with a four-type fixture (rfc + features +
spec + tasks stitched through the canonical lineage) and exhaustive
per-type × per-status assertions. A new AS 7.1 integration test
asserts the header appears above the flat listing on a populated
repo. Both slice task checkboxes flipped to [x].

Addresses FR-016; Acceptance Scenarios 7.1, 7.2.

https://claude.ai/code/session_01AaMLC8qV6muTEkSRwFNd4o