### PR TITLE
Vitest-style visual overhaul for `smithy status`

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -676,24 +676,29 @@ describe('CLI status', () => {
     });
 
     const lines = output.split('\n');
-    const headerLine = lines[0] ?? '';
-    // All four plural type labels appear in the canonical order.
-    expect(headerLine).toMatch(
-      /RFCs:.*·\s*Features:.*·\s*Specs:.*·\s*Tasks:/,
-    );
+    // The vitest-style summary block opens with ` Smithy Status` as
+    // line 0, followed by a blank line, then per-type count rows.
+    expect(lines[0]).toBe(' Smithy Status');
+    // Every surviving type label (plural form) appears in the header
+    // block. With every type populated, RFCs/Features/Specs/Tasks all
+    // render their own row.
+    const headerBlock = lines.slice(0, lines.findIndex((l) => l.includes('Example')) || lines.length).join('\n');
+    expect(headerBlock).toContain('RFCs');
+    expect(headerBlock).toContain('Features');
+    expect(headerBlock).toContain('Specs');
+    expect(headerBlock).toContain('Tasks');
     // Header precedes the tree body. The first rendered title (from
-    // US2 Slice 2 `renderTree`) comes after the header line (AS 7.1:
+    // US2 Slice 2 `renderTree`) comes after the header block (AS 7.1:
     // header "above" the body).
     const firstTreeLineIndex = lines.findIndex((l) =>
       l.includes('Feature A'),
     );
     expect(firstTreeLineIndex).toBeGreaterThan(0);
-    // Header segments use the stable "N done / N in-progress / N not-started"
-    // shape — status segments whose count is zero are suppressed, and a
-    // type with every count zero still renders with a "0 done" placeholder
-    // (SD-011). Only done / in-progress / not-started appear — `unknown`
-    // is intentionally omitted per FR-016 / SD-012.
-    expect(headerLine).not.toMatch(/unknown/);
+    // Header segments use the icon-driven format: `<n> ✓   <n> ◐   <n> ○`.
+    // Only done / in-progress / not-started appear — `unknown` is
+    // intentionally omitted per FR-016 / SD-012.
+    expect(headerBlock).not.toMatch(/unknown/);
+    expect(headerBlock).toContain('\u2713');
   });
 
   it('exits 0 with a friendly hint on an empty repo', () => {
@@ -775,12 +780,12 @@ describe('CLI status', () => {
     expect(storyLine).toBeDefined();
     expect(storyLine!).toMatch(/└─/);
 
-    // The DONE marker appears at least once — the fully-completed
-    // tasks record rolls up to DONE on every ancestor. Because this
+    // The done icon (✓) appears at least once — the fully-completed
+    // tasks record rolls up to done on every ancestor. Because this
     // test passes `--all`, collapsing is bypassed and every level
     // shows the marker inline (the default collapsed path is covered
     // by the US3 collapse-behavior test below).
-    expect(output).toContain('DONE');
+    expect(output).toContain('\u2713');
   });
 
   it('emits a valid (empty) JSON payload for an empty repo in --format json mode', () => {
@@ -1033,13 +1038,15 @@ describe('CLI status', () => {
     const defaultOut = execFileSync('node', [CLI, 'status', '--root', tmpDir], {
       encoding: 'utf-8',
     });
-    // Split off the summary header (line 0) from the tree body so the
-    // summary counts (which mention every type) do not leak into the
-    // body assertions.
-    const [, ...defaultBodyLines] = defaultOut.split('\n');
-    const defaultBody = defaultBodyLines.join('\n');
+    // Split off the multi-line summary header from the tree body so
+    // the summary counts (which mention every type) do not leak into
+    // the body assertions. The tree body starts at the first line
+    // containing the RFC title `Example`.
+    const defaultLines = defaultOut.split('\n');
+    const bodyStart = defaultLines.findIndex((l) => l.includes('Example'));
+    const defaultBody = defaultLines.slice(bodyStart).join('\n');
     expect(defaultBody).toContain('Example');
-    expect(defaultBody).toContain('DONE');
+    expect(defaultBody).toContain('\u2713');
     // Descendant titles of the done RFC must not appear under it.
     expect(defaultBody).not.toContain('Feature Map');
     expect(defaultBody).not.toContain('Feature A');
@@ -1201,7 +1208,7 @@ describe('CLI status', () => {
     // Done records emit no hint line: the finished tasks file is done
     // and must not have an arrow beneath its rendered line.
     const finishedLineIndex = lines.findIndex((l) =>
-      l.includes('Finished') && l.includes('DONE'),
+      l.includes('Finished') && l.includes('\u2713'),
     );
     expect(finishedLineIndex).toBeGreaterThanOrEqual(0);
     // The very next non-empty line must NOT be a hint line for the
@@ -1441,10 +1448,10 @@ describe('CLI status', () => {
       );
       // The aggregate summary header still prints above the hint
       // (SD-010).
-      expect(result.stdout).toMatch(/RFCs:.*·\s*Features:.*·\s*Specs:.*·\s*Tasks:/);
+      expect(result.stdout).toContain(' Smithy Status');
     });
 
-    it('text-mode summary header is byte-identical with and without filter flags', () => {
+    it('text-mode summary count rows are byte-identical with and without filter flags', () => {
       writeFilterFixture();
       const unfiltered = execFileSync(
         'node',
@@ -1456,13 +1463,29 @@ describe('CLI status', () => {
         [CLI, 'status', '--root', tmpDir, '--status', 'in-progress'],
         { encoding: 'utf-8' },
       );
-      const unfilteredHeader = (unfiltered.split('\n')[0] ?? '').trim();
-      const filteredHeader = (filtered.split('\n')[0] ?? '').trim();
-      expect(filteredHeader).toBe(unfilteredHeader);
-      // Sanity: header carries all four type labels.
-      expect(unfilteredHeader).toMatch(
-        /RFCs:.*·\s*Features:.*·\s*Specs:.*·\s*Tasks:/,
-      );
+      // Extract just the count rows (the lines between ` Smithy
+      // Status` and the first blank-line separator that follows). The
+      // `Next:` line can legitimately differ between filtered and
+      // unfiltered runs because it reads off the filtered tree, while
+      // the count rows are computed pre-filter per SD-010 and must be
+      // byte-identical.
+      const extractRows = (output: string): string => {
+        const lines = output.split('\n');
+        const start = lines.findIndex((l) => l === ' Smithy Status');
+        expect(start).toBeGreaterThanOrEqual(0);
+        // Skip the blank line right after the title, then collect
+        // contiguous non-blank rows.
+        const rows: string[] = [];
+        for (let i = start + 2; i < lines.length; i++) {
+          if (lines[i]!.length === 0) break;
+          rows.push(lines[i]!);
+        }
+        return rows.join('\n');
+      };
+      expect(extractRows(filtered)).toBe(extractRows(unfiltered));
+      // Sanity: the unfiltered count rows carry at least one type
+      // label.
+      expect(extractRows(unfiltered)).toMatch(/(RFCs|Features|Specs|Tasks)/);
     });
   });
 });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -682,7 +682,14 @@ describe('CLI status', () => {
     // Every surviving type label (plural form) appears in the header
     // block. With every type populated, RFCs/Features/Specs/Tasks all
     // render their own row.
-    const headerBlock = lines.slice(0, lines.findIndex((l) => l.includes('Example')) || lines.length).join('\n');
+    // `findIndex` returns -1 when the substring is missing, and -1 is
+    // truthy — so a `|| lines.length` fallback would miss the case
+    // entirely and silently drop the last line via `slice(0, -1)`. Use
+    // an explicit `-1` check instead.
+    const bodyStartIdx = lines.findIndex((l) => l.includes('Example'));
+    const headerBlock = lines
+      .slice(0, bodyStartIdx === -1 ? lines.length : bodyStartIdx)
+      .join('\n');
     expect(headerBlock).toContain('RFCs');
     expect(headerBlock).toContain('Features');
     expect(headerBlock).toContain('Specs');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,7 +93,8 @@ program
   .option('--type <artifact-type>', 'Filter by artifact type: rfc|features|spec|tasks')
   .option('--all', 'Disable collapsing of done subtrees so every artifact surfaces')
   .option('--graph', 'Render the cross-artifact dependency graph (stub — wired in US2/US10)')
-  .option('--no-color', 'Suppress ANSI color output (stub — no colored text yet)')
+  .option('--no-color', 'Suppress ANSI color output')
+  .option('--ascii', 'Use ASCII tree connectors and icons (auto when terminal is not UTF-8)')
   .action((opts: Record<string, unknown>) => {
     const statusOpts: StatusOptions = { ...opts } as StatusOptions;
     return statusAction(statusOpts);

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -179,6 +179,54 @@ describe('formatSummaryHeader', () => {
     expect(output).not.toContain('\u25D0');
     expect(output).not.toContain('\u25CB');
   });
+
+  it('paints count columns by status kind when color is on (nonzero done green, nonzero wip yellow, nonzero not-started white, zero dim)', () => {
+    const colorTheme = createTheme({ color: true, encoding: 'utf8' });
+    const summary = makeSummary({
+      spec: { done: 2, 'in-progress': 3, 'not-started': 1 },
+      tasks: { done: 0, 'in-progress': 5, 'not-started': 0 },
+    });
+    const output = formatSummaryHeader(summary, colorTheme, null);
+    const { paint } = colorTheme;
+
+    // Spec row: all three counts nonzero → each picks up its status
+    // color. Counts are right-padded to a 2-char column (`0` / `3` /
+    // `5` → max width 1, but Tasks row has `0` only too, so width
+    // stays 1). With `3/0/0 (1)` vs `2/3/1 (5)`, max width is 1.
+    expect(output).toContain(paint.done('2'));
+    expect(output).toContain(paint.inProgress('3'));
+    expect(output).toContain(paint.white('1'));
+
+    // Tasks row: the zero done count dims, the nonzero wip paints
+    // yellow, the zero not-started dims.
+    expect(output).toContain(paint.inProgress('5'));
+    // At least two zeros in the tasks row → at least two dim-painted
+    // zero counts.
+    const dimmedZero = paint.dim('0');
+    const dimZeroCount = output.split(dimmedZero).length - 1;
+    expect(dimZeroCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('bolds both the `Next:` label and the command verb when color is on', () => {
+    const colorTheme = createTheme({ color: true, encoding: 'utf8' });
+    const summary = makeSummary({ spec: { done: 1 } });
+    const action: NextAction = {
+      command: 'smithy.forge',
+      arguments: ['specs/foo/01-story.tasks.md'],
+      reason: 'because',
+    };
+    const output = formatSummaryHeader(summary, colorTheme, action);
+    const { paint } = colorTheme;
+    // Next: label is bold.
+    expect(output).toContain(paint.bold('Next:'));
+    // Command verb is bold; args stay default (not bold).
+    expect(output).toContain(paint.bold('smithy.forge'));
+    expect(output).toContain(' specs/foo/01-story.tasks.md');
+    // And that the args segment is not itself bold-wrapped.
+    expect(output).not.toContain(
+      paint.bold('smithy.forge specs/foo/01-story.tasks.md'),
+    );
+  });
 });
 
 function makeRecord(overrides: Partial<ArtifactRecord> = {}): ArtifactRecord {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -86,13 +86,42 @@ describe('formatSummaryHeader', () => {
     expect(output).not.toContain('RFCs');
   });
 
-  it('collapses to a single "No artifacts found." line when every row would be suppressed', () => {
+  it('collapses to a single "No artifacts found." line when every row would be suppressed AND no parse errors exist', () => {
     const summary = makeSummary();
     const output = formatSummaryHeader(summary, theme, null);
     expect(output).toContain(' Smithy Status');
     expect(output).toContain('No artifacts found.');
     expect(output).not.toContain('\u2713');
     expect(output).not.toContain('\u25CB');
+    expect(output).not.toContain('parse errors');
+  });
+
+  it('surfaces a parse-error message instead of "No artifacts found." when unknown-only records exist', () => {
+    // Scan discovered artifacts but every one is `unknown` (parse
+    // failure). The count columns can't render those since they only
+    // enumerate done/in-progress/not-started, but claiming "No
+    // artifacts found." above a tree body that then prints the
+    // unknown rows would lie to the user. Header should point at the
+    // tree instead.
+    const summary = makeSummary({
+      spec: { unknown: 3 },
+    });
+    summary.parse_error_count = 3;
+    const output = formatSummaryHeader(summary, theme, null);
+    expect(output).toContain(' Smithy Status');
+    expect(output).not.toContain('No artifacts found.');
+    expect(output).toContain('3 artifacts with parse errors');
+    expect(output).toContain('see tree below');
+  });
+
+  it('uses the singular noun when exactly one parse-error record exists', () => {
+    const summary = makeSummary({
+      spec: { unknown: 1 },
+    });
+    summary.parse_error_count = 1;
+    const output = formatSummaryHeader(summary, theme, null);
+    expect(output).toContain('1 artifact with parse errors');
+    expect(output).not.toContain('1 artifacts with parse errors');
   });
 
   it('right-pads counts to the widest count in surviving rows so two-digit counters align', () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatSummaryHeader, pickTopNextAction } from './status.js';
+import type {
+  ArtifactRecord,
+  NextAction,
+  ScanSummary,
+  StatusTree,
+} from '../status/index.js';
+import { createTheme, type Theme } from '../status/theme.js';
+
+const theme: Theme = createTheme({ color: false, encoding: 'utf8' });
+
+function emptyCounts(): ScanSummary['counts'] {
+  return {
+    rfc: { done: 0, 'in-progress': 0, 'not-started': 0, unknown: 0 },
+    features: { done: 0, 'in-progress': 0, 'not-started': 0, unknown: 0 },
+    spec: { done: 0, 'in-progress': 0, 'not-started': 0, unknown: 0 },
+    tasks: { done: 0, 'in-progress': 0, 'not-started': 0, unknown: 0 },
+  };
+}
+
+function makeSummary(overrides: {
+  rfc?: Partial<ScanSummary['counts']['rfc']>;
+  features?: Partial<ScanSummary['counts']['features']>;
+  spec?: Partial<ScanSummary['counts']['spec']>;
+  tasks?: Partial<ScanSummary['counts']['tasks']>;
+} = {}): ScanSummary {
+  const counts = emptyCounts();
+  Object.assign(counts.rfc, overrides.rfc ?? {});
+  Object.assign(counts.features, overrides.features ?? {});
+  Object.assign(counts.spec, overrides.spec ?? {});
+  Object.assign(counts.tasks, overrides.tasks ?? {});
+  return {
+    counts,
+    orphan_count: 0,
+    broken_link_count: 0,
+    parse_error_count: 0,
+  };
+}
+
+describe('formatSummaryHeader', () => {
+  it('renders the vitest-style block with the title and a blank separator line', () => {
+    const summary = makeSummary({
+      spec: { done: 2, 'in-progress': 3, 'not-started': 1 },
+      tasks: { done: 36, 'in-progress': 2, 'not-started': 8 },
+    });
+    const output = formatSummaryHeader(summary, theme, null);
+    const lines = output.split('\n');
+    expect(lines[0]).toBe(' Smithy Status');
+    expect(lines[1]).toBe('');
+    // Surviving rows live in the label column sized to the longest
+    // surviving label (`Specs`/`Tasks` → 5).
+    expect(lines[2]).toBe('  Specs    2 \u2713    3 \u25D0    1 \u25CB');
+    expect(lines[3]).toBe('  Tasks   36 \u2713    2 \u25D0    8 \u25CB');
+  });
+
+  it('suppresses rows whose done/in-progress/not-started counts are all zero', () => {
+    const summary = makeSummary({
+      spec: { done: 2, 'in-progress': 3, 'not-started': 1 },
+      tasks: { done: 36, 'in-progress': 2, 'not-started': 8 },
+    });
+    const output = formatSummaryHeader(summary, theme, null);
+    expect(output).not.toContain('RFCs');
+    expect(output).not.toContain('Features');
+    expect(output).toContain('Specs');
+    expect(output).toContain('Tasks');
+  });
+
+  it('keeps a row when at least one of done/in-progress/not-started is nonzero (mixed zero segments survive)', () => {
+    const summary = makeSummary({
+      tasks: { done: 36, 'in-progress': 0, 'not-started': 8 },
+    });
+    const output = formatSummaryHeader(summary, theme, null);
+    // Zero-count segment still renders — only all-zero ROWS are dropped.
+    expect(output).toContain('0 \u25D0');
+    expect(output).toContain('36 \u2713');
+    expect(output).toContain('8 \u25CB');
+  });
+
+  it('ignores unknown counts so a row with only unknown entries is still dropped', () => {
+    const summary = makeSummary({
+      rfc: { unknown: 5 },
+    });
+    const output = formatSummaryHeader(summary, theme, null);
+    expect(output).not.toContain('RFCs');
+  });
+
+  it('collapses to a single "No artifacts found." line when every row would be suppressed', () => {
+    const summary = makeSummary();
+    const output = formatSummaryHeader(summary, theme, null);
+    expect(output).toContain(' Smithy Status');
+    expect(output).toContain('No artifacts found.');
+    expect(output).not.toContain('\u2713');
+    expect(output).not.toContain('\u25CB');
+  });
+
+  it('right-pads counts to the widest count in surviving rows so two-digit counters align', () => {
+    const summary = makeSummary({
+      spec: { done: 2, 'in-progress': 3, 'not-started': 1 },
+      tasks: { done: 36, 'in-progress': 2, 'not-started': 8 },
+    });
+    const output = formatSummaryHeader(summary, theme, null);
+    const lines = output.split('\n');
+    // The leading count of each row sits in a 2-wide column so `2` and
+    // `36` line up.
+    const specLine = lines.find((l) => l.includes('Specs'))!;
+    const tasksLine = lines.find((l) => l.includes('Tasks'))!;
+    expect(specLine).toContain(' 2 \u2713');
+    expect(tasksLine).toContain('36 \u2713');
+    // Both count columns of both rows align at the same column index.
+    const specIcon = specLine.indexOf('\u2713');
+    const tasksIcon = tasksLine.indexOf('\u2713');
+    expect(specIcon).toBe(tasksIcon);
+  });
+
+  it('sizes the label column to the longest surviving label so RFCs+Features force an 8-char column', () => {
+    const summary = makeSummary({
+      rfc: { done: 1 },
+      features: { done: 1 },
+      spec: { done: 1 },
+      tasks: { done: 1 },
+    });
+    const output = formatSummaryHeader(summary, theme, null);
+    const lines = output.split('\n');
+    const rfcLine = lines.find((l) => l.includes('RFCs'))!;
+    const featuresLine = lines.find((l) => l.includes('Features'))!;
+    const specLine = lines.find((l) => l.includes('Specs'))!;
+    const tasksLine = lines.find((l) => l.includes('Tasks'))!;
+    const rfcCount = rfcLine.indexOf('1');
+    const featuresCount = featuresLine.indexOf('1');
+    const specCount = specLine.indexOf('1');
+    const tasksCount = tasksLine.indexOf('1');
+    // All four rows align their count column because labels are padded
+    // to `Features` width.
+    expect(rfcCount).toBe(featuresCount);
+    expect(rfcCount).toBe(specCount);
+    expect(rfcCount).toBe(tasksCount);
+  });
+
+  it('emits a `Next:` line when a non-null next action is supplied', () => {
+    const summary = makeSummary({
+      spec: { done: 1 },
+    });
+    const action: NextAction = {
+      command: 'smithy.forge',
+      arguments: ['specs/foo/01-story.tasks.md'],
+      reason: 'because',
+    };
+    const output = formatSummaryHeader(summary, theme, action);
+    const lines = output.split('\n');
+    // Next: line at the end, prefixed with the theme's bold "Next:"
+    // label (identity when color is off) and the hint body without the
+    // arrow glyph.
+    const nextLine = lines[lines.length - 1]!;
+    expect(nextLine).toBe(
+      '  Next: smithy.forge specs/foo/01-story.tasks.md',
+    );
+  });
+
+  it('omits the `Next:` line entirely when nextAction is null', () => {
+    const summary = makeSummary({
+      spec: { done: 1 },
+    });
+    const output = formatSummaryHeader(summary, theme, null);
+    expect(output).not.toContain('Next:');
+  });
+
+  it('uses ASCII glyphs when the theme is ASCII-encoded', () => {
+    const asciiTheme = createTheme({ color: false, encoding: 'ascii' });
+    const summary = makeSummary({
+      spec: { done: 2, 'in-progress': 3, 'not-started': 1 },
+    });
+    const output = formatSummaryHeader(summary, asciiTheme, null);
+    expect(output).toContain('[x]');
+    expect(output).toContain('[~]');
+    expect(output).toContain('[ ]');
+    expect(output).not.toContain('\u2713');
+    expect(output).not.toContain('\u25D0');
+    expect(output).not.toContain('\u25CB');
+  });
+});
+
+function makeRecord(overrides: Partial<ArtifactRecord> = {}): ArtifactRecord {
+  return {
+    type: 'rfc',
+    path: 'docs/rfcs/0001.rfc.md',
+    title: 'RFC',
+    status: 'in-progress',
+    dependency_order: { rows: [], id_prefix: 'M', format: 'table' },
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe('pickTopNextAction', () => {
+  it('returns null for an empty tree', () => {
+    const tree: StatusTree = { roots: [] };
+    expect(pickTopNextAction(tree)).toBeNull();
+  });
+
+  it('returns null when every record is done (no actionable next step)', () => {
+    const tree: StatusTree = {
+      roots: [
+        {
+          record: makeRecord({ status: 'done', next_action: null }),
+          children: [],
+        },
+      ],
+    };
+    expect(pickTopNextAction(tree)).toBeNull();
+  });
+
+  it('returns the first actionable record in render order', () => {
+    const action: NextAction = {
+      command: 'smithy.render',
+      arguments: ['docs/rfcs/0001.rfc.md'],
+      reason: 'because',
+    };
+    const tree: StatusTree = {
+      roots: [
+        {
+          record: makeRecord({ status: 'in-progress', next_action: action }),
+          children: [],
+        },
+      ],
+    };
+    expect(pickTopNextAction(tree)).toEqual(action);
+  });
+
+  it('skips suppressed actions and descends into children to find the first actionable hint', () => {
+    const rootAction: NextAction = {
+      command: 'smithy.mark',
+      arguments: ['docs/rfcs/0001.features.md', '1'],
+      reason: 'because',
+      suppressed_by_ancestor: true,
+    };
+    const childAction: NextAction = {
+      command: 'smithy.forge',
+      arguments: ['specs/foo/01.tasks.md'],
+      reason: 'because',
+    };
+    const tree: StatusTree = {
+      roots: [
+        {
+          record: makeRecord({
+            status: 'not-started',
+            next_action: rootAction,
+          }),
+          children: [
+            {
+              record: makeRecord({
+                type: 'tasks',
+                path: 'specs/foo/01.tasks.md',
+                title: 'Child',
+                status: 'not-started',
+                next_action: childAction,
+              }),
+              children: [],
+            },
+          ],
+        },
+      ],
+    };
+    expect(pickTopNextAction(tree)).toEqual(childAction);
+  });
+
+  it('walks roots in order and returns the first actionable across the whole forest', () => {
+    const secondAction: NextAction = {
+      command: 'smithy.render',
+      arguments: ['docs/rfcs/0002.rfc.md'],
+      reason: 'because',
+    };
+    const tree: StatusTree = {
+      roots: [
+        {
+          record: makeRecord({
+            status: 'done',
+            path: 'docs/rfcs/0001.rfc.md',
+            next_action: null,
+          }),
+          children: [],
+        },
+        {
+          record: makeRecord({
+            status: 'in-progress',
+            path: 'docs/rfcs/0002.rfc.md',
+            next_action: secondAction,
+          }),
+          children: [],
+        },
+      ],
+    };
+    expect(pickTopNextAction(tree)).toEqual(secondAction);
+  });
+});

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -38,14 +38,23 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { buildTree, collapseTree, filterRecords, renderTree, scan } from '../status/index.js';
-import type { FilterRecordsOptions } from '../status/index.js';
+import {
+  buildTree,
+  collapseTree,
+  filterRecords,
+  formatNextAction,
+  renderTree,
+  scan,
+} from '../status/index.js';
+import type { FilterRecordsOptions, NextAction } from '../status/index.js';
+import { buildTheme, type Theme } from '../status/theme.js';
 import type {
   ArtifactRecord,
   ArtifactType,
   ScanSummary,
   Status,
   StatusTree,
+  TreeNode,
 } from '../status/index.js';
 
 /**
@@ -83,10 +92,17 @@ export interface StatusOptions {
   /** Stub: render the cross-artifact graph. Parsed but not wired (US2/US10). */
   graph?: boolean;
   /**
-   * Stub: suppress ANSI colors. Parsed but not wired — no text rendering
-   * in this slice uses color yet.
+   * Suppress ANSI colors. Set by Commander's `--no-color` flag (produces
+   * `color: false`). Honored alongside the ambient `NO_COLOR` env var.
    */
   color?: boolean;
+  /**
+   * Force ASCII glyphs (tree connectors and status icons). Set by
+   * Commander's `--ascii` flag. Also kicks in automatically when the
+   * terminal locale does not advertise UTF-8 or on Windows shells that
+   * mangle box-drawing characters.
+   */
+  ascii?: boolean;
 }
 
 /**
@@ -232,13 +248,6 @@ export function statusAction(opts: StatusOptions = {}): void {
     return;
   }
 
-  // US7 Slice 1: per-type roll-up header printed above the tree
-  // output whenever the scan finds at least one artifact. Kept pure
-  // and derived from the already-computed `ScanSummary` so the tree
-  // renderer can keep, move, or wrap the call site without touching
-  // the helper.
-  console.log(formatSummaryHeader(summary));
-
   // US2 Slice 2 + US3 Slice 1 + US6 Slice 1: default text output is a
   // hierarchical tree built from the US6-filtered record set (the full
   // scan when `--status` / `--type` are absent), then passed through
@@ -250,10 +259,7 @@ export function statusAction(opts: StatusOptions = {}): void {
   // ("Orphaned Specs", "Broken Links") surface at the top of
   // `tree.roots` and render as their own headings above their grouped
   // children; `collapseTree` never collapses them regardless of
-  // `--all`. `color: opts.color !== false` preserves the future
-  // `--no-color` wire-up by disabling color only when Commander sets
-  // `opts.color` to `false`; today the renderer emits plain text with
-  // UTF-8 box-drawing connectors and no color regardless.
+  // `--all`.
   //
   // US4 Slice 2: enable `renderHints` so the tree renderer attaches
   // an indented `→ <command> <args>` hint beneath every actionable,
@@ -263,11 +269,17 @@ export function statusAction(opts: StatusOptions = {}): void {
   // `collapseTree` drops their descendants before `renderTree` sees
   // them. The `--format json` branch above is untouched — this flag
   // only affects text-mode output (SD-016).
+  const theme = buildTheme({
+    noColor: opts.color === false,
+    ascii: opts.ascii === true,
+  });
   const tree = collapseTree(buildTree(filteredRecords), {
     all: opts.all === true,
   });
+  const topNextAction = pickTopNextAction(tree);
+  console.log(formatSummaryHeader(summary, theme, topNextAction));
   const rendered = renderTree(tree, {
-    color: opts.color !== false,
+    theme,
     renderHints: true,
   });
   if (rendered.length > 0) {
@@ -343,48 +355,125 @@ function summarize(records: ArtifactRecord[]): ScanSummary {
 }
 
 /**
- * Render the per-type roll-up header printed above the text-mode flat
- * listing (US7 Slice 1, AS 7.1). A pure function of {@link ScanSummary}
- * so the caller can be moved or wrapped later (e.g., by the US2 tree
- * renderer) without touching this helper.
+ * Render the vitest-style summary block printed above the tree (US7
+ * Slice 1, AS 7.1). Pure function of {@link ScanSummary} and
+ * {@link Theme} so it can be moved or wrapped later without touching
+ * state.
  *
- * Format (SD-010 / SD-011 / SD-012):
- * - Single line with plural type labels in the canonical order
- *   `RFCs`, `Features`, `Specs`, `Tasks` regardless of count.
- * - Types are joined by ` · ` (U+00B7, one space either side).
- * - Within a type, status segments use ` / ` as the separator and
- *   appear in the fixed order `done`, `in-progress`, `not-started`.
- * - Segments whose count is zero are suppressed when at least one
- *   sibling segment is non-zero, so sparse types stay compact.
- * - A type whose counts are all zero still appears with a stable
- *   `0 done` placeholder to preserve the four-type column structure.
- * - `unknown` counts and the `orphan_count` / `broken_link_count` /
- *   `parse_error_count` summary fields are intentionally omitted —
- *   FR-016 enumerates only done / in-progress / not-started.
+ * Layout:
+ *
+ * ```
+ *  Smithy Status
+ *
+ *   Specs      2 ✓   3 ◐   1 ○
+ *   Tasks     36 ✓   2 ◐   8 ○
+ *
+ *   Next: <top-level suggested next action, if any>
+ * ```
+ *
+ * - Type rows whose done/in-progress/not-started counts are all zero
+ *   are suppressed so an empty RFCs/Features row doesn't eat a line
+ *   of visual budget. If every type has zero counts, the block
+ *   collapses to a single dim `No artifacts found.` line.
+ * - Label column is left-padded to the longest *surviving* label so
+ *   removing RFCs/Features tightens the column (`Specs`/`Tasks` fit
+ *   in a 5-char column).
+ * - Counts are right-padded to the widest count across surviving rows
+ *   so two-digit counters (`36`) align under single-digit ones.
+ * - Nonzero counts paint white, zero counts paint dim. Icons are
+ *   painted via the theme's status colors.
+ * - The `Next:` line is omitted when no actionable next step exists.
+ *
+ * `unknown` counts and the `orphan_count` / `broken_link_count` /
+ * `parse_error_count` summary fields are intentionally omitted —
+ * FR-016 enumerates only done / in-progress / not-started.
  */
-function formatSummaryHeader(summary: ScanSummary): string {
+function formatSummaryHeader(
+  summary: ScanSummary,
+  theme: Theme,
+  nextAction: NextAction | null,
+): string {
   const TYPE_ORDER: Array<{ type: ArtifactType; label: string }> = [
     { type: 'rfc', label: 'RFCs' },
     { type: 'features', label: 'Features' },
     { type: 'spec', label: 'Specs' },
     { type: 'tasks', label: 'Tasks' },
   ];
-  const STATUS_ORDER: Array<Exclude<Status, 'unknown'>> = [
-    'done',
-    'in-progress',
-    'not-started',
-  ];
 
-  const segments = TYPE_ORDER.map(({ type, label }) => {
-    const counts = summary.counts[type];
-    const parts = STATUS_ORDER.filter((s) => counts[s] > 0).map(
-      (s) => `${counts[s]} ${s}`,
-    );
-    const body = parts.length > 0 ? parts.join(' / ') : '0 done';
-    return `${label}: ${body}`;
+  type Row = { label: string; done: number; wip: number; not: number };
+  const rows: Row[] = [];
+  for (const { type, label } of TYPE_ORDER) {
+    const c = summary.counts[type];
+    const done = c.done;
+    const wip = c['in-progress'];
+    const not = c['not-started'];
+    if (done + wip + not === 0) continue;
+    rows.push({ label, done, wip, not });
+  }
+
+  const title = theme.paint.bold(' Smithy Status');
+  if (rows.length === 0) {
+    return `${title}\n\n  ${theme.paint.dim('No artifacts found.')}`;
+  }
+
+  const labelWidth = rows.reduce((w, r) => Math.max(w, r.label.length), 0);
+  const countWidth = rows.reduce(
+    (w, r) => Math.max(w, String(r.done).length, String(r.wip).length, String(r.not).length),
+    1,
+  );
+
+  const paintCount = (n: number): string => {
+    const padded = String(n).padStart(countWidth, ' ');
+    return n === 0 ? theme.paint.dim(padded) : theme.paint.white(padded);
+  };
+
+  const rowLines = rows.map((r) => {
+    const label = r.label.padEnd(labelWidth, ' ');
+    const done = `${paintCount(r.done)} ${theme.paint.done(theme.icons.done)}`;
+    const wip = `${paintCount(r.wip)} ${theme.paint.inProgress(theme.icons.inProgress)}`;
+    const not = `${paintCount(r.not)} ${theme.paint.notStarted(theme.icons.notStarted)}`;
+    return `  ${label}   ${done}   ${wip}   ${not}`;
   });
 
-  return segments.join(' · ');
+  const lines = [title, '', ...rowLines];
+  if (nextAction !== null) {
+    lines.push('');
+    lines.push(
+      `  ${theme.paint.bold('Next:')} ${formatNextAction(nextAction, theme.glyphs.arrow).slice(theme.glyphs.arrow.length)}`,
+    );
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Pick the first actionable, non-suppressed {@link NextAction} from a
+ * rendered {@link StatusTree} in render order (depth-first, input
+ * order). Group sentinels carry no next action and are skipped. Returns
+ * `null` when the tree has no actionable record — either every record
+ * is done or every actionable record is suppressed by an ancestor.
+ */
+function pickTopNextAction(tree: StatusTree): NextAction | null {
+  for (const root of tree.roots) {
+    const found = findNextAction(root);
+    if (found !== null) return found;
+  }
+  return null;
+}
+
+function findNextAction(node: TreeNode): NextAction | null {
+  const action = node.record.next_action;
+  if (
+    action !== undefined &&
+    action !== null &&
+    action.suppressed_by_ancestor !== true
+  ) {
+    return action;
+  }
+  for (const child of node.children) {
+    const found = findNextAction(child);
+    if (found !== null) return found;
+  }
+  return null;
 }
 
 function emptyCounts(): ScanSummary['counts'] {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -388,7 +388,7 @@ function summarize(records: ArtifactRecord[]): ScanSummary {
  * `parse_error_count` summary fields are intentionally omitted —
  * FR-016 enumerates only done / in-progress / not-started.
  */
-function formatSummaryHeader(
+export function formatSummaryHeader(
   summary: ScanSummary,
   theme: Theme,
   nextAction: NextAction | null,
@@ -452,7 +452,7 @@ function formatSummaryHeader(
  * `null` when the tree has no actionable record — either every record
  * is done or every actionable record is suppressed by an ancestor.
  */
-function pickTopNextAction(tree: StatusTree): NextAction | null {
+export function pickTopNextAction(tree: StatusTree): NextAction | null {
   for (const root of tree.roots) {
     const found = findNextAction(root);
     if (found !== null) return found;

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -413,6 +413,18 @@ export function formatSummaryHeader(
 
   const title = theme.paint.bold(' Smithy Status');
   if (rows.length === 0) {
+    // No done/in-progress/not-started rows to display. Two reasons this
+    // can happen: (a) the scan genuinely found nothing — empty repo —
+    // or (b) every record is `unknown` (parse errors). Case (b) must
+    // NOT claim "No artifacts found.", because the tree below will
+    // render the unknown rows and users would be told something false
+    // right above contradicting evidence. Distinguish via
+    // `parse_error_count` (which counts unknown records) and point at
+    // the tree for detail.
+    if (summary.parse_error_count > 0) {
+      const noun = summary.parse_error_count === 1 ? 'artifact' : 'artifacts';
+      return `${title}\n\n  ${theme.paint.dim(`${summary.parse_error_count} ${noun} with parse errors — see tree below.`)}`;
+    }
     return `${title}\n\n  ${theme.paint.dim('No artifacts found.')}`;
   }
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -422,25 +422,43 @@ export function formatSummaryHeader(
     1,
   );
 
-  const paintCount = (n: number): string => {
+  // Per-status count coloring: nonzero done → green, nonzero wip →
+  // yellow, nonzero not-started → white. Zero → dim across the board.
+  // This matches the rule used by `formatParentCounter` and the tasks
+  // counter in the tree renderer, so the summary block and the body
+  // share one visual language.
+  const paintCount = (n: number, kind: 'done' | 'wip' | 'not'): string => {
     const padded = String(n).padStart(countWidth, ' ');
-    return n === 0 ? theme.paint.dim(padded) : theme.paint.white(padded);
+    if (n === 0) return theme.paint.dim(padded);
+    if (kind === 'done') return theme.paint.done(padded);
+    if (kind === 'wip') return theme.paint.inProgress(padded);
+    return theme.paint.white(padded);
   };
 
   const rowLines = rows.map((r) => {
     const label = r.label.padEnd(labelWidth, ' ');
-    const done = `${paintCount(r.done)} ${theme.paint.done(theme.icons.done)}`;
-    const wip = `${paintCount(r.wip)} ${theme.paint.inProgress(theme.icons.inProgress)}`;
-    const not = `${paintCount(r.not)} ${theme.paint.notStarted(theme.icons.notStarted)}`;
+    const done = `${paintCount(r.done, 'done')} ${theme.paint.done(theme.icons.done)}`;
+    const wip = `${paintCount(r.wip, 'wip')} ${theme.paint.inProgress(theme.icons.inProgress)}`;
+    const not = `${paintCount(r.not, 'not')} ${theme.paint.notStarted(theme.icons.notStarted)}`;
     return `  ${label}   ${done}   ${wip}   ${not}`;
   });
 
   const lines = [title, '', ...rowLines];
   if (nextAction !== null) {
     lines.push('');
-    lines.push(
-      `  ${theme.paint.bold('Next:')} ${formatNextAction(nextAction, theme.glyphs.arrow).slice(theme.glyphs.arrow.length)}`,
+    // Split the formatted hint into `<command>` and `<args>` so the
+    // command verb can be bolded while args stay in the terminal
+    // default. `formatNextAction` returns `<arrow><command> <args…>` —
+    // strip the leading arrow glyph, then peel off the command token.
+    const hint = formatNextAction(nextAction, theme.glyphs.arrow).slice(
+      theme.glyphs.arrow.length,
     );
+    const spaceIdx = hint.indexOf(' ');
+    const boldHint =
+      spaceIdx === -1
+        ? theme.paint.bold(hint)
+        : `${theme.paint.bold(hint.slice(0, spaceIdx))}${hint.slice(spaceIdx)}`;
+    lines.push(`  ${theme.paint.bold('Next:')} ${boldHint}`);
   }
   return lines.join('\n');
 }

--- a/src/status/render.test.ts
+++ b/src/status/render.test.ts
@@ -22,6 +22,14 @@ import { createTheme, type Theme } from './theme.js';
  */
 const utf8Theme: Theme = createTheme({ color: false, encoding: 'utf8' });
 const asciiTheme: Theme = createTheme({ color: false, encoding: 'ascii' });
+/**
+ * Color-on UTF-8 theme used by the per-segment coloring tests. The
+ * production paint helpers use `picocolors.createColors(true)` so
+ * ANSI escapes emit regardless of whether the test runner inherits a
+ * TTY — assertions interpolate the same helpers to avoid hardcoding
+ * escape sequences.
+ */
+const colorTheme: Theme = createTheme({ color: true, encoding: 'utf8' });
 
 /**
  * Minimal `ArtifactRecord` factory for renderer tests. Only the fields
@@ -866,5 +874,184 @@ describe('renderTree — ASCII fallback theme', () => {
     const output = renderTree(tree, { theme: asciiTheme });
     expect(output).toContain('[!]');
     expect(output).not.toContain('\u2717');
+  });
+});
+
+describe('renderTree — per-segment counter coloring (color on)', () => {
+  // Interpolate the same paint helpers the production code uses so
+  // assertions don't encode raw ANSI escape sequences. Tests still
+  // verify the paint KIND — e.g., the done count goes through
+  // `paint.done` (green), the wip count through `paint.inProgress`
+  // (yellow), etc. — by comparing against `colorTheme.paint.*`-wrapped
+  // fragments.
+  const { paint } = colorTheme;
+
+  it('parent counter paints each nonzero segment with its status color and leaves zeros dim', () => {
+    // Parent with 2 done / 0 wip / 1 not-started children → counter
+    // should be `2[green]/[dim]0[dim]/[dim]1[white] (3)[dim]` beside a
+    // yellow `◐`.
+    const rfc = makeRecord({
+      type: 'rfc',
+      path: 'docs/rfcs/demo.rfc.md',
+      title: 'Demo',
+      status: 'in-progress',
+      parent_path: null,
+    });
+    const childA = makeRecord({
+      type: 'features',
+      path: 'docs/rfcs/a.features.md',
+      title: 'A',
+      status: 'done',
+      parent_path: 'docs/rfcs/demo.rfc.md',
+    });
+    const childB = makeRecord({
+      type: 'features',
+      path: 'docs/rfcs/b.features.md',
+      title: 'B',
+      status: 'done',
+      parent_path: 'docs/rfcs/demo.rfc.md',
+    });
+    const childC = makeRecord({
+      type: 'features',
+      path: 'docs/rfcs/c.features.md',
+      title: 'C',
+      status: 'not-started',
+      parent_path: 'docs/rfcs/demo.rfc.md',
+    });
+    const tree = buildTree([rfc, childA, childB, childC]);
+    const output = renderTree(tree, { theme: colorTheme });
+    const rootLine = output.split('\n')[0]!;
+
+    // Nonzero done count → green, via paint.done.
+    expect(rootLine).toContain(paint.done('2'));
+    // Zero wip count → dim.
+    expect(rootLine).toContain(paint.dim('0'));
+    // Nonzero not-started count → white.
+    expect(rootLine).toContain(paint.white('1'));
+    // Separators and total are dim.
+    expect(rootLine).toContain(paint.dim('/'));
+    expect(rootLine).toContain(paint.dim('(3)'));
+    // In-progress icon stays yellow.
+    expect(rootLine).toContain(paint.inProgress(colorTheme.icons.inProgress));
+  });
+
+  it('parent counter nonzero wip segment paints yellow via paint.inProgress', () => {
+    const rfc = makeRecord({
+      type: 'rfc',
+      path: 'docs/rfcs/demo.rfc.md',
+      title: 'Demo',
+      status: 'in-progress',
+      parent_path: null,
+    });
+    const wipChild = makeRecord({
+      type: 'features',
+      path: 'docs/rfcs/wip.features.md',
+      title: 'WIP',
+      status: 'in-progress',
+      parent_path: 'docs/rfcs/demo.rfc.md',
+    });
+    const tree = buildTree([rfc, wipChild]);
+    const output = renderTree(tree, { theme: colorTheme });
+    const rootLine = output.split('\n')[0]!;
+
+    // `0/1/0 (1)` → the middle `1` is the wip segment and should be
+    // yellow.
+    expect(rootLine).toContain(paint.inProgress('1'));
+    // The done and not-started zero segments stay dim.
+    expect(rootLine).toContain(paint.dim('0'));
+  });
+
+  it('task counter paints the completed segment green and keeps the total dim', () => {
+    const parent = makeRecord({
+      type: 'spec',
+      path: 'specs/f/f.spec.md',
+      title: 'F',
+      status: 'in-progress',
+      parent_path: null,
+    });
+    const tasks = makeRecord({
+      type: 'tasks',
+      path: 'specs/f/01-story.tasks.md',
+      title: 'Story',
+      status: 'in-progress',
+      completed: 3,
+      total: 7,
+      parent_path: 'specs/f/f.spec.md',
+    });
+    const output = renderTree(buildTree([parent, tasks]), {
+      theme: colorTheme,
+    });
+    // Completed count `3` is green.
+    expect(output).toContain(paint.done('3'));
+    // `/7` is dim (including the leading slash so the pair reads as
+    // muted structural chrome behind the bright completed count).
+    expect(output).toContain(paint.dim('/7'));
+  });
+
+  it('task counter fades the completed segment to dim when zero tasks are done', () => {
+    const parent = makeRecord({
+      type: 'spec',
+      path: 'specs/f/f.spec.md',
+      title: 'F',
+      status: 'in-progress',
+      parent_path: null,
+    });
+    const tasks = makeRecord({
+      type: 'tasks',
+      path: 'specs/f/01-story.tasks.md',
+      title: 'Story',
+      status: 'in-progress',
+      completed: 0,
+      total: 4,
+      parent_path: 'specs/f/f.spec.md',
+    });
+    const output = renderTree(buildTree([parent, tasks]), {
+      theme: colorTheme,
+    });
+    // Zero completed → dim, not green (nothing done yet).
+    expect(output).toContain(paint.dim('0'));
+    // Note: `/4` is also dim, so we only assert the count itself to
+    // avoid false matches on the adjacent `/4` substring.
+    expect(output).not.toContain(paint.done('0'));
+  });
+
+  it('unknown records paint the warning parenthetical dim while keeping the ⚠ icon colored', () => {
+    const tree = buildTree([
+      makeRecord({
+        type: 'spec',
+        path: 'specs/broken/broken.spec.md',
+        title: 'Broken',
+        status: 'unknown',
+        warnings: ['parser: legacy checkbox format detected'],
+        parent_path: null,
+      }),
+    ]);
+    const output = renderTree(tree, { theme: colorTheme });
+    // Icon is yellow.
+    expect(output).toContain(paint.unknown(colorTheme.icons.unknown));
+    // Parenthetical (including the `unknown` word) is dim so the ⚠
+    // carries the alarm and the detail fades.
+    expect(output).toContain(
+      paint.dim('unknown (parser: legacy checkbox format detected)'),
+    );
+  });
+
+  it('broken-link rows dim the `[missing parent: …]` suffix while keeping the ✗ red', () => {
+    const broken = makeRecord({
+      type: 'tasks',
+      path: 'specs/lost/01-dangling.tasks.md',
+      title: 'Dangling',
+      status: 'not-started',
+      parent_path: 'specs/deleted/deleted.spec.md',
+      parent_missing: true,
+    });
+    const tree = buildTree([broken]);
+    const output = renderTree(tree, { theme: colorTheme });
+    // ✗ prefix is red via paint.error.
+    expect(output).toContain(paint.error(colorTheme.icons.error));
+    // `[missing parent: ...]` is dim.
+    expect(output).toContain(
+      paint.dim('[missing parent: specs/deleted/deleted.spec.md]'),
+    );
   });
 });

--- a/src/status/render.test.ts
+++ b/src/status/render.test.ts
@@ -311,6 +311,53 @@ describe('renderTree — status markers', () => {
     expect(lines[0]).toBe('Childless  \u25D0');
   });
 
+  it('excludes unknown direct children from the parent counter total so displayed segments always sum to (total)', () => {
+    // Parent with 1 done + 1 in-progress + 1 unknown. The counter
+    // should display `1/1/0 (2)` — the unknown child is skipped in
+    // both the segment counts AND the (total) so the displayed
+    // segments always sum to the total. The unknown child still
+    // renders beneath the parent with its own ⚠ marker.
+    const parent = makeRecord({
+      type: 'features',
+      path: 'docs/rfcs/0001.features.md',
+      title: 'Parent',
+      status: 'in-progress',
+      parent_path: null,
+    });
+    const done = makeRecord({
+      type: 'spec',
+      path: 'specs/d/d.spec.md',
+      title: 'Done Spec',
+      status: 'done',
+      parent_path: 'docs/rfcs/0001.features.md',
+    });
+    const wip = makeRecord({
+      type: 'spec',
+      path: 'specs/w/w.spec.md',
+      title: 'WIP Spec',
+      status: 'in-progress',
+      parent_path: 'docs/rfcs/0001.features.md',
+    });
+    const broken = makeRecord({
+      type: 'spec',
+      path: 'specs/u/u.spec.md',
+      title: 'Broken Spec',
+      status: 'unknown',
+      warnings: ['parser: legacy checkbox format detected'],
+      parent_path: 'docs/rfcs/0001.features.md',
+    });
+    const output = renderTree(buildTree([parent, done, wip, broken]), {
+      theme: utf8Theme,
+    });
+    const lines = output.split('\n');
+    // Counter renders 1/1/0 (2) — displayed segments (1+1+0) sum to 2.
+    expect(lines[0]).toBe('Parent  \u25D0  1/1/0 (2)');
+    // Unknown child still surfaces as its own ⚠ row beneath the
+    // parent, so nothing is hidden.
+    expect(output).toContain('Broken Spec');
+    expect(output).toContain('\u26A0');
+  });
+
   it('renders the not-started icon (○) for not-started records (real and virtual)', () => {
     const tree = buildTree([
       makeRecord({

--- a/src/status/render.test.ts
+++ b/src/status/render.test.ts
@@ -528,6 +528,30 @@ describe('renderTree — story number prefix', () => {
     );
     expect(output).toBe('Demo RFC  \u2713');
   });
+
+  it('strips a leading `Tasks: ` prefix even when parent_row_id is missing', () => {
+    // Defensive: an orphan real tasks file has a `Tasks: <title>` H1 but
+    // the scanner never populated `parent_row_id` (no parent row owns
+    // it). The renderer must still drop the prefix so the row reads
+    // cleanly rather than shouting `Tasks:` at every orphan.
+    const orphanTasks = makeRecord({
+      type: 'tasks',
+      path: 'specs/unlinked/01-ghost.tasks.md',
+      title: 'Tasks: Ghost Work',
+      status: 'not-started',
+      parent_path: 'specs/unlinked/unlinked.spec.md',
+      parent_missing: true,
+    });
+    // Broken-link row: the renderer prefixes with ✗ and appends the
+    // dangling parent reference, but the title itself must have the
+    // `Tasks: ` prefix stripped.
+    const output = renderTree(
+      { roots: [{ record: orphanTasks, children: [] }] },
+      { theme: utf8Theme },
+    );
+    expect(output).toContain('Ghost Work');
+    expect(output).not.toContain('Tasks: Ghost');
+  });
 });
 
 describe('renderTree — renderHints option (US4 Slice 2)', () => {

--- a/src/status/render.test.ts
+++ b/src/status/render.test.ts
@@ -13,6 +13,15 @@ import {
   type DependencyOrderTable,
   type StatusTree,
 } from './index.js';
+import { createTheme, type Theme } from './theme.js';
+
+/**
+ * Deterministic themes for assertions. Colors are disabled so snapshots
+ * stay ANSI-free; encoding toggles between UTF-8 (default contract) and
+ * ASCII (fallback for non-UTF-8 terminals).
+ */
+const utf8Theme: Theme = createTheme({ color: false, encoding: 'utf8' });
+const asciiTheme: Theme = createTheme({ color: false, encoding: 'ascii' });
 
 /**
  * Minimal `ArtifactRecord` factory for renderer tests. Only the fields
@@ -50,10 +59,10 @@ function makeRecord(overrides: Partial<ArtifactRecord> = {}): ArtifactRecord {
 describe('renderTree — empty and trivial trees', () => {
   it('returns the empty string for an empty tree', () => {
     const tree: StatusTree = { roots: [] };
-    expect(renderTree(tree)).toBe('');
+    expect(renderTree(tree, { theme: utf8Theme })).toBe('');
   });
 
-  it('renders a single-root tree with no connectors and a status marker', () => {
+  it('renders a single-root tree with no connectors and a done icon', () => {
     const tree = buildTree([
       makeRecord({
         type: 'rfc',
@@ -63,13 +72,15 @@ describe('renderTree — empty and trivial trees', () => {
         parent_path: null,
       }),
     ]);
-    const output = renderTree(tree);
-    // Exactly one line; no connectors on the root; DONE marker.
+    const output = renderTree(tree, { theme: utf8Theme });
     const lines = output.split('\n');
     expect(lines).toHaveLength(1);
+    // No connectors on the root.
     expect(lines[0]).not.toMatch(/[├└]/);
     expect(lines[0]).toContain('Demo RFC');
-    expect(lines[0]).toContain('DONE');
+    // Done icon (`✓`) replaces the legacy `DONE` marker.
+    expect(lines[0]).toContain('\u2713');
+    expect(lines[0]).not.toContain('DONE');
   });
 
   it('is a pure function: same input produces identical output on repeat calls', () => {
@@ -82,7 +93,9 @@ describe('renderTree — empty and trivial trees', () => {
       }),
     ];
     const tree = buildTree(records);
-    expect(renderTree(tree)).toBe(renderTree(tree));
+    expect(renderTree(tree, { theme: utf8Theme })).toBe(
+      renderTree(tree, { theme: utf8Theme }),
+    );
   });
 });
 
@@ -120,23 +133,23 @@ describe('renderTree — full RFC → features → spec → tasks chain', () => 
 
   it('nests descendants under ancestors using └─ connectors on only-child branches', () => {
     const tree = buildTree([rfc, features, spec, tasks]);
-    const output = renderTree(tree);
+    const output = renderTree(tree, { theme: utf8Theme });
     const lines = output.split('\n');
     expect(lines).toHaveLength(4);
 
-    // Root line — no connector.
-    expect(lines[0]).toBe('Demo RFC  in progress');
-    // Each subsequent line has exactly one └─ (last sibling) at the
-    // correct indentation level. Only-child chains add blank spacers,
-    // not vertical bars.
-    expect(lines[1]).toBe('└─ Demo Features  in progress');
-    expect(lines[2]).toBe('   └─ Feature A  in progress');
-    expect(lines[3]).toBe('      └─ Story One  2/5');
+    // Each line carries the in-progress icon. In-progress parents also
+    // render a `done/wip/not-started (total)` counter derived from their
+    // direct children.
+    expect(lines[0]).toBe('Demo RFC  \u25D0  0/1/0 (1)');
+    expect(lines[1]).toBe('└─ Demo Features  \u25D0  0/1/0 (1)');
+    expect(lines[2]).toBe('   └─ Feature A  \u25D0  0/1/0 (1)');
+    // In-progress tasks row keeps the compact completed/total counter.
+    expect(lines[3]).toBe('      └─ Story One  \u25D0 2/5');
   });
 
   it('uses titles, not file paths, as the primary label (AS 2.4)', () => {
     const tree = buildTree([rfc, features, spec, tasks]);
-    const output = renderTree(tree);
+    const output = renderTree(tree, { theme: utf8Theme });
     expect(output).not.toContain('docs/rfcs/0001-demo.rfc.md');
     expect(output).not.toContain('specs/feature-a/feature-a.spec.md');
     expect(output).toContain('Demo RFC');
@@ -146,9 +159,11 @@ describe('renderTree — full RFC → features → spec → tasks chain', () => 
 
   it('renders every ArtifactRecord exactly once (no silent drops, no duplicates)', () => {
     const tree = buildTree([rfc, features, spec, tasks]);
-    const output = renderTree(tree);
+    const output = renderTree(tree, { theme: utf8Theme });
     for (const record of [rfc, features, spec, tasks]) {
-      const occurrences = output.split('\n').filter((l) => l.includes(record.title)).length;
+      const occurrences = output
+        .split('\n')
+        .filter((l) => l.includes(record.title)).length;
       expect(occurrences).toBe(1);
     }
   });
@@ -156,7 +171,6 @@ describe('renderTree — full RFC → features → spec → tasks chain', () => 
 
 describe('renderTree — sibling connectors', () => {
   it('uses ├─ for non-last siblings and └─ for the last sibling, with │ spacers inherited by non-last subtrees', () => {
-    // RFC with two features, the first of which has a spec child.
     const rfc = makeRecord({
       type: 'rfc',
       path: 'docs/rfcs/0001.rfc.md',
@@ -187,20 +201,22 @@ describe('renderTree — sibling connectors', () => {
     });
 
     const tree = buildTree([rfc, featuresA, specA, featuresB]);
-    const lines = renderTree(tree).split('\n');
+    const lines = renderTree(tree, { theme: utf8Theme }).split('\n');
 
-    expect(lines[0]).toBe('Demo  in progress');
+    // RFC has two direct children (Features A + B): 0 done, 1 wip, 1 not-started.
+    expect(lines[0]).toBe('Demo  \u25D0  0/1/1 (2)');
     // Features A is a non-last sibling, so its connector is ├─ and
-    // its own child's prefix inherits a │ spacer.
-    expect(lines[1]).toBe('├─ Features A  in progress');
-    expect(lines[2]).toBe('│  └─ Spec A  in progress');
-    // Features B is the last sibling under the RFC.
-    expect(lines[3]).toBe('└─ Features B  not started');
+    // its own child's prefix inherits a │ spacer. Features A has one
+    // in-progress child, so its counter is 0/1/0 (1).
+    expect(lines[1]).toBe('├─ Features A  \u25D0  0/1/0 (1)');
+    expect(lines[2]).toBe('│  └─ Spec A  \u25D0');
+    // Features B has no children (leaf not-started features row).
+    expect(lines[3]).toBe('└─ Features B  \u25CB');
   });
 });
 
 describe('renderTree — status markers', () => {
-  it('renders DONE for done records regardless of type', () => {
+  it('renders the done icon (✓) for done records regardless of type', () => {
     const tree = buildTree([
       makeRecord({
         type: 'rfc',
@@ -210,10 +226,10 @@ describe('renderTree — status markers', () => {
         parent_path: null,
       }),
     ]);
-    expect(renderTree(tree)).toContain('DONE');
+    expect(renderTree(tree, { theme: utf8Theme })).toContain('\u2713');
   });
 
-  it('renders the completed/total counter for in-progress tasks records', () => {
+  it('renders the completed/total counter beside the in-progress icon for tasks records', () => {
     const parent = makeRecord({
       type: 'spec',
       path: 'specs/f/f.spec.md',
@@ -230,33 +246,64 @@ describe('renderTree — status markers', () => {
       total: 7,
       parent_path: 'specs/f/f.spec.md',
     });
-    // Orphan parent falls through to a real root (features/rfc/tasks
-    // with parent_path=null go to roots, not Orphaned Specs — that's
-    // a spec-only group). This one IS a spec with null parent, so it
-    // lands under the Orphaned Specs group. Walk that group's child
-    // to reach the spec node.
     const tree = buildTree([parent, tasks]);
-    const output = renderTree(tree);
-    // Exactly the `3/7` counter surfaces for the tasks record.
-    expect(output).toContain('Story  3/7');
+    const output = renderTree(tree, { theme: utf8Theme });
+    // Tasks row carries `◐ 3/7`.
+    expect(output).toContain('Story  \u25D0 3/7');
   });
 
-  it('renders an unambiguous "in progress" marker distinct from DONE for non-tasks in-progress records', () => {
+  it('renders the in-progress icon (◐) with a done/wip/not-started counter on parent records', () => {
+    const parent = makeRecord({
+      type: 'features',
+      path: 'docs/rfcs/0001.features.md',
+      title: 'Features',
+      status: 'in-progress',
+      parent_path: null,
+    });
+    const done = makeRecord({
+      type: 'spec',
+      path: 'specs/a/a.spec.md',
+      title: 'A',
+      status: 'done',
+      parent_path: 'docs/rfcs/0001.features.md',
+    });
+    const wip = makeRecord({
+      type: 'spec',
+      path: 'specs/b/b.spec.md',
+      title: 'B',
+      status: 'in-progress',
+      parent_path: 'docs/rfcs/0001.features.md',
+    });
+    const notStarted = makeRecord({
+      type: 'spec',
+      path: 'specs/c/c.spec.md',
+      title: 'C',
+      status: 'not-started',
+      parent_path: 'docs/rfcs/0001.features.md',
+    });
+    const tree = buildTree([parent, done, wip, notStarted]);
+    const output = renderTree(tree, { theme: utf8Theme });
+    const firstLine = output.split('\n')[0]!;
+    expect(firstLine).toBe('Features  \u25D0  1/1/1 (3)');
+    expect(firstLine).not.toContain('in progress');
+    expect(firstLine).not.toContain('DONE');
+  });
+
+  it('renders the in-progress icon with no counter when the parent has no direct children', () => {
     const tree = buildTree([
       makeRecord({
         type: 'features',
         path: 'docs/rfcs/0001.features.md',
-        title: 'Features',
+        title: 'Childless',
         status: 'in-progress',
         parent_path: null,
       }),
     ]);
-    const output = renderTree(tree);
-    expect(output).toContain('in progress');
-    expect(output).not.toContain('DONE');
+    const lines = renderTree(tree, { theme: utf8Theme }).split('\n');
+    expect(lines[0]).toBe('Childless  \u25D0');
   });
 
-  it('renders "not started" for not-started records (real and virtual)', () => {
+  it('renders the not-started icon (○) for not-started records (real and virtual)', () => {
     const tree = buildTree([
       makeRecord({
         type: 'rfc',
@@ -274,13 +321,14 @@ describe('renderTree — status markers', () => {
         parent_path: 'docs/rfcs/real.rfc.md',
       }),
     ]);
-    const output = renderTree(tree);
+    const output = renderTree(tree, { theme: utf8Theme });
     // Both the real root and the virtual child carry the marker.
     const lines = output.split('\n');
-    expect(lines.filter((l) => l.includes('not started'))).toHaveLength(2);
+    expect(lines.filter((l) => l.includes('\u25CB'))).toHaveLength(2);
+    expect(output).not.toContain('not started');
   });
 
-  it('surfaces at least one warning for unknown records', () => {
+  it('surfaces at least one warning for unknown records alongside the unknown icon (⚠)', () => {
     const tree = buildTree([
       makeRecord({
         type: 'spec',
@@ -291,9 +339,8 @@ describe('renderTree — status markers', () => {
         parent_path: null,
       }),
     ]);
-    const output = renderTree(tree);
-    // Spec with parent_path=null routes to Orphaned Specs. The child
-    // line carries the warning content.
+    const output = renderTree(tree, { theme: utf8Theme });
+    expect(output).toContain('\u26A0');
     expect(output).toContain('unknown');
     expect(output).toContain('legacy checkbox format detected');
   });
@@ -309,17 +356,17 @@ describe('renderTree — synthetic groups', () => {
       parent_path: null,
     });
     const tree = buildTree([orphan]);
-    const lines = renderTree(tree).split('\n');
+    const lines = renderTree(tree, { theme: utf8Theme }).split('\n');
 
     expect(lines[0]).toBe('Orphaned Specs');
-    // The group heading carries no status marker of its own.
-    expect(lines[0]).not.toContain('DONE');
-    expect(lines[0]).not.toContain('not started');
+    // The group heading carries no icon of its own.
+    expect(lines[0]).not.toContain('\u2713');
+    expect(lines[0]).not.toContain('\u25CB');
     // Its sole member is nested beneath with a └─ connector.
-    expect(lines[1]).toBe('└─ Orphan Story  not started');
+    expect(lines[1]).toBe('└─ Orphan Story  \u25CB');
   });
 
-  it('renders a "Broken Links" top-level heading and surfaces the dangling parent path on each child', () => {
+  it('renders a "Broken Links" heading and prefixes each child with a ✗ plus the dangling parent path', () => {
     const broken = makeRecord({
       type: 'tasks',
       path: 'specs/lost/01-dangling.tasks.md',
@@ -331,15 +378,16 @@ describe('renderTree — synthetic groups', () => {
       parent_missing: true,
     });
     const tree = buildTree([broken]);
-    const lines = renderTree(tree).split('\n');
+    const lines = renderTree(tree, { theme: utf8Theme }).split('\n');
 
     expect(lines[0]).toBe('Broken Links');
-    // Broken-link line surfaces the dangling parent reference inline
-    // alongside the title, and still ends with its status marker.
+    // Broken-link line carries the red error icon (✗), the dangling
+    // parent reference inline, and its status icon at the end.
+    expect(lines[1]).toContain('\u2717');
     expect(lines[1]).toContain('Dangling Story');
     expect(lines[1]).toContain('specs/deleted/deleted.spec.md');
     expect(lines[1]).toMatch(/└─ /);
-    expect(lines[1]).toMatch(/not started$/);
+    expect(lines[1]!.endsWith('\u25CB')).toBe(true);
   });
 
   it('orders Orphaned Specs before Broken Links when both groups are populated', () => {
@@ -356,7 +404,7 @@ describe('renderTree — synthetic groups', () => {
       parent_path: 'specs/deleted/deleted.spec.md',
       parent_missing: true,
     });
-    const output = renderTree(buildTree([orphan, broken]));
+    const output = renderTree(buildTree([orphan, broken]), { theme: utf8Theme });
     const lines = output.split('\n');
     const orphanIndex = lines.findIndex((l) => l === 'Orphaned Specs');
     const brokenIndex = lines.findIndex((l) => l === 'Broken Links');
@@ -384,9 +432,9 @@ describe('renderTree — group sentinel detection', () => {
         },
       ],
     };
-    const output = renderTree(tree);
-    // The real record still carries its status marker.
-    expect(output).toBe('Orphaned Specs  DONE');
+    const output = renderTree(tree, { theme: utf8Theme });
+    // The real record still carries its status icon.
+    expect(output).toBe('Orphaned Specs  \u2713');
     // And is NOT misrouted via the sentinel constants.
     expect(output).not.toContain(ORPHANED_SPECS_PATH);
     expect(output).not.toContain(BROKEN_LINKS_PATH);
@@ -394,12 +442,12 @@ describe('renderTree — group sentinel detection', () => {
 });
 
 describe('renderTree — story number prefix', () => {
-  it('injects zero-padded story number after a leading `Tasks: ` prefix', () => {
+  it('strips the legacy `Tasks: ` H1 prefix and injects the zero-padded story number', () => {
     // Real tasks file: H1 is `# Tasks: <title>`, so the record's title
-    // carries the `Tasks: ` prefix verbatim. The scanner's Phase 2
-    // populates `parent_row_id` from the owning spec row (e.g. US3),
-    // and the renderer must slot `03` in after the `Tasks: ` prefix —
-    // not before it — so the type prefix stays visible.
+    // carries the `Tasks: ` prefix verbatim. The new renderer drops the
+    // prefix entirely (every task row already renders beneath a tasks
+    // context) and prepends the zero-padded US<N> digits so the tree
+    // mirrors the parent's dep-order numbering.
     const tasks = makeRecord({
       type: 'tasks',
       path: 'specs/feature-a/03-suggest-next.tasks.md',
@@ -408,16 +456,14 @@ describe('renderTree — story number prefix', () => {
       parent_path: 'specs/feature-a/feature-a.spec.md',
       parent_row_id: 'US3',
     });
-    const output = renderTree({
-      roots: [{ record: tasks, children: [] }],
-    });
-    expect(output).toBe('Tasks: 03 Suggest the Next Command  not started');
+    const output = renderTree(
+      { roots: [{ record: tasks, children: [] }] },
+      { theme: utf8Theme },
+    );
+    expect(output).toBe('03 Suggest the Next Command  \u25CB');
   });
 
   it('prefixes virtual records (from `—` spec rows) with their US number', () => {
-    // Virtual records carry the parent row's title verbatim (no
-    // `Tasks: ` prefix). The renderer must prepend the zero-padded
-    // number directly to the title.
     const virt = makeRecord({
       type: 'tasks',
       path: 'specs/feature-a/07-collapse.tasks.md',
@@ -427,10 +473,11 @@ describe('renderTree — story number prefix', () => {
       parent_path: 'specs/feature-a/feature-a.spec.md',
       parent_row_id: 'US7',
     });
-    const output = renderTree({
-      roots: [{ record: virt, children: [] }],
-    });
-    expect(output).toBe('07 Collapse Completed Items  not started');
+    const output = renderTree(
+      { roots: [{ record: virt, children: [] }] },
+      { theme: utf8Theme },
+    );
+    expect(output).toBe('07 Collapse Completed Items  \u25CB');
   });
 
   it('zero-pads single-digit US numbers and preserves multi-digit numbers', () => {
@@ -450,21 +497,24 @@ describe('renderTree — story number prefix', () => {
       parent_path: 'specs/a/a.spec.md',
       parent_row_id: 'US12',
     });
-    const output = renderTree({
-      roots: [
-        { record: us1, children: [] },
-        { record: us12, children: [] },
-      ],
-    });
+    const output = renderTree(
+      {
+        roots: [
+          { record: us1, children: [] },
+          { record: us12, children: [] },
+        ],
+      },
+      { theme: utf8Theme },
+    );
     expect(output.split('\n')).toEqual([
-      'Tasks: 01 One  DONE',
-      'Tasks: 12 Twelve  DONE',
+      '01 One  \u2713',
+      '12 Twelve  \u2713',
     ]);
   });
 
-  it('leaves records without parent_row_id unchanged', () => {
-    // Top-level RFCs and orphan tasks have no parent row and must not
-    // gain a spurious number prefix.
+  it('leaves records without parent_row_id unchanged aside from the `Tasks: ` strip', () => {
+    // Top-level RFCs have no parent row, carry no `Tasks: ` prefix, and
+    // must not gain a spurious number prefix.
     const rfc = makeRecord({
       type: 'rfc',
       path: 'docs/rfcs/demo.rfc.md',
@@ -472,16 +522,16 @@ describe('renderTree — story number prefix', () => {
       status: 'done',
       parent_path: null,
     });
-    const output = renderTree({ roots: [{ record: rfc, children: [] }] });
-    expect(output).toBe('Demo RFC  DONE');
+    const output = renderTree(
+      { roots: [{ record: rfc, children: [] }] },
+      { theme: utf8Theme },
+    );
+    expect(output).toBe('Demo RFC  \u2713');
   });
 });
 
 describe('renderTree — renderHints option (US4 Slice 2)', () => {
   it('default (no renderHints) emits no hint line even when records carry next_action', () => {
-    // Backwards-compatibility guard: the renderHints flag defaults to
-    // false, so legacy callers (and legacy render.test.ts snapshots)
-    // continue to see a pure tree with no hint annotations.
     const record = makeRecord({
       type: 'tasks',
       path: 'specs/f/01-story.tasks.md',
@@ -494,9 +544,10 @@ describe('renderTree — renderHints option (US4 Slice 2)', () => {
         reason: 'because',
       },
     });
-    const output = renderTree({
-      roots: [{ record, children: [] }],
-    });
+    const output = renderTree(
+      { roots: [{ record, children: [] }] },
+      { theme: utf8Theme },
+    );
     expect(output).not.toContain('\u2192');
     expect(output).not.toContain('smithy.forge');
   });
@@ -515,7 +566,9 @@ describe('renderTree — renderHints option (US4 Slice 2)', () => {
       },
     });
     const tree = { roots: [{ record, children: [] }] };
-    expect(renderTree(tree)).toBe(renderTree(tree, { renderHints: false }));
+    expect(renderTree(tree, { theme: utf8Theme })).toBe(
+      renderTree(tree, { theme: utf8Theme, renderHints: false }),
+    );
   });
 
   it('renderHints: true emits an indented hint line beneath an actionable record', () => {
@@ -533,13 +586,13 @@ describe('renderTree — renderHints option (US4 Slice 2)', () => {
     });
     const output = renderTree(
       { roots: [{ record: rfc, children: [] }] },
-      { renderHints: true },
+      { theme: utf8Theme, renderHints: true },
     );
     const lines = output.split('\n');
-    // First line is the record line; second line is the hint.
     expect(lines).toHaveLength(2);
-    expect(lines[0]).toBe('Demo RFC  in progress');
-    // Two-space pad + arrow + command + args.
+    // Root has no children, so the in-progress icon renders without a
+    // counter.
+    expect(lines[0]).toBe('Demo RFC  \u25D0');
     expect(lines[1]).toBe('  \u2192 smithy.render docs/rfcs/demo.rfc.md');
   });
 
@@ -554,11 +607,11 @@ describe('renderTree — renderHints option (US4 Slice 2)', () => {
     });
     const output = renderTree(
       { roots: [{ record: rfc, children: [] }] },
-      { renderHints: true },
+      { theme: utf8Theme, renderHints: true },
     );
     const lines = output.split('\n');
     expect(lines).toHaveLength(1);
-    expect(lines[0]).toContain('DONE');
+    expect(lines[0]).toContain('\u2713');
     expect(output).not.toContain('\u2192');
   });
 
@@ -578,19 +631,14 @@ describe('renderTree — renderHints option (US4 Slice 2)', () => {
     });
     const output = renderTree(
       { roots: [{ record, children: [] }] },
-      { renderHints: true },
+      { theme: utf8Theme, renderHints: true },
     );
-    // No hint line; only the record line.
     expect(output.split('\n')).toHaveLength(1);
     expect(output).not.toContain('\u2192');
     expect(output).not.toContain('smithy.forge');
   });
 
   it('renderHints: true emits a hint line beneath a nested record with the correct tree-prefix inheritance', () => {
-    // RFC → features → spec → tasks chain; the tasks record is the
-    // last descendant. The hint should inherit the same indentation
-    // as the descendants of the tasks record would (all blank spacers
-    // because every intermediate node is a last-sibling).
     const rfc = makeRecord({
       type: 'rfc',
       path: 'docs/rfcs/demo.rfc.md',
@@ -630,14 +678,13 @@ describe('renderTree — renderHints option (US4 Slice 2)', () => {
       },
     });
     const tree = buildTree([rfc, features, spec, tasks]);
-    const output = renderTree(tree, { renderHints: true });
+    const output = renderTree(tree, { theme: utf8Theme, renderHints: true });
     const lines = output.split('\n');
-    // Five lines: RFC, features, spec, tasks, hint.
     expect(lines).toHaveLength(5);
-    expect(lines[0]).toBe('Demo RFC  in progress');
-    expect(lines[1]).toBe('└─ Demo Features  in progress');
-    expect(lines[2]).toBe('   └─ Spec A  in progress');
-    expect(lines[3]).toBe('      └─ Story One  1/3');
+    expect(lines[0]).toBe('Demo RFC  \u25D0  0/1/0 (1)');
+    expect(lines[1]).toBe('└─ Demo Features  \u25D0  0/1/0 (1)');
+    expect(lines[2]).toBe('   └─ Spec A  \u25D0  0/1/0 (1)');
+    expect(lines[3]).toBe('      └─ Story One  \u25D0 1/3');
     // The hint line lives beneath the tasks record. It uses the
     // two-space hint pad, anchored at the deepest child-spacer column
     // (nine leading spaces for this last-sibling-only chain).
@@ -646,10 +693,6 @@ describe('renderTree — renderHints option (US4 Slice 2)', () => {
   });
 
   it('renderHints: true does not emit a hint for group sentinel nodes', () => {
-    // An orphaned spec surfaces under the "Orphaned Specs" group; the
-    // group sentinel itself has no next_action and must not emit a
-    // hint line. The spec child may or may not emit a hint depending
-    // on its own next_action.
     const orphan = makeRecord({
       type: 'spec',
       path: 'specs/orphan/orphan.spec.md',
@@ -659,16 +702,13 @@ describe('renderTree — renderHints option (US4 Slice 2)', () => {
       next_action: null,
     });
     const tree = buildTree([orphan]);
-    const output = renderTree(tree, { renderHints: true });
+    const output = renderTree(tree, { theme: utf8Theme, renderHints: true });
     const lines = output.split('\n');
-    // Group heading first; no arrow follows it.
     expect(lines[0]).toBe('Orphaned Specs');
-    // The very next line must not be a hint (no arrow under a group heading).
     expect(lines[1]).not.toMatch(/^\s*\u2192/);
   });
 
   it('renderHints: true emits a hint line only for records whose next_action is non-null and not suppressed', () => {
-    // Mixed tree: one actionable record + one suppressed + one done.
     const rfc = makeRecord({
       type: 'rfc',
       path: 'docs/rfcs/demo.rfc.md',
@@ -695,23 +735,16 @@ describe('renderTree — renderHints option (US4 Slice 2)', () => {
       },
     });
     const tree = buildTree([rfc, features]);
-    const output = renderTree(tree, { renderHints: true });
-    // Exactly ONE arrow line — the un-suppressed RFC root.
+    const output = renderTree(tree, { theme: utf8Theme, renderHints: true });
     const arrowLines = output.split('\n').filter((l) => l.includes('\u2192'));
     expect(arrowLines).toHaveLength(1);
     expect(arrowLines[0]).toContain('smithy.render');
-    // The suppressed features record has no hint line.
     expect(output).not.toContain('smithy.mark');
   });
 });
 
 describe('renderTree — orphaned tasks error output', () => {
   it('renders real tasks with no parent as flat ERROR lines (not nested tree rows)', () => {
-    // A real on-disk `.tasks.md` that could not be linked to a spec is
-    // always an error condition. The renderer must surface it as an
-    // `ERROR:` line per orphan — no tree connectors, no "Orphaned
-    // Tasks" heading — so the diagnostic is visible in log scrapes and
-    // CI output and is clearly distinguishable from regular rows.
     const tree = buildTree([
       makeRecord({
         type: 'tasks',
@@ -727,7 +760,7 @@ describe('renderTree — orphaned tasks error output', () => {
       }),
     ]);
 
-    const output = renderTree(tree);
+    const output = renderTree(tree, { theme: utf8Theme });
     const lines = output.split('\n');
     expect(lines).toEqual([
       'ERROR: Orphaned task file specs/lost/01-lost.tasks.md could not be linked to a spec',
@@ -735,9 +768,79 @@ describe('renderTree — orphaned tasks error output', () => {
     ]);
     // The sentinel path must never leak into the rendered output.
     expect(output).not.toContain(ORPHANED_TASKS_PATH);
-    // No tree connectors or status markers on ERROR lines.
+    // No tree connectors on ERROR lines.
     expect(output).not.toContain('├─');
     expect(output).not.toContain('└─');
-    expect(output).not.toContain('not started');
+  });
+});
+
+describe('renderTree — ASCII fallback theme', () => {
+  it('swaps UTF-8 box-drawing connectors for ASCII equivalents and icons for bracketed sigils', () => {
+    const rfc = makeRecord({
+      type: 'rfc',
+      path: 'docs/rfcs/0001.rfc.md',
+      title: 'Demo',
+      status: 'in-progress',
+      parent_path: null,
+    });
+    const specA = makeRecord({
+      type: 'spec',
+      path: 'specs/a/a.spec.md',
+      title: 'A',
+      status: 'done',
+      parent_path: 'docs/rfcs/0001.rfc.md',
+    });
+    const specB = makeRecord({
+      type: 'spec',
+      path: 'specs/b/b.spec.md',
+      title: 'B',
+      status: 'not-started',
+      parent_path: 'docs/rfcs/0001.rfc.md',
+    });
+    const tree = buildTree([rfc, specA, specB]);
+    const output = renderTree(tree, { theme: asciiTheme });
+    const lines = output.split('\n');
+    expect(lines[0]).toBe('Demo  [~]  1/0/1 (2)');
+    expect(lines[1]).toBe('+- A  [x]');
+    expect(lines[2]).toBe('`- B  [ ]');
+    // No UTF-8 characters leaked through.
+    expect(output).not.toMatch(/[├└│─◐✓○⚠✗]/);
+  });
+
+  it('uses the ASCII arrow (->) for hint lines', () => {
+    const rfc = makeRecord({
+      type: 'rfc',
+      path: 'docs/rfcs/demo.rfc.md',
+      title: 'Demo RFC',
+      status: 'in-progress',
+      parent_path: null,
+      next_action: {
+        command: 'smithy.render',
+        arguments: ['docs/rfcs/demo.rfc.md'],
+        reason: 'because',
+      },
+    });
+    const output = renderTree(
+      { roots: [{ record: rfc, children: [] }] },
+      { theme: asciiTheme, renderHints: true },
+    );
+    const lines = output.split('\n');
+    expect(lines[1]).toBe('  -> smithy.render docs/rfcs/demo.rfc.md');
+    expect(output).not.toContain('\u2192');
+  });
+
+  it('prefixes broken-link rows with [!] under the ASCII theme', () => {
+    const broken = makeRecord({
+      type: 'tasks',
+      path: 'specs/lost/01-dangling.tasks.md',
+      title: 'Dangling',
+      status: 'not-started',
+      parent_path: 'specs/deleted/deleted.spec.md',
+      parent_missing: true,
+    });
+    const tree = buildTree([broken]);
+    const output = renderTree(tree, { theme: asciiTheme });
+    expect(output).toContain('[!]');
+    expect(output).not.toContain('\u2717');
   });
 });

--- a/src/status/render.ts
+++ b/src/status/render.ts
@@ -369,6 +369,14 @@ function formatStatusMarker(
  * nonzero `not-started` stays default/white, and any zero segment
  * fades to dim. Separators (`/`), parens, and the total inside the
  * parens are always dim so the numbers themselves carry the signal.
+ *
+ * `unknown`-status direct children are excluded from the counter (and
+ * from its `(total)`) so the row stays internally consistent: a
+ * counter that displays `done/wip/not-started` must not also claim a
+ * total larger than the three segments can explain. Any excluded
+ * `unknown` child still surfaces as its own `⚠ unknown (…)` row under
+ * this parent, so nothing is hidden — the anomaly just isn't counted
+ * toward lifecycle progress here.
  */
 function formatParentCounter(node: TreeNode, theme: Theme): string {
   const counts: Record<Status, number> = {
@@ -380,6 +388,7 @@ function formatParentCounter(node: TreeNode, theme: Theme): string {
   let total = 0;
   for (const child of node.children) {
     if (isGroupSentinel(child.record)) continue;
+    if (child.record.status === 'unknown') continue;
     counts[child.record.status] += 1;
     total += 1;
   }

--- a/src/status/render.ts
+++ b/src/status/render.ts
@@ -17,42 +17,47 @@
  *   beneath them like any other children.
  *
  * - Every non-root node is preceded by a tree connector drawn from the
- *   classic box-drawing set: `├─ ` for non-last siblings, `└─ ` for
- *   the last sibling of each parent. Descendants of a non-last sibling
- *   inherit a `│  ` spacer; descendants of the last sibling inherit a
- *   blank spacer, so vertical bars trail only the branches that still
- *   have siblings below them.
+ *   active {@link Theme}'s `glyphs` bundle: `theme.glyphs.branch` for
+ *   non-last siblings, `theme.glyphs.lastBranch` for the last sibling
+ *   of each parent. Descendants of a non-last sibling inherit the
+ *   `theme.glyphs.vertical` spacer; descendants of the last sibling
+ *   inherit the `theme.glyphs.blank` spacer, so vertical bars trail
+ *   only the branches that still have siblings below them.
  *
- * - Each rendered line uses the record's `title` as the primary label
- *   — file paths intentionally stay out of the visual field and live
- *   only in the JSON payload. Broken-link records additionally append
- *   their dangling `parent_path` so reviewers can see what the source
- *   file claims without opening it.
+ * - Each rendered line uses the record's `title` as the primary label —
+ *   file paths intentionally stay out of the visual field and live only
+ *   in the JSON payload. Broken-link records additionally append their
+ *   dangling `parent_path` so reviewers can see what the source file
+ *   claims without opening it.
  *
  * ## Status markers
  *
  * Every real record (every non-group node) carries a trailing status
- * marker separated from the label by two spaces. The exact mapping is:
+ * marker separated from the label by two spaces. The marker is a
+ * colored icon (`theme.icons.*` painted via `theme.paint.*`) followed
+ * by an optional counter:
  *
  * | Record state | Marker |
  * |--------------|--------|
- * | `status === 'done'` | `DONE` |
- * | `status === 'in-progress'` on a tasks record | `<completed-slices>/<total-slices>` |
- * | `status === 'in-progress'` on a parent record | `in progress` |
- * | `status === 'not-started'` (real or virtual) | `not started` |
- * | `status === 'unknown'` | `unknown (<first warning>)` |
+ * | `status === 'done'` | `✓` |
+ * | `status === 'in-progress'` on a tasks record | `◐ <completed>/<total>` |
+ * | `status === 'in-progress'` on a parent record | `◐ <done>/<wip>/<not-started> (<total>)` |
+ * | `status === 'not-started'` (real or virtual) | `○` |
+ * | `status === 'unknown'` | `⚠ (<first warning>)` |
  *
- * The markers are plain ASCII so they survive non-UTF-8 terminals and
- * copy/paste into tickets. SD-011 leaves the exact wording to
- * implementation; the table above is the convention that lands with
- * this slice. SD-012 asks for an unambiguous marker on `in-progress`
- * parents distinct from `DONE` — `in progress` lowercase satisfies
- * that. `renderTree` emits every node it receives verbatim with its
- * marker inline — collapsing of done subtrees is handled upstream by
- * the pure `collapseTree` transform that sits between `buildTree`
- * and `renderTree` in the text-mode pipeline (or bypassed under
- * `--all`), so the input tree is already the view the caller wants
- * rendered.
+ * A broken-link parent (see `parent_missing === true`) additionally
+ * gets a red error prefix (`theme.icons.error` painted red) ahead of
+ * the title so the break is hard to miss in a dense tree.
+ *
+ * ASCII fallback (`theme.encoding === 'ascii'`) swaps every icon for
+ * a copy-safe bracketed sigil (`[x]`, `[~]`, `[ ]`, `[?]`, `[!]`) and
+ * every tree connector for an ASCII equivalent, so the output survives
+ * non-UTF-8 terminals and grep-based log scrapes. `renderTree` emits
+ * every node it receives verbatim with its marker inline — collapsing
+ * of done subtrees is handled upstream by the pure `collapseTree`
+ * transform that sits between `buildTree` and `renderTree` in the
+ * text-mode pipeline (or bypassed under `--all`), so the input tree is
+ * already the view the caller wants rendered.
  *
  * Group sentinel nodes (detected via the reserved
  * `ORPHANED_SPECS_PATH` / `BROKEN_LINKS_PATH` values) are rendered as
@@ -61,23 +66,27 @@
  */
 
 import { formatNextAction } from './suggester.js';
+import { createTheme, type Theme } from './theme.js';
 import {
   BROKEN_LINKS_PATH,
   ORPHANED_SPECS_PATH,
   ORPHANED_TASKS_PATH,
 } from './tree.js';
-import type { ArtifactRecord, StatusTree, TreeNode } from './types.js';
+import type { ArtifactRecord, Status, StatusTree, TreeNode } from './types.js';
 
 /**
- * Options accepted by {@link renderTree}. The `color` flag is reserved
- * so a future ANSI palette (SD-001) can slot in without changing the
- * call sites that already pass `{ color: true }`. It is a no-op today:
- * the renderer emits plain text with UTF-8 box-drawing connectors and
- * no ANSI color.
+ * Options accepted by {@link renderTree}. A default theme (UTF-8 glyphs,
+ * no color) is used when `theme` is omitted so legacy call sites that
+ * pass only `{ renderHints: true }` keep rendering sensibly.
  */
 export interface RenderTreeOptions {
-  /** Reserved for ANSI color output (currently a no-op). */
-  color?: boolean;
+  /**
+   * Theme bundle controlling glyphs, icons, and paint helpers. Callers
+   * typically build it once at the top of `statusAction` via
+   * {@link buildTheme}; tests construct deterministic themes via
+   * {@link createTheme}.
+   */
+  theme?: Theme;
   /**
    * When `true`, append an indented next-action hint line beneath every
    * real record whose `next_action` is non-null and not suppressed by
@@ -93,6 +102,13 @@ export interface RenderTreeOptions {
    */
   renderHints?: boolean;
 }
+
+/**
+ * Default theme used when `renderTree` is called without an explicit
+ * theme. Keeps UTF-8 glyphs (matching legacy tests that assert on
+ * `├─`/`└─`) and disables color so snapshots remain ANSI-free.
+ */
+const DEFAULT_THEME: Theme = createTheme({ color: false, encoding: 'utf8' });
 
 /**
  * Render a {@link StatusTree} as a block of indented, tree-connector
@@ -111,9 +127,10 @@ export function renderTree(
     return '';
   }
   const renderHints = options.renderHints === true;
+  const theme = options.theme ?? DEFAULT_THEME;
   const lines: string[] = [];
   for (const root of tree.roots) {
-    renderRoot(root, lines, renderHints);
+    renderRoot(root, lines, renderHints, theme);
   }
   return lines.join('\n');
 }
@@ -132,22 +149,31 @@ function renderRoot(
   node: TreeNode,
   lines: string[],
   renderHints: boolean,
+  theme: Theme,
 ): void {
   if (node.record.path === ORPHANED_TASKS_PATH) {
     for (const child of node.children) {
+      const prefix = theme.paint.error('ERROR:');
       lines.push(
-        `ERROR: Orphaned task file ${child.record.path} could not be linked to a spec`,
+        `${prefix} Orphaned task file ${child.record.path} could not be linked to a spec`,
       );
     }
     return;
   }
-  lines.push(formatLine(node.record, ''));
+  lines.push(formatLine(node.record, '', node, theme));
   // A root's descendants inherit no parent spacer, so the hint line
   // (when enabled) is anchored at column 0 plus the two-space hint pad.
-  maybePushHint(node.record, '', lines, renderHints);
+  maybePushHint(node.record, '', lines, renderHints, theme);
   const { children } = node;
   for (let i = 0; i < children.length; i++) {
-    renderChild(children[i]!, '', i === children.length - 1, lines, renderHints);
+    renderChild(
+      children[i]!,
+      '',
+      i === children.length - 1,
+      lines,
+      renderHints,
+      theme,
+    );
   }
 }
 
@@ -163,20 +189,21 @@ function renderChild(
   isLast: boolean,
   lines: string[],
   renderHints: boolean,
+  theme: Theme,
 ): void {
-  const connector = isLast ? '└─ ' : '├─ ';
-  lines.push(formatLine(node.record, parentPrefix + connector));
+  const connector = isLast ? theme.glyphs.lastBranch : theme.glyphs.branch;
+  lines.push(formatLine(node.record, parentPrefix + connector, node, theme));
 
   // Descendants of a non-last sibling still need a trailing vertical
   // bar so the connector columns line up; the last sibling's subtree
   // gets plain spaces because nothing else sits below it.
-  const childSpacer = isLast ? '   ' : '│  ';
+  const childSpacer = isLast ? theme.glyphs.blank : theme.glyphs.vertical;
   const nextPrefix = parentPrefix + childSpacer;
   // The hint line visually attaches to this record, so it inherits the
   // same prefix the record's own children would use (the `nextPrefix`),
   // keeping the hint anchored beneath the record but out of the way of
   // real descendants below it.
-  maybePushHint(node.record, nextPrefix, lines, renderHints);
+  maybePushHint(node.record, nextPrefix, lines, renderHints, theme);
   const { children } = node;
   for (let i = 0; i < children.length; i++) {
     renderChild(
@@ -185,6 +212,7 @@ function renderChild(
       i === children.length - 1,
       lines,
       renderHints,
+      theme,
     );
   }
 }
@@ -212,13 +240,16 @@ function maybePushHint(
   recordPrefix: string,
   lines: string[],
   renderHints: boolean,
+  theme: Theme,
 ): void {
   if (!renderHints) return;
   if (isGroupSentinel(record)) return;
   const action = record.next_action;
   if (action === null || action === undefined) return;
   if (action.suppressed_by_ancestor === true) return;
-  lines.push(`${recordPrefix}  ${formatNextAction(action)}`);
+  lines.push(
+    `${recordPrefix}  ${formatNextAction(action, theme.glyphs.arrow)}`,
+  );
 }
 
 /**
@@ -229,42 +260,47 @@ function maybePushHint(
  * number injected into the label so the tree mirrors the parent's
  * canonical dep-order numbering.
  */
-function formatLine(record: ArtifactRecord, prefix: string): string {
+function formatLine(
+  record: ArtifactRecord,
+  prefix: string,
+  node: TreeNode,
+  theme: Theme,
+): string {
   if (isGroupSentinel(record)) {
     return `${prefix}${record.title}`;
   }
 
-  const marker = formatStatusMarker(record);
+  const marker = formatStatusMarker(record, node, theme);
   const titleWithNumber = applyStoryNumber(record.title, record.parent_row_id);
-  const label =
+  const isBroken =
     record.parent_missing === true &&
     typeof record.parent_path === 'string' &&
-    record.parent_path.length > 0
-      ? `${titleWithNumber} [missing parent: ${record.parent_path}]`
-      : titleWithNumber;
+    record.parent_path.length > 0;
+  const errorPrefix = isBroken
+    ? `${theme.paint.error(theme.icons.error)} `
+    : '';
+  const label = isBroken
+    ? `${errorPrefix}${titleWithNumber} [missing parent: ${record.parent_path}]`
+    : titleWithNumber;
 
   return `${prefix}${label}  ${marker}`;
 }
 
 /**
- * Inject the parent row's zero-padded numeric prefix into `title`.
- * When the title carries a type prefix like `Tasks: …` (emitted by
- * `smithy.cut` as the H1 of every tasks file), the number slots in
- * after that prefix so the prefix stays visible. Otherwise the number
- * prefixes the title directly. Returns the title unchanged when
- * `rowId` is missing or has no trailing digits.
+ * Inject the parent row's zero-padded numeric prefix into `title`. The
+ * legacy `Tasks: ` prefix emitted by `smithy.cut` as the H1 of every
+ * tasks file is stripped — every rendered task row already lives under
+ * a tasks-context parent in the tree, so repeating `Tasks: ` on every
+ * line is noise. Returns the title unchanged (minus any `Tasks: `
+ * prefix) when `rowId` is missing or has no trailing digits.
  */
 function applyStoryNumber(title: string, rowId: string | undefined): string {
-  if (rowId === undefined) return title;
+  const stripped = title.replace(/^Tasks:\s+/, '');
+  if (rowId === undefined) return stripped;
   const digits = rowId.match(/[0-9]+$/)?.[0];
-  if (digits === undefined) return title;
+  if (digits === undefined) return stripped;
   const nn = digits.padStart(2, '0');
-  const tasksPrefix = /^(Tasks:\s+)/;
-  const prefixMatch = tasksPrefix.exec(title);
-  if (prefixMatch !== null) {
-    return `${prefixMatch[1]}${nn} ${title.slice(prefixMatch[0].length)}`;
-  }
-  return `${nn} ${title}`;
+  return `${nn} ${stripped}`;
 }
 
 /**
@@ -286,23 +322,59 @@ function isGroupSentinel(record: ArtifactRecord): boolean {
  * Derive the trailing status marker for a real record. See the module
  * JSDoc for the full mapping.
  */
-function formatStatusMarker(record: ArtifactRecord): string {
+function formatStatusMarker(
+  record: ArtifactRecord,
+  node: TreeNode,
+  theme: Theme,
+): string {
   switch (record.status) {
     case 'done':
-      return 'DONE';
-    case 'in-progress':
+      return theme.paint.done(theme.icons.done);
+    case 'in-progress': {
+      const icon = theme.paint.inProgress(theme.icons.inProgress);
       if (record.type === 'tasks') {
         const completed = record.completed ?? 0;
         const total = record.total ?? 0;
-        return `${completed}/${total}`;
+        return `${icon} ${completed}/${total}`;
       }
-      return 'in progress';
+      const counter = formatParentCounter(node, theme);
+      return counter === '' ? icon : `${icon}  ${counter}`;
+    }
     case 'not-started':
-      return 'not started';
+      return theme.paint.notStarted(theme.icons.notStarted);
     case 'unknown': {
       const first =
         record.warnings.length > 0 ? record.warnings[0] : 'parse error';
-      return `unknown (${first})`;
+      return `${theme.paint.unknown(theme.icons.unknown)} unknown (${first})`;
     }
   }
+}
+
+/**
+ * Compute the compact `done/wip/not-started (total)` counter rendered
+ * beside an in-progress parent record's icon. Walks the parent's direct
+ * children (not the full subtree) so the counter answers "how far along
+ * is this row's immediate batch of work?". Returns the empty string
+ * when the parent has no non-group children, so callers can suppress
+ * the whole counter for sentinel-free parents.
+ */
+function formatParentCounter(node: TreeNode, theme: Theme): string {
+  const counts: Record<Status, number> = {
+    done: 0,
+    'in-progress': 0,
+    'not-started': 0,
+    unknown: 0,
+  };
+  let total = 0;
+  for (const child of node.children) {
+    if (isGroupSentinel(child.record)) continue;
+    counts[child.record.status] += 1;
+    total += 1;
+  }
+  if (total === 0) return '';
+  const done = counts.done;
+  const wip = counts['in-progress'];
+  const not = counts['not-started'];
+  const body = `${done}/${wip}/${not} (${total})`;
+  return theme.paint.dim(body);
 }

--- a/src/status/render.ts
+++ b/src/status/render.ts
@@ -280,7 +280,7 @@ function formatLine(
     ? `${theme.paint.error(theme.icons.error)} `
     : '';
   const label = isBroken
-    ? `${errorPrefix}${titleWithNumber} [missing parent: ${record.parent_path}]`
+    ? `${errorPrefix}${titleWithNumber} ${theme.paint.dim(`[missing parent: ${record.parent_path}]`)}`
     : titleWithNumber;
 
   return `${prefix}${label}  ${marker}`;
@@ -335,7 +335,12 @@ function formatStatusMarker(
       if (record.type === 'tasks') {
         const completed = record.completed ?? 0;
         const total = record.total ?? 0;
-        return `${icon} ${completed}/${total}`;
+        const completedPaint =
+          completed === 0
+            ? theme.paint.dim(String(completed))
+            : theme.paint.done(String(completed));
+        const slashTotal = theme.paint.dim(`/${total}`);
+        return `${icon} ${completedPaint}${slashTotal}`;
       }
       const counter = formatParentCounter(node, theme);
       return counter === '' ? icon : `${icon}  ${counter}`;
@@ -345,7 +350,7 @@ function formatStatusMarker(
     case 'unknown': {
       const first =
         record.warnings.length > 0 ? record.warnings[0] : 'parse error';
-      return `${theme.paint.unknown(theme.icons.unknown)} unknown (${first})`;
+      return `${theme.paint.unknown(theme.icons.unknown)} ${theme.paint.dim(`unknown (${first})`)}`;
     }
   }
 }
@@ -357,6 +362,13 @@ function formatStatusMarker(
  * is this row's immediate batch of work?". Returns the empty string
  * when the parent has no non-group children, so callers can suppress
  * the whole counter for sentinel-free parents.
+ *
+ * Each segment is painted by its own status color so the row carries
+ * the same semantic accent as the icons elsewhere in the tree: a
+ * nonzero `done` count is green, nonzero `in-progress` is yellow,
+ * nonzero `not-started` stays default/white, and any zero segment
+ * fades to dim. Separators (`/`), parens, and the total inside the
+ * parens are always dim so the numbers themselves carry the signal.
  */
 function formatParentCounter(node: TreeNode, theme: Theme): string {
   const counts: Record<Status, number> = {
@@ -375,6 +387,14 @@ function formatParentCounter(node: TreeNode, theme: Theme): string {
   const done = counts.done;
   const wip = counts['in-progress'];
   const not = counts['not-started'];
-  const body = `${done}/${wip}/${not} (${total})`;
-  return theme.paint.dim(body);
+  const paintSegment = (kind: 'done' | 'wip' | 'not', n: number): string => {
+    const s = String(n);
+    if (n === 0) return theme.paint.dim(s);
+    if (kind === 'done') return theme.paint.done(s);
+    if (kind === 'wip') return theme.paint.inProgress(s);
+    return theme.paint.white(s);
+  };
+  const slash = theme.paint.dim('/');
+  const totalBody = theme.paint.dim(`(${total})`);
+  return `${paintSegment('done', done)}${slash}${paintSegment('wip', wip)}${slash}${paintSegment('not', not)} ${totalBody}`;
 }

--- a/src/status/render.ts
+++ b/src/status/render.ts
@@ -43,7 +43,7 @@
  * | `status === 'in-progress'` on a tasks record | `◐ <completed>/<total>` |
  * | `status === 'in-progress'` on a parent record | `◐ <done>/<wip>/<not-started> (<total>)` |
  * | `status === 'not-started'` (real or virtual) | `○` |
- * | `status === 'unknown'` | `⚠ (<first warning>)` |
+ * | `status === 'unknown'` | `⚠ unknown (<first warning>)` |
  *
  * A broken-link parent (see `parent_missing === true`) additionally
  * gets a red error prefix (`theme.icons.error` painted red) ahead of

--- a/src/status/suggester.ts
+++ b/src/status/suggester.ts
@@ -297,15 +297,17 @@ export function suggestNextAction(
 
 /**
  * Format a {@link NextAction} as a one-line, copy-pasteable hint string
- * of the form `→ <command> <arg1> <arg2>...`.
+ * of the form `<arrow> <command> <arg1> <arg2>...`.
  *
- * When `arguments` is empty the result collapses to `→ <command>` with
- * no trailing whitespace. The returned string never contains embedded
- * newlines — it is exactly one line.
+ * When `arguments` is empty the result collapses to `<arrow> <command>`
+ * with no trailing whitespace. The returned string never contains
+ * embedded newlines — it is exactly one line.
  *
- * The prefix character is the Unicode rightwards arrow `→` (U+2192),
- * separated from the command by a single ASCII space. Multiple
- * arguments are joined by single ASCII spaces.
+ * The arrow defaults to the Unicode rightwards arrow `→` (U+2192)
+ * followed by a single ASCII space, matching the original hint style.
+ * Callers that need an ASCII fallback (non-UTF-8 terminal) pass the
+ * ASCII variant (`-> `) from the theme bundle so no trailing whitespace
+ * handling differs between the two bundles.
  *
  * This function is pure and performs no I/O. It is intentionally
  * colocated with {@link suggestNextAction} so downstream callers that
@@ -314,12 +316,17 @@ export function suggestNextAction(
  * same formatter to attach hints beneath tree nodes (SD-016).
  *
  * @param action The next action to format.
+ * @param arrow Optional arrow prefix (including its trailing space).
+ * Defaults to `'→ '`.
  * @returns A single-line hint string.
  */
-export function formatNextAction(action: NextAction): string {
+export function formatNextAction(
+  action: NextAction,
+  arrow: string = '\u2192 ',
+): string {
   const args = action.arguments;
   if (args.length === 0) {
-    return `\u2192 ${action.command}`;
+    return `${arrow}${action.command}`;
   }
-  return `\u2192 ${action.command} ${args.join(' ')}`;
+  return `${arrow}${action.command} ${args.join(' ')}`;
 }

--- a/src/status/theme.test.ts
+++ b/src/status/theme.test.ts
@@ -62,10 +62,13 @@ describe('resolveColor', () => {
     expect(resolveColor({ noColor: true })).toBe(false);
   });
 
-  it('returns false when NO_COLOR env var is set to any non-empty value', () => {
+  it('returns false whenever NO_COLOR is set — including the empty-string case, per no-color.org', () => {
     process.env.NO_COLOR = '1';
     expect(resolveColor()).toBe(false);
     process.env.NO_COLOR = 'yes';
+    expect(resolveColor()).toBe(false);
+    // no-color.org: "presence of the variable, regardless of value"
+    process.env.NO_COLOR = '';
     expect(resolveColor()).toBe(false);
   });
 

--- a/src/status/theme.test.ts
+++ b/src/status/theme.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  buildTheme,
+  createTheme,
+  resolveColor,
+  resolveGlyphs,
+} from './theme.js';
+
+/**
+ * The detection helpers read `process.env` and `process.stdout.isTTY`
+ * directly. Snapshot the relevant values before each test and restore
+ * them after so one branch can't leak into another.
+ */
+const ENV_KEYS = ['NO_COLOR', 'FORCE_COLOR', 'LANG', 'LC_ALL', 'LC_CTYPE'];
+
+function snapshotEnv(): Record<string, string | undefined> {
+  const snap: Record<string, string | undefined> = {};
+  for (const k of ENV_KEYS) {
+    snap[k] = process.env[k];
+  }
+  return snap;
+}
+
+function restoreEnv(snap: Record<string, string | undefined>): void {
+  for (const k of ENV_KEYS) {
+    const v = snap[k];
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+}
+
+function clearEnv(): void {
+  for (const k of ENV_KEYS) {
+    delete process.env[k];
+  }
+}
+
+describe('resolveColor', () => {
+  let snap: Record<string, string | undefined>;
+  let origIsTTY: boolean | undefined;
+
+  beforeEach(() => {
+    snap = snapshotEnv();
+    clearEnv();
+    origIsTTY = process.stdout.isTTY;
+  });
+
+  afterEach(() => {
+    restoreEnv(snap);
+    Object.defineProperty(process.stdout, 'isTTY', {
+      configurable: true,
+      value: origIsTTY,
+    });
+  });
+
+  it('returns false when --no-color is set', () => {
+    process.env.FORCE_COLOR = '1';
+    expect(resolveColor({ noColor: true })).toBe(false);
+  });
+
+  it('returns false when NO_COLOR env var is set to any non-empty value', () => {
+    process.env.NO_COLOR = '1';
+    expect(resolveColor()).toBe(false);
+    process.env.NO_COLOR = 'yes';
+    expect(resolveColor()).toBe(false);
+  });
+
+  it('returns true when FORCE_COLOR is truthy, even without a TTY', () => {
+    process.env.FORCE_COLOR = '1';
+    Object.defineProperty(process.stdout, 'isTTY', {
+      configurable: true,
+      value: false,
+    });
+    expect(resolveColor()).toBe(true);
+  });
+
+  it('returns false when FORCE_COLOR is "0" or "false"', () => {
+    Object.defineProperty(process.stdout, 'isTTY', {
+      configurable: true,
+      value: false,
+    });
+    process.env.FORCE_COLOR = '0';
+    expect(resolveColor()).toBe(false);
+    process.env.FORCE_COLOR = 'false';
+    expect(resolveColor()).toBe(false);
+  });
+
+  it('falls back to isTTY when no env overrides are set', () => {
+    Object.defineProperty(process.stdout, 'isTTY', {
+      configurable: true,
+      value: true,
+    });
+    expect(resolveColor()).toBe(true);
+    Object.defineProperty(process.stdout, 'isTTY', {
+      configurable: true,
+      value: false,
+    });
+    expect(resolveColor()).toBe(false);
+  });
+
+  it('NO_COLOR takes priority over FORCE_COLOR', () => {
+    process.env.NO_COLOR = '1';
+    process.env.FORCE_COLOR = '1';
+    expect(resolveColor()).toBe(false);
+  });
+});
+
+describe('resolveGlyphs', () => {
+  let snap: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    snap = snapshotEnv();
+    clearEnv();
+  });
+
+  afterEach(() => {
+    restoreEnv(snap);
+  });
+
+  it('returns "ascii" when explicitly requested', () => {
+    process.env.LANG = 'en_US.UTF-8';
+    expect(resolveGlyphs({ ascii: true })).toBe('ascii');
+  });
+
+  it('returns "utf8" when LANG advertises UTF-8', () => {
+    process.env.LANG = 'en_US.UTF-8';
+    expect(resolveGlyphs()).toBe('utf8');
+  });
+
+  it('recognizes both "UTF-8" and "utf8" forms case-insensitively', () => {
+    process.env.LANG = 'en_US.utf8';
+    expect(resolveGlyphs()).toBe('utf8');
+    process.env.LC_ALL = 'C.UTF-8';
+    expect(resolveGlyphs()).toBe('utf8');
+  });
+
+  it('returns "ascii" when LANG is a non-UTF-8 locale like C', () => {
+    process.env.LANG = 'C';
+    // On non-Windows platforms this triggers the "locale set but no
+    // UTF-8 marker" branch, which returns ASCII.
+    const glyphs = resolveGlyphs();
+    expect(glyphs).toBe(process.platform === 'win32' ? 'ascii' : 'ascii');
+  });
+
+  it('LC_ALL wins over LANG when present', () => {
+    process.env.LANG = 'C';
+    process.env.LC_ALL = 'en_US.UTF-8';
+    expect(resolveGlyphs()).toBe('utf8');
+  });
+
+  it('returns "utf8" when no locale env vars are set on non-Windows platforms', () => {
+    // Empty signal on POSIX → assume UTF-8. Windows always falls back to
+    // ASCII because cmd.exe / legacy PowerShell mangle box-drawing.
+    const glyphs = resolveGlyphs();
+    expect(glyphs).toBe(process.platform === 'win32' ? 'ascii' : 'utf8');
+  });
+});
+
+describe('createTheme', () => {
+  it('pairs utf8 encoding with UTF-8 glyphs and icons', () => {
+    const theme = createTheme({ color: false, encoding: 'utf8' });
+    expect(theme.encoding).toBe('utf8');
+    expect(theme.glyphs.branch).toBe('\u251C\u2500 ');
+    expect(theme.glyphs.lastBranch).toBe('\u2514\u2500 ');
+    expect(theme.glyphs.vertical).toBe('\u2502  ');
+    expect(theme.glyphs.arrow).toBe('\u2192 ');
+    expect(theme.icons.done).toBe('\u2713');
+    expect(theme.icons.inProgress).toBe('\u25D0');
+    expect(theme.icons.notStarted).toBe('\u25CB');
+    expect(theme.icons.unknown).toBe('\u26A0');
+    expect(theme.icons.error).toBe('\u2717');
+  });
+
+  it('pairs ascii encoding with ASCII glyphs and bracketed icons', () => {
+    const theme = createTheme({ color: false, encoding: 'ascii' });
+    expect(theme.encoding).toBe('ascii');
+    expect(theme.glyphs.branch).toBe('+- ');
+    expect(theme.glyphs.lastBranch).toBe('`- ');
+    expect(theme.glyphs.vertical).toBe('|  ');
+    expect(theme.glyphs.arrow).toBe('-> ');
+    expect(theme.icons.done).toBe('[x]');
+    expect(theme.icons.inProgress).toBe('[~]');
+    expect(theme.icons.notStarted).toBe('[ ]');
+    expect(theme.icons.unknown).toBe('[?]');
+    expect(theme.icons.error).toBe('[!]');
+  });
+
+  it('paint helpers are identity functions when color is disabled', () => {
+    const theme = createTheme({ color: false, encoding: 'utf8' });
+    expect(theme.color).toBe(false);
+    expect(theme.paint.done('hello')).toBe('hello');
+    expect(theme.paint.inProgress('hello')).toBe('hello');
+    expect(theme.paint.notStarted('hello')).toBe('hello');
+    expect(theme.paint.unknown('hello')).toBe('hello');
+    expect(theme.paint.error('hello')).toBe('hello');
+    expect(theme.paint.dim('hello')).toBe('hello');
+    expect(theme.paint.bold('hello')).toBe('hello');
+    expect(theme.paint.white('hello')).toBe('hello');
+  });
+
+  it('paint helpers wrap strings in ANSI escapes when color is enabled', () => {
+    const theme = createTheme({ color: true, encoding: 'utf8' });
+    expect(theme.color).toBe(true);
+    const painted = theme.paint.done('hello');
+    // picocolors emits ANSI escape sequences: `\u001B[<code>mhello\u001B[<reset>m`.
+    expect(painted).not.toBe('hello');
+    expect(painted).toContain('hello');
+    expect(painted).toMatch(/\u001B\[/);
+  });
+});
+
+describe('buildTheme', () => {
+  let snap: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    snap = snapshotEnv();
+    clearEnv();
+  });
+
+  afterEach(() => {
+    restoreEnv(snap);
+  });
+
+  it('honors --no-color by returning a color-off theme', () => {
+    process.env.FORCE_COLOR = '1';
+    const theme = buildTheme({ noColor: true });
+    expect(theme.color).toBe(false);
+  });
+
+  it('honors --ascii by returning an ascii-encoded theme', () => {
+    process.env.LANG = 'en_US.UTF-8';
+    const theme = buildTheme({ ascii: true });
+    expect(theme.encoding).toBe('ascii');
+    expect(theme.glyphs.branch).toBe('+- ');
+  });
+
+  it('picks up env-driven defaults when no opts are passed', () => {
+    process.env.NO_COLOR = '1';
+    process.env.LANG = 'en_US.UTF-8';
+    const theme = buildTheme();
+    expect(theme.color).toBe(false);
+    expect(theme.encoding).toBe('utf8');
+  });
+});

--- a/src/status/theme.ts
+++ b/src/status/theme.ts
@@ -148,7 +148,7 @@ const COLOR_PAINT: ThemePaint = (() => {
  */
 export function resolveColor(opts: { noColor?: boolean } = {}): boolean {
   if (opts.noColor === true) return false;
-  if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== '') {
+  if (process.env.NO_COLOR !== undefined) {
     return false;
   }
   const force = process.env.FORCE_COLOR;

--- a/src/status/theme.ts
+++ b/src/status/theme.ts
@@ -121,16 +121,24 @@ const IDENTITY_PAINT: ThemePaint = {
   white: IDENTITY,
 };
 
-const COLOR_PAINT: ThemePaint = {
-  done: pc.green,
-  inProgress: pc.yellow,
-  notStarted: pc.dim,
-  unknown: pc.yellow,
-  error: pc.red,
-  dim: pc.dim,
-  bold: pc.bold,
-  white: pc.white,
-};
+const COLOR_PAINT: ThemePaint = (() => {
+  // picocolors auto-detects TTY / NO_COLOR and returns identity
+  // functions when color is off. We've already decided to emit color
+  // at this point, so force-enable via `createColors(true)` so the
+  // helpers actually emit ANSI escapes regardless of the ambient
+  // environment.
+  const c = pc.createColors(true);
+  return {
+    done: c.green,
+    inProgress: c.yellow,
+    notStarted: c.dim,
+    unknown: c.yellow,
+    error: c.red,
+    dim: c.dim,
+    bold: c.bold,
+    white: c.white,
+  };
+})();
 
 /**
  * Resolve whether ANSI color output is appropriate for the current process.

--- a/src/status/theme.ts
+++ b/src/status/theme.ts
@@ -1,0 +1,205 @@
+/**
+ * Terminal theme for the status renderer: color / encoding detection and a
+ * bundled {@link Theme} carrying the glyphs, icons, and paint helpers the
+ * renderer and summary header consume.
+ *
+ * The detection helpers ({@link resolveColor} and {@link resolveGlyphs}) read
+ * `process.env`, `process.stdout.isTTY`, and `process.platform`. They are
+ * exported so tests can exercise each branch independently without relying on
+ * the ambient environment. {@link buildTheme} is the one-stop factory that
+ * `statusAction` calls once and threads into the renderer. Tests that want a
+ * deterministic theme pass hand-rolled bundles through {@link createTheme}
+ * instead of touching the detectors.
+ */
+
+import pc from 'picocolors';
+
+/**
+ * Tree-drawing glyphs plus the hint arrow and bullet. UTF-8 bundle uses the
+ * classic box-drawing characters; the ASCII bundle uses characters that
+ * survive non-UTF-8 terminals and grep-based log scrapes.
+ */
+export interface ThemeGlyphs {
+  /** Connector prefix for a non-last sibling (`├─ ` / `+- `). */
+  branch: string;
+  /** Connector prefix for the last sibling of each parent (`└─ ` / `\`- `). */
+  lastBranch: string;
+  /** Spacer inherited by descendants of a non-last sibling (`│  ` / `|  `). */
+  vertical: string;
+  /** Blank spacer inherited by descendants of the last sibling (`   `). */
+  blank: string;
+  /** Next-action hint arrow (`→ ` / `-> `). */
+  arrow: string;
+  /** Middle-dot separator reserved for summary lines (`·` / `-`). */
+  middot: string;
+}
+
+/**
+ * Status-marker icons rendered alongside each record line.
+ */
+export interface ThemeIcons {
+  done: string;
+  inProgress: string;
+  notStarted: string;
+  unknown: string;
+  error: string;
+}
+
+/**
+ * Paint helpers: each is a string → string transformer. When color is
+ * disabled every helper is the identity function so output remains ANSI-free
+ * on terminals that would mangle escape sequences.
+ */
+export interface ThemePaint {
+  done: (s: string) => string;
+  inProgress: (s: string) => string;
+  notStarted: (s: string) => string;
+  unknown: (s: string) => string;
+  error: (s: string) => string;
+  dim: (s: string) => string;
+  bold: (s: string) => string;
+  white: (s: string) => string;
+}
+
+/**
+ * Bundled theme threaded through the renderer and the summary header.
+ */
+export interface Theme {
+  /** Whether paint helpers emit ANSI escapes. */
+  color: boolean;
+  /** Whether glyphs are UTF-8 or ASCII. */
+  encoding: 'utf8' | 'ascii';
+  glyphs: ThemeGlyphs;
+  icons: ThemeIcons;
+  paint: ThemePaint;
+}
+
+const UTF8_GLYPHS: ThemeGlyphs = {
+  branch: '├─ ',
+  lastBranch: '└─ ',
+  vertical: '│  ',
+  blank: '   ',
+  arrow: '→ ',
+  middot: '·',
+};
+
+const ASCII_GLYPHS: ThemeGlyphs = {
+  branch: '+- ',
+  lastBranch: '`- ',
+  vertical: '|  ',
+  blank: '   ',
+  arrow: '-> ',
+  middot: '-',
+};
+
+const UTF8_ICONS: ThemeIcons = {
+  done: '\u2713',
+  inProgress: '\u25D0',
+  notStarted: '\u25CB',
+  unknown: '\u26A0',
+  error: '\u2717',
+};
+
+const ASCII_ICONS: ThemeIcons = {
+  done: '[x]',
+  inProgress: '[~]',
+  notStarted: '[ ]',
+  unknown: '[?]',
+  error: '[!]',
+};
+
+const IDENTITY = (s: string): string => s;
+
+const IDENTITY_PAINT: ThemePaint = {
+  done: IDENTITY,
+  inProgress: IDENTITY,
+  notStarted: IDENTITY,
+  unknown: IDENTITY,
+  error: IDENTITY,
+  dim: IDENTITY,
+  bold: IDENTITY,
+  white: IDENTITY,
+};
+
+const COLOR_PAINT: ThemePaint = {
+  done: pc.green,
+  inProgress: pc.yellow,
+  notStarted: pc.dim,
+  unknown: pc.yellow,
+  error: pc.red,
+  dim: pc.dim,
+  bold: pc.bold,
+  white: pc.white,
+};
+
+/**
+ * Resolve whether ANSI color output is appropriate for the current process.
+ * Respects the widely-honored `NO_COLOR` (any value disables color) and
+ * `FORCE_COLOR` (any truthy value forces color on) env vars, Commander's
+ * `--no-color` opt-out, and falls back to detecting an attached TTY.
+ */
+export function resolveColor(opts: { noColor?: boolean } = {}): boolean {
+  if (opts.noColor === true) return false;
+  if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== '') {
+    return false;
+  }
+  const force = process.env.FORCE_COLOR;
+  if (force !== undefined && force !== '' && force !== '0' && force !== 'false') {
+    return true;
+  }
+  return process.stdout.isTTY === true;
+}
+
+/**
+ * Resolve which glyph bundle to use. Explicit `--ascii` wins; otherwise we
+ * fall back to ASCII whenever the locale doesn't advertise UTF-8 or the
+ * platform is Windows without an obvious UTF-8 marker — cmd.exe and legacy
+ * PowerShell routinely emit mojibake for box-drawing characters.
+ */
+export function resolveGlyphs(opts: { ascii?: boolean } = {}): 'utf8' | 'ascii' {
+  if (opts.ascii === true) return 'ascii';
+  const localeSignal = `${process.env.LC_ALL ?? ''};${process.env.LC_CTYPE ?? ''};${process.env.LANG ?? ''}`;
+  const hasUtf8 = /utf-?8/i.test(localeSignal);
+  if (hasUtf8) return 'utf8';
+  if (process.platform === 'win32') return 'ascii';
+  return localeSignal.length > 2 ? 'ascii' : 'utf8';
+}
+
+/**
+ * Factory that takes an already-resolved bundle and stitches it into a
+ * {@link Theme}. Useful from tests where deterministic values are preferred
+ * over environment-dependent detection.
+ */
+export function createTheme(params: {
+  color: boolean;
+  encoding: 'utf8' | 'ascii';
+}): Theme {
+  const glyphs = params.encoding === 'utf8' ? UTF8_GLYPHS : ASCII_GLYPHS;
+  const icons = params.encoding === 'utf8' ? UTF8_ICONS : ASCII_ICONS;
+  const paint = params.color ? COLOR_PAINT : IDENTITY_PAINT;
+  return {
+    color: params.color,
+    encoding: params.encoding,
+    glyphs,
+    icons,
+    paint,
+  };
+}
+
+/**
+ * One-stop factory: detects color + encoding from the environment and
+ * returns the fully-assembled {@link Theme}. Call once at the top of
+ * `statusAction` and thread the result through `renderTree` and the
+ * summary header.
+ */
+export function buildTheme(
+  opts: { noColor?: boolean; ascii?: boolean } = {},
+): Theme {
+  const colorOpts: { noColor?: boolean } = {};
+  if (opts.noColor !== undefined) colorOpts.noColor = opts.noColor;
+  const glyphOpts: { ascii?: boolean } = {};
+  if (opts.ascii !== undefined) glyphOpts.ascii = opts.ascii;
+  const color = resolveColor(colorOpts);
+  const encoding = resolveGlyphs(glyphOpts);
+  return createTheme({ color, encoding });
+}


### PR DESCRIPTION
## Summary

Replace the single-line summary header with a vitest-inspired aligned block, swap textual status markers (`DONE` / `in progress` / `not started`) for colored icons (`✓` `◐` `○`), add a `done/wip/not-started (total)` counter on in-progress parent rows, drop the noisy `Tasks: ` prefix from task rows, and route every glyph through a new theme bundle so non-UTF-8 terminals get an automatic ASCII fallback.

### What changed

- **New `src/status/theme.ts`** — centralizes color and encoding detection (`NO_COLOR`, `FORCE_COLOR`, `--no-color`, `isTTY`; `LANG`/`LC_ALL` and Windows-aware glyph fallback) and exports a `Theme` bundle of glyphs (`branch`, `lastBranch`, `vertical`, `blank`, `arrow`), icons, and `picocolors`-backed paint helpers. Color-on path goes through `pc.createColors(true)` so ANSI escapes actually emit under vitest / non-TTY parents.
- **`src/status/render.ts`** — threads the theme through every connector and marker. Empty-tree behavior, hint placement, and group-sentinel handling are unchanged. Broken-link rows gain a red `✗` prefix. The `Tasks:` H1 prefix is stripped from task-row labels (story numbers like `01`, `06` still render).
- **`src/commands/status.ts`** — `formatSummaryHeader` now produces the vitest-style block, suppresses rows whose done/in-progress/not-started counts are all zero, dynamically sizes label and count columns to surviving rows, paints zero counts dim, and appends a top-level `Next:` hint when one exists. New `pickTopNextAction` walks the rendered tree to surface the topmost actionable hint. Both exported so tests can exercise them without going through the CLI subprocess.
- **`src/status/suggester.ts`** — `formatNextAction` accepts an optional arrow override so the renderer can hand it the theme's ASCII or UTF-8 arrow glyph (default unchanged).
- **`src/cli.ts`** — `--ascii` is wired; `--no-color` now actually disables color instead of being a stub.

### Sample output (UTF-8, color off)

```
 Smithy Status

  Specs    2 ✓    3 ◐    1 ○
  Tasks   36 ✓    2 ◐    8 ○

  Next: smithy.cut specs/2026-03-21-002-smithy-orders-issue-templates 1
Orphaned Specs
├─ Smithy Evals Framework  ◐  8/1/2 (11)
│    → smithy.cut specs/2026-04-06-003-smithy-evals-framework 6
│  ├─ 06 Verify Sub-Agent Invocation  ○
│  └─ 07 Define Eval Scenarios Declaratively  ◐ 1/2
└─ Smithy Status Skill  ◐  8/0/2 (10)
```

## Status

- [x] Production code typechecks (`npm run typecheck`)
- [x] Bundle builds (`npm run build`)
- [x] Manual smoke test against this repo's `smithy status` output
- [x] `src/status/render.test.ts` rewritten against the new icon/theme contract (33 tests passing)
- [x] New `src/status/theme.test.ts` covering detection helpers + `createTheme` + `buildTheme` (19 tests)
- [x] New `src/commands/status.test.ts` covering `formatSummaryHeader` and `pickTopNextAction` (15 tests)
- [x] `src/cli.test.ts` updated for the multi-line header (byte-identity check now covers count rows only — the `Next:` line legitimately differs between filtered runs since it reads off the filtered tree)
- [x] **Full suite: 548/548 passing, 19/19 files**

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` clean
- [x] Manual: `node dist/cli.js status` (default), `--no-color` (verified this repo), plus visual inspection of the new header, icons, parent counter, and `Next:` line.
- [ ] Optional follow-up: spot-check `--ascii`, `NO_COLOR=1`, `LANG=C`, and Windows cmd.exe to confirm the auto-ASCII fallback behaves in the wild.

https://claude.ai/code/session_01DvMbVAyYS7sJVVtuvfEiRw