### PR TITLE
forge(us9): add migration-pointer text to format_legacy warning

### DIFF
--- a/specs/2026-04-12-004-smithy-status-skill/09-scanner-classifies-without-checkboxes.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/09-scanner-classifies-without-checkboxes.tasks.md
@@ -27,7 +27,7 @@
   - The warning body points at where the canonical 4-column schema is documented (the agent-skills template README).
   - The `format_legacy:` prefix is preserved so downstream consumers keyed off it continue to match.
 
-- [ ] **Lock AS 9.5 via tagged legacy-format assertions in parser and scanner tests**
+- [x] **Lock AS 9.5 via tagged legacy-format assertions in parser and scanner tests**
 
   Update the existing legacy-detection test in `src/status/parser.test.ts` and the legacy-format test in `src/status/scanner.test.ts` to reference AS 9.5 in their descriptions and assert both the `format_legacy:` prefix and the new migration-pointer body text propagate from the parser constant through to the scanner's `ArtifactRecord.warnings`.
 
@@ -37,7 +37,7 @@
   - The scanner-side test confirms the legacy spec record carries `status: 'unknown'` and the updated warning text flows through unchanged.
   - No tolerant parsing of the legacy format is introduced — the record's `rows` remain empty per FR-028.
 
-- [ ] **Add an AS 9.6 parser regression test for checkboxes inside `## Dependency Order`**
+- [x] **Add an AS 9.6 parser regression test for checkboxes inside `## Dependency Order`**
 
   Add a `parseDependencyTable` unit test in `src/status/parser.test.ts` that feeds the parser a valid 4-column table followed by freestanding `- [ ]` / `- [x]` lines inside the same `## Dependency Order` section. The test pins the invariant that such checkboxes are semantically meaningless for classification: the parsed result remains `format: 'table'` with the valid rows preserved, and no `format_legacy` warning is emitted.
 

--- a/specs/2026-04-12-004-smithy-status-skill/09-scanner-classifies-without-checkboxes.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/09-scanner-classifies-without-checkboxes.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Add migration-pointer text to the `format_legacy` warning**
+- [x] **Add migration-pointer text to the `format_legacy` warning**
 
   Define a module-level string constant in `src/status/parser.ts` holding the `format_legacy` warning and reference it from the legacy-detection branch of `parseDependencyTable`. The constant's body must satisfy FR-028 by pointing authors at the canonical 4-column schema documentation so a user encountering a legacy section has a concrete migration reference.
 

--- a/src/status/parser.test.ts
+++ b/src/status/parser.test.ts
@@ -63,7 +63,11 @@ body
     expect(result.table.id_prefix).toBe('US');
   });
 
-  it('detects legacy format from checkbox list under Dependency Order', () => {
+  it('AS 9.5: detects legacy format from checkbox list under Dependency Order and emits migration-pointer warning', () => {
+    // AS 9.5 — legacy checkbox-based `## Dependency Order` sections
+    // must emit a `format_legacy` warning whose body points at the
+    // canonical 4-column schema documentation (FR-028). No tolerant
+    // parsing is performed: rows stay empty.
     const markdown = `# Old Spec
 
 ## Dependency Order
@@ -278,6 +282,50 @@ Another paragraph.
     expect(result.table.rows).toEqual([]);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toMatch(/no 4-column table header/);
+  });
+
+  it('AS 9.6: ignores trailing freestanding checkboxes inside a valid 4-column Dependency Order section', () => {
+    // AS 9.6 — under the new unified table format, checkboxes are
+    // semantically meaningless inside `## Dependency Order`. A valid
+    // 4-column table followed by trailing `- [ ]` / `- [x]` lines
+    // must still parse as `format: 'table'` with the valid rows
+    // preserved and no `format_legacy` warning.
+    //
+    // Note: interleaved-checkbox tolerance (a freestanding checkbox
+    // between two valid table rows) is out of scope and tracked as
+    // specification debt SD-010 in
+    // `09-scanner-classifies-without-checkboxes.tasks.md`.
+    const markdown = `## Dependency Order
+
+| ID  | Title | Depends On | Artifact              |
+|-----|-------|------------|-----------------------|
+| US1 | First | —          | specs/a/us1.tasks.md  |
+| US2 | Second| US1        | —                     |
+
+- [x] Stray legacy completion marker
+- [ ] Another stray checkbox
+
+## Next
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.format).toBe('table');
+    expect(result.table.rows).toEqual([
+      {
+        id: 'US1',
+        title: 'First',
+        depends_on: [],
+        artifact_path: 'specs/a/us1.tasks.md',
+      },
+      {
+        id: 'US2',
+        title: 'Second',
+        depends_on: ['US1'],
+        artifact_path: null,
+      },
+    ]);
+    expect(
+      result.warnings.some((w) => w.startsWith('format_legacy:')),
+    ).toBe(false);
   });
 
   it('rejects headers that are missing one of the canonical column labels', () => {

--- a/src/status/parser.test.ts
+++ b/src/status/parser.test.ts
@@ -79,6 +79,10 @@ body
     expect(result.table.rows).toEqual([]);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toMatch(/^format_legacy:/);
+    // FR-028: warning body must point at the canonical 4-column schema doc.
+    expect(result.warnings[0]).toContain(
+      'src/templates/agent-skills/README.md',
+    );
   });
 
   it('parses as table when checkboxes appear inside the Title column of a 4-column table', () => {

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -45,7 +45,7 @@ const EM_DASH = '—';
  * reference. The `format_legacy: ` prefix is load-bearing — downstream
  * consumers key off it — so do not alter it.
  */
-export const FORMAT_LEGACY_WARNING =
+const FORMAT_LEGACY_WARNING =
   'format_legacy: `## Dependency Order` uses checkbox list; expected 4-column table (ID | Title | Depends On | Artifact). ' +
   'Migrate this section to the canonical 4-column schema — see `src/templates/agent-skills/README.md`.';
 

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -37,6 +37,18 @@ const ID_PREFIX_BY_TYPE: Record<ArtifactType, IdPrefix> = {
 const ID_REGEX = /^(M|F|US|S)[1-9][0-9]*$/;
 const EM_DASH = '—';
 
+/**
+ * Warning emitted when a `## Dependency Order` section uses the legacy
+ * checkbox-list format instead of the canonical 4-column table. FR-028
+ * requires this text to point authors at the canonical schema
+ * documentation so encountering the warning gives a concrete migration
+ * reference. The `format_legacy: ` prefix is load-bearing — downstream
+ * consumers key off it — so do not alter it.
+ */
+export const FORMAT_LEGACY_WARNING =
+  'format_legacy: `## Dependency Order` uses checkbox list; expected 4-column table (ID | Title | Depends On | Artifact). ' +
+  'Migrate this section to the canonical 4-column schema — see `src/templates/agent-skills/README.md` for the canonical 4-column schema.';
+
 const EXPECTED_HEADERS = ['id', 'title', 'depends on', 'artifact'] as const;
 type ColumnName = (typeof EXPECTED_HEADERS)[number];
 type ColumnIndex = Record<ColumnName, number>;
@@ -69,9 +81,7 @@ export function parseDependencyTable(
     // No 4-column header — check for legacy checkbox format.
     const hasCheckbox = lines.some((line) => /^\s*-\s*\[[ xX]\]/.test(line));
     if (hasCheckbox) {
-      warnings.push(
-        'format_legacy: `## Dependency Order` uses checkbox list; expected 4-column table (ID | Title | Depends On | Artifact)',
-      );
+      warnings.push(FORMAT_LEGACY_WARNING);
       return {
         table: { rows: [], id_prefix, format: 'legacy' },
         warnings,

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -47,7 +47,7 @@ const EM_DASH = '—';
  */
 export const FORMAT_LEGACY_WARNING =
   'format_legacy: `## Dependency Order` uses checkbox list; expected 4-column table (ID | Title | Depends On | Artifact). ' +
-  'Migrate this section to the canonical 4-column schema — see `src/templates/agent-skills/README.md` for the canonical 4-column schema.';
+  'Migrate this section to the canonical 4-column schema — see `src/templates/agent-skills/README.md`.';
 
 const EXPECTED_HEADERS = ['id', 'title', 'depends on', 'artifact'] as const;
 type ColumnName = (typeof EXPECTED_HEADERS)[number];

--- a/src/status/scanner.test.ts
+++ b/src/status/scanner.test.ts
@@ -428,7 +428,12 @@ ${TABLE_HEADER}
     expect(collisionWarnings).toHaveLength(1);
   });
 
-  it('legacy-format artifact yields a spec record with status=unknown', () => {
+  it('AS 9.5: legacy-format artifact yields a spec record with status=unknown and migration-pointer warning', () => {
+    // AS 9.5 — the scanner surfaces the parser's `format_legacy`
+    // warning verbatim on the record's `warnings` list, carries
+    // `status: 'unknown'`, and keeps `rows` empty (no tolerant
+    // parsing per FR-028). The warning body points at the canonical
+    // 4-column schema documentation.
     write(
       'specs/feature-a/feature-a.spec.md',
       `# Spec\n\n## Dependency Order\n\n- [x] US1: First story\n- [ ] US2: Second story\n`,
@@ -438,6 +443,14 @@ ${TABLE_HEADER}
     expect(spec).toBeDefined();
     expect(spec?.status).toBe('unknown');
     expect(spec?.dependency_order.format).toBe('legacy');
+    expect(spec?.dependency_order.rows).toEqual([]);
+    const legacyWarnings = spec?.warnings.filter((w) =>
+      w.startsWith('format_legacy:'),
+    );
+    expect(legacyWarnings).toHaveLength(1);
+    expect(legacyWarnings?.[0]).toContain(
+      'src/templates/agent-skills/README.md',
+    );
   });
 
   it('broken-link detection: tasks **Source** header points at a missing spec → parent_missing=true, parent_path=declared path', () => {


### PR DESCRIPTION
Slice 1 Task 1: define FORMAT_LEGACY_WARNING module constant in
src/status/parser.ts pointing legacy-section authors at the canonical
4-column schema in src/templates/agent-skills/README.md. Satisfies FR-028's
"suggest the migration path" requirement. The format_legacy: prefix is
preserved so downstream consumers keyed off it continue to match.

https://claude.ai/code/session_01JpBAEaNwC1iMphchaQYxDH