### PR TITLE
Add safe tmux read-only flags to permissions

### DIFF
--- a/src/permissions.test.ts
+++ b/src/permissions.test.ts
@@ -61,6 +61,14 @@ describe('flattenPermissions', () => {
     expect(result).toContain('gh --version');
   });
 
+  it('includes safe tmux read-only flags', () => {
+    const result = flattenPermissions();
+    expect(result).toContain('tmux -V');
+    expect(result).toContain('tmux -h');
+    // No wildcard — other tmux verbs must still require approval.
+    expect(result).not.toContain('tmux *');
+  });
+
   it('flattens gh repo view with bare and wildcard variants', () => {
     const result = flattenPermissions();
     expect(result).toContain('gh repo view');

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -226,6 +226,10 @@ export const permissions: Record<string, PermissionEntry> = {
   tar: ["*", "-czf *", "-xzf *", "-xf *", "-tf *"],
   zip: ["*", "-r *"],
   unzip: ["*", "-l *"],
+  tmux: {
+    "-V": [],
+    "-h": [],
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary
- Primary outcome: Allow `tmux -V` and `tmux -h` (version and help flags) as safe read-only operations without requiring approval
- Notable behaviour changes: tmux commands are now partially whitelisted; only the safe flags are permitted, other tmux verbs still require approval
- Follow-up work deferred: None

## Context
This change enables safe, read-only tmux operations (version and help queries) to be executed without approval, improving developer experience for common diagnostic commands while maintaining security by not allowing arbitrary tmux operations.

## Implementation Notes
- Added `tmux` entry to the permissions registry with `-V` and `-h` flags explicitly allowed
- Used object notation (rather than array with wildcards) to restrict permissions to only these two safe flags
- Intentionally excluded wildcard support to ensure other tmux verbs require explicit approval
- Mirrors the pattern used for other tools with restricted command sets

## Risks & Mitigations
- Risk: Unintended tmux operations could be executed if additional flags are accidentally added | Mitigation: Test explicitly verifies that wildcard tmux is not included; code review required for any future tmux permission changes

## Testing
- Added unit test `includes safe tmux read-only flags` that verifies:
  - `tmux -V` is included in flattened permissions
  - `tmux -h` is included in flattened permissions
  - `tmux *` wildcard is explicitly NOT included
- Existing test suite passes

https://claude.ai/code/session_01DdUdywk5tQ1rUUvGTPdYfo