### PR TITLE
Wire US6 filters: implement filterRecords with ancestor retention

### DIFF
--- a/specs/2026-04-12-004-smithy-status-skill/06-filter-and-scope-view.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/06-filter-and-scope-view.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Create pure `filterRecords` module with ancestor-aware status and type projection**
+- [x] **Create pure `filterRecords` module with ancestor-aware status and type projection**
 
   Add `src/status/filter.ts` exporting `filterRecords(records, opts)` where `opts` accepts optional `status: Status`, `type: ArtifactType`, and `root: string` fields; re-export it (plus its options type) from `src/status/index.ts`. The function is pure — no I/O, no input mutation, stable output for stable input — and operates on the flat `ArtifactRecord[]` produced by `scan()` before `buildTree()` synthesizes any sentinel group nodes. When `opts.status` is set, keep records whose `status` matches plus every ancestor reachable via recursive `parent_path` walks through the input set, so AS 6.1's "ancestors still rendered for context" holds. When `opts.type` is set, keep records whose `type` matches plus those same ancestor-by-`parent_path` records (the renderer's existing rules surface them as AS 6.3 headers; no new rendering behavior is introduced here). When both fields are set, apply intersection — a record must satisfy both predicates (or be an ancestor of a record that does) to survive. When `opts.root` is set, treat it as a no-op inside the filter: `statusAction` already narrows the scan via `scan(resolvedRoot)`, so the field is accepted for signature symmetry only. Virtual records (`virtual === true`, `status: 'not-started'`) are treated identically to real records of the same `type` and `status`. Co-locate `src/status/filter.test.ts` and exercise every branch against synthetic `ArtifactRecord[]` fixtures built in-memory.
 
@@ -33,7 +33,7 @@
   - Unit tests in `src/status/filter.test.ts` cover identity, each single-flag case, intersection, virtual-record handling, and the empty-input case — all in-memory, no disk fixtures.
   - `filterRecords` and its options type are re-exported from `src/status/index.ts`.
 
-- [ ] **Wire `filterRecords` into `statusAction`, keep `ScanSummary` pre-filter, refresh stub comments, add CLI integration tests**
+- [x] **Wire `filterRecords` into `statusAction`, keep `ScanSummary` pre-filter, refresh stub comments, add CLI integration tests**
 
   In `src/commands/status.ts`, call `filterRecords(records, { status: opts.status, type: opts.type, root: resolvedRoot })` after `scan(resolvedRoot)` and feed the filtered record set into both `buildTree()` and the JSON payload's `records` / `tree` fields. `summarize()` and `formatSummaryHeader()` continue to consume the unfiltered `records` so `ScanSummary.counts` and the rendered summary line remain aggregate over the full scan (satisfies the contracts' aggregate-summary framing; see SD-010). Delete the "stub — wired in US6" annotations on the `StatusOptions.status` / `StatusOptions.type` JSDoc entries and the stub mention in the file-level doc block at the top of `src/commands/status.ts`; likewise remove the matching "(stub — wired in US6)" suffixes on the `--status` and `--type` options in `src/cli.ts`. Extend `src/cli.test.ts` with integration tests that drive the built CLI against a synthetic temp-dir fixture covering every US6 acceptance scenario plus the summary-stability assumption called out in the plan. Confirm the existing "accepts all downstream option stubs without error" test remains green.
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1265,6 +1265,29 @@ describe('CLI status', () => {
       );
     });
 
+    it('prints a friendly no-match hint (not the pathological fallback warning) when filters retain zero records', () => {
+      writeFilterFixture();
+      // No artifact in the fixture has `status: done`, so this
+      // filter matches nothing. The exit should be 0 and the output
+      // should carry the summary header + a no-match line — not the
+      // "tree rendering produced no output" warning (which is
+      // reserved for real cycle/rendering bugs where the filter
+      // retained records but the tree came back empty).
+      const result = spawnSync(
+        'node',
+        [CLI, 'status', '--root', tmpDir, '--status', 'done'],
+        { encoding: 'utf-8' },
+      );
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('No artifacts match the current filter');
+      expect(result.stdout).not.toContain(
+        'tree rendering produced no output',
+      );
+      // The aggregate summary header still prints above the hint
+      // (SD-010).
+      expect(result.stdout).toMatch(/RFCs:.*·\s*Features:.*·\s*Specs:.*·\s*Tasks:/);
+    });
+
     it('text-mode summary header is byte-identical with and without filter flags', () => {
       writeFilterFixture();
       const unfiltered = execFileSync(

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1062,4 +1062,228 @@ describe('CLI status', () => {
       'specs/feature-a/01-first.tasks.md',
     );
   });
+
+  describe('US6 filters (--status, --type, --root)', () => {
+    // Shared fixture for the US6 filter tests: two sibling features
+    // under one RFC. Feature A is entirely in-progress (its spec has
+    // an in-progress tasks file), feature B is entirely not-started
+    // (its spec's only story row has `Artifact: —`, so the scanner
+    // emits a virtual not-started tasks record for it). This gives
+    // the filter something to discriminate in both dimensions
+    // (status and type) without needing four independent fixtures.
+    function writeFilterFixture(): void {
+      write(
+        'docs/rfcs/demo.rfc.md',
+        `# RFC: Demo\n\n## Dependency Order\n\n${TABLE_HEADER}\n| M1 | Milestone | — | docs/rfcs/demo.features.md |\n`,
+      );
+      write(
+        'docs/rfcs/demo.features.md',
+        `# Feature Map\n\n## Dependency Order\n\n${TABLE_HEADER}\n| F1 | Feature A | — | specs/feature-a |\n| F2 | Feature B | — | specs/feature-b |\n`,
+      );
+      // Feature A: spec → tasks with 1/2 ticked → in-progress.
+      write(
+        'specs/feature-a/feature-a.spec.md',
+        `# Feature Specification: Feature A\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story A | — | specs/feature-a/01-story-a.tasks.md |\n`,
+      );
+      // Master's a3fa215 counts completed slices, not individual
+      // checkboxes, so feature A's tasks file supplies one fully-
+      // checked slice plus one open slice — yielding 1/2 slices done
+      // → in-progress at rollup.
+      write(
+        'specs/feature-a/01-story-a.tasks.md',
+        `# Story A Tasks\n\n## Slice 1: Done Slice\n\n- [x] Done task A\n- [x] Done task B\n\n## Slice 2: Open Slice\n\n- [ ] Open task\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Done Slice | — | — |\n| S2 | Open Slice | — | — |\n`,
+      );
+      // Feature B: spec with an Artifact-— row → virtual
+      // not-started tasks record is synthesized by the scanner.
+      write(
+        'specs/feature-b/feature-b.spec.md',
+        `# Feature Specification: Feature B\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story B | — | — |\n`,
+      );
+    }
+
+    function runStatusJson(args: string[]): {
+      status: number;
+      payload: {
+        summary: {
+          counts: Record<string, Record<string, number>>;
+          parse_error_count: number;
+        };
+        records: Array<{
+          type: string;
+          path: string;
+          status: string;
+          virtual?: boolean;
+          parent_path?: string | null;
+        }>;
+        tree: { roots: Array<{ record: { path: string } }> };
+      };
+      raw: string;
+    } {
+      const result = spawnSync(
+        'node',
+        [CLI, 'status', '--format', 'json', '--root', tmpDir, ...args],
+        { encoding: 'utf-8' },
+      );
+      return {
+        status: result.status ?? 0,
+        payload: JSON.parse(result.stdout) as ReturnType<
+          typeof runStatusJson
+        >['payload'],
+        raw: result.stdout,
+      };
+    }
+
+    it('--status in-progress keeps in-progress records and their ancestors (AS 6.1)', () => {
+      writeFilterFixture();
+      const { status, payload } = runStatusJson(['--status', 'in-progress']);
+      expect(status).toBe(0);
+
+      const paths = payload.records.map((r) => r.path).sort();
+      // Chain A survives (tasks match + ancestors). Nothing from
+      // chain B survives — feature B's spec and virtual tasks are
+      // not-started, and the shared features/rfc are retained only
+      // because chain A's records walked through them.
+      expect(paths).toEqual(
+        [
+          'docs/rfcs/demo.rfc.md',
+          'docs/rfcs/demo.features.md',
+          'specs/feature-a/feature-a.spec.md',
+          'specs/feature-a/01-story-a.tasks.md',
+        ].sort(),
+      );
+      // Feature B artifacts are dropped.
+      expect(paths).not.toContain('specs/feature-b/feature-b.spec.md');
+    });
+
+    it('--type spec retains only specs plus their ancestors (AS 6.3)', () => {
+      writeFilterFixture();
+      const { status, payload } = runStatusJson(['--type', 'spec']);
+      expect(status).toBe(0);
+
+      const types = payload.records.map((r) => r.type).sort();
+      // Only rfc, features, spec, spec remain — no tasks records,
+      // because tasks are descendants of a spec, not ancestors.
+      expect(types).toEqual(['features', 'rfc', 'spec', 'spec']);
+      // Both specs made it in as direct matches.
+      const specPaths = payload.records
+        .filter((r) => r.type === 'spec')
+        .map((r) => r.path)
+        .sort();
+      expect(specPaths).toEqual([
+        'specs/feature-a/feature-a.spec.md',
+        'specs/feature-b/feature-b.spec.md',
+      ]);
+    });
+
+    it('--root <path> narrows the scan to artifacts under that root (AS 6.2)', () => {
+      // AS 6.2 is about narrowing the scan root. The scanner walks
+      // `specs/`, `docs/rfcs/`, `specs/strikes/` under the supplied
+      // root, so to exercise narrowing we lay down two independent
+      // sub-repos inside the temp dir and verify `--root subrepoA`
+      // surfaces only sub-repo A's artifacts. This exercises the
+      // US1-Slice-3 `--root` wire-up end-to-end under US6.
+      write(
+        'subrepoA/specs/feature-a/feature-a.spec.md',
+        `# Feature Specification: Feature A\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story A | — | — |\n`,
+      );
+      write(
+        'subrepoB/specs/feature-b/feature-b.spec.md',
+        `# Feature Specification: Feature B\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story B | — | — |\n`,
+      );
+
+      const subrepoA = path.join(tmpDir, 'subrepoA');
+      const result = spawnSync(
+        'node',
+        [CLI, 'status', '--format', 'json', '--root', subrepoA],
+        { encoding: 'utf-8' },
+      );
+      expect(result.status).toBe(0);
+      const payload = JSON.parse(result.stdout) as {
+        records: Array<{ path: string; title: string }>;
+      };
+      const titles = payload.records.map((r) => r.title).sort();
+      // Feature A is in scope; Feature B is not discoverable from
+      // subrepoA's root.
+      expect(titles).toContain('Feature A');
+      expect(titles).not.toContain('Feature B');
+    });
+
+    it('--status in-progress --type spec yields the intersection (matches both predicates + shared ancestors)', () => {
+      writeFilterFixture();
+      const { status, payload } = runStatusJson([
+        '--status',
+        'in-progress',
+        '--type',
+        'spec',
+      ]);
+      expect(status).toBe(0);
+
+      const paths = payload.records.map((r) => r.path).sort();
+      // Only Feature A's spec is BOTH a spec AND in-progress. Its
+      // ancestors (rfc, features) are retained; Feature B's spec is
+      // dropped because it is not in-progress; tasks records are
+      // dropped because they are not specs.
+      expect(paths).toEqual(
+        [
+          'docs/rfcs/demo.rfc.md',
+          'docs/rfcs/demo.features.md',
+          'specs/feature-a/feature-a.spec.md',
+        ].sort(),
+      );
+    });
+
+    it('--format json emits the filtered records and tree', () => {
+      writeFilterFixture();
+      const { payload } = runStatusJson(['--status', 'in-progress']);
+      // `records` and `tree.roots` are both computed from the
+      // filtered set — Feature B's tree must not leak into `tree`.
+      const treePaths: string[] = [];
+      const walk = (nodes: typeof payload.tree.roots): void => {
+        for (const n of nodes) {
+          treePaths.push(n.record.path);
+          walk(
+            (n as unknown as {
+              children: typeof payload.tree.roots;
+            }).children,
+          );
+        }
+      };
+      walk(payload.tree.roots);
+      expect(treePaths).not.toContain('specs/feature-b/feature-b.spec.md');
+      expect(treePaths).toContain('specs/feature-a/01-story-a.tasks.md');
+    });
+
+    it('summary counts are byte-identical with and without filter flags against the same fixture (SD-010)', () => {
+      writeFilterFixture();
+      const unfiltered = runStatusJson([]);
+      const filtered = runStatusJson(['--status', 'in-progress']);
+      // Summary is aggregate over the full scan regardless of
+      // filters — locked in by SD-010 to preserve the JSON
+      // contract's aggregate-summary framing.
+      expect(JSON.stringify(filtered.payload.summary)).toBe(
+        JSON.stringify(unfiltered.payload.summary),
+      );
+    });
+
+    it('text-mode summary header is byte-identical with and without filter flags', () => {
+      writeFilterFixture();
+      const unfiltered = execFileSync(
+        'node',
+        [CLI, 'status', '--root', tmpDir],
+        { encoding: 'utf-8' },
+      );
+      const filtered = execFileSync(
+        'node',
+        [CLI, 'status', '--root', tmpDir, '--status', 'in-progress'],
+        { encoding: 'utf-8' },
+      );
+      const unfilteredHeader = (unfiltered.split('\n')[0] ?? '').trim();
+      const filteredHeader = (filtered.split('\n')[0] ?? '').trim();
+      expect(filteredHeader).toBe(unfilteredHeader);
+      // Sanity: header carries all four type labels.
+      expect(unfilteredHeader).toMatch(
+        /RFCs:.*·\s*Features:.*·\s*Specs:.*·\s*Tasks:/,
+      );
+    });
+  });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,19 +78,19 @@ program
       .choices(['text', 'json'])
       .default('text'),
   )
-  // `--all` is fully wired (US3); `--status` / `--type` / `--graph` /
-  // `--no-color` remain stubs that Commander parses so `smithy status
-  // --help` advertises the full surface. `--status` and `--type` will
-  // be wired in US6, `--graph` in US10; `--no-color` has no effect
-  // until a colored renderer lands.
+  // `--all` is wired (US3) and `--status` / `--type` are wired (US6).
+  // `--graph` and `--no-color` remain stubs that Commander parses so
+  // `smithy status --help` advertises the full surface; `--graph` is
+  // owned by US10 and `--no-color` has no effect until a colored
+  // renderer lands.
   //
   // `--status` and `--type` deliberately do NOT use Commander
   // `.choices()` because Commander's invalid-choice handler exits with
   // code 1, while the contracts mandate exit code 2 for invalid values
   // on these two flags. `statusAction` validates them manually and
   // sets `process.exitCode = 2`.
-  .option('--status <state>', 'Filter by status: done|in-progress|not-started|unknown (stub — wired in US6)')
-  .option('--type <artifact-type>', 'Filter by artifact type: rfc|features|spec|tasks (stub — wired in US6)')
+  .option('--status <state>', 'Filter by status: done|in-progress|not-started|unknown')
+  .option('--type <artifact-type>', 'Filter by artifact type: rfc|features|spec|tasks')
   .option('--all', 'Disable collapsing of done subtrees so every artifact surfaces')
   .option('--graph', 'Render the cross-artifact dependency graph (stub — wired in US2/US10)')
   .option('--no-color', 'Suppress ANSI color output (stub — no colored text yet)')

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -262,14 +262,26 @@ export function statusAction(opts: StatusOptions = {}): void {
     return;
   }
 
-  // Defensive fallback: the scanner found records but `buildTree`
-  // produced an empty `roots` array — either a pathological cycle
-  // where two records claim each other as parents, or the US6 filter
-  // retained no records at all. The slice's acceptance criterion
-  // forbids silent drops ("every ArtifactRecord is represented by
-  // exactly one line"), so surface every retained record on its own
-  // line with a diagnostic header so operators can still see what
-  // the scanner found.
+  // US6: the filter retained no records. This is a valid outcome —
+  // the scan found artifacts but none match `--status` / `--type` —
+  // so print a friendly no-match hint instead of the pathological
+  // fallback warning below. The summary header printed above still
+  // reflects the full scan per SD-010, so users can see what was
+  // scanned even when the filtered view is empty.
+  if (filteredRecords.length === 0) {
+    console.log('No artifacts match the current filter.');
+    return;
+  }
+
+  // Defensive fallback: the scanner found records, the filter
+  // retained at least one, but `buildTree` still produced an empty
+  // `roots` array. The only realistic way this happens today is a
+  // pathological cycle where two records claim each other as
+  // parents, so neither reaches a root. The slice's acceptance
+  // criterion forbids silent drops ("every ArtifactRecord is
+  // represented by exactly one line"), so surface every retained
+  // record on its own line with a diagnostic header so operators
+  // can still see what the scanner found.
   console.log(
     'warning: tree rendering produced no output — listing records flat to avoid silent drops.',
   );

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -19,19 +19,26 @@
  *      pointing at `smithy.ignite` / `smithy.mark` and exit 0 — the
  *      contracts treat this as "not an error".
  *
- * `--all` now disables done-subtree collapsing in text mode via the
- * pure `collapseTree` transform inserted between `buildTree` and
- * `renderTree` (US3); JSON mode continues to emit the uncollapsed
- * `buildTree(records)` structure unconditionally. Option stubs for
- * `--status`, `--type`, `--graph`, and `--no-color` remain accepted
- * but have no behavioral effect yet — US6 wires the filter flags and
- * US10 wires `--graph`.
+ * `--status`, `--type`, and `--root` are wired end-to-end (US6):
+ * `--root` is honored by `scan(resolvedRoot)` upstream, and
+ * `filterRecords` applies the status / type predicates between the
+ * scan and the tree / JSON emission with ancestor retention so AS 6.1
+ * and AS 6.3 render correctly. `ScanSummary` is deliberately computed
+ * from the pre-filter record set so the `summary` block keeps its
+ * aggregate-scan framing (see SD-010). `--all` now disables
+ * done-subtree collapsing in text mode via the pure `collapseTree`
+ * transform inserted between `buildTree` and `renderTree` (US3); JSON
+ * mode continues to emit the uncollapsed tree structure
+ * unconditionally. Remaining stubs (`--graph`, `--no-color`) are
+ * accepted but have no behavioral effect — US10 wires `--graph`; a
+ * colored renderer will wire `--no-color`.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { buildTree, collapseTree, renderTree, scan } from '../status/index.js';
+import { buildTree, collapseTree, filterRecords, renderTree, scan } from '../status/index.js';
+import type { FilterRecordsOptions } from '../status/index.js';
 import type {
   ArtifactRecord,
   ArtifactType,
@@ -53,9 +60,15 @@ export interface StatusOptions {
   root?: string;
   /** Output format. Defaults to `text`. */
   format?: 'text' | 'json';
-  /** Stub: filter by status. Parsed but not wired (US6). */
+  /**
+   * Filter by status. Retains matching records and every ancestor by
+   * `parent_path` so the renderer keeps context (AS 6.1).
+   */
   status?: Status;
-  /** Stub: filter by artifact type. Parsed but not wired (US6). */
+  /**
+   * Filter by artifact type. Retains matching records and their
+   * ancestors as headers (AS 6.3). Descendants are hidden.
+   */
   type?: ArtifactType;
   /**
    * Disable done-subtree collapsing in text mode. When truthy, every
@@ -173,7 +186,22 @@ export function statusAction(opts: StatusOptions = {}): void {
   }
 
   const records = scan(resolvedRoot);
+  // US6: apply the `--status` / `--type` filters to the classified
+  // record set before it reaches `buildTree` / the JSON emitter.
+  // Ancestor retention inside `filterRecords` preserves AS 6.1 / AS
+  // 6.3 context without any renderer change. `--root` is a no-op
+  // here (the scan was already narrowed above); we pass it through
+  // for signature symmetry. `summarize(records)` stays above the
+  // filter call so `ScanSummary` / the header remain aggregate over
+  // the full scan per SD-010.
   const summary = summarize(records);
+  // Build a sparse options object — `exactOptionalPropertyTypes` in
+  // tsconfig forbids assigning `undefined` to optional fields, so we
+  // only set each key when Commander actually populated it.
+  const filterOpts: FilterRecordsOptions = { root: resolvedRoot };
+  if (opts.status !== undefined) filterOpts.status = opts.status;
+  if (opts.type !== undefined) filterOpts.type = opts.type;
+  const filteredRecords = filterRecords(records, filterOpts);
 
   // JSON mode: always emit a valid JSON payload, even on an empty
   // repo. Machine consumers (CI, the smithy.status agent skill) parse
@@ -182,8 +210,8 @@ export function statusAction(opts: StatusOptions = {}): void {
   if (opts.format === 'json') {
     const payload: StatusJsonPayload = {
       summary,
-      records,
-      tree: buildTree(records),
+      records: filteredRecords,
+      tree: buildTree(filteredRecords),
       graph: {
         nodes: {},
         layers: [],
@@ -210,22 +238,22 @@ export function statusAction(opts: StatusOptions = {}): void {
   // the helper.
   console.log(formatSummaryHeader(summary));
 
-  // US2 Slice 2 + US3 Slice 1: default text output is a hierarchical
-  // tree built from the same `ArtifactRecord[]` the JSON payload
-  // uses, then passed through the pure `collapseTree` transform so
-  // any fully-`done` subtree collapses to a single `DONE` line with
-  // no descendants (AS 3.1, 3.3, 3.4). Passing `--all` routes through
-  // the same transform with `{ all: true }`, which returns a fresh
-  // but structurally equivalent tree so every artifact still
-  // surfaces (AS 3.5). Group sentinels ("Orphaned Specs", "Broken
-  // Links") surface at the top of `tree.roots` and render as their
-  // own headings above their grouped children; `collapseTree` never
-  // collapses them regardless of `--all`. `color: opts.color !== false`
-  // preserves the future `--no-color` wire-up by disabling color
-  // only when Commander sets `opts.color` to `false`; today the
-  // renderer emits plain text with UTF-8 box-drawing connectors and
-  // no color regardless.
-  const tree = collapseTree(buildTree(records), {
+  // US2 Slice 2 + US3 Slice 1 + US6 Slice 1: default text output is a
+  // hierarchical tree built from the US6-filtered record set (the full
+  // scan when `--status` / `--type` are absent), then passed through
+  // the pure `collapseTree` transform so any fully-`done` subtree
+  // collapses to a single `DONE` line with no descendants (AS 3.1,
+  // 3.3, 3.4). Passing `--all` routes through the same transform with
+  // `{ all: true }`, which returns a fresh but structurally equivalent
+  // tree so every artifact still surfaces (AS 3.5). Group sentinels
+  // ("Orphaned Specs", "Broken Links") surface at the top of
+  // `tree.roots` and render as their own headings above their grouped
+  // children; `collapseTree` never collapses them regardless of
+  // `--all`. `color: opts.color !== false` preserves the future
+  // `--no-color` wire-up by disabling color only when Commander sets
+  // `opts.color` to `false`; today the renderer emits plain text with
+  // UTF-8 box-drawing connectors and no color regardless.
+  const tree = collapseTree(buildTree(filteredRecords), {
     all: opts.all === true,
   });
   const rendered = renderTree(tree, { color: opts.color !== false });
@@ -235,18 +263,17 @@ export function statusAction(opts: StatusOptions = {}): void {
   }
 
   // Defensive fallback: the scanner found records but `buildTree`
-  // produced an empty `roots` array — the only realistic way this
-  // happens today is a pathological cycle where two records claim
-  // each other as parents, so neither reaches a root. The slice's
-  // acceptance criterion forbids silent drops ("every ArtifactRecord
-  // is represented by exactly one line"), so surface every record on
-  // its own line with a diagnostic header so operators can still see
-  // what the scanner found. Matches the spirit of the US1 flat
-  // listing this slice replaces.
+  // produced an empty `roots` array — either a pathological cycle
+  // where two records claim each other as parents, or the US6 filter
+  // retained no records at all. The slice's acceptance criterion
+  // forbids silent drops ("every ArtifactRecord is represented by
+  // exactly one line"), so surface every retained record on its own
+  // line with a diagnostic header so operators can still see what
+  // the scanner found.
   console.log(
     'warning: tree rendering produced no output — listing records flat to avoid silent drops.',
   );
-  for (const record of records) {
+  for (const record of filteredRecords) {
     console.log(
       `${record.type}\t${record.path}\t${record.title}\t${record.status}`,
     );

--- a/src/status/filter.test.ts
+++ b/src/status/filter.test.ts
@@ -1,0 +1,423 @@
+import { describe, expect, it } from 'vitest';
+// Import through the `./index.js` barrel — that is the stable public
+// surface downstream modules consume, and these tests double as an
+// assertion that the barrel re-exports the filter correctly.
+import {
+  filterRecords,
+  type ArtifactRecord,
+  type ArtifactType,
+  type DependencyOrderTable,
+  type FilterRecordsOptions,
+  type Status,
+} from './index.js';
+
+/**
+ * Build a synthetic `ArtifactRecord` with the minimum fields populated
+ * to participate in filtering. Tests pass `overrides` for the fields
+ * they care about (type, path, status, parent_path, virtual).
+ */
+function makeRecord(overrides: Partial<ArtifactRecord> = {}): ArtifactRecord {
+  const type: ArtifactType = overrides.type ?? 'spec';
+  const idPrefix: DependencyOrderTable['id_prefix'] =
+    type === 'rfc'
+      ? 'M'
+      : type === 'features'
+        ? 'F'
+        : type === 'spec'
+          ? 'US'
+          : 'S';
+  return {
+    type,
+    path: overrides.path ?? `specs/sample.${type === 'tasks' ? 'tasks' : type}.md`,
+    title: overrides.title ?? 'Sample',
+    status: overrides.status ?? 'unknown',
+    dependency_order: overrides.dependency_order ?? {
+      rows: [],
+      id_prefix: idPrefix,
+      format: 'table',
+    },
+    warnings: overrides.warnings ?? [],
+    ...overrides,
+  };
+}
+
+/**
+ * Build a canonical full-chain RFC→features→spec→tasks fixture where
+ * the tasks file has the given status (for testing ancestor retention
+ * under `--status`). Order is scanner-order: deepest first is NOT
+ * required — we emit parent-first so tests that assert order stability
+ * are explicit about what they expect.
+ */
+function fullChain(taskStatus: Status): ArtifactRecord[] {
+  return [
+    makeRecord({
+      type: 'rfc',
+      path: 'docs/rfcs/demo.rfc.md',
+      title: 'Demo RFC',
+      status: 'in-progress',
+      parent_path: null,
+    }),
+    makeRecord({
+      type: 'features',
+      path: 'docs/rfcs/demo.features.md',
+      title: 'Demo Features',
+      status: 'in-progress',
+      parent_path: 'docs/rfcs/demo.rfc.md',
+    }),
+    makeRecord({
+      type: 'spec',
+      path: 'specs/feature-a/feature-a.spec.md',
+      title: 'Feature A',
+      status: 'in-progress',
+      parent_path: 'docs/rfcs/demo.features.md',
+    }),
+    makeRecord({
+      type: 'tasks',
+      path: 'specs/feature-a/01-first.tasks.md',
+      title: 'First',
+      status: taskStatus,
+      parent_path: 'specs/feature-a/feature-a.spec.md',
+    }),
+  ];
+}
+
+describe('filterRecords — identity behavior', () => {
+  it('returns the input array unchanged when no predicates are supplied', () => {
+    const records = fullChain('done');
+    const result = filterRecords(records, {});
+    expect(result).toBe(records);
+  });
+
+  it('returns the input array unchanged when only `root` is supplied (root is a no-op inside the filter)', () => {
+    const records = fullChain('in-progress');
+    const result = filterRecords(records, { root: '/tmp/whatever' });
+    expect(result).toBe(records);
+  });
+
+  it('returns an empty array unchanged on empty input', () => {
+    const result = filterRecords([], { status: 'in-progress' });
+    expect(result).toEqual([]);
+  });
+});
+
+describe('filterRecords — status predicate with ancestor retention (AS 6.1)', () => {
+  it('keeps status-matching records plus every ancestor by parent_path', () => {
+    const records = fullChain('in-progress');
+    const result = filterRecords(records, { status: 'in-progress' });
+    // The tasks record matches, and its ancestors (spec, features,
+    // rfc) walk up the chain. Every record in the fixture is
+    // `in-progress`, so the whole chain survives.
+    expect(result.map((r) => r.path)).toEqual([
+      'docs/rfcs/demo.rfc.md',
+      'docs/rfcs/demo.features.md',
+      'specs/feature-a/feature-a.spec.md',
+      'specs/feature-a/01-first.tasks.md',
+    ]);
+  });
+
+  it('drops unrelated siblings whose status does not match and who are not ancestors of a match', () => {
+    // Two independent chains under the same RFC. Only the first chain
+    // has an in-progress tasks file; the second is entirely
+    // not-started. Under `--status in-progress`, chain A survives in
+    // full (tasks match + ancestors) while chain B is dropped wholesale
+    // — including the features / spec / tasks nodes that share nothing
+    // but the RFC.
+    const records: ArtifactRecord[] = [
+      makeRecord({
+        type: 'rfc',
+        path: 'rfc.md',
+        status: 'in-progress',
+        parent_path: null,
+      }),
+      makeRecord({
+        type: 'features',
+        path: 'featuresA.md',
+        status: 'in-progress',
+        parent_path: 'rfc.md',
+      }),
+      makeRecord({
+        type: 'spec',
+        path: 'specA.md',
+        status: 'in-progress',
+        parent_path: 'featuresA.md',
+      }),
+      makeRecord({
+        type: 'tasks',
+        path: 'tasksA.md',
+        status: 'in-progress',
+        parent_path: 'specA.md',
+      }),
+      makeRecord({
+        type: 'features',
+        path: 'featuresB.md',
+        status: 'not-started',
+        parent_path: 'rfc.md',
+      }),
+      makeRecord({
+        type: 'spec',
+        path: 'specB.md',
+        status: 'not-started',
+        parent_path: 'featuresB.md',
+      }),
+      makeRecord({
+        type: 'tasks',
+        path: 'tasksB.md',
+        status: 'not-started',
+        parent_path: 'specB.md',
+      }),
+    ];
+    const result = filterRecords(records, { status: 'in-progress' });
+    expect(result.map((r) => r.path)).toEqual([
+      'rfc.md',
+      'featuresA.md',
+      'specA.md',
+      'tasksA.md',
+    ]);
+  });
+
+  it('terminates ancestor walks at records not present in the input (no crash on dangling parent_path)', () => {
+    const records: ArtifactRecord[] = [
+      makeRecord({
+        type: 'tasks',
+        path: 'orphan.tasks.md',
+        status: 'in-progress',
+        parent_path: 'specs/missing.spec.md',
+      }),
+    ];
+    const result = filterRecords(records, { status: 'in-progress' });
+    expect(result.map((r) => r.path)).toEqual(['orphan.tasks.md']);
+  });
+});
+
+describe('filterRecords — type predicate with ancestor retention (AS 6.3)', () => {
+  it('keeps type-matching records plus their ancestors so the renderer can surface them as headers', () => {
+    const records = fullChain('done');
+    const result = filterRecords(records, { type: 'spec' });
+    // spec matches directly; its ancestors (features, rfc) walk up.
+    // The tasks descendant is NOT an ancestor of the spec, so it is
+    // dropped — matches the AS 6.3 "descendants hidden" promise.
+    expect(result.map((r) => r.path)).toEqual([
+      'docs/rfcs/demo.rfc.md',
+      'docs/rfcs/demo.features.md',
+      'specs/feature-a/feature-a.spec.md',
+    ]);
+  });
+
+  it('drops descendants of type matches', () => {
+    const records = fullChain('in-progress');
+    const result = filterRecords(records, { type: 'features' });
+    expect(result.map((r) => r.type)).toEqual(['rfc', 'features']);
+  });
+});
+
+describe('filterRecords — intersection semantics (both status and type)', () => {
+  it('retains a record only when both predicates match (or it is an ancestor of such a record)', () => {
+    // Two specs under the same RFC → features chain. One spec is
+    // in-progress, the other is not-started. `--status in-progress
+    // --type spec` should retain only the first spec plus its
+    // ancestors.
+    const records: ArtifactRecord[] = [
+      makeRecord({
+        type: 'rfc',
+        path: 'rfc.md',
+        status: 'in-progress',
+        parent_path: null,
+      }),
+      makeRecord({
+        type: 'features',
+        path: 'features.md',
+        status: 'in-progress',
+        parent_path: 'rfc.md',
+      }),
+      makeRecord({
+        type: 'spec',
+        path: 'specA.md',
+        status: 'in-progress',
+        parent_path: 'features.md',
+      }),
+      makeRecord({
+        type: 'spec',
+        path: 'specB.md',
+        status: 'not-started',
+        parent_path: 'features.md',
+      }),
+    ];
+    const result = filterRecords(records, {
+      status: 'in-progress',
+      type: 'spec',
+    });
+    expect(result.map((r) => r.path)).toEqual([
+      'rfc.md',
+      'features.md',
+      'specA.md',
+    ]);
+  });
+
+  it('returns an empty array when no record matches both predicates', () => {
+    // No `spec` record is `done` in this fixture, so the intersection
+    // is empty and no ancestors get pulled in.
+    const records = fullChain('in-progress');
+    const result = filterRecords(records, { status: 'done', type: 'spec' });
+    expect(result).toEqual([]);
+  });
+
+  it('drops an ancestor-by-type-only record when status does not match', () => {
+    // A spec that matches `--type spec` but not `--status done` must
+    // NOT be retained solely by virtue of being a type match — under
+    // intersection semantics, the `--status` predicate also applies.
+    const records: ArtifactRecord[] = [
+      makeRecord({
+        type: 'rfc',
+        path: 'rfc.md',
+        status: 'in-progress',
+        parent_path: null,
+      }),
+      makeRecord({
+        type: 'spec',
+        path: 'spec.md',
+        status: 'in-progress',
+        parent_path: 'rfc.md',
+      }),
+    ];
+    const result = filterRecords(records, { status: 'done', type: 'spec' });
+    expect(result).toEqual([]);
+  });
+});
+
+describe('filterRecords — virtual records', () => {
+  it('retains a virtual record whose status matches, and walks its parent chain', () => {
+    // A virtual not-started tasks record emitted for an `Artifact: —`
+    // row on a parent spec. The virtual record has `status:
+    // 'not-started'` and a non-null `parent_path`, identical to the
+    // shape scanner.ts produces.
+    const records: ArtifactRecord[] = [
+      makeRecord({
+        type: 'spec',
+        path: 'spec.md',
+        status: 'in-progress',
+        parent_path: null,
+      }),
+      makeRecord({
+        type: 'tasks',
+        path: 'virtual-01.tasks.md',
+        status: 'not-started',
+        virtual: true,
+        parent_path: 'spec.md',
+      }),
+    ];
+    const result = filterRecords(records, { status: 'not-started' });
+    expect(result.map((r) => r.path)).toEqual(['spec.md', 'virtual-01.tasks.md']);
+  });
+
+  it('treats a virtual record as an ancestor-eligible node just like a real record', () => {
+    // Virtual spec (from an `Artifact: —` row on a feature map) sits
+    // between a features record and a (hypothetical) tasks record. The
+    // tasks record is the match; the virtual spec and the features
+    // record are retained as ancestors.
+    const records: ArtifactRecord[] = [
+      makeRecord({
+        type: 'features',
+        path: 'features.md',
+        status: 'in-progress',
+        parent_path: null,
+      }),
+      makeRecord({
+        type: 'spec',
+        path: 'virtual-spec.md',
+        status: 'not-started',
+        virtual: true,
+        parent_path: 'features.md',
+      }),
+      makeRecord({
+        type: 'tasks',
+        path: 'tasks.md',
+        status: 'in-progress',
+        parent_path: 'virtual-spec.md',
+      }),
+    ];
+    const result = filterRecords(records, { status: 'in-progress' });
+    expect(result.map((r) => r.path)).toEqual([
+      'features.md',
+      'virtual-spec.md',
+      'tasks.md',
+    ]);
+  });
+});
+
+describe('filterRecords — purity and ordering', () => {
+  it('does not mutate the input array', () => {
+    const records = fullChain('in-progress');
+    const snapshot = records.slice();
+    filterRecords(records, { status: 'in-progress' });
+    expect(records).toEqual(snapshot);
+  });
+
+  it('produces stable output for stable input (same input twice yields equal output)', () => {
+    const records = fullChain('in-progress');
+    const opts: FilterRecordsOptions = { status: 'in-progress', type: 'spec' };
+    const a = filterRecords(records, opts);
+    const b = filterRecords(records, opts);
+    expect(a).toEqual(b);
+  });
+
+  it('preserves input order and emits each record exactly once', () => {
+    // A spec matches `--type spec`, and its ancestor (features) also
+    // has to be walked. The features record already appears earlier in
+    // the input, so the result should list it once (not once-as-match
+    // + once-as-ancestor) and in its original position.
+    const records: ArtifactRecord[] = [
+      makeRecord({
+        type: 'rfc',
+        path: 'rfc.md',
+        status: 'in-progress',
+        parent_path: null,
+      }),
+      makeRecord({
+        type: 'features',
+        path: 'features.md',
+        status: 'in-progress',
+        parent_path: 'rfc.md',
+      }),
+      makeRecord({
+        type: 'spec',
+        path: 'spec1.md',
+        status: 'in-progress',
+        parent_path: 'features.md',
+      }),
+      makeRecord({
+        type: 'spec',
+        path: 'spec2.md',
+        status: 'in-progress',
+        parent_path: 'features.md',
+      }),
+    ];
+    const result = filterRecords(records, { type: 'spec' });
+    expect(result.map((r) => r.path)).toEqual([
+      'rfc.md',
+      'features.md',
+      'spec1.md',
+      'spec2.md',
+    ]);
+  });
+
+  it('tolerates a cyclic parent_path chain without infinite looping', () => {
+    // Defensive — scanner output should be acyclic, but two records
+    // referencing each other as parents must not hang the filter.
+    const records: ArtifactRecord[] = [
+      makeRecord({
+        type: 'spec',
+        path: 'a.md',
+        status: 'in-progress',
+        parent_path: 'b.md',
+      }),
+      makeRecord({
+        type: 'spec',
+        path: 'b.md',
+        status: 'in-progress',
+        parent_path: 'a.md',
+      }),
+    ];
+    const result = filterRecords(records, { status: 'in-progress' });
+    expect(result.map((r) => r.path).sort()).toEqual(['a.md', 'b.md']);
+  });
+});

--- a/src/status/filter.ts
+++ b/src/status/filter.ts
@@ -1,0 +1,148 @@
+/**
+ * Pure record-level filter applied between {@link scan} and
+ * {@link buildTree}. Given the flat {@link ArtifactRecord} array the
+ * scanner produces, `filterRecords` retains only those records that
+ * satisfy the user-supplied `--status` and `--type` predicates, plus
+ * every ancestor reachable from a retained record via `parent_path`.
+ * Ancestor retention is what lets the renderer honor US6 AS 6.1 ("only
+ * in-progress artifacts and their ancestors appear") and AS 6.3 ("only
+ * spec-level artifacts appear — ancestors shown as headers, descendants
+ * hidden") without any changes to the renderer itself.
+ *
+ * This module is side-effect-free: no filesystem I/O, no network, no
+ * mutation of its input array or any of the records inside it. Passing
+ * the same input twice yields the same output. The function is
+ * composed upstream of `buildTree` so downstream modules — the tree
+ * projector, renderer, and JSON emitter — see a smaller record set but
+ * are otherwise unchanged.
+ *
+ * ## Semantics
+ *
+ * - **Identity.** When no filter predicates are supplied (`status` and
+ *   `type` both absent), the returned array is equal to the input
+ *   array — same records, same order, no copies stripped or
+ *   rearranged.
+ *
+ * - **`--status` projection.** When `opts.status` is set, a record is
+ *   retained iff its `status` matches (the "match set") OR it appears
+ *   on the `parent_path` chain of some record in the match set. Walks
+ *   use only records present in the input array — a `parent_path` that
+ *   does not resolve to an input record terminates the walk quietly
+ *   (consistent with `buildTree`'s "Broken Links" handling).
+ *
+ * - **`--type` projection.** Identical to `--status` but keyed off
+ *   `record.type`. Ancestor retention still applies so the renderer can
+ *   surface them as AS 6.3 headers.
+ *
+ * - **Intersection.** When both predicates are set, a record must
+ *   satisfy both (or be the ancestor of a record that satisfies both)
+ *   to survive. Specifically, the match set is the set of records
+ *   where status AND type match, and ancestors of that set are
+ *   included.
+ *
+ * - **Virtual records.** Records with `virtual === true` (always
+ *   `status: 'not-started'`) are filtered on the same rules as real
+ *   records of the same `type` and `status`. No special-casing — a
+ *   virtual record participates in ancestor walks identically, and a
+ *   virtual record that matches the status/type predicates is retained
+ *   just like a real one.
+ *
+ * - **Root.** `opts.root` is accepted for signature symmetry with the
+ *   CLI options surface but has no effect inside the filter. The scan
+ *   root is already honored by `statusAction` via `scan(resolvedRoot)`
+ *   upstream; narrowing again here would be a no-op that confuses
+ *   future readers.
+ *
+ * - **Order & dedup.** Output preserves input order. When a record is
+ *   both a predicate match and an ancestor of another match, it
+ *   appears exactly once.
+ */
+
+import type { ArtifactRecord, ArtifactType, Status } from './types.js';
+
+/**
+ * Options accepted by {@link filterRecords}. Mirrors the three filter
+ * flags exposed by `smithy status` (`--status`, `--type`, `--root`).
+ * All fields are optional; an empty object yields identity behavior.
+ */
+export interface FilterRecordsOptions {
+  /** Keep records with this status plus their ancestors. */
+  status?: Status;
+  /** Keep records with this artifact type plus their ancestors. */
+  type?: ArtifactType;
+  /**
+   * Accepted for signature symmetry with the CLI options surface. The
+   * scan root is honored upstream by `scan(resolvedRoot)`; this field
+   * is a no-op inside the filter.
+   */
+  root?: string;
+}
+
+/**
+ * Apply the status / type predicates (with ancestor retention) to a
+ * flat record array. See the module-level JSDoc for the full
+ * semantics.
+ *
+ * Pure function: no I/O, no input mutation, stable output for stable
+ * input.
+ */
+export function filterRecords(
+  records: ArtifactRecord[],
+  opts: FilterRecordsOptions = {},
+): ArtifactRecord[] {
+  // Identity fast-path: no predicates means the filter is a no-op. We
+  // return the input array unchanged (not a shallow copy) because the
+  // module-level contract promises `array equals input array` in this
+  // case, and downstream consumers already treat the result as
+  // read-only.
+  if (opts.status === undefined && opts.type === undefined) {
+    return records;
+  }
+
+  // Index records by path so ancestor walks can jump from a child's
+  // `parent_path` to the parent record in O(1). When two records
+  // share a path (the scanner flags this as a collision warning), the
+  // first wins — matching `buildTree`'s behavior.
+  const recordsByPath = new Map<string, ArtifactRecord>();
+  for (const record of records) {
+    if (!recordsByPath.has(record.path)) {
+      recordsByPath.set(record.path, record);
+    }
+  }
+
+  const retained = new Set<ArtifactRecord>();
+
+  for (const record of records) {
+    const statusMatches =
+      opts.status === undefined || record.status === opts.status;
+    const typeMatches = opts.type === undefined || record.type === opts.type;
+    if (!statusMatches || !typeMatches) continue;
+
+    // Direct match: retain the record and walk up its `parent_path`
+    // chain, adding every ancestor that lives in the input set. The
+    // walk terminates on a null/undefined `parent_path`, on a path
+    // that does not resolve to an input record, or on a cycle (a
+    // record we have already seen during this walk — defensive, since
+    // scanner output should be acyclic).
+    let cursor: ArtifactRecord | undefined = record;
+    const walkSeen = new Set<ArtifactRecord>();
+    while (cursor !== undefined && !walkSeen.has(cursor)) {
+      walkSeen.add(cursor);
+      retained.add(cursor);
+      const parentPath = cursor.parent_path;
+      if (parentPath === null || parentPath === undefined) break;
+      cursor = recordsByPath.get(parentPath);
+    }
+  }
+
+  // Preserve input order and dedupe by only emitting each record
+  // once — the `retained` set handles the dedup, and a single pass
+  // over `records` preserves the order.
+  const result: ArtifactRecord[] = [];
+  for (const record of records) {
+    if (retained.has(record)) {
+      result.push(record);
+    }
+  }
+  return result;
+}

--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -23,3 +23,4 @@ export {
 } from './tree.js';
 export { collapseTree, type CollapseTreeOptions } from './collapse.js';
 export { renderTree, type RenderTreeOptions } from './render.js';
+export { filterRecords, type FilterRecordsOptions } from './filter.js';


### PR DESCRIPTION
## Summary
- **Primary outcome:** Implement the `filterRecords` pure function that applies `--status` and `--type` predicates to artifact records with ancestor retention, enabling AS 6.1 and AS 6.3 filtering semantics. Wire it end-to-end in `statusAction` so `smithy status --status <status> --type <type>` filters the output correctly.
- **Notable behaviour changes:** `smithy status` with `--status` or `--type` flags now filters the displayed records and JSON output to show only matching artifacts plus their ancestors (for context). The summary header remains aggregate over the full scan per SD-010.
- **Follow-up work deferred:** `--all`, `--graph`, and `--no-color` remain option stubs; US3 and US10 will wire those.

## Context
This implements US6 (Filter and Scope View) acceptance criteria 6.1 and 6.3:
- **AS 6.1:** `--status in-progress` shows only in-progress artifacts and their ancestors.
- **AS 6.3:** `--type spec` shows only spec-level artifacts and their ancestors (descendants hidden).

The filter is composed upstream of `buildTree` and the JSON emitter so downstream modules see a smaller record set without any changes to their logic. Ancestor retention is the key: when a record matches the predicates, we walk its `parent_path` chain and include every ancestor present in the input, allowing the renderer to surface them as context headers.

## Implementation Notes

### Key architectural choices
1. **Pure function, no side effects:** `filterRecords` is side-effect-free (no I/O, no input mutation). Passing the same input twice yields the same output. This makes it testable and composable.

2. **Ancestor retention via parent_path walk:** When a record matches the status/type predicates, we walk up its `parent_path` chain and retain every ancestor found in the input. This preserves context without requiring the renderer to change.

3. **Intersection semantics:** When both `--status` and `--type` are supplied, a record must satisfy both predicates (or be an ancestor of a record that does) to survive. The match set is the intersection; ancestors of that set are included.

4. **Identity fast-path:** When no predicates are supplied, the function returns the input array unchanged (not a copy), honoring the contract that "no filters = identity behavior."

5. **Virtual record handling:** Records with `virtual === true` (synthesized by the scanner for `Artifact: —` rows) are filtered on the same rules as real records. No special-casing — they participate in ancestor walks identically.

6. **Order and dedup:** Output preserves input order. When a record is both a predicate match and an ancestor of another match, it appears exactly once.

7. **Graceful handling of broken links:** A `parent_path` that does not resolve to an input record terminates the walk quietly (consistent with `buildTree`'s "Broken Links" handling). Cyclic parent chains are detected and break the walk to prevent infinite loops.

8. **Summary stays aggregate:** `summarize(records)` is called before filtering so the summary header and JSON `summary` block remain aggregate over the full scan, preserving the contract promised by SD-010.

### Impacted modules
- **`src/status/filter.ts`** (new): Pure `filterRecords` function with full JSDoc and semantics.
- **`src/status/index.ts`**: Export `filterRecords` and `FilterRecordsOptions` from the barrel.
- **`src/commands/status.ts`**: Wire `filterRecords` between `scan()` and `buildTree()` / JSON emission. Build a sparse options object to avoid assigning `undefined` to optional fields (per `exactOptionalPropertyTypes`).
- **`src/cli.ts`**: Update comments to reflect that `--status` and `--type` are now wired (US6); `--all` and `--graph` remain stubs.

## Risks & Mitigations
| Risk | Mitigation |
|------|-----------|
| Filtering breaks the tree or JSON output | Comprehensive unit tests in `src/status/filter.test.ts` (

https://claude.ai/code/session_012LJHSqqzvvV5yCnY5Rnsvd