### PR TITLE
Add per-case and total duration rendering to eval reports

### DIFF
--- a/evals/lib/report.test.ts
+++ b/evals/lib/report.test.ts
@@ -591,6 +591,69 @@ describe('formatReport', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Duration rendering (US11 AS 11.2 / FR-009)
+  // -----------------------------------------------------------------------
+  describe('duration rendering', () => {
+    it('renders the per-case duration on a single passing case line', () => {
+      const results: EvalResult[] = [
+        makeResult({ scenario_name: 'alpha', duration_ms: 1234 }),
+      ];
+      const report = buildReport(results, 1500);
+      const out = formatReport(report);
+      const lines = out.split('\n');
+
+      const caseLine = lines.find((l) => l.includes('alpha'));
+      expect(caseLine).toBeDefined();
+      expect(caseLine!).toContain('1234ms');
+    });
+
+    it('renders per-case durations and a total elapsed line on a mixed-status report', () => {
+      const results: EvalResult[] = [
+        makeResult({ scenario_name: 'alpha', status: 'pass', duration_ms: 100 }),
+        makeResult({ scenario_name: 'beta', status: 'fail', duration_ms: 250 }),
+        makeResult({
+          scenario_name: 'gamma',
+          status: 'timeout',
+          duration_ms: 60000,
+          error: 'timed out',
+        }),
+      ];
+      const report = buildReport(results, 60500);
+      const out = formatReport(report);
+      const lines = out.split('\n');
+
+      const alphaLine = lines.find((l) => l.includes('alpha'));
+      const betaLine = lines.find((l) => l.includes('beta'));
+      const gammaLine = lines.find((l) => l.includes('gamma'));
+      expect(alphaLine).toBeDefined();
+      expect(betaLine).toBeDefined();
+      expect(gammaLine).toBeDefined();
+      expect(alphaLine!).toContain('100ms');
+      expect(betaLine!).toContain('250ms');
+      expect(gammaLine!).toContain('60000ms');
+
+      const totalLine = lines.find((l) => l.startsWith('Total elapsed:'));
+      expect(totalLine).toBeDefined();
+      expect(totalLine!).toContain('60500ms');
+    });
+
+    it('renders a valid summary with a zero total for an empty results array', () => {
+      const report = buildReport([], 0);
+      const out = formatReport(report);
+      const lines = out.split('\n');
+
+      expect(lines[0]).toBe('Eval Summary');
+      const totalLine = lines.find((l) => l.startsWith('Total elapsed:'));
+      expect(totalLine).toBeDefined();
+      expect(totalLine!).toContain('0ms');
+
+      const finalLine = lines[lines.length - 1] ?? '';
+      expect(finalLine).toMatch(/\bPASS\b/);
+      expect(finalLine).toContain('0');
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Determinism
   // -----------------------------------------------------------------------
   describe('determinism', () => {

--- a/evals/lib/report.ts
+++ b/evals/lib/report.ts
@@ -143,11 +143,12 @@ function statusToken(status: EvalResult['status']): string {
  * Output shape:
  *
  *     Eval Summary
- *       [PASS] strike-health-check
- *       [FAIL] plan-standalone
- *       [TIMEOUT] scout-standalone
- *       [ERROR] clarify-standalone
+ *       [PASS] strike-health-check (1234ms)
+ *       [FAIL] plan-standalone (5678ms)
+ *       [TIMEOUT] scout-standalone (120000ms)
+ *       [ERROR] clarify-standalone (42ms)
  *
+ *     Total elapsed: 127000ms
  *     Result: FAIL (1/4 passed, 4 total)
  *
  * The function is pure: no I/O, no `console.log`, no mutation of `report`.
@@ -156,18 +157,22 @@ function statusToken(status: EvalResult['status']): string {
  * status tokens (`PASS`, `FAIL`, `TIMEOUT`, `ERROR`) are distinct strings,
  * so word-boundary matchers can distinguish a timeout case from a fail
  * case (AS 9.3). The final aggregate line carries the overall result
- * (`PASS` or `FAIL`) plus the total case count (AS 9.1, 9.2).
+ * (`PASS` or `FAIL`) plus the total case count (AS 9.1, 9.2); the
+ * `Total elapsed:` line precedes it so the `Result:` line remains last
+ * (US11 AS 11.2, FR-009). Durations render as integer milliseconds with
+ * the `ms` suffix uniformly across per-case and total lines.
  */
 export function formatReport(report: EvalReport): string {
   const lines: string[] = ['Eval Summary'];
 
   for (const result of report.results) {
     const token = statusToken(result.status);
-    lines.push(`  [${token}] ${result.scenario_name}`);
+    lines.push(`  [${token}] ${result.scenario_name} (${result.duration_ms}ms)`);
   }
 
   const overallToken = report.overall_status === 'pass' ? 'PASS' : 'FAIL';
   lines.push('');
+  lines.push(`Total elapsed: ${report.total_duration_ms}ms`);
   lines.push(
     `Result: ${overallToken} (${report.passed}/${report.total_cases} passed, ${report.total_cases} total)`,
   );

--- a/evals/run-evals.ts
+++ b/evals/run-evals.ts
@@ -90,18 +90,26 @@ if (!fixtureStat.isDirectory()) {
 }
 
 // ---------------------------------------------------------------------------
-// Scenario (US7 will replace this with YAML loading)
+// Scenarios (US7 will replace this with YAML loading)
 // ---------------------------------------------------------------------------
 //
 // The scenario definition lives in `./lib/strike-scenario.ts` as a single
 // source of truth shared with `strike-scenario.test.ts`. When the user
 // passes `--timeout`, layer it on top of the imported constant; otherwise
 // leave `scenario.timeout` undefined so the runner's DEFAULT_TIMEOUT_MS
-// applies (FR-004).
-const scenario: EvalScenario =
+// applies (FR-004). The list is held as an array so the pre-execution case
+// count (US11 AS 11.1) sources its value from `scenarios.length` — US7 can
+// swap in an N-element YAML-loaded array without touching the count line.
+const scenarios: EvalScenario[] = [
   timeoutOverrideSec !== undefined
     ? { ...strikeScenario, timeout: timeoutOverrideSec }
-    : { ...strikeScenario };
+    : { ...strikeScenario },
+];
+
+console.log(`Running ${scenarios.length} case(s)`);
+console.log('');
+
+const scenario = scenarios[0]!;
 
 console.log(`Running scenario: ${scenario.name}`);
 console.log(`  Skill:   ${scenario.skill}`);

--- a/specs/2026-04-06-003-smithy-evals-framework/11-cost-and-time-transparency.tasks.md
+++ b/specs/2026-04-06-003-smithy-evals-framework/11-cost-and-time-transparency.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Render per-case and total durations in `formatReport`**
+- [x] **Render per-case and total durations in `formatReport`**
 
   Extend the pure `formatReport` function in `evals/lib/report.ts` so the returned string exposes wall-clock timings the caller already provides on `EvalReport`. Each per-case line must include the result's `duration_ms`, and the aggregate section must include a total elapsed-time line sourced from `report.total_duration_ms`. Output must remain deterministic and stable — existing status-token placement (`PASS`/`FAIL`/`TIMEOUT`/`ERROR`) and the existing `Result: …` aggregate line must be preserved so that prior snapshot-style assertions in `report.test.ts` continue to locate their anchors. The function remains pure: no `console.log`, no mutation of `report`.
 
@@ -31,7 +31,7 @@
   - Unit tests cover: (a) single passing case duration rendering, (b) mixed-status report with total-duration rendering, (c) empty `results` array still renders a valid summary with a zero-or-placeholder total
   - Existing `report.test.ts` assertions for `PASS` / `FAIL` / `TIMEOUT` / `ERROR` token placement and the overall-result line continue to pass
 
-- [ ] **Print pre-execution case count in `run-evals.ts`**
+- [x] **Print pre-execution case count in `run-evals.ts`**
 
   Emit a "Running N case(s)" status line from `evals/run-evals.ts` before invoking `runScenario`, satisfying AS 11.1. The count must be derived from an explicit variable — not hardcoded to `1` — so that US7's YAML scenario loading can replace the single scenario with an N-element list and this line automatically reports the correct count with no further change. The existing per-scenario intro block (`Running scenario: …`, `Skill:`, `Prompt:`, `Fixture:`, `Timeout:`) remains unchanged below the new line. Preflight and fixture-validation failures must still short-circuit before the count is printed — the count line only appears after the runner has committed to executing at least one case.
 


### PR DESCRIPTION
## Summary
- **Primary outcome:** Extend `formatReport()` to display wall-clock durations for each test case and a total elapsed-time line, improving transparency into evaluation performance.
- **Notable behaviour changes:** Eval report output now includes `(Xms)` duration suffix on each case line and a new `Total elapsed: Xms` line before the final result summary.
- **Follow-up work deferred:** US7 will replace hardcoded scenario with YAML-loaded array; this change prepares `run-evals.ts` to support that by deriving case count from `scenarios.length`.

## Context
Implements **US11 AS 11.2 / FR-009** from the cost-and-time-transparency specification. Users need visibility into how long each test case takes and the total wall-clock time for the evaluation run. This change surfaces timing data that `EvalReport` already carries but was not being displayed.

## Implementation Notes

### Key Changes
1. **`evals/lib/report.ts`** — Extended `formatReport()` to:
   - Append `(${result.duration_ms}ms)` to each per-case line
   - Insert a new `Total elapsed: ${report.total_duration_ms}ms` line before the final `Result:` line
   - Preserve existing status-token placement and result-line position for backward compatibility with snapshot tests

2. **`evals/run-evals.ts`** — Refactored scenario handling:
   - Changed `scenario` from a single object to `scenarios` array (currently length 1)
   - Added pre-execution console output: `Running N case(s)`
   - Extracted `scenario = scenarios[0]!` to support future YAML-loaded multi-scenario arrays without code changes to the case-count line

3. **`evals/lib/report.test.ts`** — Added three new test cases:
   - Single passing case with duration rendering
   - Mixed-status report with per-case and total durations
   - Empty results array with zero total (edge case)

### Architectural Notes
- `formatReport()` remains pure: no I/O, no mutation, deterministic output.
- Duration format is uniform across all lines: integer milliseconds with `ms` suffix.
- The `Total elapsed:` line is inserted *before* the `Result:` line so the latter remains the final line (preserving existing snapshot anchors).
- Scenario array structure enables US7's YAML loading to swap in an N-element list without touching the case-count reporting logic.

## Risks & Mitigations
| Risk | Mitigation |
|------|-----------|
| Snapshot test breakage in `report.test.ts` | Existing assertions for status tokens and result line are preserved; new tests validate duration rendering separately. |
| Output format instability | Durations are deterministic (sourced from `EvalResult` and `EvalReport` fields); no randomness or timing-dependent logic. |
| Future scenario array expansion | Current code structure (`scenarios` array, extracted `scenario = scenarios[0]!`) is designed to support multi-scenario loading without modification. |

## Rollback Plan
- Revert changes to `evals/lib/report.ts` (remove duration suffixes and total-elapsed line).
- Revert `evals/run-evals.ts` to single `scenario` object and remove the `Running N case(s)` console output.
- Remove new test cases from `evals/lib/report.test.ts`.

## Testing
- **Unit tests added:** Three new test cases in `evals/lib/report.test.ts` cover single-case, mixed-status, and empty-results scenarios.
- **Existing tests:** All prior `formatReport` assertions for status-token placement and result-line format continue to pass (verified by snapshot stability).
- **Type safety:** No new runtime dependencies; changes are localized to report formatting and scenario initialization.

No manual testing required beyond running the test suite (`npm test`).

https://claude.ai/code/session_011HQoSGARPZPEbLM2ETP67K