### PR TITLE
Restructure dependency order as table for clarity

### DIFF
--- a/specs/2026-04-06-003-smithy-evals-framework/06-verify-sub-agent-invocation.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/06-verify-sub-agent-invocation.tasks.md
@@ -74,10 +74,10 @@ Patterns used below are grounded in `evals/spike/FINDINGS.md` — not speculativ
 
 ## Dependency Order
 
-Recommended implementation sequence:
-
-1. [ ] **Slice 1 — Strike Sub-Agent Evidence for Plan, Reconcile, Clarify** — The verifier machinery already exists; extending the scenario is the minimum viable increment and surfaces three of the four acceptance scenarios (6.2, 6.3, 6.4) with a single scenario data change.
-2. [ ] **Slice 2 — Standalone Scout Scenario and Multi-Scenario Orchestration** — Builds on Slice 1 by introducing a second scenario and teaching `run-evals.ts` to aggregate multiple results. Resolves AS 6.1 via the standalone path and lays the groundwork for US7's YAML-driven multi-scenario loader.
+| ID | Title                                                          | Depends On | Artifact |
+|----|----------------------------------------------------------------|------------|----------|
+| S1 | Strike Sub-Agent Evidence for Plan, Reconcile, Clarify         | —          | —        |
+| S2 | Standalone Scout Scenario and Multi-Scenario Orchestration     | S1         | —        |
 
 ### Cross-Story Dependencies
 


### PR DESCRIPTION
## Summary
- Primary outcome: Convert the dependency order section from a numbered list to a structured table format for improved readability and maintainability.
- Notable behaviour changes: None—this is a documentation restructuring.
- Follow-up work deferred: None.

## Context
The dependency order documentation in the sub-agent invocation verification spec was presented as a narrative numbered list. Converting to a table format makes the relationships between slices (S1, S2) and their dependencies more scannable and aligns with the canonical `## Dependency Order` schema defined in `src/templates/agent-skills/README.md` and summarised in `CLAUDE.md`.

## Implementation Notes
- Changed from prose list format to the canonical markdown table with columns: ID, Title, Depends On, Artifact.
- Slice 1 (S1) has no dependencies (marked with "—").
- Slice 2 (S2) depends on S1 (marked as "S1").
- Per the repo's Dependency Order rules, **slice rows always use "—" in the Artifact column** because slices live inline within the `.tasks.md` file; the Artifact column is only populated for milestones / features / user stories that point to downstream files. Implementation progress for slices is tracked via the checkboxes inside each `## Slice N:` body, not via this table.
- No functional changes to the acceptance scenarios or implementation guidance.

## Risks &amp; Mitigations
- Risk: None—this is a documentation-only change.
- Mitigation: N/A

## Rollback Plan
Revert to the previous numbered list format if the table format is deemed less effective during review.

## Testing
No testing needed—this is a documentation restructuring with no code or functional changes.

https://claude.ai/code/session_01XwWikSqmonwB6AeZmfkaKY