### PR TITLE
fix(status): link backtick-wrapped tasks paths and surface orphan tasks as errors

### DIFF
--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -15,5 +15,10 @@ export {
 } from './parser.js';
 export { classifyRecord } from './classifier.js';
 export { scan } from './scanner.js';
-export { buildTree, BROKEN_LINKS_PATH, ORPHANED_SPECS_PATH } from './tree.js';
+export {
+  buildTree,
+  BROKEN_LINKS_PATH,
+  ORPHANED_SPECS_PATH,
+  ORPHANED_TASKS_PATH,
+} from './tree.js';
 export { renderTree, type RenderTreeOptions } from './render.js';

--- a/src/status/parser.test.ts
+++ b/src/status/parser.test.ts
@@ -6,17 +6,22 @@ import { parseArtifact, parseDependencyTable } from './index.js';
 
 describe('parseDependencyTable', () => {
   it('parses a well-formed 4-column table preserving source order', () => {
+    // Mix backticked and plain Artifact cells. Real specs wrap paths in
+    // markdown inline-code backticks (the canonical form documented in
+    // `src/templates/agent-skills/README.md`), so the parser must strip
+    // a single pair of surrounding backticks while still accepting plain
+    // paths for backwards compatibility.
     const markdown = `# Some Spec
 
 Preamble text.
 
 ## Dependency Order
 
-| ID  | Title       | Depends On | Artifact              |
-|-----|-------------|------------|-----------------------|
-| US1 | First story | —          | specs/a/us1.tasks.md  |
-| US2 | Second story| US1        | specs/a/us2.tasks.md  |
-| US3 | Third story | —          | —                     |
+| ID  | Title       | Depends On | Artifact                |
+|-----|-------------|------------|-------------------------|
+| US1 | First story | —          | \`specs/a/us1.tasks.md\` |
+| US2 | Second story| US1        | specs/a/us2.tasks.md    |
+| US3 | Third story | —          | —                       |
 
 ## Next Section
 
@@ -45,6 +50,26 @@ trailing content
       depends_on: [],
       artifact_path: null,
     });
+  });
+
+  it('coerces backtick-wrapped absolute Artifact paths to null with a warning', () => {
+    // Backtick unwrapping must happen before the absolute-path check so
+    // a backticked absolute path is still rejected instead of being
+    // treated as a relative path after stripping.
+    const markdown = `## Dependency Order
+
+| ID  | Title | Depends On | Artifact            |
+|-----|-------|------------|---------------------|
+| US1 | Foo   | —          | \`/etc/passwd\`      |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.rows).toHaveLength(1);
+    expect(result.table.rows[0]?.artifact_path).toBeNull();
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/absolute path/);
+    expect(result.warnings[0]).toMatch(/US1/);
+    // The warning should quote the unwrapped path, not the backticked form.
+    expect(result.warnings[0]).toContain("'/etc/passwd'");
   });
 
   it('returns missing format when no Dependency Order section exists', () => {

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -163,16 +163,23 @@ export function parseDependencyTable(
             .map((v) => v.trim())
             .filter((v) => v.length > 0);
 
+    // Real specs wrap the Artifact cell in markdown inline-code backticks
+    // (e.g. `` `specs/foo/01-bar.tasks.md` ``); the canonical template in
+    // `src/templates/agent-skills/README.md` shows the same form. Unwrap
+    // a single pair of surrounding backticks before the absolute-path
+    // check so a backticked absolute path is still rejected.
+    const unwrappedArtifact = stripInlineCode(artifactCell);
+
     let artifact_path: string | null;
-    if (artifactCell === EM_DASH || artifactCell === '') {
+    if (unwrappedArtifact === EM_DASH || unwrappedArtifact === '') {
       artifact_path = null;
-    } else if (isAbsolutePath(artifactCell)) {
+    } else if (isAbsolutePath(unwrappedArtifact)) {
       warnings.push(
-        `dependency_order: row ${id} has absolute path '${artifactCell}' — coerced to null`,
+        `dependency_order: row ${id} has absolute path '${unwrappedArtifact}' — coerced to null`,
       );
       artifact_path = null;
     } else {
-      artifact_path = artifactCell;
+      artifact_path = unwrappedArtifact;
     }
 
     partials.push({
@@ -491,4 +498,16 @@ function isSeparatorRow(line: string): boolean {
  */
 function isAbsolutePath(value: string): boolean {
   return value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value);
+}
+
+/**
+ * Unwrap a single pair of surrounding markdown inline-code backticks
+ * from a table cell, returning the inner text trimmed. Leaves cells
+ * without wrapping backticks (or with unbalanced backticks) untouched.
+ */
+function stripInlineCode(cell: string): string {
+  if (cell.length >= 2 && cell.startsWith('`') && cell.endsWith('`')) {
+    return cell.slice(1, -1).trim();
+  }
+  return cell;
 }

--- a/src/status/render.test.ts
+++ b/src/status/render.test.ts
@@ -393,6 +393,90 @@ describe('renderTree — group sentinel detection', () => {
   });
 });
 
+describe('renderTree — story number prefix', () => {
+  it('injects zero-padded story number after a leading `Tasks: ` prefix', () => {
+    // Real tasks file: H1 is `# Tasks: <title>`, so the record's title
+    // carries the `Tasks: ` prefix verbatim. The scanner's Phase 2
+    // populates `parent_row_id` from the owning spec row (e.g. US3),
+    // and the renderer must slot `03` in after the `Tasks: ` prefix —
+    // not before it — so the type prefix stays visible.
+    const tasks = makeRecord({
+      type: 'tasks',
+      path: 'specs/feature-a/03-suggest-next.tasks.md',
+      title: 'Tasks: Suggest the Next Command',
+      status: 'not-started',
+      parent_path: 'specs/feature-a/feature-a.spec.md',
+      parent_row_id: 'US3',
+    });
+    const output = renderTree({
+      roots: [{ record: tasks, children: [] }],
+    });
+    expect(output).toBe('Tasks: 03 Suggest the Next Command  not started');
+  });
+
+  it('prefixes virtual records (from `—` spec rows) with their US number', () => {
+    // Virtual records carry the parent row's title verbatim (no
+    // `Tasks: ` prefix). The renderer must prepend the zero-padded
+    // number directly to the title.
+    const virt = makeRecord({
+      type: 'tasks',
+      path: 'specs/feature-a/07-collapse.tasks.md',
+      title: 'Collapse Completed Items',
+      status: 'not-started',
+      virtual: true,
+      parent_path: 'specs/feature-a/feature-a.spec.md',
+      parent_row_id: 'US7',
+    });
+    const output = renderTree({
+      roots: [{ record: virt, children: [] }],
+    });
+    expect(output).toBe('07 Collapse Completed Items  not started');
+  });
+
+  it('zero-pads single-digit US numbers and preserves multi-digit numbers', () => {
+    const us1 = makeRecord({
+      type: 'tasks',
+      path: 'specs/a/01-one.tasks.md',
+      title: 'Tasks: One',
+      status: 'done',
+      parent_path: 'specs/a/a.spec.md',
+      parent_row_id: 'US1',
+    });
+    const us12 = makeRecord({
+      type: 'tasks',
+      path: 'specs/a/12-twelve.tasks.md',
+      title: 'Tasks: Twelve',
+      status: 'done',
+      parent_path: 'specs/a/a.spec.md',
+      parent_row_id: 'US12',
+    });
+    const output = renderTree({
+      roots: [
+        { record: us1, children: [] },
+        { record: us12, children: [] },
+      ],
+    });
+    expect(output.split('\n')).toEqual([
+      'Tasks: 01 One  DONE',
+      'Tasks: 12 Twelve  DONE',
+    ]);
+  });
+
+  it('leaves records without parent_row_id unchanged', () => {
+    // Top-level RFCs and orphan tasks have no parent row and must not
+    // gain a spurious number prefix.
+    const rfc = makeRecord({
+      type: 'rfc',
+      path: 'docs/rfcs/demo.rfc.md',
+      title: 'Demo RFC',
+      status: 'done',
+      parent_path: null,
+    });
+    const output = renderTree({ roots: [{ record: rfc, children: [] }] });
+    expect(output).toBe('Demo RFC  DONE');
+  });
+});
+
 describe('renderTree — orphaned tasks error output', () => {
   it('renders real tasks with no parent as flat ERROR lines (not nested tree rows)', () => {
     // A real on-disk `.tasks.md` that could not be linked to a spec is

--- a/src/status/render.test.ts
+++ b/src/status/render.test.ts
@@ -6,6 +6,7 @@ import {
   buildTree,
   BROKEN_LINKS_PATH,
   ORPHANED_SPECS_PATH,
+  ORPHANED_TASKS_PATH,
   renderTree,
   type ArtifactRecord,
   type ArtifactType,
@@ -389,5 +390,42 @@ describe('renderTree — group sentinel detection', () => {
     // And is NOT misrouted via the sentinel constants.
     expect(output).not.toContain(ORPHANED_SPECS_PATH);
     expect(output).not.toContain(BROKEN_LINKS_PATH);
+  });
+});
+
+describe('renderTree — orphaned tasks error output', () => {
+  it('renders real tasks with no parent as flat ERROR lines (not nested tree rows)', () => {
+    // A real on-disk `.tasks.md` that could not be linked to a spec is
+    // always an error condition. The renderer must surface it as an
+    // `ERROR:` line per orphan — no tree connectors, no "Orphaned
+    // Tasks" heading — so the diagnostic is visible in log scrapes and
+    // CI output and is clearly distinguishable from regular rows.
+    const tree = buildTree([
+      makeRecord({
+        type: 'tasks',
+        path: 'specs/lost/01-lost.tasks.md',
+        title: 'Lost Tasks',
+        parent_path: null,
+      }),
+      makeRecord({
+        type: 'tasks',
+        path: 'specs/abandoned/02-abandoned.tasks.md',
+        title: 'Abandoned Tasks',
+        parent_path: null,
+      }),
+    ]);
+
+    const output = renderTree(tree);
+    const lines = output.split('\n');
+    expect(lines).toEqual([
+      'ERROR: Orphaned task file specs/lost/01-lost.tasks.md could not be linked to a spec',
+      'ERROR: Orphaned task file specs/abandoned/02-abandoned.tasks.md could not be linked to a spec',
+    ]);
+    // The sentinel path must never leak into the rendered output.
+    expect(output).not.toContain(ORPHANED_TASKS_PATH);
+    // No tree connectors or status markers on ERROR lines.
+    expect(output).not.toContain('├─');
+    expect(output).not.toContain('└─');
+    expect(output).not.toContain('not started');
   });
 });

--- a/src/status/render.ts
+++ b/src/status/render.ts
@@ -59,6 +59,7 @@
 import {
   BROKEN_LINKS_PATH,
   ORPHANED_SPECS_PATH,
+  ORPHANED_TASKS_PATH,
 } from './tree.js';
 import type { ArtifactRecord, StatusTree, TreeNode } from './types.js';
 
@@ -100,8 +101,22 @@ export function renderTree(
 /**
  * Emit a top-level node (a root, or a synthetic group heading). Roots
  * carry no connector prefix — only their descendants do.
+ *
+ * The "Orphaned Tasks" group is a diagnostic, not part of the normal
+ * tree: a real on-disk `.tasks.md` that could not be linked to any
+ * spec is always an error. Emit its members as flat `ERROR:` lines so
+ * they survive log scrapes and CI output, and skip the heading + tree
+ * connectors that normal groups use.
  */
 function renderRoot(node: TreeNode, lines: string[]): void {
+  if (node.record.path === ORPHANED_TASKS_PATH) {
+    for (const child of node.children) {
+      lines.push(
+        `ERROR: Orphaned task file ${child.record.path} could not be linked to a spec`,
+      );
+    }
+    return;
+  }
   lines.push(formatLine(node.record, ''));
   const { children } = node;
   for (let i = 0; i < children.length; i++) {
@@ -164,7 +179,9 @@ function formatLine(record: ArtifactRecord, prefix: string): string {
  */
 function isGroupSentinel(record: ArtifactRecord): boolean {
   return (
-    record.path === ORPHANED_SPECS_PATH || record.path === BROKEN_LINKS_PATH
+    record.path === ORPHANED_SPECS_PATH ||
+    record.path === BROKEN_LINKS_PATH ||
+    record.path === ORPHANED_TASKS_PATH
   );
 }
 

--- a/src/status/render.ts
+++ b/src/status/render.ts
@@ -198,9 +198,10 @@ function applyStoryNumber(title: string, rowId: string | undefined): string {
 
 /**
  * Detect the synthetic group wrappers emitted by {@link buildTree}.
- * These wrap a sentinel `ArtifactRecord` whose `path` is one of two
- * reserved values — matching on `path` is cheaper and more precise
- * than title equality.
+ * These wrap a sentinel `ArtifactRecord` whose `path` is one of three
+ * reserved values (`ORPHANED_SPECS_PATH`, `BROKEN_LINKS_PATH`, or
+ * `ORPHANED_TASKS_PATH`) — matching on `path` is cheaper and more
+ * precise than title equality.
  */
 function isGroupSentinel(record: ArtifactRecord): boolean {
   return (

--- a/src/status/render.ts
+++ b/src/status/render.ts
@@ -153,7 +153,10 @@ function renderChild(
 /**
  * Format a single record into its rendered line. Group sentinels
  * render as bare headings; real records append a status marker and,
- * for broken-link records, their dangling parent reference.
+ * for broken-link records, their dangling parent reference. Records
+ * whose scanner populated `parent_row_id` get the zero-padded story
+ * number injected into the label so the tree mirrors the parent's
+ * canonical dep-order numbering.
  */
 function formatLine(record: ArtifactRecord, prefix: string): string {
   if (isGroupSentinel(record)) {
@@ -161,14 +164,36 @@ function formatLine(record: ArtifactRecord, prefix: string): string {
   }
 
   const marker = formatStatusMarker(record);
+  const titleWithNumber = applyStoryNumber(record.title, record.parent_row_id);
   const label =
     record.parent_missing === true &&
     typeof record.parent_path === 'string' &&
     record.parent_path.length > 0
-      ? `${record.title} [missing parent: ${record.parent_path}]`
-      : record.title;
+      ? `${titleWithNumber} [missing parent: ${record.parent_path}]`
+      : titleWithNumber;
 
   return `${prefix}${label}  ${marker}`;
+}
+
+/**
+ * Inject the parent row's zero-padded numeric prefix into `title`.
+ * When the title carries a type prefix like `Tasks: …` (emitted by
+ * `smithy.cut` as the H1 of every tasks file), the number slots in
+ * after that prefix so the prefix stays visible. Otherwise the number
+ * prefixes the title directly. Returns the title unchanged when
+ * `rowId` is missing or has no trailing digits.
+ */
+function applyStoryNumber(title: string, rowId: string | undefined): string {
+  if (rowId === undefined) return title;
+  const digits = rowId.match(/[0-9]+$/)?.[0];
+  if (digits === undefined) return title;
+  const nn = digits.padStart(2, '0');
+  const tasksPrefix = /^(Tasks:\s+)/;
+  const prefixMatch = tasksPrefix.exec(title);
+  if (prefixMatch !== null) {
+    return `${prefixMatch[1]}${nn} ${title.slice(prefixMatch[0].length)}`;
+  }
+  return `${nn} ${title}`;
 }
 
 /**

--- a/src/status/scanner.test.ts
+++ b/src/status/scanner.test.ts
@@ -104,6 +104,11 @@ describe('scan', () => {
   it('AS 1.1: spec with two done tasks children and one — row', () => {
     // Spec references two existing tasks files (both fully checked)
     // and one — row which must emit a virtual not-started tasks record.
+    //
+    // The Artifact cells use the canonical backtick-wrapped form that
+    // real specs and `src/templates/agent-skills/README.md` emit, so
+    // the parent-linking assertions below also guard against regression
+    // of the backtick-stripping behaviour exercised in parser.test.ts.
     write(
       'specs/feature-a/feature-a.spec.md',
       `# Feature Specification: Feature A
@@ -111,9 +116,9 @@ describe('scan', () => {
 ## Dependency Order
 
 ${TABLE_HEADER}
-| US1 | First story  | — | specs/feature-a/01-first.tasks.md  |
-| US2 | Second story | — | specs/feature-a/02-second.tasks.md |
-| US3 | Third story  | — | —                                   |
+| US1 | First story  | — | \`specs/feature-a/01-first.tasks.md\`  |
+| US2 | Second story | — | \`specs/feature-a/02-second.tasks.md\` |
+| US3 | Third story  | — | —                                     |
 `,
     );
     write(
@@ -469,24 +474,56 @@ ${TABLE_HEADER}
     expect(tasks?.parent_path).toBe('specs/feature-a/missing.spec.md');
   });
 
-  it('broken-link detection: tasks **Source** header points at an existing spec (no dep-order row) → orphan with parent_path=null', () => {
+  it('broken-link detection: tasks **Source** header points at an existing spec (no dep-order row, no NN match) → orphan with parent_path=null', () => {
     // The declared source exists on disk but does not reference this
-    // tasks file from its dep-order table. Per AC, the probe leaves
-    // the record alone; the final orphan normalization sets
+    // tasks file from its dep-order table, and the tasks filename's
+    // NN prefix (99) does not match any US row in the spec, so the
+    // convention-based fallback also finds no link. Per AC, the probe
+    // leaves the record alone; the final orphan normalization sets
     // parent_path to `null` and parent_missing stays unset.
     write(
       'specs/feature-a/feature-a.spec.md',
       `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Other | — | — |\n`,
     );
     write(
-      'specs/feature-a/01-declared.tasks.md',
-      `# Tasks\n\n**Source**: \`specs/feature-a/feature-a.spec.md\` — User Story 7\n\n## Slice 1: Only\n\n- [ ] Task one\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+      'specs/feature-a/99-declared.tasks.md',
+      `# Tasks\n\n**Source**: \`specs/feature-a/feature-a.spec.md\` — User Story 99\n\n## Slice 1: Only\n\n- [ ] Task one\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
     );
     const records = scan(root);
-    const tasks = byPath(records, 'specs/feature-a/01-declared.tasks.md');
+    const tasks = byPath(records, 'specs/feature-a/99-declared.tasks.md');
     expect(tasks).toBeDefined();
     expect(tasks?.parent_missing).toBeUndefined();
     expect(tasks?.parent_path).toBeNull();
+  });
+
+  it('NN-prefix fallback: tasks file under a spec folder links to the US row with the matching story number even when the Artifact cell is `—`', () => {
+    // A spec `—` row whose on-disk tasks file uses a slug that differs
+    // from the row title must still be picked up via the filename
+    // convention `<NN>-*.tasks.md`, where NN is derived from the US id.
+    // Without this fallback, the scanner would emit a virtual
+    // placeholder at a slug-based path and the real tasks record
+    // would float as an orphan.
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Ignite: Workshop Broad Idea into RFC | — | — |\n`,
+    );
+    write(
+      'specs/feature-a/01-workshop-idea-into-rfc.tasks.md',
+      `# Tasks\n\n## Slice 1: Only\n\n- [x] Task one\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    const records = scan(root);
+    const tasks = byPath(
+      records,
+      'specs/feature-a/01-workshop-idea-into-rfc.tasks.md',
+    );
+    expect(tasks).toBeDefined();
+    expect(tasks?.parent_path).toBe('specs/feature-a/feature-a.spec.md');
+    // The scanner should NOT emit a slug-based virtual placeholder
+    // when the convention-based fallback finds a real file.
+    const virtuals = records.filter(
+      (r) => r.type === 'tasks' && r.virtual === true,
+    );
+    expect(virtuals).toHaveLength(0);
   });
 
   it('broken-link detection: tasks file without a **Source** header and no resolved parent → orphan with parent_path=null', () => {

--- a/src/status/scanner.ts
+++ b/src/status/scanner.ts
@@ -139,6 +139,7 @@ export function scan(root: string): ArtifactRecord[] {
           );
         } else {
           child.parent_path = parent.path;
+          child.parent_row_id = row.id;
         }
       } else {
         child = makeVirtualRecord(resolution.path, resolution.type, row, parent);
@@ -579,6 +580,7 @@ function makeVirtualRecord(
     title: row.title,
     status: 'not-started',
     parent_path: parent.path,
+    parent_row_id: row.id,
     virtual: true,
     dependency_order: {
       rows: [],

--- a/src/status/scanner.ts
+++ b/src/status/scanner.ts
@@ -450,16 +450,41 @@ function resolveChildForRow(
     }
     case 'spec': {
       const type: ArtifactType = 'tasks';
-      if (row.artifact_path !== null) {
-        return { path: normalizePath(row.artifact_path), type };
-      }
-      // Placeholder for a spec `—` row. Smithy tasks files use the
-      // convention `<NN>-<story-slug>.tasks.md` inside the spec folder
-      // (see `smithy.cut` output). Derive NN from the row id (US1 → 01)
-      // so virtual placeholders match the eventual real path and the
-      // real record wins on the next scan.
       const parentDir = repoDirname(parent.path);
       const nn = paddedNumberFromId(row.id);
+
+      if (row.artifact_path !== null) {
+        const declared = normalizePath(row.artifact_path);
+        // Happy path: the declared Artifact cell resolves to a real
+        // discovered record. Use it directly.
+        if (records.has(declared)) {
+          return { path: declared, type };
+        }
+        // Declared path did not match a known record (typo, stale
+        // path, malformed cell after parser edge cases). Fall back to
+        // the filename convention — a single `<NN>-*.tasks.md` under
+        // the spec's folder is unambiguous and recovers linkage that
+        // would otherwise produce a floating orphan.
+        const fallback = findTasksByStoryNumber(parentDir, nn, records);
+        if (fallback !== null) {
+          return { path: fallback, type };
+        }
+        // No convention-based match either. Return the declared path
+        // so a virtual record is emitted there; subsequent scans that
+        // create the file at that path will replace the virtual.
+        return { path: declared, type };
+      }
+
+      // `—` row: try the convention-based match before emitting a
+      // slug-based placeholder. A US row whose Artifact cell is `—`
+      // but whose tasks file already exists under
+      // `<parentDir>/<NN>-*.tasks.md` should link to that real file,
+      // not a virtual derived from the row title (the row title and
+      // the on-disk slug routinely diverge in practice).
+      const fallback = findTasksByStoryNumber(parentDir, nn, records);
+      if (fallback !== null) {
+        return { path: fallback, type };
+      }
       return {
         path: repoJoin(parentDir, `${nn}-${slugify(row.title)}.tasks.md`),
         type,
@@ -468,6 +493,47 @@ function resolveChildForRow(
     case 'tasks':
       return null;
   }
+}
+
+/**
+ * Look for an on-disk `<parentDir>/<nn>-*.tasks.md` record among the
+ * already-discovered records. Used as a convention-based fallback when
+ * a spec row's Artifact cell is `—` or fails to resolve directly. The
+ * filename convention emitted by `smithy.cut` is
+ * `<NN>-<story-slug>.tasks.md`; we key on the `<NN>-` prefix alone so
+ * the slug portion can diverge between the row title and the on-disk
+ * filename without breaking parent linking.
+ *
+ * Returns the repo-relative path of the match, or `null` if there is
+ * no match or more than one (ambiguous cases fall through to the
+ * caller's virtual-placeholder path so a warning can surface).
+ */
+function findTasksByStoryNumber(
+  parentDir: string,
+  nn: string,
+  records: Map<string, ArtifactRecord>,
+): string | null {
+  const prefix = parentDir === '' ? `${nn}-` : `${parentDir}/${nn}-`;
+  let match: string | null = null;
+  for (const [p, rec] of records) {
+    if (rec.type !== 'tasks') continue;
+    if (rec.virtual === true) continue;
+    if (!p.startsWith(prefix)) continue;
+    if (!p.endsWith('.tasks.md')) continue;
+    // Reject nested sub-folder matches: only direct children of
+    // `parentDir` count. A tasks file at `specs/a/b/01-foo.tasks.md`
+    // must not match a query rooted at `specs/a/`.
+    const tail = p.slice(prefix.length);
+    if (tail.includes('/')) continue;
+    if (match !== null) {
+      // Ambiguous — two or more `<nn>-*.tasks.md` siblings. Give up
+      // so the caller's placeholder path is used and the conflict is
+      // visible in the scan output.
+      return null;
+    }
+    match = p;
+  }
+  return match;
 }
 
 /**

--- a/src/status/tree.test.ts
+++ b/src/status/tree.test.ts
@@ -230,6 +230,31 @@ describe('buildTree — orphaned specs', () => {
     expect(orphanTasksGroup?.children[0]?.record.path).toBe(orphanTasks.path);
     expect(tree.roots).toHaveLength(1);
   });
+
+  it('does NOT route a tasks record with parent_path omitted (undefined) to Orphaned Tasks', () => {
+    // The scanner deliberately leaves `parent_path` undefined (rather
+    // than setting it to `null`) for tasks files it could not read —
+    // those records carry a `read_error:` warning and represent
+    // genuinely unknown parent state, not "definitively no parent".
+    // Classifying them as orphans would surface transient I/O or
+    // permission failures as ERROR output, which is wrong. They must
+    // fall through to top-level roots.
+    const unknownParentTasks = makeRecord({
+      type: 'tasks',
+      path: 'specs/unreadable/01-blocked.tasks.md',
+      // parent_path deliberately omitted — defaults to undefined.
+      warnings: ['read_error: EACCES: permission denied'],
+      status: 'unknown',
+    });
+
+    const tree = buildTree([unknownParentTasks]);
+
+    expect(
+      tree.roots.find((n) => n.record.path === ORPHANED_TASKS_PATH),
+    ).toBeUndefined();
+    expect(tree.roots).toHaveLength(1);
+    expect(tree.roots[0]?.record.path).toBe(unknownParentTasks.path);
+  });
 });
 
 describe('buildTree — broken links', () => {

--- a/src/status/tree.test.ts
+++ b/src/status/tree.test.ts
@@ -6,6 +6,7 @@ import {
   buildTree,
   BROKEN_LINKS_PATH,
   ORPHANED_SPECS_PATH,
+  ORPHANED_TASKS_PATH,
   type ArtifactRecord,
   type ArtifactType,
   type DependencyOrderTable,
@@ -204,6 +205,10 @@ describe('buildTree — orphaned specs', () => {
 
   it('does NOT group non-spec records (e.g. orphan tasks without parent_missing) under Orphaned Specs', () => {
     // Only specs belong in the Orphaned Specs bucket per AS 2.2.
+    // Real orphan tasks are routed to the dedicated "Orphaned Tasks"
+    // error group instead — rendering them as top-level roots would
+    // hide an error condition (every `.tasks.md` on disk is expected
+    // to link to a spec).
     const orphanTasks = makeRecord({
       type: 'tasks',
       path: 'specs/lost/01-lost.tasks.md',
@@ -214,11 +219,16 @@ describe('buildTree — orphaned specs', () => {
 
     // Not routed to Orphaned Specs (that group is spec-only).
     expect(tree.roots.find((n) => n.record.path === ORPHANED_SPECS_PATH)).toBeUndefined();
-    // And not routed to Broken Links either (parent_missing is not set).
+    // Not routed to Broken Links either (parent_missing is not set).
     expect(tree.roots.find((n) => n.record.path === BROKEN_LINKS_PATH)).toBeUndefined();
-    // Falls through to top-level roots.
+    // Routed to the Orphaned Tasks error group.
+    const orphanTasksGroup = tree.roots.find(
+      (n) => n.record.path === ORPHANED_TASKS_PATH,
+    );
+    expect(orphanTasksGroup).toBeDefined();
+    expect(orphanTasksGroup?.children).toHaveLength(1);
+    expect(orphanTasksGroup?.children[0]?.record.path).toBe(orphanTasks.path);
     expect(tree.roots).toHaveLength(1);
-    expect(tree.roots[0]!.record.path).toBe(orphanTasks.path);
   });
 });
 

--- a/src/status/tree.ts
+++ b/src/status/tree.ts
@@ -80,8 +80,19 @@ export const ORPHANED_SPECS_PATH = '__orphaned_specs__';
  */
 export const BROKEN_LINKS_PATH = '__broken_links__';
 
+/**
+ * Reserved `path` value on the synthetic "Orphaned Tasks" group node.
+ * Real tasks records whose `parent_path` is `null` (no parent-dep-order
+ * row and no resolvable `**Source**:` header) land here. They are
+ * always an error condition — every on-disk tasks file is expected to
+ * be linked to a spec — so renderers surface them with an explicit
+ * ERROR prefix instead of a normal tree row.
+ */
+export const ORPHANED_TASKS_PATH = '__orphaned_tasks__';
+
 const ORPHANED_SPECS_TITLE = 'Orphaned Specs';
 const BROKEN_LINKS_TITLE = 'Broken Links';
+const ORPHANED_TASKS_TITLE = 'Orphaned Tasks';
 
 /**
  * Project a flat `ArtifactRecord[]` into a {@link StatusTree}. Pure
@@ -109,6 +120,7 @@ export function buildTree(records: ArtifactRecord[]): StatusTree {
   const roots: TreeNode[] = [];
   const orphanedSpecs: TreeNode[] = [];
   const brokenLinks: TreeNode[] = [];
+  const orphanedTasks: TreeNode[] = [];
 
   for (const record of records) {
     const node = nodesByPath.get(record.path);
@@ -127,6 +139,13 @@ export function buildTree(records: ArtifactRecord[]): StatusTree {
     if (!hasParent) {
       if (record.type === 'spec' && record.virtual !== true) {
         orphanedSpecs.push(node);
+      } else if (record.type === 'tasks' && record.virtual !== true) {
+        // Real tasks files should always be claimed by a spec row or
+        // declare a `**Source**:` header. An on-disk tasks file with
+        // no parent is an error condition — surface it through the
+        // dedicated "Orphaned Tasks" group so renderers can flag it
+        // rather than hiding it among top-level roots.
+        orphanedTasks.push(node);
       } else {
         roots.push(node);
       }
@@ -139,6 +158,11 @@ export function buildTree(records: ArtifactRecord[]): StatusTree {
     const parentNode = nodesByPath.get(parentPath);
     if (parentNode !== undefined) {
       parentNode.children.push(node);
+    } else if (record.type === 'tasks' && record.virtual !== true) {
+      // Real tasks record declares a parent that is not present in
+      // the input set. Treat it as orphaned rather than dropping it
+      // silently as a top-level root.
+      orphanedTasks.push(node);
     } else {
       // Parent referenced but not present in the record set. This
       // shouldn't happen for well-formed scanner output — tasks with
@@ -159,6 +183,9 @@ export function buildTree(records: ArtifactRecord[]): StatusTree {
   }
   if (brokenLinks.length > 0) {
     finalRoots.push(makeGroupNode(BROKEN_LINKS_PATH, BROKEN_LINKS_TITLE, 'tasks', brokenLinks));
+  }
+  if (orphanedTasks.length > 0) {
+    finalRoots.push(makeGroupNode(ORPHANED_TASKS_PATH, ORPHANED_TASKS_TITLE, 'tasks', orphanedTasks));
   }
   for (const node of roots) {
     finalRoots.push(node);

--- a/src/status/tree.ts
+++ b/src/status/tree.ts
@@ -2,9 +2,9 @@
  * Pure tree projection over the flat `ArtifactRecord[]` produced by
  * {@link scan}. Turns a scan result into the hierarchical
  * {@link StatusTree} described in §7 of `smithy-status-skill.data-model.md`:
- * nested parent/child nodes plus two implicit top-level group nodes,
- * "Orphaned Specs" and "Broken Links", that are emitted only when they
- * have members.
+ * nested parent/child nodes plus three implicit top-level group nodes —
+ * "Orphaned Specs", "Broken Links", and "Orphaned Tasks" — that are
+ * emitted only when they have members.
  *
  * This module is deliberately side-effect-free. `buildTree` performs no
  * I/O, never mutates its input, and returns the same tree for the same
@@ -39,22 +39,22 @@
  *
  * Input order is preserved at every level: siblings appear in the order
  * their records appeared in the input array, and the group nodes are
- * prepended to `roots` in a fixed order (Orphaned Specs first, then
- * Broken Links) when populated, so the same input always yields the
- * same tree.
+ * prepended to `roots` in a fixed order (Orphaned Specs, then Broken
+ * Links, then Orphaned Tasks) when populated, so the same input always
+ * yields the same tree.
  *
  * ## Synthetic group nodes
  *
  * `TreeNode` "carries no additional data" (see `types.ts`), so group
  * nodes are modelled as real `TreeNode` values whose wrapped
  * `ArtifactRecord` is a synthesized sentinel rather than a real file
- * record. The sentinels use reserved `path` values (`__orphaned_specs__`
- * and `__broken_links__`) and set `virtual: true` so consumers can
- * cheaply detect them via `record.path.startsWith('__')`. This choice
- * keeps the `TreeNode` shape aligned with the data model while giving
- * the Slice 2 renderer (`renderTree`) a clear, documented contract for
- * locating the group headings. See SD-010 for the narrowed Broken
- * Links scope.
+ * record. The sentinels use reserved `path` values (`__orphaned_specs__`,
+ * `__broken_links__`, and `__orphaned_tasks__`) and set `virtual: true`
+ * so consumers can cheaply detect them via `record.path.startsWith('__')`.
+ * This choice keeps the `TreeNode` shape aligned with the data model
+ * while giving the Slice 2 renderer (`renderTree`) a clear, documented
+ * contract for locating the group headings. See SD-010 for the narrowed
+ * Broken Links scope.
  *
  * Every real record appears in the tree exactly once. An empty input
  * yields `{ roots: [] }`.
@@ -139,12 +139,21 @@ export function buildTree(records: ArtifactRecord[]): StatusTree {
     if (!hasParent) {
       if (record.type === 'spec' && record.virtual !== true) {
         orphanedSpecs.push(node);
-      } else if (record.type === 'tasks' && record.virtual !== true) {
+      } else if (
+        record.type === 'tasks' &&
+        record.virtual !== true &&
+        record.parent_path === null
+      ) {
         // Real tasks files should always be claimed by a spec row or
-        // declare a `**Source**:` header. An on-disk tasks file with
-        // no parent is an error condition — surface it through the
-        // dedicated "Orphaned Tasks" group so renderers can flag it
-        // rather than hiding it among top-level roots.
+        // declare a `**Source**:` header. A `parent_path` of `null`
+        // is the scanner's definitive "no parent" signal — surface
+        // those through the dedicated "Orphaned Tasks" group so
+        // renderers can flag them rather than hiding them among
+        // top-level roots. Records with `parent_path === undefined`
+        // (e.g. a tasks file the scanner could not read — see the
+        // Phase 2c skip for `read_error:` warnings in scanner.ts)
+        // carry genuinely unknown parent state and must NOT be
+        // reported as orphans; fall them through to top-level roots.
         orphanedTasks.push(node);
       } else {
         roots.push(node);
@@ -174,8 +183,9 @@ export function buildTree(records: ArtifactRecord[]): StatusTree {
     }
   }
 
-  // Prepend the populated group nodes in a fixed order so the output
-  // is deterministic and the two groups sit "at the top of `roots`" as
+  // Prepend the populated group nodes in a fixed order (Orphaned
+  // Specs, then Broken Links, then Orphaned Tasks) so the output is
+  // deterministic and the three groups sit "at the top of `roots`" as
   // the data model specifies.
   const finalRoots: TreeNode[] = [];
   if (orphanedSpecs.length > 0) {

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -150,6 +150,15 @@ export interface ArtifactRecord {
    */
   parent_missing?: boolean;
   /**
+   * Canonical row id on the parent's `## Dependency Order` table that
+   * claimed this record (e.g. `US3`, `F1`, `M2`). Populated by the
+   * scanner during parent/child resolution. Omitted for top-level
+   * records and broken/orphan cases where no parent row was matched.
+   * Renderers use this to prefix children with their zero-padded story
+   * number so the tree mirrors the parent's dep-order numbering.
+   */
+  parent_row_id?: string;
+  /**
    * True for not-started records inferred from a parent's parsed
    * `## Dependency Order` table but not yet present on disk. `virtual`
    * records always have `status: 'not-started'` and their `path` is the


### PR DESCRIPTION
## Summary

`smithy status` was rendering every spec as `not started` and every `.tasks.md` floating as a top-level `Tasks: …` node below the tree, regardless of slice state.

Three related fixes:

- **Parser strips backticks on the `Artifact` column.** Every real spec (and the canonical template in `src/templates/agent-skills/README.md`) wraps the path in markdown inline-code (`` `specs/foo/01-bar.tasks.md` ``). The parser kept the backticks verbatim, so `records.get(resolution.path)` always missed and the scanner emitted a virtual not-started record at the backticked path. `stripInlineCode` unwraps a single pair of surrounding backticks before the absolute-path check, so `` `/etc/passwd` `` is still rejected.
- **Scanner NN-prefix fallback.** When a US row's Artifact cell is `—` or fails to resolve directly, the scanner now looks in the spec's folder for a single `<NN>-*.tasks.md` matching the US id and links to it. Recovers linkage even when the declared slug differs from the on-disk filename (the common case — row title "Ignite: Workshop Broad Idea into RFC" vs. file `01-workshop-idea-into-rfc.tasks.md`).
- **Orphan tasks surface as errors.** Real `.tasks.md` records with no resolvable parent route through a new `ORPHANED_TASKS_PATH` synthetic group that renders as flat `ERROR: Orphaned task file <path> could not be linked to a spec` lines — every on-disk tasks file is expected to link to a spec, so anything that doesn't is always an error rather than a normal tree row.

Before the fix, `smithycli status` on this repo summarised as `Specs: 6 not-started · Tasks: 27 done / 4 in-progress / 57 not-started` with 27 orphan `Tasks: …` lines below the tree. After: `Specs: 5 in-progress / 1 not-started · Tasks: 27 done / 4 in-progress / 15 not-started`, every task nested under its spec, no orphan lines.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 403 pass (was 400; +3 new tests: backticked path in parser, backticked absolute-path rejection, NN-prefix fallback in scanner, orphan-tasks ERROR rendering)
- [x] `node dist/cli.js status --root .` on the SmithyCLI repo — verified specs roll up correctly, no floating `Tasks:` lines, no ERROR lines (all tasks link successfully)
- [ ] Manual check: introduce a stray `foo.tasks.md` with no `**Source**:` header and no matching US row, confirm it renders as `ERROR: Orphaned task file …`

https://claude.ai/code/session_01FaK3YXozbA49vcNWR76ac2