### PR TITLE
Define Graph Types and Repair JSON Stub (US10 Slice 1)

### DIFF
--- a/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
@@ -27,7 +27,7 @@
   - The module-level JSDoc in `types.ts` is updated so the "still owned by User Story 10" note on `DependencyGraph` / `DependencyNode` reads accurately for their new landed state.
   - `npm run typecheck` and `npm test` pass with no new errors.
 
-- [ ] **Re-type `StatusJsonPayload.graph` as `DependencyGraph`**
+- [x] **Re-type `StatusJsonPayload.graph` as `DependencyGraph`**
 
   Replace the local inline type on the `graph` field of `StatusJsonPayload` in `src/commands/status.ts` with the imported `DependencyGraph`. The existing zero-value object literal (`{ nodes: {}, layers: [], cycles: [], dangling_refs: [] }`) already satisfies the new type — the runtime emission is unchanged in this slice. Slice 3 replaces that literal with a live `buildDependencyGraph(records)` call.
 

--- a/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Add `DependencyGraph` and `DependencyNode` to the status type surface**
+- [x] **Add `DependencyGraph` and `DependencyNode` to the status type surface**
 
   Extend `src/status/types.ts` with `DependencyNode` and `DependencyGraph` per data-model §6. `DependencyNode` carries `record_path`, `row`, and the rolled-up `status`. `DependencyGraph` carries `nodes` (keyed by fully-qualified `<artifact-path>#<row-id>` IDs), `layers`, `cycles`, and `dangling_refs`. The existing `export * from './types.js'` re-export in `src/status/index.ts` picks both up automatically.
 

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatSummaryHeader, pickTopNextAction } from './status.js';
+import {
+  formatSummaryHeader,
+  pickTopNextAction,
+  type StatusJsonPayload,
+} from './status.js';
 import type {
   ArtifactRecord,
+  DependencyGraph,
   NextAction,
   ScanSummary,
   StatusTree,
@@ -369,5 +374,82 @@ describe('pickTopNextAction', () => {
       ],
     };
     expect(pickTopNextAction(tree)).toEqual(secondAction);
+  });
+});
+
+/**
+ * US10 Slice 1: lock in the type wiring between the JSON payload's
+ * `graph` field and the canonical {@link DependencyGraph} type. The
+ * compile-time assertions below would have failed against the
+ * previous inline structural type (`Record<string, never>` / `[]`
+ * literal tuples) because a populated `DependencyGraph` is not
+ * assignable to that shape. The runtime guard re-checks the
+ * zero-value stub still slots into the new type.
+ */
+describe('StatusJsonPayload.graph type wiring (US10 Slice 1)', () => {
+  it('accepts a populated DependencyGraph as the graph field', () => {
+    const fqId = 'specs/sample/sample.spec.md#US1';
+    const populated: DependencyGraph = {
+      nodes: {
+        [fqId]: {
+          record_path: 'specs/sample/sample.spec.md',
+          row: {
+            id: 'US1',
+            title: 'Sample story',
+            depends_on: [],
+            artifact_path: null,
+          },
+          status: 'not-started',
+        },
+      },
+      layers: [{ layer: 0, node_ids: [fqId] }],
+      cycles: [],
+      dangling_refs: [],
+    };
+    // Compile-time assertion: assigning a populated DependencyGraph
+    // to the `graph` field must typecheck. Under the previous inline
+    // type this would have produced TS2322 because `Record<string,
+    // DependencyNode>` is not assignable to `Record<string, never>`.
+    const payload: StatusJsonPayload = {
+      summary: {
+        counts: emptyCounts(),
+        orphan_count: 0,
+        broken_link_count: 0,
+        parse_error_count: 0,
+      },
+      records: [],
+      tree: { roots: [] },
+      graph: populated,
+    };
+    expect(payload.graph.nodes[fqId]?.record_path).toBe(
+      'specs/sample/sample.spec.md',
+    );
+    expect(payload.graph.layers[0]?.node_ids).toEqual([fqId]);
+  });
+
+  it('still accepts the zero-value runtime stub (Slice 1 emission unchanged)', () => {
+    // Mirrors the literal currently emitted by `statusAction` in JSON
+    // mode — Slice 3 swaps it for `buildDependencyGraph(records)`.
+    const stub: DependencyGraph = {
+      nodes: {},
+      layers: [],
+      cycles: [],
+      dangling_refs: [],
+    };
+    const payload: StatusJsonPayload = {
+      summary: {
+        counts: emptyCounts(),
+        orphan_count: 0,
+        broken_link_count: 0,
+        parse_error_count: 0,
+      },
+      records: [],
+      tree: { roots: [] },
+      graph: stub,
+    };
+    expect(payload.graph.nodes).toEqual({});
+    expect(payload.graph.layers).toEqual([]);
+    expect(payload.graph.cycles).toEqual([]);
+    expect(payload.graph.dangling_refs).toEqual([]);
   });
 });

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -13,9 +13,11 @@
  *      roll-up summary header followed by a hierarchical tree with
  *      next-action hints (default, via {@link renderTree} with
  *      `renderHints: true`). The JSON `tree` field is populated via
- *      {@link buildTree} (US2 Slice 1); the `graph` field is still
- *      stubbed and owned by US10. The top-level JSON shape is stable
- *      from US1 onward so consumers can depend on it today.
+ *      {@link buildTree} (US2 Slice 1); the `graph` field is typed
+ *      as the canonical {@link DependencyGraph} (US10 Slice 1) but
+ *      the runtime still emits a zero-value graph object until the
+ *      builder lands in US10 Slice 3. The top-level JSON shape is
+ *      stable from US1 onward so consumers can depend on it today.
  *   6. On an empty repo (no discovered artifacts), print a friendly hint
  *      pointing at `smithy.ignite` / `smithy.mark` and exit 0 — the
  *      contracts treat this as "not an error".
@@ -31,8 +33,8 @@
  * transform inserted between `buildTree` and `renderTree` (US3); JSON
  * mode continues to emit the uncollapsed tree structure
  * unconditionally. Remaining stubs (`--graph`, `--no-color`) are
- * accepted but have no behavioral effect — US10 wires `--graph`; a
- * colored renderer will wire `--no-color`.
+ * accepted but have no behavioral effect — US10 Slice 3 wires
+ * `--graph`; a colored renderer will wire `--no-color`.
  */
 
 import fs from 'node:fs';
@@ -51,6 +53,7 @@ import { buildTheme, type Theme } from '../status/theme.js';
 import type {
   ArtifactRecord,
   ArtifactType,
+  DependencyGraph,
   ScanSummary,
   Status,
   StatusTree,
@@ -89,7 +92,7 @@ export interface StatusOptions {
    * uncollapsed `buildTree(records)` structure.
    */
   all?: boolean;
-  /** Stub: render the cross-artifact graph. Parsed but not wired (US2/US10). */
+  /** Stub: render the cross-artifact graph. Parsed but not wired — US10 Slice 3 wires it. */
   graph?: boolean;
   /**
    * Suppress ANSI colors. Set by Commander's `--no-color` flag (produces
@@ -107,20 +110,19 @@ export interface StatusOptions {
 
 /**
  * Contract-shaped JSON payload emitted by `--format json`. `tree` is
- * now populated by {@link buildTree} (US2 Slice 1); `graph` is still a
- * stub owned by US10. The keys are emitted unconditionally so machine
- * consumers can depend on the top-level shape.
+ * populated by {@link buildTree} (US2 Slice 1); `graph` is typed as the
+ * canonical {@link DependencyGraph} (US10 Slice 1) but the runtime
+ * still emits a zero-value graph object. The graph builder (US10
+ * Slice 2) and live wiring (US10 Slice 3) replace the stub literal
+ * with `buildDependencyGraph(records)` in subsequent slices. The keys
+ * are emitted unconditionally so machine consumers can depend on the
+ * top-level shape.
  */
-interface StatusJsonPayload {
+export interface StatusJsonPayload {
   summary: ScanSummary;
   records: ArtifactRecord[];
   tree: StatusTree;
-  graph: {
-    nodes: Record<string, never>;
-    layers: [];
-    cycles: [];
-    dangling_refs: [];
-  };
+  graph: DependencyGraph;
 }
 
 /**

--- a/src/status/types.test.ts
+++ b/src/status/types.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+// Import through the `./index.js` barrel so these tests assert that the
+// new graph types are re-exported on the stable public surface.
+import {
+  type DependencyGraph,
+  type DependencyNode,
+  type DependencyRow,
+} from './index.js';
+
+/**
+ * Compile-time + runtime assertions that `DependencyGraph` and
+ * `DependencyNode` exist on the public surface and match the shape
+ * documented in `smithy-status-skill.data-model.md` §6.
+ *
+ * These tests are deliberately lightweight: TypeScript catches any
+ * missing fields or mistyped fields at compile time when the literals
+ * below are annotated with the imported interface; the runtime
+ * `expect(...).toBeDefined()` calls just guarantee the file is exercised
+ * by `vitest run` so a regression on the type surface is surfaced as a
+ * failing build / failing test, not a silent type drift.
+ */
+describe('status type surface — DependencyGraph / DependencyNode', () => {
+  it('DependencyNode wraps record_path, row, and rolled-up status', () => {
+    const row: DependencyRow = {
+      id: 'US1',
+      title: 'Sample story',
+      depends_on: [],
+      artifact_path: null,
+    };
+    const node: DependencyNode = {
+      record_path: 'specs/sample/sample.spec.md',
+      row,
+      status: 'not-started',
+    };
+    expect(node.record_path).toBe('specs/sample/sample.spec.md');
+    expect(node.row.id).toBe('US1');
+    expect(node.status).toBe('not-started');
+  });
+
+  it('DependencyGraph carries nodes (FQ-keyed), layers (with node_ids), cycles, and dangling_refs', () => {
+    const fqId = 'specs/sample/sample.spec.md#US1';
+    const row: DependencyRow = {
+      id: 'US1',
+      title: 'Sample story',
+      depends_on: [],
+      artifact_path: null,
+    };
+    const graph: DependencyGraph = {
+      nodes: {
+        [fqId]: {
+          record_path: 'specs/sample/sample.spec.md',
+          row,
+          status: 'not-started',
+        },
+      },
+      layers: [{ layer: 0, node_ids: [fqId] }],
+      cycles: [],
+      dangling_refs: [],
+    };
+
+    expect(Object.keys(graph.nodes)).toEqual([fqId]);
+    expect(graph.layers).toHaveLength(1);
+    expect(graph.layers[0]?.layer).toBe(0);
+    expect(graph.layers[0]?.node_ids).toEqual([fqId]);
+    expect(graph.cycles).toEqual([]);
+    expect(graph.dangling_refs).toEqual([]);
+  });
+
+  it('DependencyGraph supports cycles and dangling_refs entries', () => {
+    const a = 'specs/a.spec.md#US1';
+    const b = 'specs/a.spec.md#US2';
+    const graph: DependencyGraph = {
+      nodes: {},
+      layers: [],
+      cycles: [[a, b]],
+      dangling_refs: [{ source_id: a, missing_id: 'specs/a.spec.md#US99' }],
+    };
+
+    expect(graph.cycles[0]).toEqual([a, b]);
+    expect(graph.dangling_refs[0]).toEqual({
+      source_id: a,
+      missing_id: 'specs/a.spec.md#US99',
+    });
+  });
+});

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -10,8 +10,10 @@
  * The type surface grows incrementally story-by-story. User Story 1 shipped
  * `ArtifactRecord`, `NextAction`, `DependencyRow`, `DependencyOrderTable`,
  * and `ScanSummary`; User Story 2 Slice 1 adds `TreeNode` and `StatusTree`
- * alongside them. `DependencyGraph` / `DependencyNode` are still owned by
- * User Story 10.
+ * alongside them. User Story 10 Slice 1 lands `DependencyNode` and
+ * `DependencyGraph` as the cross-artifact graph type surface — the
+ * builder (`buildDependencyGraph`) and the `--graph` text renderer arrive
+ * in subsequent slices, but the types are now stable for downstream use.
  */
 
 /**
@@ -238,4 +240,65 @@ export interface ScanSummary {
   broken_link_count: number;
   /** Records with `status === 'unknown'`. */
   parse_error_count: number;
+}
+
+/**
+ * One node in the cross-artifact {@link DependencyGraph}. A thin wrapper
+ * carrying the owning {@link ArtifactRecord}'s path, the underlying
+ * {@link DependencyRow}, and the rolled-up {@link Status} that the
+ * classifier computed for that record. Per data-model §6, the `status`
+ * here is the owning record's classified status (derived from the
+ * downstream artifact), not a status synthesized from the row alone.
+ */
+export interface DependencyNode {
+  /** Repo-relative path to the owning {@link ArtifactRecord}. */
+  record_path: string;
+  /** The underlying parsed dependency-order row. */
+  row: DependencyRow;
+  /** Rolled-up status from the owning {@link ArtifactRecord}. */
+  status: ArtifactRecord['status'];
+}
+
+/**
+ * The cross-artifact DAG built by unioning every artifact's
+ * {@link DependencyOrderTable} and stitching nodes together via
+ * `artifact_path` links. Mirrors `smithy-status-skill.data-model.md` §6
+ * exactly.
+ *
+ * Nodes are keyed by fully-qualified ID — `<artifact-path>#<row-id>`
+ * (e.g., `specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.spec.md#US2`).
+ * Fully-qualified IDs allow the same short ID (`US1`) to appear in
+ * multiple specs without collision.
+ *
+ * Per SD-012, the per-layer ID array is canonically named `node_ids`
+ * (the data-model + contracts wording). The AS 10.5 prose reads
+ * `ids: string[]`; that drift is tracked as SD-012 and resolved in
+ * favor of `node_ids` here.
+ */
+export interface DependencyGraph {
+  /**
+   * All nodes in the graph, keyed by fully-qualified
+   * `<artifact-path>#<row-id>` ID.
+   */
+  nodes: Record<string, DependencyNode>;
+  /**
+   * Topological layers. Layer 0 contains nodes with no incoming edges in
+   * the unioned graph; each subsequent layer contains nodes whose
+   * dependencies are all in earlier layers. Used directly by the
+   * `--graph` renderer.
+   */
+  layers: Array<{ layer: number; node_ids: string[] }>;
+  /**
+   * Each inner array is a cycle's participating fully-qualified node IDs
+   * in traversal order. Empty when the graph is a DAG. Non-empty cycles
+   * suppress layer computation for the nodes involved and trigger a
+   * structured warning.
+   */
+  cycles: string[][];
+  /**
+   * Any `depends_on` references the parser could not resolve — surfaced
+   * on the corresponding {@link ArtifactRecord} as warnings but retained
+   * here for JSON consumers.
+   */
+  dangling_refs: Array<{ source_id: string; missing_id: string }>;
 }


### PR DESCRIPTION
## Source

- Spec: [`specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.spec.md`](../blob/master/specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.spec.md)
- Tasks: [`specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md`](../blob/master/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md)

## Slice

**Slice 1 of 3 — Define Graph Types and Repair JSON Stub**

> `DependencyGraph` and `DependencyNode` exist as first-class exported types, and `StatusJsonPayload.graph` is re-typed to `DependencyGraph`. The runtime continues to emit a zero-value graph object that satisfies the new type — no user-observable change, but downstream slices can import the types from the stable module entry point.

## Addresses

- **FR-026** — data-model contract alignment for the status JSON payload's `graph` field.
- **AS 10.5** — shape only at this slice; values still empty (the live builder lands in Slice 2 and is wired in Slice 3).

## Tasks completed

- [x] Add `DependencyGraph` and `DependencyNode` to the status type surface (`src/status/types.ts`, re-exported through `src/status/index.ts`; module JSDoc refreshed).
- [x] Re-type `StatusJsonPayload.graph` as `DependencyGraph` in `src/commands/status.ts` — the existing zero-value runtime stub still satisfies the new type, JSON gating unchanged.

Both types match `smithy-status-skill.data-model.md` §6 exactly, including the canonical `node_ids` field on each layer per the SD-012 reconciliation in favor of the data-model + contracts wording over the AS 10.5 prose typo.

## Review

`smithy-implementation-review` returned **no findings**. Notes from the reviewer:

- Implementation is tight and on-scope; the runtime literal in `statusAction` is correctly unchanged and the JSON gating is unchanged.
- New tests in `src/status/types.test.ts` and `src/commands/status.test.ts` exercise the FQ-key convention, the `node_ids` field name, the cycles `string[][]` shape, the dangling-ref structure, and the assignability of both a populated and a zero-value `DependencyGraph` to `StatusJsonPayload.graph`. Each test catches a real regression (would have failed against the previous `Record<string, never>` / empty-tuple inline type).
- `StatusJsonPayload` is now exported (was previously internal) so the type-wiring test can reference it without copy-pasting the shape; reviewer evaluated this as the cleanest option and acceptable.

## Documentation

`smithy-maid` returned **clean — no documentation staleness detected**. All forward references to "Slice 2 / Slice 3" are intentional and accurate; SD-012 remains explicitly deferred to Slice 3 per the slice plan.

## Validation

Run on the slice-1 HEAD after both implementation commits landed.

| Command          | Result |
|------------------|--------|
| `npm run build`     | ✅ ESM build success in 32ms (`dist/cli.js` 100.04 KB) |
| `npm run typecheck` | ✅ clean — no errors |
| `npm test`          | ✅ 21 files / **611 tests passed** (was 609 — added 2 type-wiring tests) |

## Specification debt referenced

- **SD-012** — AS 10.5 prose drift (`ids` vs `node_ids`). Implementation adopts `node_ids` (matches data-model §6 + contracts JSON example). Spec-prose reconciliation is tracked for Slice 3's audit task and is **not** silently rewritten in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
