### PR TITLE
Add platform-scoped package-manager permissions (brew, apt, dpkg, uv, cargo)

### DIFF
--- a/src/agents/claude.test.ts
+++ b/src/agents/claude.test.ts
@@ -451,6 +451,56 @@ describe('buildClaudeAllowList', () => {
     expect(remoteEntries).not.toContain('Bash(git remote *)');
     expect(remoteEntries.length).toBe(2);
   });
+
+  it('threads platformManagers through to Bash() wrapping (mac)', () => {
+    const macList = buildClaudeAllowList([], ['mac']);
+    expect(macList).toContain('Bash(brew list)');
+    expect(macList).toContain('Bash(brew info *)');
+    expect(macList.some(e => e.startsWith('Bash(apt '))).toBe(false);
+    expect(macList.some(e => e.startsWith('Bash(apt-cache'))).toBe(false);
+    expect(macList.some(e => e.startsWith('Bash(dpkg'))).toBe(false);
+  });
+
+  it('threads platformManagers through to Bash() wrapping (linux)', () => {
+    const linuxList = buildClaudeAllowList([], ['linux']);
+    expect(linuxList).toContain('Bash(apt list)');
+    expect(linuxList).toContain('Bash(apt-cache search *)');
+    expect(linuxList).toContain('Bash(dpkg -l)');
+    expect(linuxList.some(e => e.startsWith('Bash(brew'))).toBe(false);
+  });
+
+  it('wraps uv commands under python toolchain', () => {
+    const pyList = buildClaudeAllowList(['python']);
+    expect(pyList).toContain('Bash(uv --version)');
+    expect(pyList).toContain('Bash(uv add *)');
+    expect(pyList).toContain('Bash(uv sync)');
+    expect(pyList).toContain('Bash(uv pip install *)');
+  });
+
+  it('wraps cargo dep-management commands under rust toolchain', () => {
+    const rustList = buildClaudeAllowList(['rust']);
+    expect(rustList).toContain('Bash(cargo add *)');
+    expect(rustList).toContain('Bash(cargo update)');
+    expect(rustList).toContain('Bash(cargo fetch)');
+    expect(rustList).toContain('Bash(cargo search *)');
+    expect(rustList).toContain('Bash(cargo info *)');
+    expect(rustList).not.toContain('Bash(cargo install *)');
+    expect(rustList).not.toContain('Bash(cargo publish *)');
+  });
+
+  it('does not wrap mutating package-manager commands in Bash()', () => {
+    const list = buildClaudeAllowList();
+    expect(list).not.toContain('Bash(brew install *)');
+    expect(list).not.toContain('Bash(brew uninstall *)');
+    expect(list).not.toContain('Bash(apt install *)');
+    expect(list).not.toContain('Bash(apt remove *)');
+    expect(list).not.toContain('Bash(dpkg -i *)');
+    expect(list).not.toContain('Bash(uv tool install *)');
+    expect(list).not.toContain('Bash(uv python install *)');
+    expect(list).not.toContain('Bash(cargo install *)');
+    expect(list).not.toContain('Bash(cargo publish *)');
+    expect(list.some(e => e.startsWith('Bash(uv run'))).toBe(false);
+  });
 });
 
 describe('buildClaudeDenyList', () => {

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import picocolors from 'picocolors';
 import { getComposedTemplates, getTemplateFilesByCategory, stripFrontmatter } from '../templates.js';
-import { flattenPermissions, claudeToolPermissions, denyPermissions, type LanguageToolchain } from '../permissions.js';
+import { flattenPermissions, claudeToolPermissions, denyPermissions, type LanguageToolchain, type PlatformPackageManager } from '../permissions.js';
 import { hooksTemplateDir, removeIfExists } from '../utils.js';
 import type { PermissionLevel, DeployablePermissionLevel, DeployLocation } from '../interactive.js';
 
@@ -128,8 +128,11 @@ export function removeLegacy(targetDir: string): number {
  * Build the Claude Code allow-list from the shared permissions.
  * Wraps each command in Bash(...) and appends Claude-specific tool permissions.
  */
-export function buildClaudeAllowList(languages?: LanguageToolchain[]): string[] {
-  const bashPermissions = flattenPermissions(languages).map(cmd => `Bash(${cmd})`);
+export function buildClaudeAllowList(
+  languages?: LanguageToolchain[],
+  platformManagers?: PlatformPackageManager[],
+): string[] {
+  const bashPermissions = flattenPermissions(languages, platformManagers).map(cmd => `Bash(${cmd})`);
   return [...bashPermissions, ...claudeToolPermissions];
 }
 
@@ -154,11 +157,16 @@ export function resolveSettingsPath(targetDir: string, level: DeployablePermissi
  * Write permissions to the appropriate settings.json using Claude Code's schema.
  * Merges with existing settings.json if present.
  */
-export function writePermissions(targetDir: string, level: DeployablePermissionLevel, languages?: LanguageToolchain[]): void {
+export function writePermissions(
+  targetDir: string,
+  level: DeployablePermissionLevel,
+  languages?: LanguageToolchain[],
+  platformManagers?: PlatformPackageManager[],
+): void {
   const settingsPath = resolveSettingsPath(targetDir, level);
   const settingsDir = path.dirname(settingsPath);
   if (!fs.existsSync(settingsDir)) fs.mkdirSync(settingsDir, { recursive: true });
-  const allowList = buildClaudeAllowList(languages);
+  const allowList = buildClaudeAllowList(languages, platformManagers);
   const denyList = buildClaudeDenyList();
 
   let config: Record<string, unknown> = {

--- a/src/agents/gemini.ts
+++ b/src/agents/gemini.ts
@@ -2,13 +2,18 @@ import fs from 'fs';
 import path from 'path';
 import picocolors from 'picocolors';
 import { getComposedTemplates, parseFrontmatterName } from '../templates.js';
-import { flattenPermissions, type LanguageToolchain } from '../permissions.js';
+import { flattenPermissions, type LanguageToolchain, type PlatformPackageManager } from '../permissions.js';
 import { removeIfExists } from '../utils.js';
 
 /**
  * Deploy Gemini templates. Returns the list of deployed file paths (relative to targetDir).
  */
-export async function deploy(targetDir: string, initPermissions: boolean, languages?: LanguageToolchain[]): Promise<string[]> {
+export async function deploy(
+  targetDir: string,
+  initPermissions: boolean,
+  languages?: LanguageToolchain[],
+  platformManagers?: PlatformPackageManager[],
+): Promise<string[]> {
   const destDir = path.join(targetDir, '.gemini');
   const skillsDir = path.join(destDir, 'skills');
   console.log(picocolors.green(`\nInitializing Gemini CLI workspace skills in ${skillsDir}...`));
@@ -31,7 +36,7 @@ export async function deploy(targetDir: string, initPermissions: boolean, langua
   for (const [, content] of templates.prompts) deployAsSkill(content);
 
   if (initPermissions) {
-    writePermissions(destDir, languages);
+    writePermissions(destDir, languages, platformManagers);
   }
 
   return deployedFiles;
@@ -60,13 +65,20 @@ export function removeLegacy(targetDir: string): number {
  * Build Gemini's allowed tool list from the shared permissions.
  * Wraps each flattened command in run_shell_command(...) format.
  */
-export function buildGeminiAllowList(languages?: LanguageToolchain[]): string[] {
-  return flattenPermissions(languages).map(cmd => `run_shell_command(${cmd})`);
+export function buildGeminiAllowList(
+  languages?: LanguageToolchain[],
+  platformManagers?: PlatformPackageManager[],
+): string[] {
+  return flattenPermissions(languages, platformManagers).map(cmd => `run_shell_command(${cmd})`);
 }
 
-function writePermissions(destDir: string, languages?: LanguageToolchain[]): void {
+function writePermissions(
+  destDir: string,
+  languages?: LanguageToolchain[],
+  platformManagers?: PlatformPackageManager[],
+): void {
   const settingsPath = path.join(destDir, 'settings.json');
-  const allowList = buildGeminiAllowList(languages);
+  const allowList = buildGeminiAllowList(languages, platformManagers);
 
   type GeminiSettings = { tools?: { allowed?: string[]; [k: string]: unknown }; [k: string]: unknown };
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -8,7 +8,8 @@ import {
   promptToolchains,
 } from '../interactive.js';
 import { detectLanguages } from '../language-detect.js';
-import type { LanguageToolchain } from '../permissions.js';
+import { detectPlatforms } from '../platform-detect.js';
+import type { LanguageToolchain, PlatformPackageManager } from '../permissions.js';
 import {
   copyDirSync,
   issueTemplatesSrcDir,
@@ -35,6 +36,12 @@ export interface InitOptions {
    */
   sessionTitles?: boolean;
   languages?: LanguageToolchain[] | undefined;
+  /**
+   * Platform-scoped package managers (brew on macOS, apt/dpkg on Linux) to
+   * include in auto-allowed permissions. When omitted, `initAction` calls
+   * `detectPlatforms()` to infer from `process.platform`.
+   */
+  platforms?: PlatformPackageManager[] | undefined;
   targetDir?: string;
   yes?: boolean;
   /** When true, suppresses the welcome banner and uses "Upgrade" in the completion message. */
@@ -93,6 +100,14 @@ export async function initAction(opts: InitOptions = {}): Promise<void> {
     }
   }
 
+  // 5c. Platform-scoped package managers (brew on macOS, apt/dpkg on Linux).
+  // Auto-detected silently from `process.platform` — no interactive prompt.
+  // Pass `opts.platforms` to override (e.g. from an integration test).
+  let platformManagers: PlatformPackageManager[] | undefined;
+  if (deployPermissions) {
+    platformManagers = opts.platforms ?? detectPlatforms();
+  }
+
   // 5b. Session-title hook (Claude only). Default on; opt out via --no-session-titles.
   const deploySessionTitles = opts.sessionTitles ?? true;
 
@@ -124,11 +139,11 @@ export async function initAction(opts: InitOptions = {}): Promise<void> {
 
   for (const a of agentsToSetup) {
     if (a === 'gemini') {
-      deployedFiles['gemini'] = await gemini.deploy(targetDir, deployPermissions && deployLocation === 'repo', languages);
+      deployedFiles['gemini'] = await gemini.deploy(targetDir, deployPermissions && deployLocation === 'repo', languages, platformManagers);
     } else if (a === 'claude') {
       deployedFiles['claude'] = await claude.deploy(targetDir, 'none', deployLocation);
       if (deployPermissions) {
-        claude.writePermissions(targetDir, deployLocation, languages);
+        claude.writePermissions(targetDir, deployLocation, languages, platformManagers);
       }
       if (deploySessionTitles) {
         const hookRel = claude.deploySessionTitleHookScript(targetDir, deployLocation);
@@ -156,6 +171,7 @@ export async function initAction(opts: InitOptions = {}): Promise<void> {
     issueTemplates: deployIssueTemplates,
     sessionTitles: deploySessionTitles,
     languages,
+    platforms: platformManagers,
     files: deployedFiles,
   });
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -20,6 +20,12 @@ export interface SmithyManifest {
   /** Whether the Claude Code session-title UserPromptSubmit hook was deployed. */
   sessionTitles?: boolean;
   languages?: string[] | undefined;
+  /**
+   * Platform package managers that were active when the manifest was written
+   * (e.g. `['mac']`, `['linux']`). Stored for debugging/introspection only —
+   * `update` re-detects from `process.platform` rather than round-tripping.
+   */
+  platforms?: string[] | undefined;
   files: Record<string, string[]>;  // agent name → relative file paths
 }
 
@@ -95,6 +101,7 @@ export interface WriteManifestOptions {
   issueTemplates: boolean;
   sessionTitles?: boolean;
   languages?: string[] | undefined;
+  platforms?: string[] | undefined;
   files: Record<string, string[]>;
 }
 
@@ -114,6 +121,7 @@ export function writeManifest(opts: WriteManifestOptions): void {
     issueTemplates: opts.issueTemplates,
     ...(opts.sessionTitles !== undefined ? { sessionTitles: opts.sessionTitles } : {}),
     ...(opts.languages !== undefined ? { languages: opts.languages } : {}),
+    ...(opts.platforms !== undefined ? { platforms: opts.platforms } : {}),
     files: opts.files,
   };
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));

--- a/src/permissions.test.ts
+++ b/src/permissions.test.ts
@@ -169,3 +169,170 @@ describe('flattenPermissions', () => {
     expect(result.some(e => e.startsWith('python'))).toBe(false);
   });
 });
+
+describe('flattenPermissions — platform filtering', () => {
+  it('includes brew, apt, apt-cache, dpkg by default (no filter)', () => {
+    const all = flattenPermissions();
+    expect(all).toContain('brew list');
+    expect(all).toContain('apt list --installed');
+    expect(all).toContain('apt-cache search *');
+    expect(all).toContain('dpkg -l');
+  });
+
+  it('filter ["mac"] includes brew, excludes apt/apt-cache/dpkg', () => {
+    const result = flattenPermissions([], ['mac']);
+    expect(result).toContain('brew list');
+    expect(result).toContain('brew --version');
+    expect(result).toContain('brew info *');
+    expect(result.some(e => e.startsWith('apt ') || e === 'apt' || e.startsWith('apt-cache') || e.startsWith('dpkg'))).toBe(false);
+    expect(result).toContain('git status'); // universal still present
+  });
+
+  it('filter ["linux"] includes apt/apt-cache/dpkg, excludes brew', () => {
+    const result = flattenPermissions([], ['linux']);
+    expect(result).toContain('apt list');
+    expect(result).toContain('apt-cache search *');
+    expect(result).toContain('dpkg -l');
+    expect(result.some(e => e.startsWith('brew'))).toBe(false);
+  });
+
+  it('filter [] (empty platforms) excludes all platform-scoped managers', () => {
+    const result = flattenPermissions([], []);
+    expect(result.some(e => e.startsWith('brew'))).toBe(false);
+    expect(result.some(e => e.startsWith('apt ') || e === 'apt' || e.startsWith('apt-cache'))).toBe(false);
+    expect(result.some(e => e.startsWith('dpkg'))).toBe(false);
+    expect(result).toContain('git status');
+  });
+
+  it('platform filter is independent of language filter', () => {
+    const result = flattenPermissions(['python'], ['mac']);
+    expect(result).toContain('brew list');
+    expect(result).toContain('uv --version');
+    expect(result.some(e => e.startsWith('apt-cache'))).toBe(false);
+    expect(result.some(e => e.startsWith('cargo'))).toBe(false);
+  });
+});
+
+describe('flattenPermissions — mutating package-manager commands are NOT auto-allowed', () => {
+  const all = flattenPermissions();
+
+  it('does not auto-allow brew install/uninstall/upgrade/reinstall/update/cleanup/tap with arg', () => {
+    expect(all).not.toContain('brew install *');
+    expect(all).not.toContain('brew uninstall *');
+    expect(all).not.toContain('brew upgrade *');
+    expect(all).not.toContain('brew reinstall *');
+    expect(all).not.toContain('brew update');
+    expect(all).not.toContain('brew cleanup *');
+    expect(all).not.toContain('brew tap *');
+    expect(all.some(e => /^brew (install|uninstall|upgrade|reinstall|cleanup|update|tap) /.test(e))).toBe(false);
+  });
+
+  it('does not auto-allow apt install/remove/upgrade/update/purge/autoremove', () => {
+    expect(all).not.toContain('apt install *');
+    expect(all).not.toContain('apt remove *');
+    expect(all).not.toContain('apt upgrade *');
+    expect(all).not.toContain('apt update');
+    expect(all).not.toContain('apt purge *');
+    expect(all).not.toContain('apt autoremove');
+    expect(all.some(e => /^apt (install|remove|upgrade|update|purge|autoremove)/.test(e))).toBe(false);
+  });
+
+  it('does not auto-allow dpkg -i / -r / -P (install/remove/purge)', () => {
+    expect(all).not.toContain('dpkg -i *');
+    expect(all).not.toContain('dpkg --install *');
+    expect(all).not.toContain('dpkg -r *');
+    expect(all).not.toContain('dpkg -P *');
+    expect(all).not.toContain('dpkg --remove *');
+    expect(all).not.toContain('dpkg --purge *');
+  });
+
+  it('does not auto-allow uv global installs, uv remove, uv run, uv self update, uv publish', () => {
+    expect(all).not.toContain('uv tool install *');
+    expect(all).not.toContain('uv tool uninstall *');
+    expect(all).not.toContain('uv tool upgrade *');
+    expect(all).not.toContain('uv python install *');
+    expect(all).not.toContain('uv python uninstall *');
+    expect(all).not.toContain('uv remove *');
+    expect(all).not.toContain('uv self update');
+    expect(all).not.toContain('uv publish *');
+    expect(all.some(e => e.startsWith('uv run'))).toBe(false);
+  });
+
+  it('does not auto-allow cargo install/uninstall/publish/login/logout/owner/yank/remove', () => {
+    expect(all).not.toContain('cargo install *');
+    expect(all).not.toContain('cargo uninstall *');
+    expect(all).not.toContain('cargo publish *');
+    expect(all).not.toContain('cargo publish');
+    expect(all).not.toContain('cargo login');
+    expect(all).not.toContain('cargo logout');
+    expect(all).not.toContain('cargo owner *');
+    expect(all).not.toContain('cargo yank *');
+    expect(all).not.toContain('cargo remove *');
+  });
+});
+
+describe('flattenPermissions — cargo dependency management additions', () => {
+  it('includes cargo add/update/fetch/generate-lockfile/package/vendor under rust toolchain', () => {
+    const result = flattenPermissions(['rust']);
+    expect(result).toContain('cargo add *');
+    expect(result).toContain('cargo update');
+    expect(result).toContain('cargo update *');
+    expect(result).toContain('cargo fetch');
+    expect(result).toContain('cargo fetch *');
+    expect(result).toContain('cargo generate-lockfile');
+    expect(result).toContain('cargo package');
+    expect(result).toContain('cargo vendor');
+  });
+
+  it('includes cargo query commands under rust toolchain', () => {
+    const result = flattenPermissions(['rust']);
+    expect(result).toContain('cargo --version');
+    expect(result).toContain('cargo search *');
+    expect(result).toContain('cargo info *');
+    expect(result).toContain('cargo pkgid');
+    expect(result).toContain('cargo locate-project');
+    expect(result).toContain('cargo verify-project');
+  });
+
+  it('preserves pre-existing cargo entries under rust toolchain', () => {
+    const result = flattenPermissions(['rust']);
+    expect(result).toContain('cargo build *');
+    expect(result).toContain('cargo test *');
+    expect(result).toContain('cargo fmt *');
+    expect(result).toContain('cargo clippy *');
+  });
+});
+
+describe('flattenPermissions — uv permissions', () => {
+  it('includes uv project-dep commands when python toolchain is selected', () => {
+    const result = flattenPermissions(['python']);
+    expect(result).toContain('uv --version');
+    expect(result).toContain('uv add *');
+    expect(result).toContain('uv sync');
+    expect(result).toContain('uv sync *');
+    expect(result).toContain('uv lock');
+    expect(result).toContain('uv pip install *');
+    expect(result).toContain('uv pip install -r *');
+    expect(result).toContain('uv pip freeze');
+    expect(result).toContain('uv pip list');
+    expect(result).toContain('uv venv');
+  });
+
+  it('excludes uv entries when python toolchain is not selected', () => {
+    const nodeOnly = flattenPermissions(['node']);
+    expect(nodeOnly.some(e => e.startsWith('uv '))).toBe(false);
+  });
+});
+
+describe('flattenPermissions — regression guard for existing install auto-allows', () => {
+  it('keeps existing project-dep install auto-allows intact', () => {
+    const all = flattenPermissions();
+    expect(all).toContain('npm install');
+    expect(all).toContain('npm ci');
+    expect(all).toContain('pip install *');
+    expect(all).toContain('pip install -r *');
+    expect(all).toContain('python -m pip install *');
+    expect(all).toContain('python -m pip install -r *');
+    expect(all).toContain('nodenv install *');
+  });
+});

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -260,9 +260,12 @@ export const permissions: Record<string, PermissionEntry> = {
   },
 
   // --- Homebrew (macOS) — read-only queries only ---
-  // Platform-scoped: included only when `['mac']` is in the platforms filter.
-  // Install/uninstall/upgrade/reinstall/cleanup/tap with arg intentionally
-  // omitted — they mutate the global system and require explicit approval.
+  // Platform-scoped when callers pass the `platformManagers` filter: `brew`
+  // is then included only for `['mac']`. If `platformManagers` is omitted,
+  // `flattenPermissions()` includes all platform-manager keys for backward
+  // compatibility. Install/uninstall/upgrade/reinstall/cleanup/tap with arg
+  // intentionally omitted — they mutate the global system and require
+  // explicit approval.
   brew: {
     "--version": [],
     "--prefix": ["", "*"],
@@ -296,7 +299,10 @@ export const permissions: Record<string, PermissionEntry> = {
   },
 
   // --- apt (Debian/Ubuntu) — read-only queries only ---
-  // Platform-scoped: included only when `['linux']` is in the platforms filter.
+  // Platform-scoped when callers pass the `platformManagers` filter: `apt`,
+  // `apt-cache`, and `dpkg` are then included only for `['linux']`. If
+  // `platformManagers` is omitted, `flattenPermissions()` includes all
+  // platform-manager keys for backward compatibility.
   // install/remove/upgrade/update/purge/autoremove intentionally omitted.
   apt: {
     "--version": [],

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -6,7 +6,20 @@ export const toolchains: Record<LanguageToolchain, { label: string; permissionKe
   node:   { label: 'Node.js (npm)',        permissionKeys: ['npm', 'npx', 'nodenv'], markers: ['package.json'] },
   java:   { label: 'Java/Kotlin (Gradle)', permissionKeys: ['./gradlew'],  markers: ['build.gradle', 'build.gradle.kts', 'settings.gradle', 'settings.gradle.kts', 'gradlew'] },
   rust:   { label: 'Rust (Cargo)',         permissionKeys: ['cargo'],               markers: ['Cargo.toml'] },
-  python: { label: 'Python (pip)',         permissionKeys: ['python', 'pip', 'pytest'], markers: ['requirements.txt', 'pyproject.toml', 'setup.py', 'Pipfile'] },
+  python: { label: 'Python (pip)',         permissionKeys: ['python', 'pip', 'pytest', 'uv'], markers: ['requirements.txt', 'pyproject.toml', 'setup.py', 'Pipfile', 'uv.lock'] },
+};
+
+/**
+ * Platform-scoped package managers. Unlike language toolchains (which reflect
+ * user choice), platforms reflect an OS fact: brew on macOS, apt/dpkg on Linux.
+ * `detectPlatforms()` (in `./platform-detect.ts`) matches `process.platform`
+ * against `osPlatforms` to decide which entries to include.
+ */
+export type PlatformPackageManager = 'mac' | 'linux';
+
+export const platforms: Record<PlatformPackageManager, { label: string; permissionKeys: string[]; osPlatforms: NodeJS.Platform[] }> = {
+  mac:   { label: 'Homebrew (macOS)', permissionKeys: ['brew'],                     osPlatforms: ['darwin'] },
+  linux: { label: 'apt/dpkg (Linux)', permissionKeys: ['apt', 'apt-cache', 'dpkg'], osPlatforms: ['linux'] },
 };
 
 export const permissions: Record<string, PermissionEntry> = {
@@ -162,6 +175,11 @@ export const permissions: Record<string, PermissionEntry> = {
   "./gradlew": ["*"],
 
   // --- Cargo (Rust) ---
+  // Project-scoped dependency commands (`add`, `update`, `fetch`,
+  // `generate-lockfile`) mirror the `npm install` / `uv add` policy.
+  // Global/publishing commands — `install`, `uninstall`, `publish`, `login`,
+  // `logout`, `owner`, `yank`, `remove` — stay out of auto-allow so Claude
+  // must ask before touching a global binary or crates.io.
   cargo: {
     "build": ["*"],
     "test": ["*"],
@@ -174,6 +192,23 @@ export const permissions: Record<string, PermissionEntry> = {
     "tree": [],
     "metadata": [],
     "version": [],
+    // Project-scoped dep management
+    "add": ["*"],
+    "update": ["", "*"],
+    "fetch": ["", "*"],
+    "generate-lockfile": [],
+    "package": ["", "*"],
+    "vendor": ["", "*"],
+    // Read-only queries
+    "--version": [],
+    "--list": [],
+    "help": ["", "*"],
+    "search": ["*"],
+    "info": ["*"],
+    "pkgid": ["", "*"],
+    "locate-project": ["", "*"],
+    "verify-project": [],
+    "read-manifest": [],
   },
 
   // --- Python ---
@@ -192,6 +227,127 @@ export const permissions: Record<string, PermissionEntry> = {
     "show": ["*"],
   },
   pytest: ["*"],
+
+  // --- uv (Python) — project-scoped dep management + read-only queries ---
+  // Part of the python toolchain (see `toolchains.python.permissionKeys`).
+  // Excludes globals: `uv tool install/uninstall`, `uv python install`,
+  // `uv remove`, `uv self update`, `uv run *` (arbitrary code), `uv publish`.
+  uv: {
+    "--version": [],
+    "add": ["*"],
+    "sync": ["", "*"],
+    "lock": ["", "*"],
+    "pip install": ["*"],
+    "pip install -r": ["*"],
+    "pip compile": ["*"],
+    "pip freeze": [],
+    "pip list": ["", "*"],
+    "pip show": ["*"],
+    "pip check": [],
+    "pip tree": ["", "*"],
+    "tree": ["", "*"],
+    "venv": ["", "*"],
+    "export": ["", "*"],
+    "cache dir": [],
+    "cache info": [],
+    "python list": ["", "*"],
+    "python find": ["", "*"],
+    "python dir": [],
+    "python pin": ["*"],
+    "tool list": [],
+    "tool dir": [],
+    "help": ["", "*"],
+  },
+
+  // --- Homebrew (macOS) — read-only queries only ---
+  // Platform-scoped: included only when `['mac']` is in the platforms filter.
+  // Install/uninstall/upgrade/reinstall/cleanup/tap with arg intentionally
+  // omitted — they mutate the global system and require explicit approval.
+  brew: {
+    "--version": [],
+    "--prefix": ["", "*"],
+    "--cellar": ["", "*"],
+    "--repository": [],
+    "--cache": [],
+    "config": [],
+    "doctor": [],
+    "list": ["", "*"],
+    "ls": ["", "*"],
+    "leaves": [],
+    "info": ["*"],
+    "desc": ["*"],
+    "search": ["*"],
+    "home": ["*"],
+    "deps": ["*"],
+    "deps --tree": ["*"],
+    "uses": ["*"],
+    "uses --installed": ["*"],
+    "outdated": [],
+    "options": ["*"],
+    "tap-info": ["*"],
+    "analytics": [],
+    "analytics state": [],
+    "commands": [],
+    "help": ["", "*"],
+    "log": ["*"],
+    "cat": ["*"],
+    "formulae": [],
+    "casks": [],
+  },
+
+  // --- apt (Debian/Ubuntu) — read-only queries only ---
+  // Platform-scoped: included only when `['linux']` is in the platforms filter.
+  // install/remove/upgrade/update/purge/autoremove intentionally omitted.
+  apt: {
+    "--version": [],
+    "list": ["", "*"],
+    "list --installed": [],
+    "list --upgradable": [],
+    "search": ["*"],
+    "show": ["*"],
+    "policy": ["", "*"],
+    "depends": ["*"],
+    "rdepends": ["*"],
+    "help": ["", "*"],
+  },
+
+  // --- apt-cache (read-only cache queries; mutation not possible here) ---
+  "apt-cache": {
+    "search": ["*"],
+    "show": ["*"],
+    "showpkg": ["*"],
+    "showsrc": ["*"],
+    "depends": ["*"],
+    "rdepends": ["*"],
+    "pkgnames": ["", "*"],
+    "policy": ["", "*"],
+    "madison": ["*"],
+    "stats": [],
+    "unmet": [],
+  },
+
+  // --- dpkg (query-only subcommands; -i/-r/-P intentionally omitted) ---
+  dpkg: {
+    "--version": [],
+    "-l": ["", "*"],
+    "--list": ["", "*"],
+    "-L": ["*"],
+    "--listfiles": ["*"],
+    "-s": ["*"],
+    "--status": ["*"],
+    "-S": ["*"],
+    "--search": ["*"],
+    "-p": ["*"],
+    "--print-avail": ["*"],
+    "-c": ["*"],
+    "--contents": ["*"],
+    "-I": ["*"],
+    "--info": ["*"],
+    "--get-selections": ["", "*"],
+    "--print-architecture": [],
+    "--compare-versions": ["*"],
+    "--help": [],
+  },
 
   // --- GitHub CLI ---
   // Entries with ["", "*"] generate both bare and wildcard permissions,
@@ -282,31 +438,56 @@ function toolchainPermissionKeys(): Set<string> {
 }
 
 /**
+ * Collect all permission keys that belong to platform-scoped package managers.
+ */
+function platformPermissionKeys(): Set<string> {
+  const keys = new Set<string>();
+  for (const p of Object.values(platforms)) {
+    for (const k of p.permissionKeys) keys.add(k);
+  }
+  return keys;
+}
+
+/**
  * Flatten the nested permissions structure into a list of command strings.
  * e.g., git.checkout ["*"] -> ["git checkout *"]
  *        cp ["*"] -> ["cp *"]
  *        npm."run build" [] -> ["npm run build"]
  *
- * When `languages` is provided, only the specified toolchain permissions are
- * included alongside universal (non-toolchain) permissions. When omitted,
- * all permissions are included (backward compatible).
+ * Filtering: `languages` and `platformManagers` each gate their own key set.
+ * When either is `undefined`, that category's keys are all included
+ * (backward compatible). When provided (even as `[]`), only keys belonging
+ * to the selected toolchains / platforms are kept; the rest are skipped.
+ * Universal permissions (those not owned by any toolchain or platform)
+ * are always included.
  */
-export function flattenPermissions(languages?: LanguageToolchain[]): string[] {
+export function flattenPermissions(
+  languages?: LanguageToolchain[],
+  platformManagers?: PlatformPackageManager[],
+): string[] {
   const result: string[] = [];
 
-  // Build the set of toolchain keys to skip (if filtering)
-  let skipKeys: Set<string> | undefined;
+  // Build the set of keys to skip based on toolchain + platform filters.
+  const skipKeys = new Set<string>();
   if (languages !== undefined) {
     const allToolchainKeys = toolchainPermissionKeys();
     const selectedKeys = new Set<string>();
     for (const lang of languages) {
       for (const k of toolchains[lang].permissionKeys) selectedKeys.add(k);
     }
-    skipKeys = new Set([...allToolchainKeys].filter(k => !selectedKeys.has(k)));
+    for (const k of allToolchainKeys) if (!selectedKeys.has(k)) skipKeys.add(k);
+  }
+  if (platformManagers !== undefined) {
+    const allPlatformKeys = platformPermissionKeys();
+    const selectedKeys = new Set<string>();
+    for (const p of platformManagers) {
+      for (const k of platforms[p].permissionKeys) selectedKeys.add(k);
+    }
+    for (const k of allPlatformKeys) if (!selectedKeys.has(k)) skipKeys.add(k);
   }
 
   for (const [cmd, value] of Object.entries(permissions)) {
-    if (skipKeys?.has(cmd)) continue;
+    if (skipKeys.has(cmd)) continue;
     if (Array.isArray(value)) {
       if (value.length === 0) {
         result.push(cmd);

--- a/src/platform-detect.test.ts
+++ b/src/platform-detect.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { detectPlatforms } from './platform-detect.js';
 
 describe('detectPlatforms', () => {
-  const originalPlatform = process.platform;
+  const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
 
   afterEach(() => {
-    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+    }
   });
 
   it('returns ["mac"] on darwin', () => {

--- a/src/platform-detect.test.ts
+++ b/src/platform-detect.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { detectPlatforms } from './platform-detect.js';
+
+describe('detectPlatforms', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  });
+
+  it('returns ["mac"] on darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+    expect(detectPlatforms()).toEqual(['mac']);
+  });
+
+  it('returns ["linux"] on linux', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    expect(detectPlatforms()).toEqual(['linux']);
+  });
+
+  it('returns [] on win32', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    expect(detectPlatforms()).toEqual([]);
+  });
+
+  it('returns [] on freebsd', () => {
+    Object.defineProperty(process, 'platform', { value: 'freebsd', configurable: true });
+    expect(detectPlatforms()).toEqual([]);
+  });
+
+  it('reads process.platform dynamically on every call', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+    expect(detectPlatforms()).toEqual(['mac']);
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    expect(detectPlatforms()).toEqual(['linux']);
+  });
+});

--- a/src/platform-detect.ts
+++ b/src/platform-detect.ts
@@ -1,8 +1,11 @@
 import { platforms, type PlatformPackageManager } from './permissions.js';
 
 /**
- * Detect which platform-scoped package managers are available on the current
+ * Detect which platform-scoped package managers are applicable to the current
  * OS by matching `process.platform` against each entry's `osPlatforms` list.
+ *
+ * This only filters by OS compatibility; it does not check whether any
+ * package-manager executable is installed or available on `PATH`.
  *
  * Reads `process.platform` dynamically on every call so tests can override it
  * via `Object.defineProperty(process, 'platform', { value: 'darwin' })`.

--- a/src/platform-detect.ts
+++ b/src/platform-detect.ts
@@ -1,0 +1,19 @@
+import { platforms, type PlatformPackageManager } from './permissions.js';
+
+/**
+ * Detect which platform-scoped package managers are available on the current
+ * OS by matching `process.platform` against each entry's `osPlatforms` list.
+ *
+ * Reads `process.platform` dynamically on every call so tests can override it
+ * via `Object.defineProperty(process, 'platform', { value: 'darwin' })`.
+ */
+export function detectPlatforms(): PlatformPackageManager[] {
+  const current = process.platform;
+  const detected: PlatformPackageManager[] = [];
+
+  for (const [name, spec] of Object.entries(platforms) as [PlatformPackageManager, typeof platforms[PlatformPackageManager]][]) {
+    if (spec.osPlatforms.includes(current)) detected.push(name);
+  }
+
+  return detected;
+}


### PR DESCRIPTION
## Summary

Auto-allows read-only queries for common package managers so Claude can answer "is brew/apt/uv installed?" or inspect package metadata without a permission prompt, while keeping global installs/uninstalls behind explicit approval — per the policy the issue commenter locked in.

- **Platform-scoped**: new `platforms` record + `detectPlatforms()` reads `process.platform` so `brew` ships only on `darwin` and `apt`/`apt-cache`/`dpkg` only on `linux`. Detection is silent (no prompt); `InitOptions.platforms?` exists for programmatic override. `update` re-detects rather than round-tripping the manifest value, so a macOS-born manifest replayed on Linux does the right thing.
- **uv joins the python toolchain** (plus `uv.lock` as a marker). Project-scoped commands (`uv add`, `uv sync`, `uv lock`, `uv pip install`, read-only queries) are auto-allowed. Globals (`uv tool install`, `uv python install`, `uv remove`, `uv self update`, `uv run *`, `uv publish`) stay gated.
- **cargo parity with npm/uv**: existing build/test/clippy/fmt entries remain; adds dep-management (`cargo add`, `cargo update`, `cargo fetch`, `cargo generate-lockfile`, `cargo package`, `cargo vendor`) and queries (`cargo search`, `cargo info`, `cargo pkgid`, `cargo locate-project`, `cargo verify-project`). `cargo install`, `cargo uninstall`, `cargo publish`, `cargo login/logout/owner/yank` remain gated.
- **brew / apt / apt-cache / dpkg**: only queries (list, info, search, show, deps, policy, `-l`/`-L`/`-s`/`-S`, etc.). All mutating subcommands are absent from the allow list.
- **Existing install auto-allows preserved** per explicit user direction: `npm install`, `npm ci`, `pip install`, `python -m pip install`, `nodenv install` are untouched.
- **Plumbing**: `flattenPermissions(languages?, platformManagers?)` threads both filters through `buildClaudeAllowList` / `buildGeminiAllowList` / `writePermissions` / `gemini.deploy`. Manifest gains an optional `platforms?: string[]` field (additive, stays at version 1).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 594 / 594 passing (includes new assertions covering platform filtering, cargo additions, uv permissions, negative assertions for brew/apt/dpkg/uv/cargo install commands, and regression guards)
- [x] `npm run build` — `dist/cli.js` rebuilds cleanly
- [x] Smoke test on Linux: `node dist/cli.js init --yes` into a fresh dir produced `.claude/settings.json` with `Bash(apt list)`, `Bash(dpkg -l)`, `Bash(uv add *)`, `Bash(cargo add *)` present; zero `Bash(brew ...)` entries; no `Bash(apt install *)`, `Bash(uv tool install *)`, or `Bash(cargo install *)`. Manifest recorded `platforms: ['linux']`.
- [ ] Manual macOS smoke test (not runnable in this environment — please verify that `init` writes `Bash(brew list)` and excludes `apt`/`dpkg`)

Closes #228