### PR TITLE
US4 Slice 1 Task 2: Add suggestNextAction and wire into scanner Phase 4

### DIFF
--- a/specs/2026-04-12-004-smithy-status-skill/04-suggest-next-command.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/04-suggest-next-command.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Add pure `suggestNextAction` module in `src/status/suggester.ts`**
+- [x] **Add pure `suggestNextAction` module in `src/status/suggester.ts`**
 
   Introduce a new pure module following the `classifier.ts` precedent: a dedicated file with a single exported function that derives a `NextAction | null` from an already-classified `ArtifactRecord` plus a boolean flag indicating whether any ancestor in the record's parent chain is `not-started`. No filesystem I/O, no network, no mutation of the input record. Re-export from `src/status/index.ts`. Apply the deterministic rule table from FR-010 (AS 4.1–4.4): `rfc` → `smithy.render`, `features` → `smithy.mark`, `spec` → `smithy.cut`, `tasks` → `smithy.forge`. Done records always return `null`. Records classified as `unknown` (parse failures) also return `null` — the data model treats `unknown` as not actionable. When the ancestor-not-started flag is `true`, the returned `NextAction` carries `suppressed_by_ancestor: true` so FR-011 suppression is visible to JSON consumers.
 
@@ -34,7 +34,7 @@
   - The module exports are visible via `import { suggestNextAction } from '../status/index.js'`.
   - The function does not read, write, or stat any file, and does not mutate the `ArtifactRecord` argument.
 
-- [ ] **Wire `suggestNextAction` into `scan()` as a post-classification pass in `src/status/scanner.ts`**
+- [x] **Wire `suggestNextAction` into `scan()` as a post-classification pass in `src/status/scanner.ts`**
 
   After the existing Phase 3 leaf-to-root classification loop, add a new pass that populates `next_action` on every record. Build an upward-walk helper keyed on `parent_path` (which Phase 2 already populates) so each record can detect whether any ancestor has `status: 'not-started'`. Call `suggestNextAction` for each record with the derived flag and assign the result to `record.next_action`. The pass must run after all statuses are finalized so ancestor classification is stable. Update the scanner module JSDoc to document the new phase. Records carrying a `read_error:` warning continue to be skipped by classification and suggestion alike — leave their `next_action` omitted (not set to `null`) so the field's absence signals "never evaluated" to JSON consumers, matching the scanner's existing skip-on-read-error behavior.
 
@@ -64,7 +64,7 @@
 
 ### Tasks
 
-- [ ] **Add pure `formatNextAction` helper and render hints in the text-mode flat listing**
+- [x] **Add pure `formatNextAction` helper and render hints in the text-mode flat listing**
 
   Introduce a small pure formatter (in `src/status/suggester.ts` alongside `suggestNextAction` so related logic stays colocated) that takes a `NextAction` and returns a one-line string of the form `→ <command> <arg1> <arg2>...` with the command and space-separated arguments. Update the text-mode branch of `statusAction` in `src/commands/status.ts` so that, after printing each record's existing flat line, it also emits an indented continuation line containing the formatted hint when `record.next_action` is non-null and `record.next_action.suppressed_by_ancestor` is not `true`. Done records and suppressed records emit no hint line. The indentation is a single leading two-space pad so the hint visually attaches to its record in both the current flat listing and the eventual tree view. `--format json` output remains untouched. Resolves SD-016.
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1077,7 +1077,7 @@ describe('CLI status', () => {
     );
     expect(jsonDefault).toBe(jsonAll);
     // Sanity: the JSON tree exposes every uncollapsed descendant.
-    const payload = JSON.parse(jsonDefault) as {
+    const collapsePayload = JSON.parse(jsonDefault) as {
       tree: {
         roots: Array<{
           record: { path: string };
@@ -1091,19 +1091,132 @@ describe('CLI status', () => {
         }>;
       };
     };
-    const rfcRoot = payload.tree.roots.find((r) =>
+    const collapseRfcRoot = collapsePayload.tree.roots.find((r) =>
       r.record.path.endsWith('.rfc.md'),
     );
-    expect(rfcRoot).toBeDefined();
-    expect(rfcRoot?.children[0]?.record.path).toBe(
+    expect(collapseRfcRoot).toBeDefined();
+    expect(collapseRfcRoot?.children[0]?.record.path).toBe(
       'docs/rfcs/01-milestone-one.features.md',
     );
-    expect(rfcRoot?.children[0]?.children[0]?.record.path).toBe(
+    expect(collapseRfcRoot?.children[0]?.children[0]?.record.path).toBe(
       'specs/feature-a/feature-a.spec.md',
     );
-    expect(rfcRoot?.children[0]?.children[0]?.children[0]?.record.path).toBe(
-      'specs/feature-a/01-first.tasks.md',
+    expect(
+      collapseRfcRoot?.children[0]?.children[0]?.children[0]?.record.path,
+    ).toBe('specs/feature-a/01-first.tasks.md');
+  });
+
+  it('text mode renders next-action hints beneath actionable records only (US4 Slice 2, AS 4.1–4.5)', () => {
+    // Fixture stitches two independent subtrees so every hint-line
+    // branch of the renderer is exercised in one invocation:
+    //
+    // 1. A not-started RFC with a virtual features child. The RFC is a
+    //    root (no ancestors) → un-suppressed → its hint line IS
+    //    emitted. The virtual features record below it inherits
+    //    `suppressed_by_ancestor: true` because its parent (the RFC)
+    //    is not-started → its hint line must NOT be emitted.
+    //
+    // 2. An independent spec whose only tasks child is fully checked
+    //    off → both records classify as `done` → neither emits a hint
+    //    line (`next_action` is null for done records). Under the
+    //    default US3 collapse pass, the done subtree collapses to a
+    //    single `DONE` line on the spec — pass `--all` so every
+    //    record surfaces and the "done records emit no hint"
+    //    assertion has the tasks line to test against.
+    write(
+      'docs/rfcs/active.rfc.md',
+      `# RFC: Active Work\n\n## Dependency Order\n\n${TABLE_HEADER}\n| M1 | Milestone One | — | docs/rfcs/active.features.md |\n`,
     );
+    write(
+      'specs/finished/finished.spec.md',
+      `# Feature Specification: Finished\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Finished Story | — | specs/finished/01-finished.tasks.md |\n`,
+    );
+    write(
+      'specs/finished/01-finished.tasks.md',
+      `# Tasks: Finished\n\n## Slice 1: Done\n\n- [x] Task one\n- [x] Task two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Done | — | — |\n`,
+    );
+
+    // Sanity-check the JSON payload first: the RFC is not-started and
+    // un-suppressed, the virtual features record IS suppressed, and
+    // the finished subtree rolls up to done with null next_actions.
+    const jsonOutput = execFileSync(
+      'node',
+      [CLI, 'status', '--format', 'json', '--root', tmpDir],
+      { encoding: 'utf-8' },
+    );
+    const payload = JSON.parse(jsonOutput) as {
+      records: Array<{
+        type: string;
+        path: string;
+        status: string;
+        next_action?: {
+          command: string;
+          arguments: string[];
+          reason: string;
+          suppressed_by_ancestor?: boolean;
+        } | null;
+      }>;
+    };
+    const rfcRecord = payload.records.find((r) => r.type === 'rfc');
+    const virtualFeatures = payload.records.find(
+      (r) => r.type === 'features' && r.path === 'docs/rfcs/active.features.md',
+    );
+    const finishedTasks = payload.records.find(
+      (r) => r.path === 'specs/finished/01-finished.tasks.md',
+    );
+    expect(rfcRecord?.status).toBe('not-started');
+    expect(rfcRecord?.next_action?.command).toBe('smithy.render');
+    expect(rfcRecord?.next_action?.suppressed_by_ancestor).toBeUndefined();
+    expect(virtualFeatures?.status).toBe('not-started');
+    expect(virtualFeatures?.next_action?.suppressed_by_ancestor).toBe(true);
+    expect(finishedTasks?.status).toBe('done');
+    expect(finishedTasks?.next_action).toBeNull();
+
+    // Text mode with `--all` so the done subtree is not collapsed:
+    // the hint lines surface exactly where expected, and the done
+    // tasks record is present in the rendered output so we can assert
+    // that no hint line attaches to it.
+    const textOutput = execFileSync(
+      'node',
+      [CLI, 'status', '--root', tmpDir, '--all'],
+      { encoding: 'utf-8' },
+    );
+    const lines = textOutput.split('\n');
+
+    // AS 4.4: the actionable RFC emits a hint line containing
+    // `smithy.render` and its rfc path.
+    const renderHintLines = lines.filter(
+      (l) => l.includes('\u2192') && l.includes('smithy.render'),
+    );
+    expect(renderHintLines).toHaveLength(1);
+    expect(renderHintLines[0]).toContain('docs/rfcs/active.rfc.md');
+
+    // AS 4.5: the suppressed features record emits NO hint line.
+    // There is only one feature-level hint-worthy command
+    // (`smithy.mark`) in the rule table; it must not appear anywhere
+    // in the text output since the only features record in the
+    // fixture is suppressed.
+    expect(textOutput).not.toContain('smithy.mark');
+
+    // Done records emit no hint line: the finished tasks file is done
+    // and must not have an arrow beneath its rendered line.
+    const finishedLineIndex = lines.findIndex((l) =>
+      l.includes('Finished') && l.includes('DONE'),
+    );
+    expect(finishedLineIndex).toBeGreaterThanOrEqual(0);
+    // The very next non-empty line must NOT be a hint line for the
+    // finished tasks record.
+    for (let i = finishedLineIndex + 1; i < lines.length; i++) {
+      const next = lines[i]!;
+      if (next.length === 0) continue;
+      expect(next).not.toMatch(/^\s*\u2192\s*smithy\.forge/);
+      break;
+    }
+
+    // There must be exactly one hint line in the entire output — the
+    // un-suppressed RFC's. No other arrow characters should appear.
+    const allHintLines = lines.filter((l) => l.includes('\u2192'));
+    expect(allHintLines).toHaveLength(1);
   });
 
   describe('US6 filters (--status, --type, --root)', () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -575,6 +575,12 @@ describe('CLI status', () => {
         title: string;
         status: string;
         dependency_order: { rows: unknown[]; id_prefix: string; format: string };
+        next_action?: {
+          command: string;
+          arguments: string[];
+          reason: string;
+          suppressed_by_ancestor?: boolean;
+        } | null;
       }>;
       tree: { roots: unknown[] };
       graph: { nodes: unknown; layers: unknown[]; cycles: unknown[]; dangling_refs: unknown[] };
@@ -624,6 +630,18 @@ describe('CLI status', () => {
     expect(payload.summary.counts.spec.done).toBe(1);
     expect(payload.summary.counts.tasks.done).toBe(1);
     expect(payload.summary.parse_error_count).toBe(0);
+
+    // US4 Slice 1 Task 2: JSON consumers see the populated
+    // next_action outcome on every classified record. Every record in
+    // this fixture rolls up to `done`, so each one must serialize
+    // `next_action: null` (evaluated, no action) rather than omit the
+    // field entirely (never evaluated).
+    expect(tasksRecord?.next_action).toBeNull();
+    expect(specRecord?.next_action).toBeNull();
+    const featuresRecord = payload.records.find((r) => r.type === 'features');
+    const rfcRecord = payload.records.find((r) => r.type === 'rfc');
+    expect(featuresRecord?.next_action).toBeNull();
+    expect(rfcRecord?.next_action).toBeNull();
   });
 
   it('text mode prints a per-type summary header above the flat listing (AS 7.1)', () => {
@@ -875,7 +893,17 @@ describe('CLI status', () => {
       { encoding: 'utf-8' },
     );
     const payload = JSON.parse(output) as {
-      records: unknown[];
+      records: Array<{
+        type: string;
+        path: string;
+        status: string;
+        next_action?: {
+          command: string;
+          arguments: string[];
+          reason: string;
+          suppressed_by_ancestor?: boolean;
+        } | null;
+      }>;
       tree: { roots: Array<{ record: { path: string; title: string }; children: unknown[] }> };
     };
 
@@ -929,6 +957,21 @@ describe('CLI status', () => {
     );
     expect(features?.[0]?.children[0]?.children[0]?.record.path).toBe(
       'specs/chain-feature/01-chain-story.tasks.md',
+    );
+
+    // US4 Slice 1 Task 2: at least one non-done record in this fixture
+    // carries a populated `next_action` with a valid smithy command.
+    // The chain's tasks file has an unchecked checkbox, so it is
+    // not-started, and the scanner's Phase 4 must have populated its
+    // next_action with smithy.forge pointing at the tasks path.
+    const chainTasks = payload.records.find(
+      (r) => r.path === 'specs/chain-feature/01-chain-story.tasks.md',
+    );
+    expect(chainTasks).toBeDefined();
+    expect(chainTasks?.status).toBe('not-started');
+    expect(chainTasks?.next_action).not.toBeNull();
+    expect(chainTasks?.next_action?.command).toMatch(
+      /^smithy\.(mark|cut|forge|render|ignite|strike)$/,
     );
   });
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -10,11 +10,12 @@
  *   3. Call {@link scan} to build the fully-classified `ArtifactRecord[]`.
  *   4. Derive a {@link ScanSummary} from the records.
  *   5. Emit either contract-shaped JSON (`--format json`) or a per-type
- *      roll-up summary header followed by a flat text listing (default).
- *      The JSON `tree` field is populated via {@link buildTree} (US2
- *      Slice 1); the `graph` field is still stubbed and owned by US10.
- *      The top-level JSON shape is stable from US1 onward so consumers
- *      can depend on it today.
+ *      roll-up summary header followed by a hierarchical tree with
+ *      next-action hints (default, via {@link renderTree} with
+ *      `renderHints: true`). The JSON `tree` field is populated via
+ *      {@link buildTree} (US2 Slice 1); the `graph` field is still
+ *      stubbed and owned by US10. The top-level JSON shape is stable
+ *      from US1 onward so consumers can depend on it today.
  *   6. On an empty repo (no discovered artifacts), print a friendly hint
  *      pointing at `smithy.ignite` / `smithy.mark` and exit 0 — the
  *      contracts treat this as "not an error".

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -253,10 +253,22 @@ export function statusAction(opts: StatusOptions = {}): void {
   // `--no-color` wire-up by disabling color only when Commander sets
   // `opts.color` to `false`; today the renderer emits plain text with
   // UTF-8 box-drawing connectors and no color regardless.
+  //
+  // US4 Slice 2: enable `renderHints` so the tree renderer attaches
+  // an indented `→ <command> <args>` hint beneath every actionable,
+  // non-suppressed record. Done records (`next_action: null`) and
+  // suppressed records (`suppressed_by_ancestor: true`) emit no hint.
+  // Collapsed done subtrees cannot leak hints either because
+  // `collapseTree` drops their descendants before `renderTree` sees
+  // them. The `--format json` branch above is untouched — this flag
+  // only affects text-mode output (SD-016).
   const tree = collapseTree(buildTree(filteredRecords), {
     all: opts.all === true,
   });
-  const rendered = renderTree(tree, { color: opts.color !== false });
+  const rendered = renderTree(tree, {
+    color: opts.color !== false,
+    renderHints: true,
+  });
   if (rendered.length > 0) {
     console.log(rendered);
     return;

--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -14,7 +14,7 @@ export {
   type ParsedDependencyTable,
 } from './parser.js';
 export { classifyRecord } from './classifier.js';
-export { suggestNextAction } from './suggester.js';
+export { formatNextAction, suggestNextAction } from './suggester.js';
 export { scan } from './scanner.js';
 export {
   buildTree,

--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -14,6 +14,7 @@ export {
   type ParsedDependencyTable,
 } from './parser.js';
 export { classifyRecord } from './classifier.js';
+export { suggestNextAction } from './suggester.js';
 export { scan } from './scanner.js';
 export {
   buildTree,

--- a/src/status/render.test.ts
+++ b/src/status/render.test.ts
@@ -477,6 +477,234 @@ describe('renderTree — story number prefix', () => {
   });
 });
 
+describe('renderTree — renderHints option (US4 Slice 2)', () => {
+  it('default (no renderHints) emits no hint line even when records carry next_action', () => {
+    // Backwards-compatibility guard: the renderHints flag defaults to
+    // false, so legacy callers (and legacy render.test.ts snapshots)
+    // continue to see a pure tree with no hint annotations.
+    const record = makeRecord({
+      type: 'tasks',
+      path: 'specs/f/01-story.tasks.md',
+      title: 'Story',
+      status: 'not-started',
+      parent_path: 'specs/f/f.spec.md',
+      next_action: {
+        command: 'smithy.forge',
+        arguments: ['specs/f/01-story.tasks.md'],
+        reason: 'because',
+      },
+    });
+    const output = renderTree({
+      roots: [{ record, children: [] }],
+    });
+    expect(output).not.toContain('\u2192');
+    expect(output).not.toContain('smithy.forge');
+  });
+
+  it('default (no renderHints) is identical to explicit renderHints: false', () => {
+    const record = makeRecord({
+      type: 'tasks',
+      path: 'specs/f/01-story.tasks.md',
+      title: 'Story',
+      status: 'not-started',
+      parent_path: 'specs/f/f.spec.md',
+      next_action: {
+        command: 'smithy.forge',
+        arguments: ['specs/f/01-story.tasks.md'],
+        reason: 'because',
+      },
+    });
+    const tree = { roots: [{ record, children: [] }] };
+    expect(renderTree(tree)).toBe(renderTree(tree, { renderHints: false }));
+  });
+
+  it('renderHints: true emits an indented hint line beneath an actionable record', () => {
+    const rfc = makeRecord({
+      type: 'rfc',
+      path: 'docs/rfcs/demo.rfc.md',
+      title: 'Demo RFC',
+      status: 'in-progress',
+      parent_path: null,
+      next_action: {
+        command: 'smithy.render',
+        arguments: ['docs/rfcs/demo.rfc.md'],
+        reason: 'because',
+      },
+    });
+    const output = renderTree(
+      { roots: [{ record: rfc, children: [] }] },
+      { renderHints: true },
+    );
+    const lines = output.split('\n');
+    // First line is the record line; second line is the hint.
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe('Demo RFC  in progress');
+    // Two-space pad + arrow + command + args.
+    expect(lines[1]).toBe('  \u2192 smithy.render docs/rfcs/demo.rfc.md');
+  });
+
+  it('renderHints: true emits no hint line for a done record', () => {
+    const rfc = makeRecord({
+      type: 'rfc',
+      path: 'docs/rfcs/demo.rfc.md',
+      title: 'Demo RFC',
+      status: 'done',
+      parent_path: null,
+      next_action: null,
+    });
+    const output = renderTree(
+      { roots: [{ record: rfc, children: [] }] },
+      { renderHints: true },
+    );
+    const lines = output.split('\n');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('DONE');
+    expect(output).not.toContain('\u2192');
+  });
+
+  it('renderHints: true emits no hint line for a suppressed record', () => {
+    const record = makeRecord({
+      type: 'tasks',
+      path: 'specs/f/01-story.tasks.md',
+      title: 'Story',
+      status: 'not-started',
+      parent_path: 'specs/f/f.spec.md',
+      next_action: {
+        command: 'smithy.forge',
+        arguments: ['specs/f/01-story.tasks.md'],
+        reason: 'because',
+        suppressed_by_ancestor: true,
+      },
+    });
+    const output = renderTree(
+      { roots: [{ record, children: [] }] },
+      { renderHints: true },
+    );
+    // No hint line; only the record line.
+    expect(output.split('\n')).toHaveLength(1);
+    expect(output).not.toContain('\u2192');
+    expect(output).not.toContain('smithy.forge');
+  });
+
+  it('renderHints: true emits a hint line beneath a nested record with the correct tree-prefix inheritance', () => {
+    // RFC → features → spec → tasks chain; the tasks record is the
+    // last descendant. The hint should inherit the same indentation
+    // as the descendants of the tasks record would (all blank spacers
+    // because every intermediate node is a last-sibling).
+    const rfc = makeRecord({
+      type: 'rfc',
+      path: 'docs/rfcs/demo.rfc.md',
+      title: 'Demo RFC',
+      status: 'in-progress',
+      parent_path: null,
+      next_action: null,
+    });
+    const features = makeRecord({
+      type: 'features',
+      path: 'docs/rfcs/demo.features.md',
+      title: 'Demo Features',
+      status: 'in-progress',
+      parent_path: 'docs/rfcs/demo.rfc.md',
+      next_action: null,
+    });
+    const spec = makeRecord({
+      type: 'spec',
+      path: 'specs/a/a.spec.md',
+      title: 'Spec A',
+      status: 'in-progress',
+      parent_path: 'docs/rfcs/demo.features.md',
+      next_action: null,
+    });
+    const tasks = makeRecord({
+      type: 'tasks',
+      path: 'specs/a/01-story.tasks.md',
+      title: 'Story One',
+      status: 'in-progress',
+      completed: 1,
+      total: 3,
+      parent_path: 'specs/a/a.spec.md',
+      next_action: {
+        command: 'smithy.forge',
+        arguments: ['specs/a/01-story.tasks.md'],
+        reason: 'because',
+      },
+    });
+    const tree = buildTree([rfc, features, spec, tasks]);
+    const output = renderTree(tree, { renderHints: true });
+    const lines = output.split('\n');
+    // Five lines: RFC, features, spec, tasks, hint.
+    expect(lines).toHaveLength(5);
+    expect(lines[0]).toBe('Demo RFC  in progress');
+    expect(lines[1]).toBe('└─ Demo Features  in progress');
+    expect(lines[2]).toBe('   └─ Spec A  in progress');
+    expect(lines[3]).toBe('      └─ Story One  1/3');
+    // The hint line lives beneath the tasks record. It uses the
+    // two-space hint pad, anchored at the deepest child-spacer column
+    // (nine leading spaces for this last-sibling-only chain).
+    expect(lines[4]).toContain('\u2192 smithy.forge specs/a/01-story.tasks.md');
+    expect(lines[4]!.startsWith(' ')).toBe(true);
+  });
+
+  it('renderHints: true does not emit a hint for group sentinel nodes', () => {
+    // An orphaned spec surfaces under the "Orphaned Specs" group; the
+    // group sentinel itself has no next_action and must not emit a
+    // hint line. The spec child may or may not emit a hint depending
+    // on its own next_action.
+    const orphan = makeRecord({
+      type: 'spec',
+      path: 'specs/orphan/orphan.spec.md',
+      title: 'Orphan',
+      status: 'not-started',
+      parent_path: null,
+      next_action: null,
+    });
+    const tree = buildTree([orphan]);
+    const output = renderTree(tree, { renderHints: true });
+    const lines = output.split('\n');
+    // Group heading first; no arrow follows it.
+    expect(lines[0]).toBe('Orphaned Specs');
+    // The very next line must not be a hint (no arrow under a group heading).
+    expect(lines[1]).not.toMatch(/^\s*\u2192/);
+  });
+
+  it('renderHints: true emits a hint line only for records whose next_action is non-null and not suppressed', () => {
+    // Mixed tree: one actionable record + one suppressed + one done.
+    const rfc = makeRecord({
+      type: 'rfc',
+      path: 'docs/rfcs/demo.rfc.md',
+      title: 'Demo RFC',
+      status: 'not-started',
+      parent_path: null,
+      next_action: {
+        command: 'smithy.render',
+        arguments: ['docs/rfcs/demo.rfc.md'],
+        reason: 'because',
+      },
+    });
+    const features = makeRecord({
+      type: 'features',
+      path: 'docs/rfcs/demo.features.md',
+      title: 'Demo Features',
+      status: 'not-started',
+      parent_path: 'docs/rfcs/demo.rfc.md',
+      next_action: {
+        command: 'smithy.mark',
+        arguments: ['docs/rfcs/demo.features.md', '1'],
+        reason: 'because',
+        suppressed_by_ancestor: true,
+      },
+    });
+    const tree = buildTree([rfc, features]);
+    const output = renderTree(tree, { renderHints: true });
+    // Exactly ONE arrow line — the un-suppressed RFC root.
+    const arrowLines = output.split('\n').filter((l) => l.includes('\u2192'));
+    expect(arrowLines).toHaveLength(1);
+    expect(arrowLines[0]).toContain('smithy.render');
+    // The suppressed features record has no hint line.
+    expect(output).not.toContain('smithy.mark');
+  });
+});
+
 describe('renderTree — orphaned tasks error output', () => {
   it('renders real tasks with no parent as flat ERROR lines (not nested tree rows)', () => {
     // A real on-disk `.tasks.md` that could not be linked to a spec is

--- a/src/status/render.ts
+++ b/src/status/render.ts
@@ -60,6 +60,7 @@
  * entities.
  */
 
+import { formatNextAction } from './suggester.js';
 import {
   BROKEN_LINKS_PATH,
   ORPHANED_SPECS_PATH,
@@ -77,6 +78,20 @@ import type { ArtifactRecord, StatusTree, TreeNode } from './types.js';
 export interface RenderTreeOptions {
   /** Reserved for ANSI color output (currently a no-op). */
   color?: boolean;
+  /**
+   * When `true`, append an indented next-action hint line beneath every
+   * real record whose `next_action` is non-null and not suppressed by
+   * an ancestor. Defaults to `false` so existing callers (and legacy
+   * tests) continue to see a pure tree with no hint annotations.
+   *
+   * The hint line uses the formatter {@link formatNextAction} and is
+   * indented with the same tree-prefix the record's descendants would
+   * inherit, plus a two-space pad (SD-016) so the hint visually
+   * attaches beneath the record line. Done records (whose `next_action`
+   * is `null`) and records carrying `suppressed_by_ancestor: true` emit
+   * no hint line. Group sentinel nodes never emit a hint line.
+   */
+  renderHints?: boolean;
 }
 
 /**
@@ -90,14 +105,15 @@ export interface RenderTreeOptions {
  */
 export function renderTree(
   tree: StatusTree,
-  _options: RenderTreeOptions = {},
+  options: RenderTreeOptions = {},
 ): string {
   if (tree.roots.length === 0) {
     return '';
   }
+  const renderHints = options.renderHints === true;
   const lines: string[] = [];
   for (const root of tree.roots) {
-    renderRoot(root, lines);
+    renderRoot(root, lines, renderHints);
   }
   return lines.join('\n');
 }
@@ -112,7 +128,11 @@ export function renderTree(
  * they survive log scrapes and CI output, and skip the heading + tree
  * connectors that normal groups use.
  */
-function renderRoot(node: TreeNode, lines: string[]): void {
+function renderRoot(
+  node: TreeNode,
+  lines: string[],
+  renderHints: boolean,
+): void {
   if (node.record.path === ORPHANED_TASKS_PATH) {
     for (const child of node.children) {
       lines.push(
@@ -122,9 +142,12 @@ function renderRoot(node: TreeNode, lines: string[]): void {
     return;
   }
   lines.push(formatLine(node.record, ''));
+  // A root's descendants inherit no parent spacer, so the hint line
+  // (when enabled) is anchored at column 0 plus the two-space hint pad.
+  maybePushHint(node.record, '', lines, renderHints);
   const { children } = node;
   for (let i = 0; i < children.length; i++) {
-    renderChild(children[i]!, '', i === children.length - 1, lines);
+    renderChild(children[i]!, '', i === children.length - 1, lines, renderHints);
   }
 }
 
@@ -139,6 +162,7 @@ function renderChild(
   parentPrefix: string,
   isLast: boolean,
   lines: string[],
+  renderHints: boolean,
 ): void {
   const connector = isLast ? '└─ ' : '├─ ';
   lines.push(formatLine(node.record, parentPrefix + connector));
@@ -148,10 +172,53 @@ function renderChild(
   // gets plain spaces because nothing else sits below it.
   const childSpacer = isLast ? '   ' : '│  ';
   const nextPrefix = parentPrefix + childSpacer;
+  // The hint line visually attaches to this record, so it inherits the
+  // same prefix the record's own children would use (the `nextPrefix`),
+  // keeping the hint anchored beneath the record but out of the way of
+  // real descendants below it.
+  maybePushHint(node.record, nextPrefix, lines, renderHints);
   const { children } = node;
   for (let i = 0; i < children.length; i++) {
-    renderChild(children[i]!, nextPrefix, i === children.length - 1, lines);
+    renderChild(
+      children[i]!,
+      nextPrefix,
+      i === children.length - 1,
+      lines,
+      renderHints,
+    );
   }
+}
+
+/**
+ * Conditionally push an indented next-action hint line beneath the
+ * record's primary line. Does nothing when any of the following holds:
+ *
+ * - `renderHints` is `false`.
+ * - The record is a group sentinel ("Orphaned Specs", "Broken Links",
+ *   "Orphaned Tasks") — these have no lifecycle and no next action.
+ * - The record's `next_action` is `null` or omitted (done and
+ *   read-error records, respectively).
+ * - `next_action.suppressed_by_ancestor === true` — suppressed hints
+ *   are intentionally hidden so only the topmost actionable ancestor's
+ *   hint surfaces (FR-011).
+ *
+ * Otherwise emit a single line of the form
+ * `<recordPrefix>  → <command> [args…]` where `recordPrefix` is the
+ * same prefix the record's descendants would inherit, and the two
+ * spaces after it are the SD-016 hint pad.
+ */
+function maybePushHint(
+  record: ArtifactRecord,
+  recordPrefix: string,
+  lines: string[],
+  renderHints: boolean,
+): void {
+  if (!renderHints) return;
+  if (isGroupSentinel(record)) return;
+  const action = record.next_action;
+  if (action === null || action === undefined) return;
+  if (action.suppressed_by_ancestor === true) return;
+  lines.push(`${recordPrefix}  ${formatNextAction(action)}`);
 }
 
 /**

--- a/src/status/scanner.test.ts
+++ b/src/status/scanner.test.ts
@@ -777,4 +777,191 @@ ${TABLE_HEADER}
     expect(tasks.parent_path).toBeUndefined();
     expect(tasks.parent_missing).toBeUndefined();
   });
+
+  // -------------------------------------------------------------------------
+  // Phase 4: next-action suggestion
+  //
+  // US4 Slice 1 Task 2 wires `suggestNextAction` into `scan()` as a
+  // post-classification pass. After Phase 3 finalizes status for every
+  // record, Phase 4 walks each record's `parent_path` chain to detect a
+  // `not-started` ancestor and calls `suggestNextAction` to populate
+  // `record.next_action`. The tests below lock the observable contract:
+  // done/unknown records get `null`, actionable records get a
+  // `NextAction` from the deterministic rule table, descendants of a
+  // `not-started` ancestor carry `suppressed_by_ancestor: true`, and
+  // records with a `read_error:` warning leave `next_action` omitted.
+  // -------------------------------------------------------------------------
+
+  it('Phase 4: every record in a fully-done chain gets next_action === null', () => {
+    write(
+      'docs/rfcs/demo.rfc.md',
+      `# RFC\n\n## Dependency Order\n\n${TABLE_HEADER}\n| M1 | Only | — | specs/feature-a/feature-a.features.md |\n`,
+    );
+    write(
+      'specs/feature-a/feature-a.features.md',
+      `# Feature Map\n\n## Dependency Order\n\n${TABLE_HEADER}\n| F1 | Only | — | specs/feature-a/ |\n`,
+    );
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Only | — | specs/feature-a/01-only.tasks.md |\n`,
+    );
+    write(
+      'specs/feature-a/01-only.tasks.md',
+      `# Tasks\n\n## Slice 1: Only\n\n- [x] One\n- [x] Two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+
+    const records = scan(root);
+    const rfc = byPath(records, 'docs/rfcs/demo.rfc.md');
+    const features = byPath(records, 'specs/feature-a/feature-a.features.md');
+    const spec = byPath(records, 'specs/feature-a/feature-a.spec.md');
+    const tasks = byPath(records, 'specs/feature-a/01-only.tasks.md');
+    expect(rfc?.status).toBe('done');
+    expect(features?.status).toBe('done');
+    expect(spec?.status).toBe('done');
+    expect(tasks?.status).toBe('done');
+    expect(rfc?.next_action).toBeNull();
+    expect(features?.next_action).toBeNull();
+    expect(spec?.next_action).toBeNull();
+    expect(tasks?.next_action).toBeNull();
+  });
+
+  it('Phase 4: actionable tasks record with in-progress ancestors gets smithy.forge and no suppression', () => {
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | One | — | specs/feature-a/01-a.tasks.md |\n| US2 | Two | — | specs/feature-a/02-b.tasks.md |\n`,
+    );
+    write(
+      'specs/feature-a/01-a.tasks.md',
+      `# Tasks\n\n## Slice 1: Only\n\n- [x] Done\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    write(
+      'specs/feature-a/02-b.tasks.md',
+      `# Tasks\n\n## Slice 1: Only\n\n- [x] Done one\n- [ ] Pending two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    const records = scan(root);
+    const spec = byPath(records, 'specs/feature-a/feature-a.spec.md');
+    const t2 = byPath(records, 'specs/feature-a/02-b.tasks.md');
+    expect(spec?.status).toBe('in-progress');
+    expect(t2?.status).toBe('in-progress');
+    expect(t2?.next_action).not.toBeNull();
+    expect(t2?.next_action?.command).toBe('smithy.forge');
+    expect(t2?.next_action?.suppressed_by_ancestor).toBeUndefined();
+    // The in-progress spec parent is also actionable and not suppressed.
+    expect(spec?.next_action?.command).toBe('smithy.cut');
+    expect(spec?.next_action?.suppressed_by_ancestor).toBeUndefined();
+  });
+
+  it('Phase 4: multi-level not-started chain — only the topmost ancestor is un-suppressed, descendants are suppressed', () => {
+    // rfc not-started (top), with a — M1 row that produces a virtual
+    // features child (not-started). The virtual features record in
+    // turn has no dependency_order rows so it stays at not-started.
+    // A real spec record under the same feature-a folder is discovered
+    // but is not linked to the rfc chain (it is an orphan for this
+    // test); we do not need it to verify the chain below.
+    //
+    // Build an explicit three-level real chain so the ancestor walk has
+    // two levels to traverse: rfc → features → spec (all not-started).
+    write(
+      'docs/rfcs/demo.rfc.md',
+      `# RFC\n\n## Dependency Order\n\n${TABLE_HEADER}\n| M1 | Only | — | specs/feature-a/feature-a.features.md |\n`,
+    );
+    write(
+      'specs/feature-a/feature-a.features.md',
+      `# Feature Map\n\n## Dependency Order\n\n${TABLE_HEADER}\n| F1 | Only | — | specs/feature-a/feature-a.spec.md |\n`,
+    );
+    write(
+      'specs/feature-a/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Only | — | — |\n`,
+    );
+
+    const records = scan(root);
+    const rfc = byPath(records, 'docs/rfcs/demo.rfc.md');
+    const features = byPath(records, 'specs/feature-a/feature-a.features.md');
+    const spec = byPath(records, 'specs/feature-a/feature-a.spec.md');
+    // All three are not-started (the tasks virtual is not-started, so
+    // spec rolls up to not-started; features' only child is spec
+    // not-started, so features is not-started; rfc's only child is
+    // features not-started, so rfc is not-started).
+    expect(rfc?.status).toBe('not-started');
+    expect(features?.status).toBe('not-started');
+    expect(spec?.status).toBe('not-started');
+
+    // Topmost ancestor (rfc) has no parent and therefore no suppression.
+    expect(rfc?.next_action).not.toBeNull();
+    expect(rfc?.next_action?.command).toBe('smithy.render');
+    expect(rfc?.next_action?.suppressed_by_ancestor).toBeUndefined();
+
+    // Features and spec are both descendants of a not-started ancestor,
+    // so their suggestions must carry the suppression flag.
+    expect(features?.next_action).not.toBeNull();
+    expect(features?.next_action?.suppressed_by_ancestor).toBe(true);
+    expect(spec?.next_action).not.toBeNull();
+    expect(spec?.next_action?.suppressed_by_ancestor).toBe(true);
+
+    // The virtual tasks record under the spec row is also suppressed —
+    // every ancestor in its chain is not-started.
+    const virtualTasks = records.find(
+      (r) => r.type === 'tasks' && r.virtual === true,
+    );
+    expect(virtualTasks).toBeDefined();
+    expect(virtualTasks?.next_action).not.toBeNull();
+    expect(virtualTasks?.next_action?.command).toBe('smithy.forge');
+    expect(virtualTasks?.next_action?.suppressed_by_ancestor).toBe(true);
+  });
+
+  it('Phase 4: top-level rfc with no feature-map children gets smithy.render and no suppression', () => {
+    // An rfc whose dependency_order table has zero rows classifies as
+    // not-started with no children — the acceptance criterion covers
+    // the "orphan top-level rfc" case from the task description.
+    write(
+      'docs/rfcs/demo.rfc.md',
+      `# RFC\n\n## Dependency Order\n\n${TABLE_HEADER}\n`,
+    );
+    const records = scan(root);
+    const rfc = byPath(records, 'docs/rfcs/demo.rfc.md');
+    expect(rfc).toBeDefined();
+    expect(rfc?.status).toBe('not-started');
+    expect(rfc?.next_action).not.toBeNull();
+    expect(rfc?.next_action?.command).toBe('smithy.render');
+    expect(rfc?.next_action?.arguments).toEqual(['docs/rfcs/demo.rfc.md']);
+    expect(rfc?.next_action?.suppressed_by_ancestor).toBeUndefined();
+  });
+
+  it('Phase 4: a read_error tasks record leaves next_action omitted (not null)', () => {
+    // Mirror the existing `broken-link detection: ... read_error ...`
+    // test: create a file, strip read permission, and verify the
+    // scanner neither classifies nor suggests on it. The `next_action`
+    // field must be ABSENT (in-operator check) to preserve the "never
+    // evaluated" semantic — distinct from `null` which means
+    // "evaluated, no action".
+    const abs = join(root, 'specs', 'feature-a', '01-broken.tasks.md');
+    write(
+      'specs/feature-a/01-broken.tasks.md',
+      `# Tasks\n\n## Slice 1: Only\n\n- [ ] Task\n`,
+    );
+    try {
+      chmodSync(abs, 0o000);
+    } catch {
+      return; // Platform without chmod — skip.
+    }
+    let records: ReturnType<typeof scan>;
+    try {
+      records = scan(root);
+    } finally {
+      try {
+        chmodSync(abs, 0o644);
+      } catch {
+        /* ignore */
+      }
+    }
+    const tasks = byPath(records, 'specs/feature-a/01-broken.tasks.md');
+    if (tasks === undefined) {
+      return; // Running as root — chmod did not block the read.
+    }
+    if (!tasks.warnings.some((w) => w.startsWith('read_error:'))) {
+      return; // Same — chmod did not produce a read error on this host.
+    }
+    expect('next_action' in tasks).toBe(false);
+    expect(tasks.next_action).toBeUndefined();
+  });
 });

--- a/src/status/scanner.test.ts
+++ b/src/status/scanner.test.ts
@@ -834,9 +834,12 @@ ${TABLE_HEADER}
       'specs/feature-a/01-a.tasks.md',
       `# Tasks\n\n## Slice 1: Only\n\n- [x] Done\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
     );
+    // Two slices: Slice 1 fully done, Slice 2 partially checked →
+    // the tasks record classifies as in-progress (1 of 2 slices done
+    // under the slice-counting rule landed in #235 on master).
     write(
       'specs/feature-a/02-b.tasks.md',
-      `# Tasks\n\n## Slice 1: Only\n\n- [x] Done one\n- [ ] Pending two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+      `# Tasks\n\n## Slice 1: First\n\n- [x] Done one\n- [x] Done two\n\n## Slice 2: Second\n\n- [x] Done three\n- [ ] Pending four\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | First | — | — |\n| S2 | Second | — | — |\n`,
     );
     const records = scan(root);
     const spec = byPath(records, 'specs/feature-a/feature-a.spec.md');

--- a/src/status/scanner.ts
+++ b/src/status/scanner.ts
@@ -82,7 +82,7 @@ const SUFFIX_TYPES: Array<readonly [string, ArtifactType]> = [
 /**
  * Walk the repo under `root`, build `ArtifactRecord` entries for every
  * discovered Smithy artifact file, and return the fully-classified
- * record set. See the module-level JSDoc for the three-phase flow.
+ * record set. See the module-level JSDoc for the four-phase flow.
  */
 export function scan(root: string): ArtifactRecord[] {
   let realRoot: string;

--- a/src/status/scanner.ts
+++ b/src/status/scanner.ts
@@ -3,7 +3,7 @@
  *
  * `scan(root)` is the single entry point that turns a working directory
  * into a fully-classified `ArtifactRecord[]` matching the data-model
- * contract in `smithy-status-skill.data-model.md`. It proceeds in three
+ * contract in `smithy-status-skill.data-model.md`. It proceeds in four
  * phases:
  *
  *   1. **Discovery / parse** — walk `specs/`, `docs/rfcs/`, and
@@ -28,6 +28,18 @@
  *      carry a `read_error:` warning from Phase 1 are preserved as
  *      `status: 'unknown'` and are not re-classified.
  *
+ *   4. **Next-action suggestion** — after every record's status has
+ *      stabilized, iterate the record set once more and call
+ *      {@link suggestNextAction} to populate `record.next_action`. An
+ *      upward walk over each record's `parent_path` chain (with a
+ *      seen-set cycle guard) detects whether any ancestor is itself
+ *      `not-started`; when so, the returned {@link NextAction} carries
+ *      `suppressed_by_ancestor: true` so FR-011 suppression is visible
+ *      to JSON consumers. Records carrying a `read_error:` warning are
+ *      skipped: their `next_action` stays omitted (not `null`) so the
+ *      field's absence signals "never evaluated" to JSON consumers,
+ *      matching the scanner's existing skip-on-read-error behavior.
+ *
  * The scanner performs no network I/O and never throws on an individual
  * artifact failure. Per-file errors are surfaced as warnings on the
  * affected record and scanning continues.
@@ -50,6 +62,7 @@ import path from 'node:path';
 
 import { classifyRecord } from './classifier.js';
 import { extractSourceHeader, parseArtifact } from './parser.js';
+import { suggestNextAction } from './suggester.js';
 import type {
   ArtifactRecord,
   ArtifactType,
@@ -244,6 +257,22 @@ export function scan(root: string): ArtifactRecord[] {
       const kids = childrenByParent.get(record.path) ?? [];
       record.status = classifyRecord(record, kids);
     }
+  }
+
+  // Phase 4: populate `next_action` on every classified record.
+  //
+  // `suggestNextAction` is pure — this pass runs once, after every
+  // status is finalized, so the suppression flag derived from the
+  // ancestor walk reflects the stable classification output. Records
+  // carrying a `read_error:` warning are skipped entirely: their
+  // `next_action` field stays omitted (not set to `null`) so JSON
+  // consumers can distinguish "never evaluated" (absent) from
+  // "evaluated, no action" (`null`).
+  for (const record of records.values()) {
+    if (hasReadError(record)) continue;
+    const kids = childrenByParent.get(record.path) ?? [];
+    const ancestorNotStarted = hasNotStartedAncestor(record, records);
+    record.next_action = suggestNextAction(record, kids, ancestorNotStarted);
   }
 
   return Array.from(records.values());
@@ -592,11 +621,42 @@ function makeVirtualRecord(
 }
 
 // ---------------------------------------------------------------------------
-// Phase 3 helpers
+// Phase 3 + Phase 4 helpers
 // ---------------------------------------------------------------------------
 
 function hasReadError(record: ArtifactRecord): boolean {
   return record.warnings.some((w) => w.startsWith('read_error:'));
+}
+
+/**
+ * Walk upward from `record` through the `parent_path` chain (resolved
+ * against the scanner's full `records` map) and return `true` as soon
+ * as any ancestor's `status` is `'not-started'`.
+ *
+ * Terminates when:
+ * - `parent_path` is `null`, `undefined`, or an empty string.
+ * - The parent path does not resolve to any known record.
+ * - A previously-seen path is revisited (cycle guard) — defensive
+ *   against malformed record sets that could otherwise loop forever.
+ *
+ * Pure function: never mutates inputs. Used by Phase 4 to populate
+ * `NextAction.suppressed_by_ancestor` per FR-011.
+ */
+function hasNotStartedAncestor(
+  record: ArtifactRecord,
+  recordsByPath: Map<string, ArtifactRecord>,
+): boolean {
+  const seen = new Set<string>();
+  let cursor: string | null | undefined = record.parent_path;
+  while (typeof cursor === 'string' && cursor.length > 0) {
+    if (seen.has(cursor)) return false;
+    seen.add(cursor);
+    const ancestor = recordsByPath.get(cursor);
+    if (ancestor === undefined) return false;
+    if (ancestor.status === 'not-started') return true;
+    cursor = ancestor.parent_path ?? null;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/status/suggester.test.ts
+++ b/src/status/suggester.test.ts
@@ -1,0 +1,430 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+// Import through the `./index.js` barrel — that is the stable public
+// surface downstream modules consume, and these tests double as an
+// assertion that the barrel re-exports `suggestNextAction` correctly.
+import {
+  suggestNextAction,
+  type ArtifactRecord,
+  type ArtifactType,
+  type DependencyOrderTable,
+  type DependencyRow,
+  type Status,
+} from './index.js';
+
+/**
+ * Build a synthetic `ArtifactRecord` with enough fields populated to
+ * exercise the suggester. Tests pass individual overrides for the
+ * fields they care about.
+ */
+function makeRecord(overrides: Partial<ArtifactRecord> = {}): ArtifactRecord {
+  const type: ArtifactType = overrides.type ?? 'spec';
+  const idPrefix: DependencyOrderTable['id_prefix'] =
+    type === 'rfc'
+      ? 'M'
+      : type === 'features'
+        ? 'F'
+        : type === 'spec'
+          ? 'US'
+          : 'S';
+  const dependency_order: DependencyOrderTable = overrides.dependency_order ?? {
+    rows: [],
+    id_prefix: idPrefix,
+    format: 'table',
+  };
+  return {
+    type,
+    path: overrides.path ?? `specs/sample.${type === 'tasks' ? 'tasks' : type}.md`,
+    title: overrides.title ?? 'Sample',
+    status: overrides.status ?? 'unknown',
+    dependency_order,
+    warnings: overrides.warnings ?? [],
+    ...overrides,
+  };
+}
+
+function makeRow(
+  id: string,
+  artifact_path: string | null = null,
+): DependencyRow {
+  return { id, title: `Row ${id}`, depends_on: [], artifact_path };
+}
+
+function makeChild(status: Status, type: ArtifactType = 'tasks'): ArtifactRecord {
+  return makeRecord({ type, status });
+}
+
+describe('suggestNextAction — done and unknown short-circuit to null', () => {
+  it('returns null for a done tasks record', () => {
+    const record = makeRecord({ type: 'tasks', status: 'done' });
+    expect(suggestNextAction(record, [], false)).toBeNull();
+  });
+
+  it('returns null for a done spec record', () => {
+    const record = makeRecord({ type: 'spec', status: 'done' });
+    expect(suggestNextAction(record, [], false)).toBeNull();
+  });
+
+  it('returns null for a done features record', () => {
+    const record = makeRecord({ type: 'features', status: 'done' });
+    expect(suggestNextAction(record, [], false)).toBeNull();
+  });
+
+  it('returns null for a done rfc record', () => {
+    const record = makeRecord({ type: 'rfc', status: 'done' });
+    expect(suggestNextAction(record, [], false)).toBeNull();
+  });
+
+  it('returns null for an unknown-status tasks record', () => {
+    const record = makeRecord({ type: 'tasks', status: 'unknown' });
+    expect(suggestNextAction(record, [], false)).toBeNull();
+  });
+
+  it('returns null for an unknown-status spec record', () => {
+    const record = makeRecord({
+      type: 'spec',
+      status: 'unknown',
+      dependency_order: { rows: [], id_prefix: 'US', format: 'legacy' },
+    });
+    expect(suggestNextAction(record, [], false)).toBeNull();
+  });
+
+  it('returns null for an unknown-status features record', () => {
+    const record = makeRecord({
+      type: 'features',
+      status: 'unknown',
+      dependency_order: { rows: [], id_prefix: 'F', format: 'missing' },
+    });
+    expect(suggestNextAction(record, [], false)).toBeNull();
+  });
+
+  it('returns null for an unknown-status rfc record', () => {
+    const record = makeRecord({
+      type: 'rfc',
+      status: 'unknown',
+      dependency_order: { rows: [], id_prefix: 'M', format: 'legacy' },
+    });
+    expect(suggestNextAction(record, [], false)).toBeNull();
+  });
+});
+
+describe('suggestNextAction — tasks records', () => {
+  it('suggests smithy.forge for a not-started tasks record', () => {
+    const record = makeRecord({
+      type: 'tasks',
+      status: 'not-started',
+      path: 'specs/x/01-foo.tasks.md',
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.forge');
+    expect(action!.arguments).toEqual(['specs/x/01-foo.tasks.md']);
+    expect(typeof action!.reason).toBe('string');
+    expect(action!.reason.length).toBeGreaterThan(0);
+    expect(action!.suppressed_by_ancestor).toBeUndefined();
+  });
+
+  it('suggests smithy.forge for an in-progress tasks record', () => {
+    const record = makeRecord({
+      type: 'tasks',
+      status: 'in-progress',
+      path: 'specs/x/02-bar.tasks.md',
+      completed: 2,
+      total: 5,
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.forge');
+    expect(action!.arguments).toEqual(['specs/x/02-bar.tasks.md']);
+    expect(action!.reason.length).toBeGreaterThan(0);
+  });
+
+  it('treats a virtual tasks record like a not-started tasks record', () => {
+    const record = makeRecord({
+      type: 'tasks',
+      status: 'not-started',
+      virtual: true,
+      path: 'specs/x/03-baz.tasks.md',
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.forge');
+    expect(action!.arguments).toEqual(['specs/x/03-baz.tasks.md']);
+  });
+});
+
+describe('suggestNextAction — rfc records', () => {
+  it('suggests smithy.render for a not-started rfc record', () => {
+    const record = makeRecord({
+      type: 'rfc',
+      status: 'not-started',
+      path: 'docs/rfcs/2026-04-12-foo.rfc.md',
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.render');
+    expect(action!.arguments).toEqual(['docs/rfcs/2026-04-12-foo.rfc.md']);
+    expect(action!.reason.length).toBeGreaterThan(0);
+  });
+
+  it('suggests smithy.render for an in-progress rfc record', () => {
+    const record = makeRecord({
+      type: 'rfc',
+      status: 'in-progress',
+      path: 'docs/rfcs/2026-04-12-foo.rfc.md',
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.render');
+    expect(action!.arguments).toEqual(['docs/rfcs/2026-04-12-foo.rfc.md']);
+  });
+});
+
+describe('suggestNextAction — features records', () => {
+  it('suggests smithy.mark with the first not-started row numeric id', () => {
+    const record = makeRecord({
+      type: 'features',
+      status: 'in-progress',
+      path: 'docs/rfcs/foo.features.md',
+      dependency_order: {
+        rows: [
+          makeRow('F1', 'specs/a'),
+          makeRow('F2', 'specs/b'),
+          makeRow('F3', 'specs/c'),
+        ],
+        id_prefix: 'F',
+        format: 'table',
+      },
+    });
+    const children: ArtifactRecord[] = [
+      makeChild('done', 'spec'),
+      makeChild('not-started', 'spec'),
+      makeChild('in-progress', 'spec'),
+    ];
+    const action = suggestNextAction(record, children, false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.mark');
+    expect(action!.arguments).toEqual(['docs/rfcs/foo.features.md', '2']);
+    expect(action!.reason.length).toBeGreaterThan(0);
+  });
+
+  it('picks the lowest-index not-started row when multiple are not-started', () => {
+    const record = makeRecord({
+      type: 'features',
+      status: 'not-started',
+      path: 'docs/rfcs/foo.features.md',
+      dependency_order: {
+        rows: [
+          makeRow('F1'),
+          makeRow('F2'),
+          makeRow('F3'),
+        ],
+        id_prefix: 'F',
+        format: 'table',
+      },
+    });
+    const children: ArtifactRecord[] = [
+      makeChild('not-started', 'spec'),
+      makeChild('not-started', 'spec'),
+      makeChild('not-started', 'spec'),
+    ];
+    const action = suggestNextAction(record, children, false);
+    expect(action!.command).toBe('smithy.mark');
+    expect(action!.arguments).toEqual(['docs/rfcs/foo.features.md', '1']);
+  });
+
+  it('treats a virtual child as not-started for matching', () => {
+    const record = makeRecord({
+      type: 'features',
+      status: 'in-progress',
+      path: 'docs/rfcs/foo.features.md',
+      dependency_order: {
+        rows: [makeRow('F1', 'specs/a'), makeRow('F2', null)],
+        id_prefix: 'F',
+        format: 'table',
+      },
+    });
+    const children: ArtifactRecord[] = [
+      makeChild('done', 'spec'),
+      makeRecord({ type: 'spec', status: 'not-started', virtual: true }),
+    ];
+    const action = suggestNextAction(record, children, false);
+    expect(action!.command).toBe('smithy.mark');
+    expect(action!.arguments).toEqual(['docs/rfcs/foo.features.md', '2']);
+  });
+
+  it('falls back to record path only when no row matches but record is actionable', () => {
+    // Pathological: actionable features record with zero rows.
+    const record = makeRecord({
+      type: 'features',
+      status: 'not-started',
+      path: 'docs/rfcs/foo.features.md',
+      dependency_order: {
+        rows: [],
+        id_prefix: 'F',
+        format: 'table',
+      },
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.mark');
+    expect(action!.arguments).toEqual(['docs/rfcs/foo.features.md']);
+  });
+});
+
+describe('suggestNextAction — spec records', () => {
+  it('suggests smithy.cut against the spec parent directory with the first not-started row numeric id', () => {
+    const record = makeRecord({
+      type: 'spec',
+      status: 'in-progress',
+      path: 'specs/2026-04-12-004-foo/smithy-status-skill.spec.md',
+      dependency_order: {
+        rows: [
+          makeRow('US1', 'specs/2026-04-12-004-foo/01-bar.tasks.md'),
+          makeRow('US2', 'specs/2026-04-12-004-foo/02-baz.tasks.md'),
+          makeRow('US3', null),
+        ],
+        id_prefix: 'US',
+        format: 'table',
+      },
+    });
+    const children: ArtifactRecord[] = [
+      makeChild('done', 'tasks'),
+      makeChild('done', 'tasks'),
+      makeRecord({ type: 'tasks', status: 'not-started', virtual: true }),
+    ];
+    const action = suggestNextAction(record, children, false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.cut');
+    expect(action!.arguments).toEqual([
+      path.dirname('specs/2026-04-12-004-foo/smithy-status-skill.spec.md'),
+      '3',
+    ]);
+    expect(action!.reason.length).toBeGreaterThan(0);
+  });
+
+  it('uses path.dirname — not the .spec.md file path — for the first argument', () => {
+    const record = makeRecord({
+      type: 'spec',
+      status: 'not-started',
+      path: 'specs/deep/nested/dir/my.spec.md',
+      dependency_order: {
+        rows: [makeRow('US1')],
+        id_prefix: 'US',
+        format: 'table',
+      },
+    });
+    const children: ArtifactRecord[] = [makeChild('not-started', 'tasks')];
+    const action = suggestNextAction(record, children, false);
+    expect(action!.command).toBe('smithy.cut');
+    expect(action!.arguments[0]).toBe('specs/deep/nested/dir');
+    expect(action!.arguments[0]).not.toContain('.spec.md');
+    expect(action!.arguments[1]).toBe('1');
+  });
+
+  it('falls back to dirname only when no row matches but record is actionable', () => {
+    const record = makeRecord({
+      type: 'spec',
+      status: 'not-started',
+      path: 'specs/empty/my.spec.md',
+      dependency_order: {
+        rows: [],
+        id_prefix: 'US',
+        format: 'table',
+      },
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.cut');
+    expect(action!.arguments).toEqual(['specs/empty']);
+  });
+});
+
+describe('suggestNextAction — ancestor suppression flag', () => {
+  it('sets suppressed_by_ancestor: true when ancestorNotStarted is true', () => {
+    const record = makeRecord({
+      type: 'tasks',
+      status: 'not-started',
+      path: 'specs/x/01.tasks.md',
+    });
+    const action = suggestNextAction(record, [], true);
+    expect(action).not.toBeNull();
+    expect(action!.suppressed_by_ancestor).toBe(true);
+  });
+
+  it('omits suppressed_by_ancestor (not false) when ancestorNotStarted is false', () => {
+    const record = makeRecord({
+      type: 'tasks',
+      status: 'not-started',
+      path: 'specs/x/01.tasks.md',
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.suppressed_by_ancestor).toBeUndefined();
+    expect('suppressed_by_ancestor' in action!).toBe(false);
+  });
+
+  it('sets suppressed_by_ancestor: true on a features record too', () => {
+    const record = makeRecord({
+      type: 'features',
+      status: 'not-started',
+      path: 'docs/rfcs/foo.features.md',
+      dependency_order: {
+        rows: [makeRow('F1')],
+        id_prefix: 'F',
+        format: 'table',
+      },
+    });
+    const action = suggestNextAction(
+      record,
+      [makeChild('not-started', 'spec')],
+      true,
+    );
+    expect(action!.suppressed_by_ancestor).toBe(true);
+    expect(action!.command).toBe('smithy.mark');
+  });
+});
+
+describe('suggestNextAction — purity', () => {
+  it('does not mutate the input ArtifactRecord', () => {
+    const record = makeRecord({
+      type: 'features',
+      status: 'in-progress',
+      path: 'docs/rfcs/foo.features.md',
+      dependency_order: {
+        rows: [makeRow('F1'), makeRow('F2')],
+        id_prefix: 'F',
+        format: 'table',
+      },
+    });
+    const snapshot = JSON.parse(JSON.stringify(record));
+    const children: ArtifactRecord[] = [
+      makeChild('done', 'spec'),
+      makeChild('not-started', 'spec'),
+    ];
+    const childrenSnapshot = JSON.parse(JSON.stringify(children));
+    suggestNextAction(record, children, false);
+    expect(record).toEqual(snapshot);
+    expect(children).toEqual(childrenSnapshot);
+  });
+
+  it('returns deterministic output for the same inputs', () => {
+    const record = makeRecord({
+      type: 'spec',
+      status: 'in-progress',
+      path: 'specs/x/my.spec.md',
+      dependency_order: {
+        rows: [makeRow('US1'), makeRow('US2')],
+        id_prefix: 'US',
+        format: 'table',
+      },
+    });
+    const children: ArtifactRecord[] = [
+      makeChild('done', 'tasks'),
+      makeChild('not-started', 'tasks'),
+    ];
+    const a = suggestNextAction(record, children, false);
+    const b = suggestNextAction(record, children, false);
+    expect(a).toEqual(b);
+  });
+});

--- a/src/status/suggester.test.ts
+++ b/src/status/suggester.test.ts
@@ -4,11 +4,13 @@ import { describe, expect, it } from 'vitest';
 // surface downstream modules consume, and these tests double as an
 // assertion that the barrel re-exports `suggestNextAction` correctly.
 import {
+  formatNextAction,
   suggestNextAction,
   type ArtifactRecord,
   type ArtifactType,
   type DependencyOrderTable,
   type DependencyRow,
+  type NextAction,
   type Status,
 } from './index.js';
 
@@ -426,5 +428,89 @@ describe('suggestNextAction — purity', () => {
     const a = suggestNextAction(record, children, false);
     const b = suggestNextAction(record, children, false);
     expect(a).toEqual(b);
+  });
+});
+
+describe('formatNextAction', () => {
+  function makeAction(overrides: Partial<NextAction> = {}): NextAction {
+    return {
+      command: overrides.command ?? 'smithy.forge',
+      arguments: overrides.arguments ?? [],
+      reason: overrides.reason ?? 'because',
+      ...overrides,
+    };
+  }
+
+  it('formats a smithy.forge action with its tasks file path', () => {
+    const action = makeAction({
+      command: 'smithy.forge',
+      arguments: ['specs/foo/01.tasks.md'],
+    });
+    expect(formatNextAction(action)).toBe('\u2192 smithy.forge specs/foo/01.tasks.md');
+  });
+
+  it('formats a smithy.cut action with folder and numeric story id', () => {
+    const action = makeAction({
+      command: 'smithy.cut',
+      arguments: ['specs/foo', '2'],
+    });
+    expect(formatNextAction(action)).toBe('\u2192 smithy.cut specs/foo 2');
+  });
+
+  it('formats a smithy.mark action with features path and numeric feature id', () => {
+    const action = makeAction({
+      command: 'smithy.mark',
+      arguments: ['features.md', '3'],
+    });
+    expect(formatNextAction(action)).toBe('\u2192 smithy.mark features.md 3');
+  });
+
+  it('formats a smithy.render action with an rfc path', () => {
+    const action = makeAction({
+      command: 'smithy.render',
+      arguments: ['path/to/rfc.rfc.md'],
+    });
+    expect(formatNextAction(action)).toBe('\u2192 smithy.render path/to/rfc.rfc.md');
+  });
+
+  it('formats an action with no arguments as command-only with no trailing space', () => {
+    const action = makeAction({ command: 'smithy.ignite', arguments: [] });
+    const formatted = formatNextAction(action);
+    expect(formatted).toBe('\u2192 smithy.ignite');
+    expect(formatted).not.toMatch(/\s$/);
+  });
+
+  it('emits exactly one line (no embedded newlines)', () => {
+    const action = makeAction({
+      command: 'smithy.cut',
+      arguments: ['specs/a', '1', '2'],
+    });
+    const formatted = formatNextAction(action);
+    expect(formatted.split('\n')).toHaveLength(1);
+    expect(formatted).not.toContain('\n');
+  });
+
+  it('uses the arrow character U+2192 as the prefix', () => {
+    const action = makeAction({
+      command: 'smithy.forge',
+      arguments: ['specs/x/01.tasks.md'],
+    });
+    expect(formatNextAction(action).startsWith('\u2192 ')).toBe(true);
+  });
+
+  it('joins multiple arguments with single spaces', () => {
+    const action = makeAction({
+      command: 'smithy.cut',
+      arguments: ['specs/a', '1'],
+    });
+    expect(formatNextAction(action)).toBe('\u2192 smithy.cut specs/a 1');
+  });
+
+  it('is a pure function — same input produces identical output on repeat calls', () => {
+    const action = makeAction({
+      command: 'smithy.mark',
+      arguments: [path.join('docs', 'rfcs', 'foo.features.md'), '2'],
+    });
+    expect(formatNextAction(action)).toBe(formatNextAction(action));
   });
 });

--- a/src/status/suggester.test.ts
+++ b/src/status/suggester.test.ts
@@ -340,6 +340,51 @@ describe('suggestNextAction — spec records', () => {
     expect(action!.command).toBe('smithy.cut');
     expect(action!.arguments).toEqual(['specs/empty']);
   });
+
+  it('preserves the virtual spec folder path when record.path ends with a trailing slash', () => {
+    // Virtual spec records emitted by the scanner (feature-map row whose
+    // `Artifact` cell points at a folder with no discovered `.spec.md`)
+    // use the folder path itself as `record.path` — including the
+    // trailing slash. `path.dirname('specs/webhooks/')` collapses to
+    // `'specs'`, which would cause smithy.cut to target the wrong
+    // directory. The first argument must be the folder itself with
+    // trailing slashes stripped.
+    const record = makeRecord({
+      type: 'spec',
+      status: 'not-started',
+      path: 'specs/webhooks/',
+      virtual: true,
+      dependency_order: {
+        rows: [],
+        id_prefix: 'US',
+        format: 'table',
+      },
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.cut');
+    expect(action!.arguments).toEqual(['specs/webhooks']);
+  });
+
+  it('preserves the virtual spec folder path even with a matching not-started row', () => {
+    const record = makeRecord({
+      type: 'spec',
+      status: 'not-started',
+      path: 'specs/webhooks/',
+      virtual: true,
+      dependency_order: {
+        rows: [makeRow('US2')],
+        id_prefix: 'US',
+        format: 'table',
+      },
+    });
+    const action = suggestNextAction(
+      record,
+      [makeChild('not-started', 'tasks')],
+      false,
+    );
+    expect(action!.arguments).toEqual(['specs/webhooks', '2']);
+  });
 });
 
 describe('suggestNextAction — ancestor suppression flag', () => {

--- a/src/status/suggester.ts
+++ b/src/status/suggester.ts
@@ -45,6 +45,25 @@ function numericIdSuffix(id: string): string | undefined {
 }
 
 /**
+ * Derive the `smithy.cut` target folder for a spec record.
+ *
+ * Real spec records have `record.path` pointing at a `.spec.md` file,
+ * so the target folder is `dirname(path)`. Virtual spec records (emitted
+ * by the scanner when a features row points at a spec folder with no
+ * discovered `.spec.md`) have `record.path` already equal to the folder
+ * itself — including a trailing slash. In that case `dirname()` would
+ * collapse `specs/webhooks/` to `specs`, breaking the suggestion. Treat
+ * trailing-slash paths as the folder itself (stripping trailing slashes)
+ * and only use `dirname()` on real file paths.
+ */
+function specFolderFromPath(specPath: string): string {
+  if (specPath.endsWith('/')) {
+    return specPath.replace(/\/+$/, '');
+  }
+  return path.dirname(specPath);
+}
+
+/**
  * Find the first resolved child whose `status` is `'not-started'` and
  * return its corresponding row's numeric id suffix. Returns `undefined`
  * if no row matches or if the matching row has no trailing digits.
@@ -137,7 +156,7 @@ export function suggestNextAction(
     }
     case 'spec': {
       command = 'smithy.cut';
-      const folder = path.dirname(record.path);
+      const folder = specFolderFromPath(record.path);
       const digits = firstNotStartedRowDigits(record, resolvedChildren);
       if (digits !== undefined) {
         args = [folder, digits];

--- a/src/status/suggester.ts
+++ b/src/status/suggester.ts
@@ -1,0 +1,172 @@
+/**
+ * Pure next-action suggester for Smithy artifact records.
+ *
+ * This module contains a single pure function, `suggestNextAction`, that
+ * derives a {@link NextAction} (or `null`) from an already-classified
+ * {@link ArtifactRecord}, its already-classified resolved children, and
+ * a boolean flag indicating whether any ancestor in the record's parent
+ * chain is itself `not-started`. It performs no filesystem I/O, no
+ * network calls, and no mutation of its inputs.
+ *
+ * The rule table mirrors FR-010 in `smithy-status-skill.spec.md` and
+ * Acceptance Scenarios 4.1–4.5:
+ *
+ * - `rfc` → `smithy.render <rfc-path>`
+ * - `features` → `smithy.mark <features-path> <first-not-started-F<N>-digits>`
+ * - `spec` → `smithy.cut <dirname(spec-path)> <first-not-started-US<N>-digits>`
+ * - `tasks` → `smithy.forge <tasks-path>`
+ *
+ * `done` records always return `null`. `unknown`-status records (parse
+ * failures that made it through classification) also return `null` — the
+ * data model treats `unknown` as not actionable. Read-error records
+ * skipped by the scanner entirely leave `next_action` omitted and never
+ * reach this function.
+ *
+ * When `ancestorNotStarted` is `true`, the returned `NextAction`
+ * carries `suppressed_by_ancestor: true` so FR-011 suppression is visible
+ * to JSON consumers. When the flag is `false`, the field is omitted
+ * entirely (not set to `false`) so the JSON payload remains sparse.
+ *
+ * The scanner (Slice 1 Task 2) orchestrates ancestor walks and calls
+ * this function once per record after all statuses are finalized.
+ */
+
+import path from 'node:path';
+
+import type { ArtifactRecord, NextAction } from './types.js';
+
+/**
+ * Extract the numeric suffix from a canonical dep-order row id
+ * (`M1`, `F2`, `US3`, `S4`). Returns the digit tail as a string or
+ * `undefined` if no trailing digits are present.
+ */
+function numericIdSuffix(id: string): string | undefined {
+  return id.match(/[0-9]+$/)?.[0];
+}
+
+/**
+ * Find the first resolved child whose `status` is `'not-started'` and
+ * return its corresponding row's numeric id suffix. Returns `undefined`
+ * if no row matches or if the matching row has no trailing digits.
+ *
+ * Rows and children are paired by index — the scanner (and the
+ * classifier's consumers) already guarantees `resolvedChildren` is in
+ * the same order as `record.dependency_order.rows`.
+ */
+function firstNotStartedRowDigits(
+  record: ArtifactRecord,
+  resolvedChildren: ArtifactRecord[],
+): string | undefined {
+  const rows = record.dependency_order.rows;
+  const limit = Math.min(rows.length, resolvedChildren.length);
+  for (let i = 0; i < limit; i++) {
+    if (resolvedChildren[i]!.status === 'not-started') {
+      const digits = numericIdSuffix(rows[i]!.id);
+      if (digits !== undefined) return digits;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Derive a {@link NextAction} (or `null`) for a single classified
+ * {@link ArtifactRecord}.
+ *
+ * Rules:
+ *
+ * 1. A `done` record returns `null` regardless of type.
+ * 2. An `unknown`-status record returns `null` regardless of type — the
+ *    data model treats `unknown` as not actionable.
+ * 3. Otherwise the record is `not-started` or `in-progress` and the
+ *    deterministic rule table from FR-010 applies:
+ *    - `rfc` → `smithy.render [record.path]`
+ *    - `features` → `smithy.mark [record.path, <first-not-started-row-digits>]`
+ *      (fallback `[record.path]` when no row matches)
+ *    - `spec` → `smithy.cut [dirname(record.path), <first-not-started-row-digits>]`
+ *      (fallback `[dirname(record.path)]` when no row matches)
+ *    - `tasks` → `smithy.forge [record.path]`
+ * 4. When `ancestorNotStarted` is `true`, the returned `NextAction`
+ *    includes `suppressed_by_ancestor: true`. Otherwise the field is
+ *    omitted entirely (never serialized as `false`).
+ *
+ * This function is pure: same inputs always produce the same output and
+ * neither the record nor the children array is mutated.
+ *
+ * @param record             The already-classified record to evaluate.
+ * @param resolvedChildren   Children whose `status` is already
+ *                           finalized, in the same order as
+ *                           `record.dependency_order.rows`. Ignored
+ *                           for `rfc` and `tasks` records.
+ * @param ancestorNotStarted True when any ancestor in the record's
+ *                           parent chain has `status: 'not-started'`.
+ *                           Drives `suppressed_by_ancestor`.
+ */
+export function suggestNextAction(
+  record: ArtifactRecord,
+  resolvedChildren: ArtifactRecord[],
+  ancestorNotStarted: boolean,
+): NextAction | null {
+  // Rules 1 & 2: done and unknown records are never actionable.
+  if (record.status === 'done' || record.status === 'unknown') {
+    return null;
+  }
+
+  // Rule 3: derive the command + arguments from the record's type.
+  let command: NextAction['command'];
+  let args: string[];
+  let reason: string;
+
+  switch (record.type) {
+    case 'rfc': {
+      command = 'smithy.render';
+      args = [record.path];
+      reason = `RFC ${record.title} is ${record.status}; run smithy.render to continue drafting it.`;
+      break;
+    }
+    case 'features': {
+      command = 'smithy.mark';
+      const digits = firstNotStartedRowDigits(record, resolvedChildren);
+      if (digits !== undefined) {
+        args = [record.path, digits];
+        reason = `Features map ${record.title} has a not-started feature F${digits}; run smithy.mark to produce its spec.`;
+      } else {
+        args = [record.path];
+        reason = `Features map ${record.title} is ${record.status}; run smithy.mark to produce its next spec.`;
+      }
+      break;
+    }
+    case 'spec': {
+      command = 'smithy.cut';
+      const folder = path.dirname(record.path);
+      const digits = firstNotStartedRowDigits(record, resolvedChildren);
+      if (digits !== undefined) {
+        args = [folder, digits];
+        reason = `Spec ${record.title} has a not-started user story US${digits}; run smithy.cut to decompose it into tasks.`;
+      } else {
+        args = [folder];
+        reason = `Spec ${record.title} is ${record.status}; run smithy.cut to decompose its stories into tasks.`;
+      }
+      break;
+    }
+    case 'tasks': {
+      command = 'smithy.forge';
+      args = [record.path];
+      reason = `Tasks file ${record.title} is ${record.status}; run smithy.forge to implement its next slice.`;
+      break;
+    }
+  }
+
+  const action: NextAction = {
+    command,
+    arguments: args,
+    reason,
+  };
+
+  // Rule 4: only emit suppressed_by_ancestor when true, so the JSON
+  // payload stays sparse (the field is optional in the NextAction type).
+  if (ancestorNotStarted) {
+    action.suppressed_by_ancestor = true;
+  }
+
+  return action;
+}

--- a/src/status/suggester.ts
+++ b/src/status/suggester.ts
@@ -186,8 +186,8 @@ export function suggestNextAction(
  * This function is pure and performs no I/O. It is intentionally
  * colocated with {@link suggestNextAction} so downstream callers that
  * need to both derive and render a next action can import from a single
- * module, and so the future US2 hierarchical tree renderer can reuse
- * the same formatter to attach hints beneath tree nodes (SD-016).
+ * module, and so the `render.ts` tree renderer (US2) can reuse the
+ * same formatter to attach hints beneath tree nodes (SD-016).
  *
  * @param action The next action to format.
  * @returns A single-line hint string.

--- a/src/status/suggester.ts
+++ b/src/status/suggester.ts
@@ -170,3 +170,32 @@ export function suggestNextAction(
 
   return action;
 }
+
+/**
+ * Format a {@link NextAction} as a one-line, copy-pasteable hint string
+ * of the form `→ <command> <arg1> <arg2>...`.
+ *
+ * When `arguments` is empty the result collapses to `→ <command>` with
+ * no trailing whitespace. The returned string never contains embedded
+ * newlines — it is exactly one line.
+ *
+ * The prefix character is the Unicode rightwards arrow `→` (U+2192),
+ * separated from the command by a single ASCII space. Multiple
+ * arguments are joined by single ASCII spaces.
+ *
+ * This function is pure and performs no I/O. It is intentionally
+ * colocated with {@link suggestNextAction} so downstream callers that
+ * need to both derive and render a next action can import from a single
+ * module, and so the future US2 hierarchical tree renderer can reuse
+ * the same formatter to attach hints beneath tree nodes (SD-016).
+ *
+ * @param action The next action to format.
+ * @returns A single-line hint string.
+ */
+export function formatNextAction(action: NextAction): string {
+  const args = action.arguments;
+  if (args.length === 0) {
+    return `\u2192 ${action.command}`;
+  }
+  return `\u2192 ${action.command} ${args.join(' ')}`;
+}


### PR DESCRIPTION
## Summary
- **Primary outcome:** Implement User Story 4 of `smithy-status-skill` — the pure `suggestNextAction` function, its integration as scanner Phase 4 (ancestor-suppression pass), and the text-mode hint renderer. `smithy status` now surfaces deterministic next-action suggestions on every classified record, both in JSON output and as copy-pasteable hint lines in the default text tree.
- **Notable behaviour changes:**
  - `scan()` gains a fourth phase: after classification, it walks each record's `parent_path` chain (with cycle guard) to detect a `not-started` ancestor, then assigns `record.next_action` via `suggestNextAction`. Done/unknown records get `null`; read-error records keep `next_action` omitted so the absence of the field continues to mean "never evaluated".
  - `renderTree` accepts an optional `renderHints` flag; `smithy status` default text mode turns it **on** so every actionable, non-suppressed record emits an indented `→ <command> <args>` hint line. Done records and records with `suppressed_by_ancestor: true` emit no hint line. JSON output is byte-identical to Slice 1 (hints never leak into JSON).
- **Follow-up work deferred:** None for US4. US5 (skill passthrough) and US6 (filter flags) are separate stories and consume this work unchanged.

## Context
- **Why now:** US4 is the "actionable" half of the status feature. Without it, `smithy status` is a diagnostic; with it, the output is a worklist that tells the user which smithy command to run next for each in-progress or not-started artifact.
- **User story:** Developers using `smithy status --format json` see deterministic next-action data on every record; developers using the default terminal output see a copy-pasteable hint line beneath each actionable item.
- **Spec reference:** FR-010 (deterministic rule table) and FR-011 (ancestor suppression) in `specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.spec.md`; AS 4.1–4.5. Resolves SD-014, SD-015, SD-016.

## Implementation Notes

### Key architectural choices
1. **Pure function design:** `suggestNextAction(record, resolvedChildren, ancestorNotStarted): NextAction | null` is pure — no I/O, no mutation. It mirrors the `classifier.ts` precedent so the scanner can compose the two functions without state.
2. **Deterministic rule table (FR-010 / SD-014 / SD-015):**
   - `rfc` → `smithy.render [record.path]`
   - `features` → `smithy.mark [record.path, <first-not-started-F<N>-digits>]` (fallback `[record.path]`)
   - `spec` → `smithy.cut [<spec-folder>, <first-not-started-US<N>-digits>]` (fallback `[<spec-folder>]`). `<spec-folder>` is `dirname(record.path)` for real `.spec.md` files and the path itself (with trailing slashes stripped) for virtual spec records emitted at folder paths.
   - `tasks` → `smithy.forge [record.path]`
   - `done` / `unknown` → `null` always
3. **Ancestor suppression (FR-011):** When `ancestorNotStarted` is `true`, the returned `NextAction` includes `suppressed_by_ancestor: true`. When `false`, the field is omitted entirely (not set to `false`) so the JSON payload stays sparse and absence means "not suppressed".
4. **Scanner Phase 4:** Added after the existing Phase 3 classification loop. For each record without a `read_error` warning, the scanner walks the `parent_path` chain — terminating on `null`, `undefined`, `''`, or a seen-set cycle guard — then calls `suggestNextAction`. Records carrying a `read_error:` warning are skipped entirely so the absence of `next_action` signals "never evaluated" to JSON consumers (distinct from `null` which means "evaluated, no action").
5. **Text-mode hints (SD-016):** `formatNextAction(action)` is a pure formatter that returns `→ <command> [args…]` (or just `→ <command>` when args is empty) — exactly one line, no embedded newlines, Unicode U+2192 arrow. `renderTree` gained an optional `renderHints` option (default `false` to preserve the existing render tests). The `smithy status` text-mode branch turns it on, so every actionable, non-suppressed, non-group record gets an indented hint line beneath its tree line. `--format json` output is unaffected.

### Impacted modules
- **`src/status/suggester.ts`** (new): Pure `suggestNextAction` + `formatNextAction`. Zero I/O, exported from the barrel.
- **`src/status/scanner.ts`**: New Phase 4 pass that populates `record.next_action` on every classified record, with cycle-safe `parent_path` walk for suppression. Module JSDoc refreshed from "three phases" to "four phases".
- **`src/status/render.ts`**: `RenderTreeOptions.renderHints?: boolean`; helper `maybePushHint` emits the indented hint line directly below each non-group, non-done, non-suppressed record.
- **`src/status/index.ts`**: Re-exports `suggestNextAction` and `formatNextAction`.
- **`src/commands/status.ts`**: Text-mode branch now calls `renderTree(tree, { color, renderHints: true })`. JSON branch untouched.

### Test coverage
- `src/status/suggester.test.ts`: rule table, purity, suppression flag on/off, virtual records, fallback paths, virtual-spec-folder preservation, and formatter edge cases (empty args → `→ <command>`).
- `src/status/scanner.test.ts`: five new Phase 4 integration tests including a three-level not-started chain that exercises suppression and a read-error record whose `next_action` stays omitted.
- `src/status/render.test.ts`: `renderHints` true/false, done, suppressed, nested, and group-sentinel cases.
- `src/cli.test.ts`: end-to-end fixture with actionable + suppressed + done records; asserts hint placement in text mode and `next_action` shapes in JSON.

### Validation
- `npm test`: 458/458 passing across 15 files.
- `npm run typecheck`: clean.
- `npm run build`: clean, 83.49 KB ESM bundle.

https://claude.ai/code/session_01RNfeSynNdiVwasYaX2a9WV