### PR TITLE
Refine next-action hints to skip real artifacts and target virtual ones

### DIFF
--- a/src/status/scanner.test.ts
+++ b/src/status/scanner.test.ts
@@ -849,9 +849,11 @@ ${TABLE_HEADER}
     expect(t2?.next_action).not.toBeNull();
     expect(t2?.next_action?.command).toBe('smithy.forge');
     expect(t2?.next_action?.suppressed_by_ancestor).toBeUndefined();
-    // The in-progress spec parent is also actionable and not suppressed.
-    expect(spec?.next_action?.command).toBe('smithy.cut');
-    expect(spec?.next_action?.suppressed_by_ancestor).toBeUndefined();
+    // Every US row on the spec is backed by a real (on-disk) tasks
+    // file, so there is nothing left to `smithy.cut` at the spec
+    // level — the per-task `forge` hints below cover the remaining
+    // work. The spec's `next_action` is therefore `null`.
+    expect(spec?.next_action).toBeNull();
   });
 
   it('Phase 4: multi-level not-started chain — only the topmost ancestor is un-suppressed, descendants are suppressed', () => {
@@ -894,21 +896,31 @@ ${TABLE_HEADER}
     expect(rfc?.next_action?.command).toBe('smithy.render');
     expect(rfc?.next_action?.suppressed_by_ancestor).toBeUndefined();
 
-    // Features and spec are both descendants of a not-started ancestor,
-    // so their suggestions must carry the suppression flag.
-    expect(features?.next_action).not.toBeNull();
-    expect(features?.next_action?.suppressed_by_ancestor).toBe(true);
+    // Features has a real (on-disk) spec child, so no `smithy.mark`
+    // hint is needed — the per-spec hint below covers the remaining
+    // work. The features record's `next_action` is therefore `null`
+    // regardless of ancestor state.
+    expect(features?.next_action).toBeNull();
+
+    // Spec has a `—` US1 row, which the scanner resolves to a virtual
+    // tasks child. `smithy.cut` fires at the spec level (a story with
+    // no tasks file yet), and because the rfc ancestor is not-started
+    // the hint carries the suppression flag.
     expect(spec?.next_action).not.toBeNull();
+    expect(spec?.next_action?.command).toBe('smithy.cut');
     expect(spec?.next_action?.suppressed_by_ancestor).toBe(true);
 
     // The virtual tasks record under the spec row is also suppressed —
-    // every ancestor in its chain is not-started.
+    // every ancestor in its chain is not-started. Virtual tasks
+    // records redirect to `smithy.cut` (the command that would
+    // create the file) rather than a `smithy.forge` that would fail
+    // on a nonexistent path.
     const virtualTasks = records.find(
       (r) => r.type === 'tasks' && r.virtual === true,
     );
     expect(virtualTasks).toBeDefined();
     expect(virtualTasks?.next_action).not.toBeNull();
-    expect(virtualTasks?.next_action?.command).toBe('smithy.forge');
+    expect(virtualTasks?.next_action?.command).toBe('smithy.cut');
     expect(virtualTasks?.next_action?.suppressed_by_ancestor).toBe(true);
   });
 

--- a/src/status/scanner.ts
+++ b/src/status/scanner.ts
@@ -261,18 +261,43 @@ export function scan(root: string): ArtifactRecord[] {
 
   // Phase 4: populate `next_action` on every classified record.
   //
-  // `suggestNextAction` is pure — this pass runs once, after every
-  // status is finalized, so the suppression flag derived from the
-  // ancestor walk reflects the stable classification output. Records
-  // carrying a `read_error:` warning are skipped entirely: their
-  // `next_action` field stays omitted (not set to `null`) so JSON
-  // consumers can distinguish "never evaluated" (absent) from
-  // "evaluated, no action" (`null`).
+  // `suggestNextAction` is pure — this pass runs after every status is
+  // finalized. Records carrying a `read_error:` warning are skipped
+  // entirely: their `next_action` field stays omitted (not set to
+  // `null`) so JSON consumers can distinguish "never evaluated"
+  // (absent) from "evaluated, no action" (`null`).
+  //
+  // Two sub-passes so the suppression flag tracks whether an ancestor
+  // actually has a hint the user could run:
+  //
+  //  4a. Compute each record's tentative `next_action` with
+  //      `ancestorNotStarted = false`. `suggestNextAction` may still
+  //      return `null` (e.g. a spec whose US rows all have real tasks
+  //      files on disk — no `smithy.cut` is needed at the spec level
+  //      because the per-task `forge` hints drive the work).
+  //
+  //  4b. For every record whose tentative action is non-null, walk
+  //      upward through `parent_path`. If any ancestor is both
+  //      `not-started` **and** has a non-null `next_action`, mark the
+  //      current record's action with `suppressed_by_ancestor: true`.
+  //      Ancestors whose `next_action` is `null` are skipped — the
+  //      user has no command to run on them, so their presence in
+  //      the chain does not justify hiding a descendant's hint
+  //      (otherwise an in-progress spec stacked under a not-started
+  //      parent would silence every task below it with nothing left
+  //      to surface).
   for (const record of records.values()) {
     if (hasReadError(record)) continue;
     const kids = childrenByParent.get(record.path) ?? [];
-    const ancestorNotStarted = hasNotStartedAncestor(record, records);
-    record.next_action = suggestNextAction(record, kids, ancestorNotStarted);
+    record.next_action = suggestNextAction(record, kids, false);
+  }
+  for (const record of records.values()) {
+    if (hasReadError(record)) continue;
+    const action = record.next_action;
+    if (action === null || action === undefined) continue;
+    if (hasActionableNotStartedAncestor(record, records)) {
+      action.suppressed_by_ancestor = true;
+    }
   }
 
   return Array.from(records.values());
@@ -631,7 +656,14 @@ function hasReadError(record: ArtifactRecord): boolean {
 /**
  * Walk upward from `record` through the `parent_path` chain (resolved
  * against the scanner's full `records` map) and return `true` as soon
- * as any ancestor's `status` is `'not-started'`.
+ * as any ancestor is both `not-started` **and** has a populated
+ * `next_action`.
+ *
+ * An ancestor with a `null` `next_action` is skipped even when its
+ * `status` is `'not-started'` — there is no hint competing for the
+ * user's attention at that level, so descendants are free to surface
+ * their own hints. This avoids silencing every task under a
+ * not-started spec whose only remaining work is per-task forges.
  *
  * Terminates when:
  * - `parent_path` is `null`, `undefined`, or an empty string.
@@ -640,9 +672,11 @@ function hasReadError(record: ArtifactRecord): boolean {
  *   against malformed record sets that could otherwise loop forever.
  *
  * Pure function: never mutates inputs. Used by Phase 4 to populate
- * `NextAction.suppressed_by_ancestor` per FR-011.
+ * `NextAction.suppressed_by_ancestor` per FR-011. Callers must have
+ * already computed `next_action` on every candidate ancestor in the
+ * records map (Phase 4a).
  */
-function hasNotStartedAncestor(
+function hasActionableNotStartedAncestor(
   record: ArtifactRecord,
   recordsByPath: Map<string, ArtifactRecord>,
 ): boolean {
@@ -653,7 +687,13 @@ function hasNotStartedAncestor(
     seen.add(cursor);
     const ancestor = recordsByPath.get(cursor);
     if (ancestor === undefined) return false;
-    if (ancestor.status === 'not-started') return true;
+    if (
+      ancestor.status === 'not-started' &&
+      ancestor.next_action !== null &&
+      ancestor.next_action !== undefined
+    ) {
+      return true;
+    }
     cursor = ancestor.parent_path ?? null;
   }
   return false;

--- a/src/status/suggester.test.ts
+++ b/src/status/suggester.test.ts
@@ -141,7 +141,31 @@ describe('suggestNextAction — tasks records', () => {
     expect(action!.reason.length).toBeGreaterThan(0);
   });
 
-  it('treats a virtual tasks record like a not-started tasks record', () => {
+  it('redirects a virtual tasks record to smithy.cut on its parent spec', () => {
+    // A virtual tasks record has no file on disk, so `smithy.forge` on
+    // its path would fail. The scanner populates `parent_path` (the
+    // owning `.spec.md`) and `parent_row_id` (`US<N>`) whenever it
+    // emits a virtual; the suggester must redirect to the `smithy.cut`
+    // invocation that would create the tasks file in the first place.
+    const record = makeRecord({
+      type: 'tasks',
+      status: 'not-started',
+      virtual: true,
+      path: 'specs/x/03-baz.tasks.md',
+      parent_path: 'specs/x/x.spec.md',
+      parent_row_id: 'US3',
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.cut');
+    expect(action!.arguments).toEqual(['specs/x', '3']);
+  });
+
+  it('falls back to smithy.forge on a virtual tasks record missing parent fields', () => {
+    // Defensive guard: if the scanner ever emits a virtual tasks
+    // record without `parent_path`/`parent_row_id` (shouldn't happen
+    // in practice), the suggester must still produce an action rather
+    // than crashing. Fall back to the legacy forge shape.
     const record = makeRecord({
       type: 'tasks',
       status: 'not-started',
@@ -183,7 +207,7 @@ describe('suggestNextAction — rfc records', () => {
 });
 
 describe('suggestNextAction — features records', () => {
-  it('suggests smithy.mark with the first not-started row numeric id', () => {
+  it('suggests smithy.mark with the first virtual (no-spec-on-disk) row numeric id', () => {
     const record = makeRecord({
       type: 'features',
       status: 'in-progress',
@@ -200,7 +224,7 @@ describe('suggestNextAction — features records', () => {
     });
     const children: ArtifactRecord[] = [
       makeChild('done', 'spec'),
-      makeChild('not-started', 'spec'),
+      makeRecord({ type: 'spec', status: 'not-started', virtual: true }),
       makeChild('in-progress', 'spec'),
     ];
     const action = suggestNextAction(record, children, false);
@@ -210,7 +234,7 @@ describe('suggestNextAction — features records', () => {
     expect(action!.reason.length).toBeGreaterThan(0);
   });
 
-  it('picks the lowest-index not-started row when multiple are not-started', () => {
+  it('picks the lowest-index virtual row when multiple features have no spec file yet', () => {
     const record = makeRecord({
       type: 'features',
       status: 'not-started',
@@ -226,16 +250,41 @@ describe('suggestNextAction — features records', () => {
       },
     });
     const children: ArtifactRecord[] = [
-      makeChild('not-started', 'spec'),
-      makeChild('not-started', 'spec'),
-      makeChild('not-started', 'spec'),
+      makeRecord({ type: 'spec', status: 'not-started', virtual: true }),
+      makeRecord({ type: 'spec', status: 'not-started', virtual: true }),
+      makeRecord({ type: 'spec', status: 'not-started', virtual: true }),
     ];
     const action = suggestNextAction(record, children, false);
     expect(action!.command).toBe('smithy.mark');
     expect(action!.arguments).toEqual(['docs/rfcs/foo.features.md', '1']);
   });
 
-  it('treats a virtual child as not-started for matching', () => {
+  it('skips a real (on-disk) not-started spec and picks the next virtual row', () => {
+    // Real not-started spec files already exist on disk — `smithy.mark`
+    // would be a no-op there. The suggester must skip real children
+    // (their own hints cover them) and only suggest mark for virtual
+    // rows where the spec file does not yet exist.
+    const record = makeRecord({
+      type: 'features',
+      status: 'in-progress',
+      path: 'docs/rfcs/foo.features.md',
+      dependency_order: {
+        rows: [makeRow('F1', 'specs/a'), makeRow('F2', null)],
+        id_prefix: 'F',
+        format: 'table',
+      },
+    });
+    const children: ArtifactRecord[] = [
+      makeChild('not-started', 'spec'), // real not-started spec file on disk
+      makeRecord({ type: 'spec', status: 'not-started', virtual: true }),
+    ];
+    const action = suggestNextAction(record, children, false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.mark');
+    expect(action!.arguments).toEqual(['docs/rfcs/foo.features.md', '2']);
+  });
+
+  it('treats a virtual child as the mark target', () => {
     const record = makeRecord({
       type: 'features',
       status: 'in-progress',
@@ -253,6 +302,27 @@ describe('suggestNextAction — features records', () => {
     const action = suggestNextAction(record, children, false);
     expect(action!.command).toBe('smithy.mark');
     expect(action!.arguments).toEqual(['docs/rfcs/foo.features.md', '2']);
+  });
+
+  it('returns null when every declared feature already has a spec file on disk', () => {
+    // All children are real (non-virtual). `smithy.mark` would be a
+    // no-op at this level; per-spec hints below this record cover the
+    // remaining work.
+    const record = makeRecord({
+      type: 'features',
+      status: 'in-progress',
+      path: 'docs/rfcs/foo.features.md',
+      dependency_order: {
+        rows: [makeRow('F1', 'specs/a'), makeRow('F2', 'specs/b')],
+        id_prefix: 'F',
+        format: 'table',
+      },
+    });
+    const children: ArtifactRecord[] = [
+      makeChild('done', 'spec'),
+      makeChild('not-started', 'spec'),
+    ];
+    expect(suggestNextAction(record, children, false)).toBeNull();
   });
 
   it('falls back to record path only when no row matches but record is actionable', () => {
@@ -275,7 +345,7 @@ describe('suggestNextAction — features records', () => {
 });
 
 describe('suggestNextAction — spec records', () => {
-  it('suggests smithy.cut against the spec parent directory with the first not-started row numeric id', () => {
+  it('suggests smithy.cut against the spec parent directory with the first virtual (no-tasks-on-disk) row numeric id', () => {
     const record = makeRecord({
       type: 'spec',
       status: 'in-progress',
@@ -316,12 +386,76 @@ describe('suggestNextAction — spec records', () => {
         format: 'table',
       },
     });
-    const children: ArtifactRecord[] = [makeChild('not-started', 'tasks')];
+    // Child is virtual — the tasks file hasn't been cut yet, so the
+    // spec-level `smithy.cut` hint fires. Real not-started children
+    // do not trigger a spec-level cut suggestion (their own `forge`
+    // hints cover them).
+    const children: ArtifactRecord[] = [
+      makeRecord({ type: 'tasks', status: 'not-started', virtual: true }),
+    ];
     const action = suggestNextAction(record, children, false);
     expect(action!.command).toBe('smithy.cut');
     expect(action!.arguments[0]).toBe('specs/deep/nested/dir');
     expect(action!.arguments[0]).not.toContain('.spec.md');
     expect(action!.arguments[1]).toBe('1');
+  });
+
+  it('returns null when every declared user story already has a tasks file on disk', () => {
+    // Regression for the Smithy Evals Framework scenario: the spec
+    // has a real (on-disk) tasks file for every US row, including a
+    // not-started one. `smithy.cut` at the spec level would be a
+    // no-op because re-cutting a story that already has a tasks file
+    // doesn't advance anything. The per-task `forge` hints below
+    // this record cover the remaining work.
+    const record = makeRecord({
+      type: 'spec',
+      status: 'in-progress',
+      path: 'specs/evals/evals.spec.md',
+      dependency_order: {
+        rows: [
+          makeRow('US1', 'specs/evals/01-a.tasks.md'),
+          makeRow('US2', 'specs/evals/02-b.tasks.md'),
+          makeRow('US3', 'specs/evals/03-c.tasks.md'),
+        ],
+        id_prefix: 'US',
+        format: 'table',
+      },
+    });
+    const children: ArtifactRecord[] = [
+      makeChild('done', 'tasks'),
+      makeChild('not-started', 'tasks'), // real — file exists, just not started
+      makeChild('done', 'tasks'),
+    ];
+    expect(suggestNextAction(record, children, false)).toBeNull();
+  });
+
+  it('skips a real not-started user story and picks the next virtual one', () => {
+    // Mixed: US1 done (real), US2 not-started (real — already cut),
+    // US3 not-started (virtual — not yet cut). Only US3 needs
+    // cutting; the spec-level hint must point at digit '3', not '2'.
+    const record = makeRecord({
+      type: 'spec',
+      status: 'in-progress',
+      path: 'specs/mix/mix.spec.md',
+      dependency_order: {
+        rows: [
+          makeRow('US1', 'specs/mix/01-a.tasks.md'),
+          makeRow('US2', 'specs/mix/02-b.tasks.md'),
+          makeRow('US3'),
+        ],
+        id_prefix: 'US',
+        format: 'table',
+      },
+    });
+    const children: ArtifactRecord[] = [
+      makeChild('done', 'tasks'),
+      makeChild('not-started', 'tasks'), // real — tasks file exists
+      makeRecord({ type: 'tasks', status: 'not-started', virtual: true }),
+    ];
+    const action = suggestNextAction(record, children, false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.cut');
+    expect(action!.arguments).toEqual(['specs/mix', '3']);
   });
 
   it('falls back to dirname only when no row matches but record is actionable', () => {
@@ -366,7 +500,7 @@ describe('suggestNextAction — spec records', () => {
     expect(action!.arguments).toEqual(['specs/webhooks']);
   });
 
-  it('preserves the virtual spec folder path even with a matching not-started row', () => {
+  it('preserves the virtual spec folder path even with a matching virtual row', () => {
     const record = makeRecord({
       type: 'spec',
       status: 'not-started',
@@ -380,7 +514,7 @@ describe('suggestNextAction — spec records', () => {
     });
     const action = suggestNextAction(
       record,
-      [makeChild('not-started', 'tasks')],
+      [makeRecord({ type: 'tasks', status: 'not-started', virtual: true })],
       false,
     );
     expect(action!.arguments).toEqual(['specs/webhooks', '2']);
@@ -422,9 +556,11 @@ describe('suggestNextAction — ancestor suppression flag', () => {
         format: 'table',
       },
     });
+    // Virtual spec child — triggers the features-level `smithy.mark`
+    // hint so we can observe the suppression flag being attached.
     const action = suggestNextAction(
       record,
-      [makeChild('not-started', 'spec')],
+      [makeRecord({ type: 'spec', status: 'not-started', virtual: true })],
       true,
     );
     expect(action!.suppressed_by_ancestor).toBe(true);

--- a/src/status/suggester.ts
+++ b/src/status/suggester.ts
@@ -9,12 +9,19 @@
  * network calls, and no mutation of its inputs.
  *
  * The rule table mirrors FR-010 in `smithy-status-skill.spec.md` and
- * Acceptance Scenarios 4.1–4.5:
+ * Acceptance Scenarios 4.1–4.5, extended so every hint represents a
+ * command whose on-disk prerequisites are satisfied:
  *
  * - `rfc` → `smithy.render <rfc-path>`
- * - `features` → `smithy.mark <features-path> <first-not-started-F<N>-digits>`
- * - `spec` → `smithy.cut <dirname(spec-path)> <first-not-started-US<N>-digits>`
- * - `tasks` → `smithy.forge <tasks-path>`
+ * - `features` → `smithy.mark <features-path> <first-virtual-F<N>-digits>`
+ *   (only when at least one feature row has no spec file on disk; null
+ *   otherwise so per-spec hints below the features map drive the work)
+ * - `spec` → `smithy.cut <dirname(spec-path)> <first-virtual-US<N>-digits>`
+ *   (only when at least one user-story row has no tasks file on disk;
+ *   null otherwise so per-task hints below the spec drive the work)
+ * - `tasks` → `smithy.forge <tasks-path>` for real tasks files, or
+ *   `smithy.cut <spec-folder> <US<N>-digits>` for virtual tasks
+ *   records (where the tasks file does not yet exist)
  *
  * `done` records always return `null`. `unknown`-status records (parse
  * failures that made it through classification) also return `null` — the
@@ -45,6 +52,31 @@ function numericIdSuffix(id: string): string | undefined {
 }
 
 /**
+ * Resolve the `smithy.cut` target (folder + story digits) for a
+ * virtual tasks record. Virtual tasks records carry the parent spec's
+ * path in `parent_path` and the canonical `US<N>` row id in
+ * `parent_row_id`; both are populated by the scanner whenever it emits
+ * a virtual. Returns `null` if either field is missing, so the caller
+ * can fall back to the legacy `smithy.forge` shape rather than
+ * crashing. The spec folder is derived via `path.dirname` of the
+ * parent spec file — exactly the same transform the real spec case
+ * applies at `specFolderFromPath`.
+ */
+function cutTargetFromVirtualTasks(
+  record: ArtifactRecord,
+): { folder: string; digits: string | undefined } | null {
+  const parentPath = record.parent_path;
+  if (typeof parentPath !== 'string' || parentPath.length === 0) {
+    return null;
+  }
+  const folder = specFolderFromPath(parentPath);
+  const digits = record.parent_row_id !== undefined
+    ? numericIdSuffix(record.parent_row_id)
+    : undefined;
+  return { folder, digits };
+}
+
+/**
  * Derive the `smithy.cut` target folder for a spec record.
  *
  * Real spec records have `record.path` pointing at a `.spec.md` file,
@@ -64,22 +96,31 @@ function specFolderFromPath(specPath: string): string {
 }
 
 /**
- * Find the first resolved child whose `status` is `'not-started'` and
+ * Find the first resolved child that is both `virtual` (the child
+ * artifact file does not yet exist on disk) and `not-started`, and
  * return its corresponding row's numeric id suffix. Returns `undefined`
  * if no row matches or if the matching row has no trailing digits.
+ *
+ * This is the "cuttable / markable" predicate — the suggester uses it
+ * to decide whether a features/spec parent should emit a
+ * `smithy.mark`/`smithy.cut` hint. Real (non-virtual) not-started
+ * children are deliberately skipped: their artifact file already
+ * exists, so the parent does not need to be told to create it again;
+ * the child itself will emit its own `smithy.forge` hint.
  *
  * Rows and children are paired by index — the scanner (and the
  * classifier's consumers) already guarantees `resolvedChildren` is in
  * the same order as `record.dependency_order.rows`.
  */
-function firstNotStartedRowDigits(
+function firstVirtualNotStartedRowDigits(
   record: ArtifactRecord,
   resolvedChildren: ArtifactRecord[],
 ): string | undefined {
   const rows = record.dependency_order.rows;
   const limit = Math.min(rows.length, resolvedChildren.length);
   for (let i = 0; i < limit; i++) {
-    if (resolvedChildren[i]!.status === 'not-started') {
+    const child = resolvedChildren[i]!;
+    if (child.virtual === true && child.status === 'not-started') {
       const digits = numericIdSuffix(rows[i]!.id);
       if (digits !== undefined) return digits;
     }
@@ -97,13 +138,24 @@ function firstNotStartedRowDigits(
  * 2. An `unknown`-status record returns `null` regardless of type — the
  *    data model treats `unknown` as not actionable.
  * 3. Otherwise the record is `not-started` or `in-progress` and the
- *    deterministic rule table from FR-010 applies:
+ *    deterministic rule table from FR-010 applies, with a
+ *    prerequisite check so every suggested command is runnable:
  *    - `rfc` → `smithy.render [record.path]`
- *    - `features` → `smithy.mark [record.path, <first-not-started-row-digits>]`
- *      (fallback `[record.path]` when no row matches)
- *    - `spec` → `smithy.cut [dirname(record.path), <first-not-started-row-digits>]`
- *      (fallback `[dirname(record.path)]` when no row matches)
- *    - `tasks` → `smithy.forge [record.path]`
+ *    - `features` → `smithy.mark [record.path, <first-virtual-row-digits>]`
+ *      when a feature has no spec file yet; `smithy.mark [record.path]`
+ *      only when the record has zero rows but is itself `not-started`;
+ *      `null` otherwise (every declared spec already exists, so the
+ *      per-spec hints cover the remaining work).
+ *    - `spec` → `smithy.cut [dirname(record.path), <first-virtual-row-digits>]`
+ *      when a user story has no tasks file yet; `smithy.cut [dirname(record.path)]`
+ *      only when the record has zero rows but is itself `not-started`;
+ *      `null` otherwise (every declared tasks file already exists, so
+ *      the per-task hints cover the remaining work).
+ *    - `tasks` → `smithy.forge [record.path]` for a real tasks record;
+ *      `smithy.cut [dirname(parent_path), <parent_row_id-digits>]` for
+ *      a virtual tasks record whose file does not yet exist (falling
+ *      back to the `smithy.forge` shape when the scanner did not
+ *      populate `parent_path`).
  * 4. When `ancestorNotStarted` is `true`, the returned `NextAction`
  *    includes `suppressed_by_ancestor: true`. Otherwise the field is
  *    omitted entirely (never serialized as `false`).
@@ -115,7 +167,9 @@ function firstNotStartedRowDigits(
  * @param resolvedChildren   Children whose `status` is already
  *                           finalized, in the same order as
  *                           `record.dependency_order.rows`. Ignored
- *                           for `rfc` and `tasks` records.
+ *                           for `rfc` records; also ignored for `tasks`
+ *                           records (their virtual/real state lives on
+ *                           the record itself).
  * @param ancestorNotStarted True when any ancestor in the record's
  *                           parent chain has `status: 'not-started'`.
  *                           Drives `suppressed_by_ancestor`.
@@ -144,30 +198,73 @@ export function suggestNextAction(
     }
     case 'features': {
       command = 'smithy.mark';
-      const digits = firstNotStartedRowDigits(record, resolvedChildren);
+      const digits = firstVirtualNotStartedRowDigits(record, resolvedChildren);
       if (digits !== undefined) {
         args = [record.path, digits];
-        reason = `Features map ${record.title} has a not-started feature F${digits}; run smithy.mark to produce its spec.`;
-      } else {
+        reason = `Features map ${record.title} has a feature F${digits} with no spec file yet; run smithy.mark to produce it.`;
+      } else if (
+        record.status === 'not-started' &&
+        record.dependency_order.rows.length === 0
+      ) {
+        // Pathological actionable features record with zero rows —
+        // surface the no-digits fallback so the user can still drive
+        // the command manually.
         args = [record.path];
         reason = `Features map ${record.title} is ${record.status}; run smithy.mark to produce its next spec.`;
+      } else {
+        // Every declared feature already has a spec file on disk.
+        // Nothing left to mark at this level — per-spec hints below
+        // this record cover the remaining work.
+        return null;
       }
       break;
     }
     case 'spec': {
       command = 'smithy.cut';
       const folder = specFolderFromPath(record.path);
-      const digits = firstNotStartedRowDigits(record, resolvedChildren);
+      const digits = firstVirtualNotStartedRowDigits(record, resolvedChildren);
       if (digits !== undefined) {
         args = [folder, digits];
-        reason = `Spec ${record.title} has a not-started user story US${digits}; run smithy.cut to decompose it into tasks.`;
-      } else {
+        reason = `Spec ${record.title} has a user story US${digits} with no tasks file yet; run smithy.cut to decompose it into tasks.`;
+      } else if (
+        record.status === 'not-started' &&
+        record.dependency_order.rows.length === 0
+      ) {
+        // Pathological actionable spec with zero rows — surface the
+        // no-digits fallback so the user can still drive the command
+        // manually.
         args = [folder];
         reason = `Spec ${record.title} is ${record.status}; run smithy.cut to decompose its stories into tasks.`;
+      } else {
+        // Every declared user story already has a tasks file on disk.
+        // The spec-level cut hint would be a no-op here; per-task
+        // hints below this record drive the remaining work.
+        return null;
       }
       break;
     }
     case 'tasks': {
+      // Virtual tasks records point at a path that does not yet exist
+      // on disk, so `smithy.forge` would fail. Redirect to the
+      // `smithy.cut` invocation that would create the file in the
+      // first place. Real tasks records keep the existing `forge`
+      // hint.
+      if (record.virtual === true) {
+        const cutTarget = cutTargetFromVirtualTasks(record);
+        if (cutTarget !== null) {
+          command = 'smithy.cut';
+          args = cutTarget.digits !== undefined
+            ? [cutTarget.folder, cutTarget.digits]
+            : [cutTarget.folder];
+          reason = cutTarget.digits !== undefined
+            ? `Tasks file ${record.title} does not exist yet; run smithy.cut to create it from user story US${cutTarget.digits}.`
+            : `Tasks file ${record.title} does not exist yet; run smithy.cut to create it.`;
+          break;
+        }
+        // Defensive fallback: scanner didn't populate parent fields.
+        // Keep the legacy forge shape rather than crashing so the
+        // suggester stays total.
+      }
       command = 'smithy.forge';
       args = [record.path];
       reason = `Tasks file ${record.title} is ${record.status}; run smithy.forge to implement its next slice.`;

--- a/src/status/suggester.ts
+++ b/src/status/suggester.ts
@@ -56,11 +56,19 @@ function numericIdSuffix(id: string): string | undefined {
  * virtual tasks record. Virtual tasks records carry the parent spec's
  * path in `parent_path` and the canonical `US<N>` row id in
  * `parent_row_id`; both are populated by the scanner whenever it emits
- * a virtual. Returns `null` if either field is missing, so the caller
- * can fall back to the legacy `smithy.forge` shape rather than
- * crashing. The spec folder is derived via `path.dirname` of the
- * parent spec file — exactly the same transform the real spec case
- * applies at `specFolderFromPath`.
+ * a virtual.
+ *
+ * Returns `null` when `parent_path` is missing or empty — in that
+ * case the scanner left us without a spec folder to target, so the
+ * caller falls back to the legacy `smithy.forge` shape rather than
+ * producing a `smithy.cut` with no arguments. When `parent_path` is
+ * present but `parent_row_id` is missing or has no numeric suffix,
+ * returns `{ folder, digits: undefined }` so the caller emits a
+ * folder-only `smithy.cut <folder>` hint — the same no-digits
+ * fallback the spec case uses for zero-row pathological specs. The
+ * spec folder is derived via `path.dirname` of the parent spec file —
+ * exactly the same transform the real spec case applies at
+ * `specFolderFromPath`.
  */
 function cutTargetFromVirtualTasks(
   record: ArtifactRecord,


### PR DESCRIPTION
## Summary
- **Primary outcome:** Refine the `suggestNextAction` logic to emit hints only when the on-disk prerequisites are satisfied. Features and spec records now return `null` when all declared children already have artifact files on disk, and virtual tasks records redirect to `smithy.cut` (which creates the file) instead of `smithy.forge` (which would fail on a nonexistent path).
- **Notable behaviour changes:** 
  - `features` records return `null` when every declared feature already has a spec file on disk (per-spec hints below cover remaining work).
  - `spec` records return `null` when every declared user story already has a tasks file on disk (per-task hints below cover remaining work).
  - Virtual `tasks` records now suggest `smithy.cut` (to create the file) instead of `smithy.forge` (which would fail).
  - The ancestor suppression logic now only marks descendants as suppressed if the ancestor has a non-null `next_action` (an actionable hint the user could run), avoiding false suppressions when an ancestor is not-started but has no remaining work.
- **Follow-up work deferred:** None.

## Context
This change implements the prerequisite-checking logic described in FR-010 and extends Acceptance Scenarios 4.1–4.5. The goal is to ensure every suggested command is actually runnable: a `smithy.mark` hint should only fire when a feature row has no spec file yet, a `smithy.cut` hint should only fire when a user story has no tasks file yet, and virtual tasks records should redirect to the command that creates them rather than one that would fail.

This unlocks correct behavior in scenarios like the Smithy Evals Framework where a spec has real (on-disk) tasks files for every user story, including not-started ones—the spec-level `smithy.cut` would be a no-op, so the per-task `forge` hints should drive the work instead.

## Implementation Notes
- **Key architectural choices:**
  - Introduced `firstVirtualNotStartedRowDigits()` to replace `firstNotStartedRowDigits()`, filtering for children that are both `virtual: true` and `status: 'not-started'`. Real not-started children are deliberately skipped because their artifact file already exists.
  - Added `cutTargetFromVirtualTasks()` to resolve the `smithy.cut` target (folder + story digits) for virtual tasks records, using `parent_path` and `parent_row_id` populated by the scanner. Falls back gracefully if these fields are missing.
  - Refactored Phase 4 of the scanner into two sub-passes: 4a computes tentative `next_action` with `ancestorNotStarted = false`, then 4b walks ancestors to apply the suppression flag only when an ancestor is both not-started **and** has a non-null `next_action`.
  - Renamed `hasNotStartedAncestor()` to `hasActionableNotStartedAncestor()` to clarify that ancestors with `null` `next_action` are skipped.

- **Impacted modules:**
  - `src/status/suggester.ts`: Core logic for computing hints; now checks virtual status and returns `null` when all children are real.
  - `src/status/scanner.ts`: Phase 4 refactored to separate tentative action computation from ancestor suppression logic.
  - `src/status/suggester.test.ts` and `src/status/scanner.test.ts`: Extensive test updates to cover virtual vs. real artifact scenarios.

## Risks & Mitigations
| Risk | Mitigation |
|------|-----------|
| Existing consumers relying on features/spec always returning a hint may break. | The change is correct per FR-010; consumers should be updated to handle `null` actions. The test suite validates the new behavior. |
| Virtual tasks records without `parent_path`/`parent_row_id` fall back to `smithy.forge`, which will fail. | This is a defensive fallback; the scanner should always populate these fields for virtual records. If it doesn't, the fallback at least doesn't crash the suggester. |
| Ancestor suppression logic is now more complex. |

https://claude.ai/code/session_012EhU8aBhpeqx82Abqnanmq