### PR TITLE
smithy status: render hierarchical tree with connectors

### DIFF
--- a/specs/2026-04-12-004-smithy-status-skill/02-render-hierarchical-status-view.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/02-render-hierarchical-status-view.tasks.md
@@ -58,7 +58,7 @@
 
 ### Tasks
 
-- [ ] **Implement `renderTree()` and replace the `statusAction` placeholder text output**
+- [x] **Implement `renderTree()` and replace the `statusAction` placeholder text output**
 
   Add `renderTree(tree: StatusTree, options?: { color?: boolean }): string` in a new `src/status/render.ts` that recursively walks `tree.roots` and emits a block of lines: each node contributes its indentation prefix, a tree connector (`├─` for any non-last child, `└─` for the last child of its parent), the record's `title`, and a status marker chosen from the record's `status` and (for tasks records) `completed` / `total` counts. Top-level group nodes ("Orphaned Specs", "Broken Links") render as their own headings above their grouped children. Update `statusAction` in `src/commands/status.ts` so the default text mode builds a `StatusTree` via `buildTree` and writes `renderTree(tree)` to stdout instead of the current `type\tpath\ttitle\tstatus` flat listing. Empty-repo, `--format json`, and error-exit paths remain unchanged. Satisfies AS 2.4 and the text-mode rows of the contracts `Outputs` table.
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -653,12 +653,13 @@ describe('CLI status', () => {
     expect(headerLine).toMatch(
       /RFCs:.*·\s*Features:.*·\s*Specs:.*·\s*Tasks:/,
     );
-    // Header precedes the flat listing. The first record line comes
-    // after the header line (AS 7.1: header "above" the listing).
-    const firstRecordLineIndex = lines.findIndex((l) =>
-      l.includes('specs/feature-a/feature-a.spec.md'),
+    // Header precedes the tree body. The first rendered title (from
+    // US2 Slice 2 `renderTree`) comes after the header line (AS 7.1:
+    // header "above" the body).
+    const firstTreeLineIndex = lines.findIndex((l) =>
+      l.includes('Feature A'),
     );
-    expect(firstRecordLineIndex).toBeGreaterThan(0);
+    expect(firstTreeLineIndex).toBeGreaterThan(0);
     // Header segments use the stable "N done / N in-progress / N not-started"
     // shape — status segments whose count is zero are suppressed, and a
     // type with every count zero still renders with a "0 done" placeholder
@@ -685,27 +686,66 @@ describe('CLI status', () => {
     expect(result.stderr).toContain('does not exist');
   });
 
-  it('emits a minimal flat text listing in type/path/title/status column order', () => {
+  it('renders a hierarchical tree with box-drawing connectors and titles (AS 2.4)', () => {
+    // US2 Slice 2: the default text mode is a hierarchical tree built
+    // by `renderTree` over the same records the JSON payload uses.
+    // This test asserts the three observable properties of AS 2.4:
+    // tree-connector characters appear, artifact titles (not paths)
+    // are the primary label, and the deepest descendant is visibly
+    // nested under its ancestor. Group headings and broken-link
+    // formatting are covered in more depth by `render.test.ts`.
+    write(
+      'docs/rfcs/example.rfc.md',
+      `# RFC: Example\n\n## Dependency Order\n\n${TABLE_HEADER}\n| M1 | Milestone One | — | docs/rfcs/01-milestone-one.features.md |\n`,
+    );
+    write(
+      'docs/rfcs/01-milestone-one.features.md',
+      `# Feature Map\n\n## Dependency Order\n\n${TABLE_HEADER}\n| F1 | Feature A | — | specs/feature-a |\n`,
+    );
     write(
       'specs/feature-a/feature-a.spec.md',
-      `# Feature Specification: Feature A\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+      `# Feature Specification: Feature A\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story One | — | specs/feature-a/01-first.tasks.md |\n`,
+    );
+    // Distinct H1 title on the tasks file so the rendered line is
+    // unambiguous — the parser extracts the first H1 as the record
+    // title, and a generic `# Tasks` would collide with the word
+    // "Tasks" in the summary-header column label.
+    write(
+      'specs/feature-a/01-first.tasks.md',
+      `# Story One\n\n## Slice 1: First\n\n- [x] Task one\n- [x] Task two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | First | — | — |\n`,
     );
 
     const output = execFileSync('node', [CLI, 'status', '--root', tmpDir], {
       encoding: 'utf-8',
     });
 
-    // Flat listing: one line per record. Column order is type, path,
-    // title, status per the Slice 3 task spec.
-    const line = output
+    // Body (everything below the US7 summary header) contains at
+    // least one tree-connector character.
+    expect(output).toMatch(/[├└]/);
+
+    // Titles are the primary label — file paths do not appear in the
+    // body. `docs/rfcs/example.rfc.md` and
+    // `specs/feature-a/01-first.tasks.md` must not leak into the
+    // rendered tree at all.
+    expect(output).not.toContain('docs/rfcs/example.rfc.md');
+    expect(output).not.toContain('specs/feature-a/01-first.tasks.md');
+    expect(output).toContain('Example');
+    expect(output).toContain('Feature A');
+    expect(output).toContain('Story One');
+
+    // The rendered tree nests Story One below Feature A via a `└─`
+    // connector. Locate the Story One line and assert it carries a
+    // connector prefix (i.e., it is not a top-level root).
+    const storyLine = output
       .split('\n')
-      .find((l) => l.includes('specs/feature-a/feature-a.spec.md'));
-    expect(line).toBeDefined();
-    const cols = (line ?? '').split('\t');
-    expect(cols[0]).toBe('spec');
-    expect(cols[1]).toBe('specs/feature-a/feature-a.spec.md');
-    expect(cols[2]).toBe('Feature A');
-    expect(cols[3]).toBe('not-started');
+      .find((l) => l.includes('Story One'));
+    expect(storyLine).toBeDefined();
+    expect(storyLine!).toMatch(/└─/);
+
+    // The DONE marker appears at least once — the fully-completed
+    // tasks record rolls up to DONE on every ancestor, and collapsing
+    // is deferred to US3, so every level shows the marker inline.
+    expect(output).toContain('DONE');
   });
 
   it('emits a valid (empty) JSON payload for an empty repo in --format json mode', () => {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -204,13 +204,34 @@ export function statusAction(opts: StatusOptions = {}): void {
   // from the same `ArtifactRecord[]` the JSON payload uses. Group
   // sentinels ("Orphaned Specs", "Broken Links") surface at the top
   // of `tree.roots` and render as their own headings above their
-  // grouped children. `color: !opts.color` reserves a wire into the
-  // `--no-color` stub once the palette lands (SD-001) — today the
-  // renderer emits plain ASCII unconditionally.
+  // grouped children. `color: opts.color !== false` preserves the
+  // future `--no-color` wire-up by disabling color only when
+  // Commander sets `opts.color` to `false`; today the renderer
+  // emits plain text with UTF-8 box-drawing connectors and no
+  // color regardless.
   const tree = buildTree(records);
   const rendered = renderTree(tree, { color: opts.color !== false });
   if (rendered.length > 0) {
     console.log(rendered);
+    return;
+  }
+
+  // Defensive fallback: the scanner found records but `buildTree`
+  // produced an empty `roots` array — the only realistic way this
+  // happens today is a pathological cycle where two records claim
+  // each other as parents, so neither reaches a root. The slice's
+  // acceptance criterion forbids silent drops ("every ArtifactRecord
+  // is represented by exactly one line"), so surface every record on
+  // its own line with a diagnostic header so operators can still see
+  // what the scanner found. Matches the spirit of the US1 flat
+  // listing this slice replaces.
+  console.log(
+    'warning: tree rendering produced no output — listing records flat to avoid silent drops.',
+  );
+  for (const record of records) {
+    console.log(
+      `${record.type}\t${record.path}\t${record.title}\t${record.status}`,
+    );
   }
 }
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -28,7 +28,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { buildTree, scan } from '../status/index.js';
+import { buildTree, renderTree, scan } from '../status/index.js';
 import type {
   ArtifactRecord,
   ArtifactType,
@@ -193,21 +193,24 @@ export function statusAction(opts: StatusOptions = {}): void {
     return;
   }
 
-  // US7 Slice 1: per-type roll-up header printed above the flat
-  // listing whenever the scan finds at least one artifact. Kept pure
-  // and derived from the already-computed `ScanSummary` so the future
-  // US2 tree renderer can keep, move, or wrap the call site without
-  // touching the helper.
+  // US7 Slice 1: per-type roll-up header printed above the tree
+  // output whenever the scan finds at least one artifact. Kept pure
+  // and derived from the already-computed `ScanSummary` so the tree
+  // renderer can keep, move, or wrap the call site without touching
+  // the helper.
   console.log(formatSummaryHeader(summary));
 
-  // Default text output: minimal flat listing. Hierarchical text
-  // rendering is owned by US2 Slice 2 (renderTree); this placeholder
-  // remains until that slice lands. Column order: type, path, title,
-  // status.
-  for (const record of records) {
-    console.log(
-      `${record.type}\t${record.path}\t${record.title}\t${record.status}`,
-    );
+  // US2 Slice 2: default text output is a hierarchical tree built
+  // from the same `ArtifactRecord[]` the JSON payload uses. Group
+  // sentinels ("Orphaned Specs", "Broken Links") surface at the top
+  // of `tree.roots` and render as their own headings above their
+  // grouped children. `color: !opts.color` reserves a wire into the
+  // `--no-color` stub once the palette lands (SD-001) — today the
+  // renderer emits plain ASCII unconditionally.
+  const tree = buildTree(records);
+  const rendered = renderTree(tree, { color: opts.color !== false });
+  if (rendered.length > 0) {
+    console.log(rendered);
   }
 }
 

--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -16,3 +16,4 @@ export {
 export { classifyRecord } from './classifier.js';
 export { scan } from './scanner.js';
 export { buildTree, BROKEN_LINKS_PATH, ORPHANED_SPECS_PATH } from './tree.js';
+export { renderTree, type RenderTreeOptions } from './render.js';

--- a/src/status/render.test.ts
+++ b/src/status/render.test.ts
@@ -1,0 +1,393 @@
+import { describe, expect, it } from 'vitest';
+
+// Import through the `./index.js` barrel so these tests also assert
+// that `renderTree` is re-exported on the stable public surface.
+import {
+  buildTree,
+  BROKEN_LINKS_PATH,
+  ORPHANED_SPECS_PATH,
+  renderTree,
+  type ArtifactRecord,
+  type ArtifactType,
+  type DependencyOrderTable,
+  type StatusTree,
+} from './index.js';
+
+/**
+ * Minimal `ArtifactRecord` factory for renderer tests. Only the fields
+ * `renderTree` actually reads (`type`, `path`, `title`, `status`,
+ * `completed`, `total`, `parent_path`, `parent_missing`, `warnings`)
+ * carry semantic weight — the rest are padded with sensible defaults
+ * so the test bodies stay small.
+ */
+function makeRecord(overrides: Partial<ArtifactRecord> = {}): ArtifactRecord {
+  const type: ArtifactType = overrides.type ?? 'spec';
+  const idPrefix: DependencyOrderTable['id_prefix'] =
+    type === 'rfc'
+      ? 'M'
+      : type === 'features'
+        ? 'F'
+        : type === 'spec'
+          ? 'US'
+          : 'S';
+  const dependency_order: DependencyOrderTable = overrides.dependency_order ?? {
+    rows: [],
+    id_prefix: idPrefix,
+    format: 'table',
+  };
+  return {
+    type,
+    path: overrides.path ?? `specs/sample.${type === 'tasks' ? 'tasks' : type}.md`,
+    title: overrides.title ?? 'Sample',
+    status: overrides.status ?? 'not-started',
+    dependency_order,
+    warnings: overrides.warnings ?? [],
+    ...overrides,
+  };
+}
+
+describe('renderTree — empty and trivial trees', () => {
+  it('returns the empty string for an empty tree', () => {
+    const tree: StatusTree = { roots: [] };
+    expect(renderTree(tree)).toBe('');
+  });
+
+  it('renders a single-root tree with no connectors and a status marker', () => {
+    const tree = buildTree([
+      makeRecord({
+        type: 'rfc',
+        path: 'docs/rfcs/0001.rfc.md',
+        title: 'Demo RFC',
+        status: 'done',
+        parent_path: null,
+      }),
+    ]);
+    const output = renderTree(tree);
+    // Exactly one line; no connectors on the root; DONE marker.
+    const lines = output.split('\n');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).not.toMatch(/[├└]/);
+    expect(lines[0]).toContain('Demo RFC');
+    expect(lines[0]).toContain('DONE');
+  });
+
+  it('is a pure function: same input produces identical output on repeat calls', () => {
+    const records: ArtifactRecord[] = [
+      makeRecord({ type: 'rfc', path: 'docs/rfcs/0001.rfc.md', parent_path: null }),
+      makeRecord({
+        type: 'features',
+        path: 'docs/rfcs/0001.features.md',
+        parent_path: 'docs/rfcs/0001.rfc.md',
+      }),
+    ];
+    const tree = buildTree(records);
+    expect(renderTree(tree)).toBe(renderTree(tree));
+  });
+});
+
+describe('renderTree — full RFC → features → spec → tasks chain', () => {
+  const rfc = makeRecord({
+    type: 'rfc',
+    path: 'docs/rfcs/0001-demo.rfc.md',
+    title: 'Demo RFC',
+    status: 'in-progress',
+    parent_path: null,
+  });
+  const features = makeRecord({
+    type: 'features',
+    path: 'docs/rfcs/0001-demo.features.md',
+    title: 'Demo Features',
+    status: 'in-progress',
+    parent_path: 'docs/rfcs/0001-demo.rfc.md',
+  });
+  const spec = makeRecord({
+    type: 'spec',
+    path: 'specs/feature-a/feature-a.spec.md',
+    title: 'Feature A',
+    status: 'in-progress',
+    parent_path: 'docs/rfcs/0001-demo.features.md',
+  });
+  const tasks = makeRecord({
+    type: 'tasks',
+    path: 'specs/feature-a/01-story.tasks.md',
+    title: 'Story One',
+    status: 'in-progress',
+    completed: 2,
+    total: 5,
+    parent_path: 'specs/feature-a/feature-a.spec.md',
+  });
+
+  it('nests descendants under ancestors using └─ connectors on only-child branches', () => {
+    const tree = buildTree([rfc, features, spec, tasks]);
+    const output = renderTree(tree);
+    const lines = output.split('\n');
+    expect(lines).toHaveLength(4);
+
+    // Root line — no connector.
+    expect(lines[0]).toBe('Demo RFC  in progress');
+    // Each subsequent line has exactly one └─ (last sibling) at the
+    // correct indentation level. Only-child chains add blank spacers,
+    // not vertical bars.
+    expect(lines[1]).toBe('└─ Demo Features  in progress');
+    expect(lines[2]).toBe('   └─ Feature A  in progress');
+    expect(lines[3]).toBe('      └─ Story One  2/5');
+  });
+
+  it('uses titles, not file paths, as the primary label (AS 2.4)', () => {
+    const tree = buildTree([rfc, features, spec, tasks]);
+    const output = renderTree(tree);
+    expect(output).not.toContain('docs/rfcs/0001-demo.rfc.md');
+    expect(output).not.toContain('specs/feature-a/feature-a.spec.md');
+    expect(output).toContain('Demo RFC');
+    expect(output).toContain('Feature A');
+    expect(output).toContain('Story One');
+  });
+
+  it('renders every ArtifactRecord exactly once (no silent drops, no duplicates)', () => {
+    const tree = buildTree([rfc, features, spec, tasks]);
+    const output = renderTree(tree);
+    for (const record of [rfc, features, spec, tasks]) {
+      const occurrences = output.split('\n').filter((l) => l.includes(record.title)).length;
+      expect(occurrences).toBe(1);
+    }
+  });
+});
+
+describe('renderTree — sibling connectors', () => {
+  it('uses ├─ for non-last siblings and └─ for the last sibling, with │ spacers inherited by non-last subtrees', () => {
+    // RFC with two features, the first of which has a spec child.
+    const rfc = makeRecord({
+      type: 'rfc',
+      path: 'docs/rfcs/0001.rfc.md',
+      title: 'Demo',
+      status: 'in-progress',
+      parent_path: null,
+    });
+    const featuresA = makeRecord({
+      type: 'features',
+      path: 'docs/rfcs/0001-a.features.md',
+      title: 'Features A',
+      status: 'in-progress',
+      parent_path: 'docs/rfcs/0001.rfc.md',
+    });
+    const featuresB = makeRecord({
+      type: 'features',
+      path: 'docs/rfcs/0001-b.features.md',
+      title: 'Features B',
+      status: 'not-started',
+      parent_path: 'docs/rfcs/0001.rfc.md',
+    });
+    const specA = makeRecord({
+      type: 'spec',
+      path: 'specs/feature-a/feature-a.spec.md',
+      title: 'Spec A',
+      status: 'in-progress',
+      parent_path: 'docs/rfcs/0001-a.features.md',
+    });
+
+    const tree = buildTree([rfc, featuresA, specA, featuresB]);
+    const lines = renderTree(tree).split('\n');
+
+    expect(lines[0]).toBe('Demo  in progress');
+    // Features A is a non-last sibling, so its connector is ├─ and
+    // its own child's prefix inherits a │ spacer.
+    expect(lines[1]).toBe('├─ Features A  in progress');
+    expect(lines[2]).toBe('│  └─ Spec A  in progress');
+    // Features B is the last sibling under the RFC.
+    expect(lines[3]).toBe('└─ Features B  not started');
+  });
+});
+
+describe('renderTree — status markers', () => {
+  it('renders DONE for done records regardless of type', () => {
+    const tree = buildTree([
+      makeRecord({
+        type: 'rfc',
+        path: 'docs/rfcs/0001.rfc.md',
+        title: 'Done RFC',
+        status: 'done',
+        parent_path: null,
+      }),
+    ]);
+    expect(renderTree(tree)).toContain('DONE');
+  });
+
+  it('renders the completed/total counter for in-progress tasks records', () => {
+    const parent = makeRecord({
+      type: 'spec',
+      path: 'specs/f/f.spec.md',
+      title: 'F',
+      status: 'in-progress',
+      parent_path: null,
+    });
+    const tasks = makeRecord({
+      type: 'tasks',
+      path: 'specs/f/01-story.tasks.md',
+      title: 'Story',
+      status: 'in-progress',
+      completed: 3,
+      total: 7,
+      parent_path: 'specs/f/f.spec.md',
+    });
+    // Orphan parent falls through to a real root (features/rfc/tasks
+    // with parent_path=null go to roots, not Orphaned Specs — that's
+    // a spec-only group). This one IS a spec with null parent, so it
+    // lands under the Orphaned Specs group. Walk that group's child
+    // to reach the spec node.
+    const tree = buildTree([parent, tasks]);
+    const output = renderTree(tree);
+    // Exactly the `3/7` counter surfaces for the tasks record.
+    expect(output).toContain('Story  3/7');
+  });
+
+  it('renders an unambiguous "in progress" marker distinct from DONE for non-tasks in-progress records', () => {
+    const tree = buildTree([
+      makeRecord({
+        type: 'features',
+        path: 'docs/rfcs/0001.features.md',
+        title: 'Features',
+        status: 'in-progress',
+        parent_path: null,
+      }),
+    ]);
+    const output = renderTree(tree);
+    expect(output).toContain('in progress');
+    expect(output).not.toContain('DONE');
+  });
+
+  it('renders "not started" for not-started records (real and virtual)', () => {
+    const tree = buildTree([
+      makeRecord({
+        type: 'rfc',
+        path: 'docs/rfcs/real.rfc.md',
+        title: 'Real RFC',
+        status: 'not-started',
+        parent_path: null,
+      }),
+      makeRecord({
+        type: 'features',
+        path: 'docs/rfcs/virtual.features.md',
+        title: 'Virtual Features',
+        status: 'not-started',
+        virtual: true,
+        parent_path: 'docs/rfcs/real.rfc.md',
+      }),
+    ]);
+    const output = renderTree(tree);
+    // Both the real root and the virtual child carry the marker.
+    const lines = output.split('\n');
+    expect(lines.filter((l) => l.includes('not started'))).toHaveLength(2);
+  });
+
+  it('surfaces at least one warning for unknown records', () => {
+    const tree = buildTree([
+      makeRecord({
+        type: 'spec',
+        path: 'specs/broken/broken.spec.md',
+        title: 'Broken',
+        status: 'unknown',
+        warnings: ['parser: legacy checkbox format detected'],
+        parent_path: null,
+      }),
+    ]);
+    const output = renderTree(tree);
+    // Spec with parent_path=null routes to Orphaned Specs. The child
+    // line carries the warning content.
+    expect(output).toContain('unknown');
+    expect(output).toContain('legacy checkbox format detected');
+  });
+});
+
+describe('renderTree — synthetic groups', () => {
+  it('renders an "Orphaned Specs" top-level heading above its members', () => {
+    const orphan = makeRecord({
+      type: 'spec',
+      path: 'specs/orphan/orphan.spec.md',
+      title: 'Orphan Story',
+      status: 'not-started',
+      parent_path: null,
+    });
+    const tree = buildTree([orphan]);
+    const lines = renderTree(tree).split('\n');
+
+    expect(lines[0]).toBe('Orphaned Specs');
+    // The group heading carries no status marker of its own.
+    expect(lines[0]).not.toContain('DONE');
+    expect(lines[0]).not.toContain('not started');
+    // Its sole member is nested beneath with a └─ connector.
+    expect(lines[1]).toBe('└─ Orphan Story  not started');
+  });
+
+  it('renders a "Broken Links" top-level heading and surfaces the dangling parent path on each child', () => {
+    const broken = makeRecord({
+      type: 'tasks',
+      path: 'specs/lost/01-dangling.tasks.md',
+      title: 'Dangling Story',
+      status: 'not-started',
+      completed: 0,
+      total: 2,
+      parent_path: 'specs/deleted/deleted.spec.md',
+      parent_missing: true,
+    });
+    const tree = buildTree([broken]);
+    const lines = renderTree(tree).split('\n');
+
+    expect(lines[0]).toBe('Broken Links');
+    // Broken-link line surfaces the dangling parent reference inline
+    // alongside the title, and still ends with its status marker.
+    expect(lines[1]).toContain('Dangling Story');
+    expect(lines[1]).toContain('specs/deleted/deleted.spec.md');
+    expect(lines[1]).toMatch(/└─ /);
+    expect(lines[1]).toMatch(/not started$/);
+  });
+
+  it('orders Orphaned Specs before Broken Links when both groups are populated', () => {
+    const orphan = makeRecord({
+      type: 'spec',
+      path: 'specs/orphan/orphan.spec.md',
+      title: 'Orphan',
+      parent_path: null,
+    });
+    const broken = makeRecord({
+      type: 'tasks',
+      path: 'specs/lost/01-dangling.tasks.md',
+      title: 'Dangling',
+      parent_path: 'specs/deleted/deleted.spec.md',
+      parent_missing: true,
+    });
+    const output = renderTree(buildTree([orphan, broken]));
+    const lines = output.split('\n');
+    const orphanIndex = lines.findIndex((l) => l === 'Orphaned Specs');
+    const brokenIndex = lines.findIndex((l) => l === 'Broken Links');
+    expect(orphanIndex).toBeGreaterThanOrEqual(0);
+    expect(brokenIndex).toBeGreaterThan(orphanIndex);
+  });
+});
+
+describe('renderTree — group sentinel detection', () => {
+  it('detects group sentinels by reserved path (not title) so a real record titled "Orphaned Specs" still renders as an ordinary node', () => {
+    // Regression guard: a real record whose title happens to match a
+    // group heading must NOT be mistaken for the group itself. The
+    // path is what identifies the sentinel.
+    const tree: StatusTree = {
+      roots: [
+        {
+          record: makeRecord({
+            type: 'rfc',
+            path: 'docs/rfcs/0001.rfc.md',
+            title: 'Orphaned Specs',
+            status: 'done',
+            parent_path: null,
+          }),
+          children: [],
+        },
+      ],
+    };
+    const output = renderTree(tree);
+    // The real record still carries its status marker.
+    expect(output).toBe('Orphaned Specs  DONE');
+    // And is NOT misrouted via the sentinel constants.
+    expect(output).not.toContain(ORPHANED_SPECS_PATH);
+    expect(output).not.toContain(BROKEN_LINKS_PATH);
+  });
+});

--- a/src/status/render.ts
+++ b/src/status/render.ts
@@ -1,0 +1,193 @@
+/**
+ * Pure text rendering over the {@link StatusTree} produced by
+ * {@link buildTree}. Walks the tree in depth-first, input-order and
+ * emits a block of lines suitable for writing to stdout in text mode.
+ *
+ * This module is deliberately side-effect-free. `renderTree` performs
+ * no I/O, does not touch `process.stdout`, and never mutates its
+ * input — the output is a pure function of the tree (and the options
+ * bag).
+ *
+ * ## Layout
+ *
+ * - Top-level nodes (`tree.roots`) are emitted flush-left, one line
+ *   per node, with no connector prefix. The synthetic "Orphaned Specs"
+ *   and "Broken Links" group nodes emitted by `buildTree` render as
+ *   plain top-level headings here — their members are then nested
+ *   beneath them like any other children.
+ *
+ * - Every non-root node is preceded by a tree connector drawn from the
+ *   classic box-drawing set: `├─ ` for non-last siblings, `└─ ` for
+ *   the last sibling of each parent. Descendants of a non-last sibling
+ *   inherit a `│  ` spacer; descendants of the last sibling inherit a
+ *   blank spacer, so vertical bars trail only the branches that still
+ *   have siblings below them.
+ *
+ * - Each rendered line uses the record's `title` as the primary label
+ *   — file paths intentionally stay out of the visual field and live
+ *   only in the JSON payload. Broken-link records additionally append
+ *   their dangling `parent_path` so reviewers can see what the source
+ *   file claims without opening it.
+ *
+ * ## Status markers
+ *
+ * Every real record (every non-group node) carries a trailing status
+ * marker separated from the label by two spaces. The exact mapping is:
+ *
+ * | Record state | Marker |
+ * |--------------|--------|
+ * | `status === 'done'` | `DONE` |
+ * | `status === 'in-progress'` on a tasks record | `<completed>/<total>` |
+ * | `status === 'in-progress'` on a parent record | `in progress` |
+ * | `status === 'not-started'` (real or virtual) | `not started` |
+ * | `status === 'unknown'` | `unknown (<first warning>)` |
+ *
+ * The markers are plain ASCII so they survive non-UTF-8 terminals and
+ * copy/paste into tickets. SD-011 leaves the exact wording to
+ * implementation; the table above is the convention that lands with
+ * this slice. SD-012 asks for an unambiguous marker on `in-progress`
+ * parents distinct from `DONE` — `in progress` lowercase satisfies
+ * that. Collapsing of done subtrees is US3's responsibility, so every
+ * record shows its marker inline here.
+ *
+ * Group sentinel nodes (detected via the reserved
+ * `ORPHANED_SPECS_PATH` / `BROKEN_LINKS_PATH` values) are rendered as
+ * pure headings with no trailing marker — they are not real lifecycle
+ * entities.
+ */
+
+import {
+  BROKEN_LINKS_PATH,
+  ORPHANED_SPECS_PATH,
+} from './tree.js';
+import type { ArtifactRecord, StatusTree, TreeNode } from './types.js';
+
+/**
+ * Options accepted by {@link renderTree}. The `color` flag is reserved
+ * so a future ANSI palette (SD-001) can slot in without changing the
+ * call sites that already pass `{ color: true }`. It is a no-op today:
+ * the renderer emits plain ASCII regardless.
+ */
+export interface RenderTreeOptions {
+  /** Reserved for ANSI color output (currently a no-op). */
+  color?: boolean;
+}
+
+/**
+ * Render a {@link StatusTree} as a block of indented, tree-connector
+ * lines. Pure function — does no I/O and does not mutate its input.
+ * Callers are responsible for writing the returned string to stdout.
+ *
+ * The returned string does NOT include a trailing newline; typical
+ * callers pipe it through `console.log`, which adds one. An empty tree
+ * yields the empty string.
+ */
+export function renderTree(
+  tree: StatusTree,
+  _options: RenderTreeOptions = {},
+): string {
+  if (tree.roots.length === 0) {
+    return '';
+  }
+  const lines: string[] = [];
+  for (const root of tree.roots) {
+    renderRoot(root, lines);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Emit a top-level node (a root, or a synthetic group heading). Roots
+ * carry no connector prefix — only their descendants do.
+ */
+function renderRoot(node: TreeNode, lines: string[]): void {
+  lines.push(formatLine(node.record, ''));
+  const { children } = node;
+  for (let i = 0; i < children.length; i++) {
+    renderChild(children[i]!, '', i === children.length - 1, lines);
+  }
+}
+
+/**
+ * Emit a non-root node, recursing into its children. `parentPrefix`
+ * contains the accumulated vertical-bar / blank spacers inherited from
+ * ancestors; this function appends the node's own connector and then
+ * builds the prefix for its own children.
+ */
+function renderChild(
+  node: TreeNode,
+  parentPrefix: string,
+  isLast: boolean,
+  lines: string[],
+): void {
+  const connector = isLast ? '└─ ' : '├─ ';
+  lines.push(formatLine(node.record, parentPrefix + connector));
+
+  // Descendants of a non-last sibling still need a trailing vertical
+  // bar so the connector columns line up; the last sibling's subtree
+  // gets plain spaces because nothing else sits below it.
+  const childSpacer = isLast ? '   ' : '│  ';
+  const nextPrefix = parentPrefix + childSpacer;
+  const { children } = node;
+  for (let i = 0; i < children.length; i++) {
+    renderChild(children[i]!, nextPrefix, i === children.length - 1, lines);
+  }
+}
+
+/**
+ * Format a single record into its rendered line. Group sentinels
+ * render as bare headings; real records append a status marker and,
+ * for broken-link records, their dangling parent reference.
+ */
+function formatLine(record: ArtifactRecord, prefix: string): string {
+  if (isGroupSentinel(record)) {
+    return `${prefix}${record.title}`;
+  }
+
+  const marker = formatStatusMarker(record);
+  const label =
+    record.parent_missing === true &&
+    typeof record.parent_path === 'string' &&
+    record.parent_path.length > 0
+      ? `${record.title} [missing parent: ${record.parent_path}]`
+      : record.title;
+
+  return `${prefix}${label}  ${marker}`;
+}
+
+/**
+ * Detect the synthetic group wrappers emitted by {@link buildTree}.
+ * These wrap a sentinel `ArtifactRecord` whose `path` is one of two
+ * reserved values — matching on `path` is cheaper and more precise
+ * than title equality.
+ */
+function isGroupSentinel(record: ArtifactRecord): boolean {
+  return (
+    record.path === ORPHANED_SPECS_PATH || record.path === BROKEN_LINKS_PATH
+  );
+}
+
+/**
+ * Derive the trailing status marker for a real record. See the module
+ * JSDoc for the full mapping.
+ */
+function formatStatusMarker(record: ArtifactRecord): string {
+  switch (record.status) {
+    case 'done':
+      return 'DONE';
+    case 'in-progress':
+      if (record.type === 'tasks') {
+        const completed = record.completed ?? 0;
+        const total = record.total ?? 0;
+        return `${completed}/${total}`;
+      }
+      return 'in progress';
+    case 'not-started':
+      return 'not started';
+    case 'unknown': {
+      const first =
+        record.warnings.length > 0 ? record.warnings[0] : 'parse error';
+      return `unknown (${first})`;
+    }
+  }
+}

--- a/src/status/render.ts
+++ b/src/status/render.ts
@@ -66,7 +66,8 @@ import type { ArtifactRecord, StatusTree, TreeNode } from './types.js';
  * Options accepted by {@link renderTree}. The `color` flag is reserved
  * so a future ANSI palette (SD-001) can slot in without changing the
  * call sites that already pass `{ color: true }`. It is a no-op today:
- * the renderer emits plain ASCII regardless.
+ * the renderer emits plain text with UTF-8 box-drawing connectors and
+ * no ANSI color.
  */
 export interface RenderTreeOptions {
   /** Reserved for ANSI color output (currently a no-op). */


### PR DESCRIPTION
Replaces the US1 placeholder flat listing with a pure `renderTree()`
that walks the `StatusTree` produced by `buildTree()` and emits
box-drawing connector lines (`├─` / `└─`) with titles as the primary
label and per-record status markers (`DONE`, `N/M`, `not started`,
`in progress`, `unknown (<warning>)`).

Wires `renderTree` into `statusAction` text mode beneath the US7
summary header. Broken-link records surface their dangling parent
reference inline. Group sentinels ("Orphaned Specs", "Broken Links")
render as top-level headings without markers. Collapsing of done
subtrees remains US3's responsibility — every record shows its
marker inline here.

Addresses FR-007, FR-016 (partial), and AS 2.4 from US2 Slice 2.

https://claude.ai/code/session_01Pc1BsvbFvq1vrFNTiq6ReP