### PR TITLE
Build the cross-artifact dependency graph

### DIFF
--- a/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
@@ -61,7 +61,7 @@
   - Within-layer node order is deterministic: sort by (a) artifact discovery order in the input `records` array, then (b) row order inside each artifact's `## Dependency Order` table (documented as SD-013).
   - The function is pure — no I/O, no mutation of input records — and is re-exported from `src/status/index.ts`.
 
-- [ ] **Stitch cross-artifact edges and emit dangling-reference diagnostics**
+- [x] **Stitch cross-artifact edges and emit dangling-reference diagnostics**
 
   Extend `buildDependencyGraph` so the unioned graph spans the full RFC → features → spec → tasks lineage. A child record's root nodes are blocked by the parent row referencing them (per data-model §Relationships, via `parent_path` + `parent_row_id`). Because the current `parseDependencyTable` drops unresolved intra-table `depends_on` IDs and only records them as warning strings, this task also extends the parse path so each `ArtifactRecord` (or its `DependencyOrderTable`) retains unresolved references in a structured field — the builder must consume that structured metadata (not stringly-typed warnings) to emit `{ source_id, missing_id }` entries in `graph.dangling_refs` with fully-qualified IDs, and to drop those missing edges from the edge set. Virtual records (`virtual: true`) participate as normal graph nodes with their rolled-up `not-started` status — synthetic tree sentinels (`ORPHANED_SPECS_PATH`, `BROKEN_LINKS_PATH`, `ORPHANED_TASKS_PATH`) are excluded from graph construction.
 

--- a/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
@@ -51,7 +51,7 @@
 
 ### Tasks
 
-- [ ] **Implement single-artifact topological layering in `buildDependencyGraph`**
+- [x] **Implement single-artifact topological layering in `buildDependencyGraph`**
 
   Create `src/status/graph.ts` exporting `buildDependencyGraph(records): DependencyGraph`. In this task, the function handles the within-artifact case: each record's `dependency_order.rows` contribute nodes keyed `<record.path>#<row.id>` whose `status` is the rolled-up status from the owning record, and intra-table `depends_on` edges are unioned into the graph. Topological layering uses Kahn's algorithm so Layer 0 contains nodes with no incoming edges. Export the function from `src/status/index.ts`.
 

--- a/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
@@ -73,7 +73,7 @@
   - Virtual records contribute to the graph using their rolled-up `not-started` status; tree sentinel records never appear as graph nodes.
   - Cross-artifact edges are derived exclusively from `parent_path` + `parent_row_id` (populated by the scanner from `artifact_path` links) — never from filename convention.
 
-- [ ] **Detect cycles and exclude cyclic nodes from layer assignment**
+- [x] **Detect cycles and exclude cyclic nodes from layer assignment**
 
   Extend `buildDependencyGraph` so cycles in the unioned graph are recorded in `graph.cycles` as arrays of participating fully-qualified node IDs in traversal order. Nodes involved in any cycle are excluded from every entry in `graph.layers` (layer computation is undefined for cyclic subgraphs per data-model §6). The exact algorithm is left to the implementer; SD-011 (below) records the recommended approach.
 

--- a/src/status/graph.test.ts
+++ b/src/status/graph.test.ts
@@ -499,3 +499,158 @@ describe('buildDependencyGraph — dangling references (AS 10.6)', () => {
     expect(graph.dangling_refs).toEqual([]);
   });
 });
+
+describe('buildDependencyGraph — cycle detection (AS 10.3)', () => {
+  const SPEC_PATH = 'specs/sample/sample.spec.md';
+
+  it('detects a two-node mutual cycle and excludes both nodes from layers', () => {
+    // US1 depends on US2 and US2 depends on US1 — mutual cycle.
+    const spec = makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1', ['US2']), row('US2', ['US1'])],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    expect(graph.cycles.length).toBe(1);
+    const cycle = graph.cycles[0];
+    expect(cycle).toBeDefined();
+    if (cycle === undefined) return;
+    // The cycle entry contains exactly both fully-qualified node IDs;
+    // ordering is deterministic by traversal from the smallest seed.
+    expect([...cycle].sort()).toEqual(
+      [`${SPEC_PATH}#US1`, `${SPEC_PATH}#US2`].sort(),
+    );
+    // The builder does not throw, and neither cyclic node lands in any
+    // layer.
+    for (const layer of graph.layers) {
+      expect(layer.node_ids).not.toContain(`${SPEC_PATH}#US1`);
+      expect(layer.node_ids).not.toContain(`${SPEC_PATH}#US2`);
+    }
+  });
+
+  it('reports cycles as an empty array for a pure DAG (regression)', () => {
+    const spec = makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1'), row('US2', ['US1']), row('US3', ['US2'])],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    expect(graph.cycles).toEqual([]);
+  });
+
+  it('detects a three-node cycle (A→B→C→A) with all three IDs in one entry', () => {
+    // US1 → US2 → US3 → US1 means each row's depends_on points to its
+    // predecessor in the cycle.
+    const spec = makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [
+          row('US1', ['US3']),
+          row('US2', ['US1']),
+          row('US3', ['US2']),
+        ],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    expect(graph.cycles.length).toBe(1);
+    const cycle = graph.cycles[0];
+    expect(cycle).toBeDefined();
+    if (cycle === undefined) return;
+    expect([...cycle].sort()).toEqual(
+      [
+        `${SPEC_PATH}#US1`,
+        `${SPEC_PATH}#US2`,
+        `${SPEC_PATH}#US3`,
+      ].sort(),
+    );
+    expect(graph.layers).toEqual([]);
+  });
+
+  it('layers non-cyclic nodes correctly while excluding cyclic ones from layers', () => {
+    // US1 ↔ US2 form a cycle; US3 is independent and US4 depends on US3.
+    // Both US3 and US4 must be layered correctly while US1 and US2 are
+    // excluded.
+    const spec = makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [
+          row('US1', ['US2']),
+          row('US2', ['US1']),
+          row('US3'),
+          row('US4', ['US3']),
+        ],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    expect(graph.cycles.length).toBe(1);
+    expect(graph.layers).toEqual([
+      { layer: 0, node_ids: [`${SPEC_PATH}#US3`] },
+      { layer: 1, node_ids: [`${SPEC_PATH}#US4`] },
+    ]);
+  });
+
+  it('detects a cross-artifact cycle defensively (parent ↔ child via parent_row_id)', () => {
+    // Defensive case: spec US1 references tasks S1 as its child via the
+    // parent_path / parent_row_id linkage; we engineer a depends_on inside
+    // the spec table that points at... well, we cannot point a spec row at
+    // a tasks row through depends_on (intra-table only). Instead we craft
+    // two spec records where each declares the other as its parent, so
+    // their root rows pin each other across the cross-artifact stitch.
+    const SPEC_A = 'specs/a/a.spec.md';
+    const SPEC_B = 'specs/b/b.spec.md';
+    const specA = makeRecord({
+      type: 'spec',
+      path: SPEC_A,
+      status: 'in-progress',
+      parent_path: SPEC_B,
+      parent_row_id: 'US1',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1')],
+      },
+    });
+    const specB = makeRecord({
+      type: 'spec',
+      path: SPEC_B,
+      status: 'in-progress',
+      parent_path: SPEC_A,
+      parent_row_id: 'US1',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1')],
+      },
+    });
+    const graph = buildDependencyGraph([specA, specB]);
+    expect(graph.cycles.length).toBe(1);
+    const cycle = graph.cycles[0];
+    expect(cycle).toBeDefined();
+    if (cycle === undefined) return;
+    expect([...cycle].sort()).toEqual(
+      [`${SPEC_A}#US1`, `${SPEC_B}#US1`].sort(),
+    );
+    // Neither cyclic node lands in any layer.
+    for (const layer of graph.layers) {
+      expect(layer.node_ids).not.toContain(`${SPEC_A}#US1`);
+      expect(layer.node_ids).not.toContain(`${SPEC_B}#US1`);
+    }
+  });
+});

--- a/src/status/graph.test.ts
+++ b/src/status/graph.test.ts
@@ -257,3 +257,245 @@ describe('buildDependencyGraph — synthetic tree sentinels are excluded', () =>
     expect(graph.layers).toEqual([]);
   });
 });
+
+describe('buildDependencyGraph — cross-artifact stitching (AS 10.2)', () => {
+  // AS 10.2 fixture: a spec lists US1 and US2; a tasks file (the child
+  // of US1 per `parent_path` / `parent_row_id`) lists S1 and S2 (S2
+  // depends on S1). Because the spec's US1 row blocks the tasks
+  // record's roots, S1 must NOT land in Layer 0 — it must land in the
+  // layer immediately after US1.
+  const SPEC_PATH = 'specs/sample/sample.spec.md';
+  const TASKS_PATH = 'specs/sample/01-first.tasks.md';
+
+  const spec = makeRecord({
+    type: 'spec',
+    path: SPEC_PATH,
+    status: 'in-progress',
+    dependency_order: {
+      id_prefix: 'US',
+      format: 'table',
+      rows: [row('US1'), row('US2', ['US1'])],
+    },
+  });
+  const tasks = makeRecord({
+    type: 'tasks',
+    path: TASKS_PATH,
+    status: 'not-started',
+    parent_path: SPEC_PATH,
+    parent_row_id: 'US1',
+    dependency_order: {
+      id_prefix: 'S',
+      format: 'table',
+      rows: [row('S1'), row('S2', ['S1'])],
+    },
+  });
+
+  it('places parent spec roots in Layer 0 and pins child tasks roots into a later layer', () => {
+    const graph = buildDependencyGraph([spec, tasks]);
+    // US1 (spec root) is the only node with no incoming edges — it
+    // alone sits in Layer 0. US2 depends on US1, S1 depends on US1
+    // (cross-artifact), so both land in Layer 1. S2 depends on S1, so
+    // it lands in Layer 2.
+    expect(graph.layers).toEqual([
+      { layer: 0, node_ids: [`${SPEC_PATH}#US1`] },
+      {
+        layer: 1,
+        node_ids: [`${SPEC_PATH}#US2`, `${TASKS_PATH}#S1`],
+      },
+      { layer: 2, node_ids: [`${TASKS_PATH}#S2`] },
+    ]);
+  });
+
+  it('cross-artifact edges only pin a child record\'s roots, not its non-root rows', () => {
+    // S2 depends on S1 inside the tasks table; the cross-artifact edge
+    // from US1 must not also pin S2 directly (otherwise its in-degree
+    // would jump to 2 and the topological depth would silently break).
+    const graph = buildDependencyGraph([spec, tasks]);
+    // S2 should appear after S1 in the layer ordering.
+    const s1Layer = graph.layers.findIndex((l) =>
+      l.node_ids.includes(`${TASKS_PATH}#S1`),
+    );
+    const s2Layer = graph.layers.findIndex((l) =>
+      l.node_ids.includes(`${TASKS_PATH}#S2`),
+    );
+    expect(s1Layer).toBeGreaterThanOrEqual(0);
+    expect(s2Layer).toBe(s1Layer + 1);
+  });
+
+  it('emits no edge when the parent record is missing (orphaned child)', () => {
+    // Tasks record references a parent path that does not appear in
+    // the records array. With no parent node to pin against, the
+    // tasks' root row (S1) lands back in Layer 0.
+    const orphan = makeRecord({
+      type: 'tasks',
+      path: 'specs/orphan/01-foo.tasks.md',
+      status: 'not-started',
+      parent_path: 'specs/missing/missing.spec.md',
+      parent_row_id: 'US1',
+      dependency_order: {
+        id_prefix: 'S',
+        format: 'table',
+        rows: [row('S1'), row('S2', ['S1'])],
+      },
+    });
+    const graph = buildDependencyGraph([orphan]);
+    expect(graph.layers).toEqual([
+      { layer: 0, node_ids: ['specs/orphan/01-foo.tasks.md#S1'] },
+      { layer: 1, node_ids: ['specs/orphan/01-foo.tasks.md#S2'] },
+    ]);
+  });
+
+  it('virtual records contribute their rolled-up not-started status when they have rows; routing through them still works when they do not', () => {
+    // A virtual record in the wild carries `format: 'missing'` /
+    // `rows: []`, but a child of that virtual must still be able to
+    // chain off the virtual's parent. Modeled here as: spec → virtual
+    // tasks (no rows) — the virtual contributes nothing itself, and
+    // the spec's roots still sit in Layer 0.
+    const virtualTasks = makeRecord({
+      type: 'tasks',
+      path: 'specs/sample/01-first.tasks.md',
+      status: 'not-started',
+      virtual: true,
+      parent_path: SPEC_PATH,
+      parent_row_id: 'US1',
+      dependency_order: {
+        id_prefix: 'S',
+        format: 'missing',
+        rows: [],
+      },
+    });
+    const graph = buildDependencyGraph([spec, virtualTasks]);
+    // Only the spec's two rows produce graph nodes; the virtual tasks
+    // record contributes nothing and produces no errors.
+    expect(Object.keys(graph.nodes).sort()).toEqual([
+      `${SPEC_PATH}#US1`,
+      `${SPEC_PATH}#US2`,
+    ]);
+    expect(graph.layers).toEqual([
+      { layer: 0, node_ids: [`${SPEC_PATH}#US1`] },
+      { layer: 1, node_ids: [`${SPEC_PATH}#US2`] },
+    ]);
+  });
+
+  it('virtual tasks records that DO carry rows contribute graph nodes with not-started status', () => {
+    const virtualTasks = makeRecord({
+      type: 'tasks',
+      path: 'specs/sample/01-first.tasks.md',
+      status: 'not-started',
+      virtual: true,
+      parent_path: SPEC_PATH,
+      parent_row_id: 'US1',
+      dependency_order: {
+        id_prefix: 'S',
+        format: 'table',
+        rows: [row('S1')],
+      },
+    });
+    const graph = buildDependencyGraph([spec, virtualTasks]);
+    const node = graph.nodes['specs/sample/01-first.tasks.md#S1'];
+    expect(node).toBeDefined();
+    if (node === undefined) return;
+    expect(node.status).toBe('not-started');
+  });
+});
+
+describe('buildDependencyGraph — dangling references (AS 10.6)', () => {
+  const SPEC_PATH = 'specs/sample/sample.spec.md';
+
+  it('emits one fully-qualified entry per unique dropped reference, drops the missing edge, and still layers valid edges', () => {
+    // US3 depends on US1 (valid) and US9 (dangling); the parser drops
+    // US9 from US3's depends_on at parse time and records it in the
+    // structured dangling_refs field.
+    const spec = makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [
+          row('US1'),
+          row('US2'),
+          row('US3', ['US1']),
+        ],
+        dangling_refs: [{ source_id: 'US3', missing_id: 'US9' }],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    expect(graph.dangling_refs).toEqual([
+      {
+        source_id: `${SPEC_PATH}#US3`,
+        missing_id: `${SPEC_PATH}#US9`,
+      },
+    ]);
+    // Valid edge US1 → US3 still pulls US3 into Layer 1; US2 stays in
+    // Layer 0 alongside US1.
+    expect(graph.layers).toEqual([
+      {
+        layer: 0,
+        node_ids: [`${SPEC_PATH}#US1`, `${SPEC_PATH}#US2`],
+      },
+      { layer: 1, node_ids: [`${SPEC_PATH}#US3`] },
+    ]);
+  });
+
+  it('de-duplicates identical (source_id, missing_id) pairs', () => {
+    const spec = makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1')],
+        dangling_refs: [
+          { source_id: 'US1', missing_id: 'US9' },
+          { source_id: 'US1', missing_id: 'US9' },
+        ],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    expect(graph.dangling_refs).toEqual([
+      {
+        source_id: `${SPEC_PATH}#US1`,
+        missing_id: `${SPEC_PATH}#US9`,
+      },
+    ]);
+  });
+
+  it('does NOT parse warning strings to derive dangling_refs', () => {
+    // The record carries a parser-style warning string but no
+    // structured `dangling_refs` field. The graph builder MUST consume
+    // the structured field exclusively, so `graph.dangling_refs` must
+    // be empty here.
+    const spec = makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      status: 'in-progress',
+      warnings: [
+        "dependency_order: US1 depends on dangling ID 'US9' — dropped",
+      ],
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1')],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    expect(graph.dangling_refs).toEqual([]);
+  });
+
+  it('returns empty dangling_refs when no records carry dropped references', () => {
+    const spec = makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1'), row('US2', ['US1'])],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    expect(graph.dangling_refs).toEqual([]);
+  });
+});

--- a/src/status/graph.test.ts
+++ b/src/status/graph.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest';
+// Import through the `./index.js` barrel so these tests also assert
+// that `buildDependencyGraph` is re-exported on the stable public
+// surface.
+import {
+  BROKEN_LINKS_PATH,
+  ORPHANED_SPECS_PATH,
+  ORPHANED_TASKS_PATH,
+  buildDependencyGraph,
+  type ArtifactRecord,
+  type ArtifactType,
+  type DependencyOrderTable,
+  type DependencyRow,
+} from './index.js';
+
+/**
+ * Build a minimal `ArtifactRecord` for graph tests. Only the fields
+ * `buildDependencyGraph` actually consults (`path`, `status`,
+ * `dependency_order`) carry semantic weight; the rest are padded with
+ * sensible defaults so the tests read clearly at call sites.
+ */
+function makeRecord(overrides: Partial<ArtifactRecord> = {}): ArtifactRecord {
+  const type: ArtifactType = overrides.type ?? 'spec';
+  const idPrefix: DependencyOrderTable['id_prefix'] =
+    type === 'rfc'
+      ? 'M'
+      : type === 'features'
+        ? 'F'
+        : type === 'spec'
+          ? 'US'
+          : 'S';
+  const dependency_order: DependencyOrderTable = overrides.dependency_order ?? {
+    rows: [],
+    id_prefix: idPrefix,
+    format: 'table',
+  };
+  return {
+    type,
+    path: overrides.path ?? `specs/sample.${type === 'tasks' ? 'tasks' : type}.md`,
+    title: overrides.title ?? 'Sample',
+    status: overrides.status ?? 'not-started',
+    dependency_order,
+    warnings: overrides.warnings ?? [],
+    ...overrides,
+  };
+}
+
+/** Build a single dependency row with sensible defaults. */
+function row(
+  id: string,
+  depends_on: string[] = [],
+  overrides: Partial<DependencyRow> = {},
+): DependencyRow {
+  return {
+    id,
+    title: overrides.title ?? `Story ${id}`,
+    depends_on,
+    artifact_path: overrides.artifact_path ?? null,
+    ...overrides,
+  };
+}
+
+describe('buildDependencyGraph — empty input', () => {
+  it('returns an empty graph for no records', () => {
+    const graph = buildDependencyGraph([]);
+    expect(graph).toEqual({
+      nodes: {},
+      layers: [],
+      cycles: [],
+      dangling_refs: [],
+    });
+  });
+
+  it('returns an empty graph for a record with no dependency-order rows', () => {
+    const record = makeRecord({
+      path: 'specs/sample/sample.spec.md',
+      dependency_order: { rows: [], id_prefix: 'US', format: 'table' },
+    });
+    const graph = buildDependencyGraph([record]);
+    expect(graph.nodes).toEqual({});
+    expect(graph.layers).toEqual([]);
+    expect(graph.cycles).toEqual([]);
+    expect(graph.dangling_refs).toEqual([]);
+  });
+});
+
+describe('buildDependencyGraph — within-artifact topological layering (AS 10.1)', () => {
+  // Spec with four user stories where US1 and US4 are independent,
+  // US2 depends on US1, and US3 depends on US2.
+  const SPEC_PATH = 'specs/sample/sample.spec.md';
+  const spec = makeRecord({
+    type: 'spec',
+    path: SPEC_PATH,
+    title: 'Sample Spec',
+    status: 'in-progress',
+    dependency_order: {
+      id_prefix: 'US',
+      format: 'table',
+      rows: [
+        row('US1'),
+        row('US2', ['US1']),
+        row('US3', ['US2']),
+        row('US4'),
+      ],
+    },
+  });
+
+  it('places US1 and US4 in Layer 0, US2 in Layer 1, and US3 in Layer 2', () => {
+    const graph = buildDependencyGraph([spec]);
+    expect(graph.layers).toEqual([
+      { layer: 0, node_ids: [`${SPEC_PATH}#US1`, `${SPEC_PATH}#US4`] },
+      { layer: 1, node_ids: [`${SPEC_PATH}#US2`] },
+      { layer: 2, node_ids: [`${SPEC_PATH}#US3`] },
+    ]);
+  });
+
+  it('emits one fully-qualified node per row carrying record_path, row, and rolled-up status', () => {
+    const graph = buildDependencyGraph([spec]);
+    expect(Object.keys(graph.nodes).sort()).toEqual([
+      `${SPEC_PATH}#US1`,
+      `${SPEC_PATH}#US2`,
+      `${SPEC_PATH}#US3`,
+      `${SPEC_PATH}#US4`,
+    ]);
+    const us2 = graph.nodes[`${SPEC_PATH}#US2`];
+    expect(us2).toBeDefined();
+    if (us2 === undefined) return;
+    expect(us2.record_path).toBe(SPEC_PATH);
+    expect(us2.status).toBe('in-progress');
+    expect(us2.row).toEqual({
+      id: 'US2',
+      title: 'Story US2',
+      depends_on: ['US1'],
+      artifact_path: null,
+    });
+  });
+
+  it('reports empty cycles and dangling_refs in this task', () => {
+    const graph = buildDependencyGraph([spec]);
+    expect(graph.cycles).toEqual([]);
+    expect(graph.dangling_refs).toEqual([]);
+  });
+});
+
+describe('buildDependencyGraph — determinism (SD-013)', () => {
+  it('orders Layer 0 by record discovery order, then by row order within each table', () => {
+    // Two records, each with two independent rows. Both records belong
+    // in Layer 0 entirely — but the layer membership must follow
+    // (a) the order records appear in the input array, then
+    // (b) the row order inside each `## Dependency Order` table.
+    const specA = makeRecord({
+      type: 'spec',
+      path: 'specs/a/a.spec.md',
+      status: 'not-started',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US2'), row('US1')],
+      },
+    });
+    const specB = makeRecord({
+      type: 'spec',
+      path: 'specs/b/b.spec.md',
+      status: 'not-started',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US10'), row('US3')],
+      },
+    });
+
+    const graph = buildDependencyGraph([specA, specB]);
+    expect(graph.layers).toEqual([
+      {
+        layer: 0,
+        node_ids: [
+          'specs/a/a.spec.md#US2',
+          'specs/a/a.spec.md#US1',
+          'specs/b/b.spec.md#US10',
+          'specs/b/b.spec.md#US3',
+        ],
+      },
+    ]);
+  });
+});
+
+describe('buildDependencyGraph — purity', () => {
+  it('does not mutate input records or their dependency-order tables', () => {
+    const original = makeRecord({
+      type: 'spec',
+      path: 'specs/sample/sample.spec.md',
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1'), row('US2', ['US1'])],
+      },
+    });
+    const snapshot = JSON.parse(JSON.stringify(original));
+    buildDependencyGraph([original]);
+    expect(original).toEqual(snapshot);
+  });
+});
+
+describe('buildDependencyGraph — non-table records contribute no nodes', () => {
+  it('skips records whose dependency_order.format is legacy or missing', () => {
+    const legacy = makeRecord({
+      path: 'specs/legacy/legacy.spec.md',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'legacy',
+        rows: [row('US1')],
+      },
+    });
+    const missing = makeRecord({
+      path: 'specs/missing/missing.spec.md',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'missing',
+        rows: [],
+      },
+    });
+    const graph = buildDependencyGraph([legacy, missing]);
+    expect(graph.nodes).toEqual({});
+    expect(graph.layers).toEqual([]);
+  });
+});
+
+describe('buildDependencyGraph — synthetic tree sentinels are excluded', () => {
+  it('drops records whose path is a tree sentinel even if they carry a dep-order table', () => {
+    const sentinel = makeRecord({
+      path: ORPHANED_SPECS_PATH,
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1')],
+      },
+    });
+    const broken = makeRecord({
+      path: BROKEN_LINKS_PATH,
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US2')],
+      },
+    });
+    const orphanedTasks = makeRecord({
+      path: ORPHANED_TASKS_PATH,
+      dependency_order: {
+        id_prefix: 'S',
+        format: 'table',
+        rows: [row('S1')],
+      },
+    });
+    const graph = buildDependencyGraph([sentinel, broken, orphanedTasks]);
+    expect(graph.nodes).toEqual({});
+    expect(graph.layers).toEqual([]);
+  });
+});

--- a/src/status/graph.ts
+++ b/src/status/graph.ts
@@ -112,6 +112,20 @@ function nodeId(recordPath: string, rowId: string): string {
 }
 
 /**
+ * Unit Separator (US, U+001F). Used as the join character for Map / Set
+ * dedupe keys built from two fully-qualified node IDs. Plain ASCII text
+ * (so the source file stays text-mode and shows up cleanly under `rg`,
+ * `file`, etc.) yet a control character that cannot appear inside a
+ * fully-qualified ID, so the joined key can be split unambiguously.
+ */
+const KEY_SEP = '\u001F';
+
+/** Build a deterministic dedupe key for an `(a, b)` pair. */
+function pairKey(a: string, b: string): string {
+  return `${a}${KEY_SEP}${b}`;
+}
+
+/**
  * Project a flat `ArtifactRecord[]` into a {@link DependencyGraph}. Pure
  * function — does no I/O and does not mutate its input. See the
  * module-level JSDoc for the scoping rules.
@@ -233,7 +247,7 @@ export function buildDependencyGraph(
     for (const ref of tableDangling) {
       const source_id = nodeId(record.path, ref.source_id);
       const missing_id = nodeId(record.path, ref.missing_id);
-      const key = `${source_id} ${missing_id}`;
+      const key = pairKey(source_id, missing_id);
       if (seenDangling.has(key)) continue;
       seenDangling.add(key);
       dangling_refs.push({ source_id, missing_id });
@@ -491,7 +505,7 @@ function addEdge(
   inDegree: Map<string, number>,
   seenEdges: Set<string>,
 ): void {
-  const key = `${source} ${target}`;
+  const key = pairKey(source, target);
   if (seenEdges.has(key)) return;
   seenEdges.add(key);
   const successors = outgoing.get(source);

--- a/src/status/graph.ts
+++ b/src/status/graph.ts
@@ -1,0 +1,200 @@
+/**
+ * Pure cross-artifact dependency-graph builder. Unions every artifact's
+ * parsed `## Dependency Order` table into a single directed graph and
+ * computes topological layers via Kahn's algorithm so the `--graph`
+ * renderer can group nodes by "ready-to-work-on" depth.
+ *
+ * This module is deliberately side-effect-free. `buildDependencyGraph`
+ * performs no I/O, never mutates its input, and returns the same graph
+ * for the same input — the graph is a pure projection of the records
+ * supplied to it.
+ *
+ * ## Scope (US10 Slice 2 Task 1)
+ *
+ * Only the within-artifact case is implemented here: every node lives
+ * inside the table that produced it, and only intra-table `depends_on`
+ * edges contribute to layering. Cross-artifact edges (parent rows
+ * blocking child roots), structured `dangling_refs`, virtual-record
+ * inclusion as graph nodes, and cycle detection are explicitly deferred
+ * to Tasks 2 and 3 of this same slice. This task therefore always
+ * returns `cycles: []` and `dangling_refs: []`.
+ *
+ * ## Node identity
+ *
+ * Nodes are keyed by fully-qualified ID — `<record.path>#<row.id>`
+ * (e.g. `specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.spec.md#US2`).
+ * Fully-qualified IDs allow the same short ID (`US1`) to appear in
+ * multiple specs without collision, which becomes essential once
+ * cross-artifact stitching lands in Task 2.
+ *
+ * ## Determinism (SD-013)
+ *
+ * Within-layer node ordering is not specified by data-model §6 or
+ * AS 10.1. The implementation orders by:
+ *   1. The artifact's discovery order in the input `records` array.
+ *   2. The row's order inside its `## Dependency Order` table.
+ * Layer assignment iterates zero-in-degree nodes in this discovery
+ * order so layer contents always mirror user-authored tables.
+ *
+ * ## Skipped records
+ *
+ * Two record classes are skipped before any node is emitted:
+ *   - Records whose `dependency_order.format !== 'table'` (i.e. legacy
+ *     or missing). The owning record is already `status: 'unknown'` in
+ *     these cases and contributes nothing meaningful to the graph.
+ *   - Records whose `path` matches one of the synthetic tree sentinels
+ *     (`ORPHANED_SPECS_PATH`, `BROKEN_LINKS_PATH`, `ORPHANED_TASKS_PATH`).
+ *     These exist purely as tree-grouping stand-ins and have no place
+ *     in the dependency graph.
+ */
+
+import {
+  BROKEN_LINKS_PATH,
+  ORPHANED_SPECS_PATH,
+  ORPHANED_TASKS_PATH,
+} from './tree.js';
+import type {
+  ArtifactRecord,
+  DependencyGraph,
+  DependencyNode,
+} from './types.js';
+
+const SENTINEL_PATHS: ReadonlySet<string> = new Set([
+  ORPHANED_SPECS_PATH,
+  BROKEN_LINKS_PATH,
+  ORPHANED_TASKS_PATH,
+]);
+
+/** Build the fully-qualified node id for a row inside a record. */
+function nodeId(recordPath: string, rowId: string): string {
+  return `${recordPath}#${rowId}`;
+}
+
+/**
+ * Project a flat `ArtifactRecord[]` into a {@link DependencyGraph}. Pure
+ * function — does no I/O and does not mutate its input. See the
+ * module-level JSDoc for the scoping rules.
+ */
+export function buildDependencyGraph(
+  records: ArtifactRecord[],
+): DependencyGraph {
+  const nodes: Record<string, DependencyNode> = {};
+  // Discovery order — the index a node was first observed at while
+  // walking records in input order and rows in table order. Drives both
+  // Kahn-queue ordering and within-layer sort.
+  const discoveryOrder = new Map<string, number>();
+  // Adjacency: for each node, the nodes it points TO (i.e. the nodes
+  // that depend on it). Kahn's algorithm consumes outgoing edges to
+  // decrement successors' in-degree.
+  const outgoing = new Map<string, string[]>();
+  // In-degree count per node; nodes with zero in-degree start in the
+  // queue.
+  const inDegree = new Map<string, number>();
+
+  let cursor = 0;
+  for (const record of records) {
+    if (SENTINEL_PATHS.has(record.path)) continue;
+    if (record.dependency_order.format !== 'table') continue;
+
+    // First pass: register every row as a node. Doing this before
+    // wiring edges means a self-referential `depends_on` still finds
+    // its target node; it also keeps the discovery-order map populated
+    // before we read it during edge construction.
+    for (const row of record.dependency_order.rows) {
+      const id = nodeId(record.path, row.id);
+      // Defensive: if two rows in the same table somehow share an ID,
+      // the first one wins — the parser already flags this as a
+      // warning on the owning record, so the graph need not re-flag it.
+      if (id in nodes) continue;
+      nodes[id] = {
+        record_path: record.path,
+        row,
+        status: record.status,
+      };
+      discoveryOrder.set(id, cursor);
+      cursor += 1;
+      outgoing.set(id, []);
+      inDegree.set(id, 0);
+    }
+  }
+
+  // Second pass: wire edges. We re-walk records so this stays a single
+  // top-level loop; per-row work is O(depends_on.length).
+  for (const record of records) {
+    if (SENTINEL_PATHS.has(record.path)) continue;
+    if (record.dependency_order.format !== 'table') continue;
+
+    for (const row of record.dependency_order.rows) {
+      const targetId = nodeId(record.path, row.id);
+      if (!(targetId in nodes)) continue;
+      for (const depId of row.depends_on) {
+        const sourceId = nodeId(record.path, depId);
+        // Within-task scope: only intra-table edges are considered. A
+        // depends_on entry whose ID does not name a sibling row in the
+        // same table is silently dropped here — Task 2 will surface
+        // these via structured `dangling_refs`.
+        if (!(sourceId in nodes)) continue;
+        const successors = outgoing.get(sourceId);
+        // `outgoing.get` is guaranteed defined because every key in
+        // `nodes` was seeded above; the explicit guard keeps TS happy
+        // without an `as` assertion.
+        if (successors === undefined) continue;
+        successors.push(targetId);
+        inDegree.set(targetId, (inDegree.get(targetId) ?? 0) + 1);
+      }
+    }
+  }
+
+  // Kahn's algorithm — group nodes whose in-degree is currently zero
+  // into a layer, decrement their successors, and repeat until the
+  // queue empties. Iterating `discoveryOrder` (which is insertion-
+  // ordered) gives the deterministic within-layer ordering required by
+  // SD-013.
+  const layers: DependencyGraph['layers'] = [];
+  const remainingInDegree = new Map(inDegree);
+  // Track which nodes have been placed in a layer so subsequent passes
+  // do not revisit them when an earlier layer's `outgoing` walk lowers
+  // their in-degree to zero.
+  const placed = new Set<string>();
+  let layerIndex = 0;
+
+  // Sort node IDs once by discovery order; we re-scan this list each
+  // pass to harvest the next layer's members.
+  const orderedIds = [...discoveryOrder.entries()]
+    .sort(([, a], [, b]) => a - b)
+    .map(([id]) => id);
+
+  while (placed.size < orderedIds.length) {
+    const layerNodeIds: string[] = [];
+    for (const id of orderedIds) {
+      if (placed.has(id)) continue;
+      if ((remainingInDegree.get(id) ?? 0) === 0) {
+        layerNodeIds.push(id);
+      }
+    }
+    if (layerNodeIds.length === 0) {
+      // Within-task scope cannot produce cycles for this slice (every
+      // edge is intra-table and the parser drops dangling refs), but
+      // breaking out defensively avoids an infinite loop if a future
+      // change introduces them. Cycle handling lands in Task 3.
+      break;
+    }
+    for (const id of layerNodeIds) {
+      placed.add(id);
+      const successors = outgoing.get(id) ?? [];
+      for (const successorId of successors) {
+        const next = (remainingInDegree.get(successorId) ?? 0) - 1;
+        remainingInDegree.set(successorId, next);
+      }
+    }
+    layers.push({ layer: layerIndex, node_ids: layerNodeIds });
+    layerIndex += 1;
+  }
+
+  return {
+    nodes,
+    layers,
+    cycles: [],
+    dangling_refs: [],
+  };
+}

--- a/src/status/graph.ts
+++ b/src/status/graph.ts
@@ -9,7 +9,7 @@
  * for the same input — the graph is a pure projection of the records
  * supplied to it.
  *
- * ## Scope (US10 Slice 2 Tasks 1 + 2)
+ * ## Scope (US10 Slice 2 Tasks 1 + 2 + 3)
  *
  * Task 1 covered the within-artifact case: every node lives inside the
  * table that produced it, and only intra-table `depends_on` edges
@@ -37,10 +37,25 @@
  *     edges still flow through them via the `parent_row_id` link from
  *     any further child that references them.
  *
- * Cycle detection still defers to Task 3; this module currently always
- * returns `cycles: []`. If a cross-artifact cycle ever produced one,
- * the Kahn pass would simply leave the cyclic nodes unplaced and the
- * `while` loop would terminate early — Task 3 will surface them.
+ * Task 3 closes the AS 10.3 loop with cycle detection:
+ *
+ *   - When Kahn's algorithm terminates, any node still carrying
+ *     non-zero in-degree is part of a cycle. The residual subgraph is
+ *     decomposed into strongly-connected components (Tarjan-style DFS),
+ *     and each non-trivial SCC (size ≥ 2, or a singleton with a
+ *     self-loop) becomes one entry in `graph.cycles` listing the
+ *     participating fully-qualified node IDs in DFS traversal order.
+ *   - Cyclic nodes are excluded from every entry in `graph.layers`;
+ *     non-cyclic nodes downstream of a cyclic node are also excluded
+ *     because their predecessors never reach in-degree zero. This
+ *     matches data-model §6's "layer computation is undefined for
+ *     cyclic subgraphs" wording — the renderer falls back to a flat
+ *     listing for cyclic graphs.
+ *   - Determinism: SCCs are sorted by their lexicographically smallest
+ *     fully-qualified ID; within each SCC, traversal starts from that
+ *     smallest node so the participating-IDs order is stable.
+ *   - Self-loops are handled gracefully (treated as a singleton SCC
+ *     cycle) even though real parser output should never produce one.
  *
  * ## Node identity
  *
@@ -253,10 +268,12 @@ export function buildDependencyGraph(
       }
     }
     if (layerNodeIds.length === 0) {
-      // Cycle detection lands in Task 3. For now, breaking out
-      // defensively avoids an infinite loop if a cross-artifact cycle
-      // were ever introduced — the cyclic nodes simply remain
-      // unplaced.
+      // No zero-in-degree nodes remain but `placed.size <
+      // orderedIds.length` — every unplaced node is part of (or blocked
+      // by) at least one cycle. Stop layering; cycle extraction below
+      // turns the residual subgraph into `graph.cycles`. Anything
+      // unplaced is excluded from the layered output entirely, per
+      // data-model §6.
       break;
     }
     for (const id of layerNodeIds) {
@@ -271,12 +288,195 @@ export function buildDependencyGraph(
     layerIndex += 1;
   }
 
+  // Cycle extraction. Any node not placed by Kahn's belongs to the
+  // residual subgraph — either inside a cycle or downstream of one.
+  // Run Tarjan's SCC algorithm on that residual to recover the cycles
+  // themselves; nodes that are merely downstream of a cycle (singleton
+  // SCC with no self-loop) are dropped on the floor — they are
+  // excluded from layers because their predecessor never resolved, but
+  // they are not themselves cyclic.
+  const residual = orderedIds.filter((id) => !placed.has(id));
+  const cycles =
+    residual.length === 0 ? [] : extractCycles(residual, outgoing);
+
   return {
     nodes,
     layers,
-    cycles: [],
+    cycles,
     dangling_refs,
   };
+}
+
+/**
+ * Run Tarjan's strongly-connected-components algorithm on the residual
+ * subgraph (the nodes Kahn's algorithm could not place) and return one
+ * entry per non-trivial SCC. A singleton SCC qualifies only if the node
+ * has a self-loop; otherwise it is a non-cyclic node that simply got
+ * stuck behind a cycle and is excluded from the result.
+ *
+ * Determinism: SCCs are sorted by their lexicographically smallest
+ * fully-qualified ID. Within each SCC, the seed for DFS traversal is
+ * that smallest ID, so the emitted ordering is stable across runs.
+ *
+ * The implementation uses an iterative Tarjan to avoid blowing the call
+ * stack on long cycle chains.
+ */
+function extractCycles(
+  residual: string[],
+  outgoing: Map<string, string[]>,
+): string[][] {
+  const residualSet = new Set(residual);
+  const index = new Map<string, number>();
+  const lowlink = new Map<string, number>();
+  const onStack = new Set<string>();
+  const stack: string[] = [];
+  let counter = 0;
+  const sccs: string[][] = [];
+
+  // Iterative Tarjan: each work-stack frame tracks the node and the
+  // index of the next successor to visit.
+  type Frame = { node: string; childIdx: number };
+
+  // Drive the outer loop in deterministic order so the seed for each
+  // unvisited SCC is the lexicographically smallest residual node not
+  // yet visited. This stabilizes the participating-IDs ordering inside
+  // each SCC and the order in which SCCs are emitted.
+  const sortedResidual = [...residual].sort();
+  for (const seed of sortedResidual) {
+    if (index.has(seed)) continue;
+    const work: Frame[] = [{ node: seed, childIdx: 0 }];
+    index.set(seed, counter);
+    lowlink.set(seed, counter);
+    counter += 1;
+    stack.push(seed);
+    onStack.add(seed);
+
+    while (work.length > 0) {
+      const frame = work[work.length - 1];
+      if (frame === undefined) break;
+      // Successor list is filtered to the residual subgraph and sorted
+      // for deterministic traversal.
+      const successors = (outgoing.get(frame.node) ?? [])
+        .filter((s) => residualSet.has(s))
+        .sort();
+      if (frame.childIdx < successors.length) {
+        const next = successors[frame.childIdx];
+        frame.childIdx += 1;
+        if (next === undefined) continue;
+        if (!index.has(next)) {
+          index.set(next, counter);
+          lowlink.set(next, counter);
+          counter += 1;
+          stack.push(next);
+          onStack.add(next);
+          work.push({ node: next, childIdx: 0 });
+        } else if (onStack.has(next)) {
+          const current = lowlink.get(frame.node) ?? 0;
+          const candidate = index.get(next) ?? 0;
+          lowlink.set(frame.node, Math.min(current, candidate));
+        }
+      } else {
+        // Frame exhausted — fold its lowlink into its parent (if any)
+        // and emit an SCC if this frame is a root.
+        const nodeLow = lowlink.get(frame.node) ?? 0;
+        const nodeIdx = index.get(frame.node) ?? 0;
+        if (nodeLow === nodeIdx) {
+          // SCC root — pop stack until we re-emerge at this node.
+          const component: string[] = [];
+          while (stack.length > 0) {
+            const popped = stack.pop();
+            if (popped === undefined) break;
+            onStack.delete(popped);
+            component.push(popped);
+            if (popped === frame.node) break;
+          }
+          // A singleton component is a real cycle only if the node has
+          // a self-loop. Multi-node components are always cycles.
+          if (component.length > 1) {
+            sccs.push(component);
+          } else if (component.length === 1) {
+            const only = component[0];
+            if (only !== undefined) {
+              const hasSelfLoop = (outgoing.get(only) ?? []).includes(only);
+              if (hasSelfLoop) {
+                sccs.push(component);
+              }
+            }
+          }
+        }
+        work.pop();
+        if (work.length > 0) {
+          const parent = work[work.length - 1];
+          if (parent !== undefined) {
+            const parentLow = lowlink.get(parent.node) ?? 0;
+            lowlink.set(parent.node, Math.min(parentLow, nodeLow));
+          }
+        }
+      }
+    }
+  }
+
+  // Reorder each SCC's IDs in DFS-traversal order starting from the
+  // smallest seed inside it. Tarjan's pop order is reverse-DFS, so we
+  // do an explicit DFS from the seed restricted to the SCC's node set
+  // to produce the documented "participating IDs in traversal order"
+  // shape.
+  const traversed = sccs.map((component) => orderByDfs(component, outgoing));
+
+  // Sort SCC entries by the lexicographically smallest fully-qualified
+  // ID inside each component so the outer ordering is deterministic.
+  traversed.sort((a, b) => {
+    const aMin = a[0] ?? '';
+    const bMin = b[0] ?? '';
+    return aMin < bMin ? -1 : aMin > bMin ? 1 : 0;
+  });
+
+  return traversed;
+}
+
+/**
+ * Walk the nodes of a single SCC in DFS order starting from its
+ * lexicographically smallest member, restricted to edges that stay
+ * inside the component. Used so each cycle entry's participating IDs
+ * appear in a stable traversal order rather than Tarjan's reverse-DFS
+ * pop order.
+ */
+function orderByDfs(
+  component: string[],
+  outgoing: Map<string, string[]>,
+): string[] {
+  if (component.length <= 1) return [...component];
+  const members = new Set(component);
+  const sorted = [...component].sort();
+  const seed = sorted[0];
+  if (seed === undefined) return [...component];
+  const visited = new Set<string>();
+  const order: string[] = [];
+  const stack: string[] = [seed];
+  while (stack.length > 0) {
+    const id = stack.pop();
+    if (id === undefined) continue;
+    if (visited.has(id)) continue;
+    visited.add(id);
+    order.push(id);
+    // Push successors in reverse-sorted order so the smallest one is
+    // popped (and visited) first, matching the documented seed-from-
+    // smallest determinism.
+    const successors = (outgoing.get(id) ?? [])
+      .filter((s) => members.has(s))
+      .sort()
+      .reverse();
+    for (const successor of successors) {
+      if (!visited.has(successor)) stack.push(successor);
+    }
+  }
+  // Defensive: any component members not reachable from the seed (in
+  // theory shouldn't happen for a true SCC) get appended in sorted
+  // order so we never drop nodes.
+  for (const id of sorted) {
+    if (!visited.has(id)) order.push(id);
+  }
+  return order;
 }
 
 /**

--- a/src/status/graph.ts
+++ b/src/status/graph.ts
@@ -507,9 +507,9 @@ function addEdge(
 ): void {
   const key = pairKey(source, target);
   if (seenEdges.has(key)) return;
-  seenEdges.add(key);
   const successors = outgoing.get(source);
   if (successors === undefined) return;
+  seenEdges.add(key);
   successors.push(target);
   inDegree.set(target, (inDegree.get(target) ?? 0) + 1);
 }

--- a/src/status/graph.ts
+++ b/src/status/graph.ts
@@ -9,23 +9,46 @@
  * for the same input — the graph is a pure projection of the records
  * supplied to it.
  *
- * ## Scope (US10 Slice 2 Task 1)
+ * ## Scope (US10 Slice 2 Tasks 1 + 2)
  *
- * Only the within-artifact case is implemented here: every node lives
- * inside the table that produced it, and only intra-table `depends_on`
- * edges contribute to layering. Cross-artifact edges (parent rows
- * blocking child roots), structured `dangling_refs`, virtual-record
- * inclusion as graph nodes, and cycle detection are explicitly deferred
- * to Tasks 2 and 3 of this same slice. This task therefore always
- * returns `cycles: []` and `dangling_refs: []`.
+ * Task 1 covered the within-artifact case: every node lives inside the
+ * table that produced it, and only intra-table `depends_on` edges
+ * contribute to layering. Task 2 extends that union with:
+ *
+ *   - Cross-artifact edges via the scanner-populated `parent_path` +
+ *     `parent_row_id` fields. A child record's "root" rows (rows whose
+ *     intra-table `depends_on` is empty) are treated as blocked by the
+ *     fully-qualified parent dep-order row that referenced the child,
+ *     so the unioned graph spans the full RFC → features → spec → tasks
+ *     lineage. Cross-artifact edges are derived exclusively from
+ *     `parent_path` / `parent_row_id` — never from filename convention.
+ *
+ *   - Structured dangling-reference reporting via
+ *     {@link DependencyOrderTable.dangling_refs}. The parser now
+ *     records every `depends_on` ID it dropped during second-pass
+ *     resolution alongside the existing warning string; the builder
+ *     consumes that structured metadata (never parses warnings) and
+ *     emits one fully-qualified `{ source_id, missing_id }` entry per
+ *     unique pair into `graph.dangling_refs`.
+ *
+ *   - Virtual records (`virtual: true`) participate as ordinary graph
+ *     nodes. In practice they have `format: 'missing'` / `rows: []`, so
+ *     they often contribute zero nodes themselves, but cross-artifact
+ *     edges still flow through them via the `parent_row_id` link from
+ *     any further child that references them.
+ *
+ * Cycle detection still defers to Task 3; this module currently always
+ * returns `cycles: []`. If a cross-artifact cycle ever produced one,
+ * the Kahn pass would simply leave the cyclic nodes unplaced and the
+ * `while` loop would terminate early — Task 3 will surface them.
  *
  * ## Node identity
  *
  * Nodes are keyed by fully-qualified ID — `<record.path>#<row.id>`
  * (e.g. `specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.spec.md#US2`).
  * Fully-qualified IDs allow the same short ID (`US1`) to appear in
- * multiple specs without collision, which becomes essential once
- * cross-artifact stitching lands in Task 2.
+ * multiple specs without collision, which is essential once
+ * cross-artifact stitching is in play.
  *
  * ## Determinism (SD-013)
  *
@@ -42,6 +65,9 @@
  *   - Records whose `dependency_order.format !== 'table'` (i.e. legacy
  *     or missing). The owning record is already `status: 'unknown'` in
  *     these cases and contributes nothing meaningful to the graph.
+ *     Virtual records typically fall into this bucket too — they hold
+ *     no rows of their own — but their `parent_path` / `parent_row_id`
+ *     links still inform cross-artifact edges into any further child.
  *   - Records whose `path` matches one of the synthetic tree sentinels
  *     (`ORPHANED_SPECS_PATH`, `BROKEN_LINKS_PATH`, `ORPHANED_TASKS_PATH`).
  *     These exist purely as tree-grouping stand-ins and have no place
@@ -90,10 +116,18 @@ export function buildDependencyGraph(
   // In-degree count per node; nodes with zero in-degree start in the
   // queue.
   const inDegree = new Map<string, number>();
+  // De-duplicating set of cross-artifact edges already wired so
+  // duplicate parent rows (extremely unusual in practice) cannot
+  // double-count a successor's in-degree.
+  const seenEdges = new Set<string>();
+
+  // Filter out sentinel-pathed records up front. We still iterate
+  // `records` for cross-artifact stitching below, but those records
+  // never contribute any nodes either way.
+  const eligible = records.filter((r) => !SENTINEL_PATHS.has(r.path));
 
   let cursor = 0;
-  for (const record of records) {
-    if (SENTINEL_PATHS.has(record.path)) continue;
+  for (const record of eligible) {
     if (record.dependency_order.format !== 'table') continue;
 
     // First pass: register every row as a node. Doing this before
@@ -118,10 +152,9 @@ export function buildDependencyGraph(
     }
   }
 
-  // Second pass: wire edges. We re-walk records so this stays a single
-  // top-level loop; per-row work is O(depends_on.length).
-  for (const record of records) {
-    if (SENTINEL_PATHS.has(record.path)) continue;
+  // Second pass: wire intra-table edges. Re-walks records so this stays
+  // a single top-level loop; per-row work is O(depends_on.length).
+  for (const record of eligible) {
     if (record.dependency_order.format !== 'table') continue;
 
     for (const row of record.dependency_order.rows) {
@@ -129,19 +162,66 @@ export function buildDependencyGraph(
       if (!(targetId in nodes)) continue;
       for (const depId of row.depends_on) {
         const sourceId = nodeId(record.path, depId);
-        // Within-task scope: only intra-table edges are considered. A
-        // depends_on entry whose ID does not name a sibling row in the
-        // same table is silently dropped here — Task 2 will surface
-        // these via structured `dangling_refs`.
+        // Intra-table edges only — `depends_on` may only reference IDs
+        // inside the same table. Anything else was a parse-time
+        // dangling reference and was dropped before reaching us.
         if (!(sourceId in nodes)) continue;
-        const successors = outgoing.get(sourceId);
-        // `outgoing.get` is guaranteed defined because every key in
-        // `nodes` was seeded above; the explicit guard keeps TS happy
-        // without an `as` assertion.
-        if (successors === undefined) continue;
-        successors.push(targetId);
-        inDegree.set(targetId, (inDegree.get(targetId) ?? 0) + 1);
+        addEdge(sourceId, targetId, outgoing, inDegree, seenEdges);
       }
+    }
+  }
+
+  // Third pass: stitch cross-artifact edges. A child record's "root"
+  // rows (rows whose intra-table `depends_on` is empty) are blocked by
+  // the parent row that referenced them. Per the data model
+  // (§Relationships), parent linkage is authoritative via
+  // `parent_path` + `parent_row_id` — populated by the scanner during
+  // Phase 2 — so we read those exclusively rather than re-deriving
+  // anything from filenames.
+  //
+  // Edges are only created when BOTH endpoints exist as graph nodes,
+  // so a missing parent record (or a parent whose dep-order table
+  // dropped the row) silently produces no edge. The child's root rows
+  // simply remain at in-degree 0 and surface as graph roots, which is
+  // the correct behavior for orphaned records.
+  for (const record of eligible) {
+    if (record.dependency_order.format !== 'table') continue;
+    const parentPath = record.parent_path;
+    const parentRowId = record.parent_row_id;
+    if (typeof parentPath !== 'string' || parentPath.length === 0) continue;
+    if (typeof parentRowId !== 'string' || parentRowId.length === 0) continue;
+    const parentNodeId = nodeId(parentPath, parentRowId);
+    if (!(parentNodeId in nodes)) continue;
+
+    for (const row of record.dependency_order.rows) {
+      // Only "root" rows (no intra-table predecessors) are pinned to the
+      // parent — non-root rows are already gated by their intra-table
+      // dependencies, which themselves transitively bottom out at the
+      // record's roots.
+      if (row.depends_on.length > 0) continue;
+      const childNodeId = nodeId(record.path, row.id);
+      if (!(childNodeId in nodes)) continue;
+      addEdge(parentNodeId, childNodeId, outgoing, inDegree, seenEdges);
+    }
+  }
+
+  // Fourth pass: collect structured dangling references from each
+  // table and lift them into the graph's `dangling_refs` field with
+  // fully-qualified IDs. We deliberately consume the parser's
+  // structured field (never the warning strings) so the surfaces stay
+  // independently typed.
+  const dangling_refs: Array<{ source_id: string; missing_id: string }> = [];
+  const seenDangling = new Set<string>();
+  for (const record of eligible) {
+    const tableDangling = record.dependency_order.dangling_refs;
+    if (tableDangling === undefined) continue;
+    for (const ref of tableDangling) {
+      const source_id = nodeId(record.path, ref.source_id);
+      const missing_id = nodeId(record.path, ref.missing_id);
+      const key = `${source_id} ${missing_id}`;
+      if (seenDangling.has(key)) continue;
+      seenDangling.add(key);
+      dangling_refs.push({ source_id, missing_id });
     }
   }
 
@@ -173,10 +253,10 @@ export function buildDependencyGraph(
       }
     }
     if (layerNodeIds.length === 0) {
-      // Within-task scope cannot produce cycles for this slice (every
-      // edge is intra-table and the parser drops dangling refs), but
-      // breaking out defensively avoids an infinite loop if a future
-      // change introduces them. Cycle handling lands in Task 3.
+      // Cycle detection lands in Task 3. For now, breaking out
+      // defensively avoids an infinite loop if a cross-artifact cycle
+      // were ever introduced — the cyclic nodes simply remain
+      // unplaced.
       break;
     }
     for (const id of layerNodeIds) {
@@ -195,6 +275,27 @@ export function buildDependencyGraph(
     nodes,
     layers,
     cycles: [],
-    dangling_refs: [],
+    dangling_refs,
   };
+}
+
+/**
+ * Wire a directed edge `source -> target` in the adjacency + in-degree
+ * maps, de-duplicating against `seenEdges` so the same pair cannot
+ * inflate `target`'s in-degree more than once.
+ */
+function addEdge(
+  source: string,
+  target: string,
+  outgoing: Map<string, string[]>,
+  inDegree: Map<string, number>,
+  seenEdges: Set<string>,
+): void {
+  const key = `${source} ${target}`;
+  if (seenEdges.has(key)) return;
+  seenEdges.add(key);
+  const successors = outgoing.get(source);
+  if (successors === undefined) return;
+  successors.push(target);
+  inDegree.set(target, (inDegree.get(target) ?? 0) + 1);
 }

--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -25,3 +25,4 @@ export {
 export { collapseTree, type CollapseTreeOptions } from './collapse.js';
 export { renderTree, type RenderTreeOptions } from './render.js';
 export { filterRecords, type FilterRecordsOptions } from './filter.js';
+export { buildDependencyGraph } from './graph.js';

--- a/src/status/parser.test.ts
+++ b/src/status/parser.test.ts
@@ -146,6 +146,55 @@ body
     expect(dangling[0]).toMatch(/US9/);
   });
 
+  it('records dangling depends_on references in a structured dangling_refs field alongside the warning string', () => {
+    // Dual surfacing per data-model §4 / §6: the warning string MUST
+    // continue to be emitted (existing callers key off it), but the
+    // dropped reference MUST also appear in a structured field on the
+    // table so `buildDependencyGraph` can consume it without parsing
+    // strings.
+    const markdown = `## Dependency Order
+
+| ID  | Title | Depends On | Artifact |
+|-----|-------|------------|----------|
+| US1 | A     | —          | —        |
+| US2 | B     | —          | —        |
+| US3 | C     | US2, US9   | —        |
+| US4 | D     | US42       | —        |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    // Warnings are unchanged — both unresolved IDs still produce one
+    // warning each, in source order.
+    const danglingWarnings = result.warnings.filter((w) => /dangling/.test(w));
+    expect(danglingWarnings).toHaveLength(2);
+    expect(danglingWarnings[0]).toMatch(/US3/);
+    expect(danglingWarnings[0]).toMatch(/US9/);
+    expect(danglingWarnings[1]).toMatch(/US4/);
+    expect(danglingWarnings[1]).toMatch(/US42/);
+    // Structured field carries bare (non-fully-qualified) IDs in source
+    // order — the table itself has no path context to fully-qualify
+    // against.
+    expect(result.table.dangling_refs).toEqual([
+      { source_id: 'US3', missing_id: 'US9' },
+      { source_id: 'US4', missing_id: 'US42' },
+    ]);
+    // Surviving valid edges are kept on the row's `depends_on`.
+    expect(result.table.rows[2]?.depends_on).toEqual(['US2']);
+    expect(result.table.rows[3]?.depends_on).toEqual([]);
+  });
+
+  it('omits the dangling_refs field entirely when no references were dropped', () => {
+    const markdown = `## Dependency Order
+
+| ID  | Title | Depends On | Artifact |
+|-----|-------|------------|----------|
+| US1 | A     | —          | —        |
+| US2 | B     | US1        | —        |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.warnings).toEqual([]);
+    expect(result.table.dangling_refs).toBeUndefined();
+  });
+
   it('coerces absolute Artifact paths to null with a warning', () => {
     const markdown = `## Dependency Order
 

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -190,7 +190,14 @@ export function parseDependencyTable(
 
   // Second pass: resolve dangling depends_on references against the
   // set of valid IDs in this table.
+  //
+  // Dual surfacing per data-model §4 / §6: every dropped reference goes
+  // both onto the parallel `warnings` list (preserved verbatim so
+  // existing callers that key off the warning text keep working) AND
+  // into the structured `dangling_refs` field on the returned table so
+  // `buildDependencyGraph` can consume it without parsing strings.
   const validIds = new Set(partials.map((p) => p.row.id));
+  const dangling_refs: Array<{ source_id: string; missing_id: string }> = [];
   for (const { row, rawDependsOn } of partials) {
     const resolved: string[] = [];
     for (const dep of rawDependsOn) {
@@ -200,14 +207,22 @@ export function parseDependencyTable(
         warnings.push(
           `dependency_order: ${row.id} depends on dangling ID '${dep}' — dropped`,
         );
+        dangling_refs.push({ source_id: row.id, missing_id: dep });
       }
     }
     row.depends_on = resolved;
     rows.push(row);
   }
 
+  // Only emit `dangling_refs` when there is something to surface — keeps
+  // the table shape cheap for the common (clean) case.
+  const table: DependencyOrderTable =
+    dangling_refs.length > 0
+      ? { rows, id_prefix, format: 'table', dangling_refs }
+      : { rows, id_prefix, format: 'table' };
+
   return {
-    table: { rows, id_prefix, format: 'table' },
+    table,
     warnings,
   };
 }

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -85,6 +85,31 @@ export interface DependencyOrderTable {
    * the owning `ArtifactRecord`.
    */
   format: 'table' | 'legacy' | 'missing';
+  /**
+   * Structured record of every `depends_on` reference that the parser
+   * dropped during the second-pass dangling-ref resolution. Each entry
+   * carries the `source_id` (the row whose `depends_on` cell named the
+   * missing target) and the `missing_id` (the unresolved ID that did
+   * not match any row in the same table). Entries are recorded in
+   * source order — a row with multiple unresolved deps appears once
+   * per missing ID.
+   *
+   * IDs are bare (e.g., `US3`, `US9`) because the table itself has no
+   * artifact-path context; `buildDependencyGraph` upgrades them to
+   * fully-qualified `<artifact-path>#<id>` form when emitting
+   * `DependencyGraph.dangling_refs`.
+   *
+   * Optional / omitted (rather than empty array) when the parser had
+   * nothing to drop — keeps the in-memory shape cheap for the common
+   * case. Consumers MUST treat `undefined` and `[]` as equivalent.
+   *
+   * Dual surfacing: data-model §4 / §6 require unresolved references to
+   * appear BOTH as a parser warning string on the owning
+   * `ArtifactRecord` AND in this structured form. Do not remove the
+   * warning when populating this field — both surfaces are part of the
+   * contract.
+   */
+  dangling_refs?: Array<{ source_id: string; missing_id: string }>;
 }
 
 /**

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -10,10 +10,12 @@
  * The type surface grows incrementally story-by-story. User Story 1 shipped
  * `ArtifactRecord`, `NextAction`, `DependencyRow`, `DependencyOrderTable`,
  * and `ScanSummary`; User Story 2 Slice 1 adds `TreeNode` and `StatusTree`
- * alongside them. User Story 10 Slice 1 lands `DependencyNode` and
- * `DependencyGraph` as the cross-artifact graph type surface — the
- * builder (`buildDependencyGraph`) and the `--graph` text renderer arrive
- * in subsequent slices, but the types are now stable for downstream use.
+ * alongside them. User Story 10 Slice 1 landed `DependencyNode` and
+ * `DependencyGraph` as the cross-artifact graph type surface; Slice 2
+ * builds them out — the within-artifact projection is implemented in
+ * `graph.ts` (`buildDependencyGraph`) and the cross-artifact / cycle
+ * extensions plus the `--graph` text renderer arrive in subsequent
+ * tasks. The types are stable for downstream use today.
  */
 
 /**

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -12,10 +12,12 @@
  * and `ScanSummary`; User Story 2 Slice 1 adds `TreeNode` and `StatusTree`
  * alongside them. User Story 10 Slice 1 landed `DependencyNode` and
  * `DependencyGraph` as the cross-artifact graph type surface; Slice 2
- * builds them out — the within-artifact projection is implemented in
- * `graph.ts` (`buildDependencyGraph`) and the cross-artifact / cycle
- * extensions plus the `--graph` text renderer arrive in subsequent
- * tasks. The types are stable for downstream use today.
+ * implements the full builder in `graph.ts` (`buildDependencyGraph`) —
+ * within-artifact topological layering, cross-artifact edge stitching via
+ * `parent_path` / `parent_row_id`, structured dangling-reference reporting,
+ * and cycle detection via Tarjan's SCC algorithm. The types are stable for
+ * downstream use. The `--graph` text renderer and JSON wiring arrive in
+ * Slice 3.
  */
 
 /**


### PR DESCRIPTION
## Source

- Spec: [smithy-status-skill.spec.md](specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.spec.md)
- Tasks: [10-visualize-dependency-graph-for-parallel-work.tasks.md](specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md)
- Data model: [smithy-status-skill.data-model.md](specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.data-model.md)
- Contracts: [smithy-status-skill.contracts.md](specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.contracts.md)

## Slice

**Slice 2** — Build the Cross-Artifact Dependency Graph.

A new pure module `src/status/graph.ts` exports `buildDependencyGraph(records: ArtifactRecord[]): DependencyGraph` that unions every artifact's `DependencyOrderTable` into a single cross-artifact directed graph, assigns topological layers when the graph is acyclic (and for the acyclic portion when cycles exist), detects cycles, and reports unresolvable `depends_on` references. Fully covered by unit tests and re-exported from `src/status/index.ts`. No caller wires it yet — CLI output is unchanged. Slice 3 will wire both consumer surfaces (JSON `graph` field and `--graph` text rendering).

## Addresses

- **FRs**: FR-025 (deterministic per-artifact dependency parsing), FR-026 (cross-artifact union with cycle detection)
- **Acceptance scenarios**: AS 10.1 (within-artifact layering), AS 10.2 (cross-artifact rolling), AS 10.3 (cycle detection at builder boundary), AS 10.6 (dangling-ref diagnostics)

## Tasks completed

- [x] Implement single-artifact topological layering in `buildDependencyGraph` (Kahn's algorithm, deterministic discovery-order within layers per SD-013)
- [x] Stitch cross-artifact edges and emit dangling-reference diagnostics (cross-artifact edges via `parent_path`/`parent_row_id`; structured `DependencyOrderTable.dangling_refs` field replaces warning-string parsing)
- [x] Detect cycles and exclude cyclic nodes from layer assignment (iterative Tarjan SCC over Kahn residual; non-cyclic nodes downstream of a cycle are excluded from layers)

## Review

`smithy-implementation-review` returned 4 Minor findings — none applied per the triage table; included here for the reviewer:

- **graph.ts `addEdge` ordering** — `seenEdges.add(key)` runs before the `successors === undefined` defensive guard. Currently unreachable (callers pre-register both endpoints), but the dedupe entry could be marked without the edge being wired in a future refactor. Consider moving the `seenEdges.add` call below the guard.
- **Missing dedicated test for "downstream of a cycle"** — the singleton-SCC-without-self-loop discard path correctly excludes a non-cyclic node whose only predecessor is cyclic from both `layers` and `cycles`. Behavior is implemented but not pinned by a dedicated test; consider adding one in Slice 3 or as a follow-up.
- **SD-011 ordering convention left implicit** — the chosen "DFS-from-smallest-seed traversal order" for cycle participating-IDs is not documented on `DependencyGraph.cycles` JSDoc. SD-011 status remains `open` in the tasks file; consider resolving it in Slice 3's PR or adding a JSDoc cross-reference.
- **Table-level `dangling_refs` dedupe contract is implicit** — `DependencyOrderTable.dangling_refs` is source-faithful (no parser-level dedupe); `DependencyGraph.dangling_refs` dedupes during fully-qualification. Consider tightening the JSDoc on the table-level field to make the dual-surface contract explicit.

## Documentation

`smithy-maid` returned five findings.

**Auto-fixes applied**:

- `src/status/types.ts` module-level JSDoc refreshed to reflect that `buildDependencyGraph` is now fully implemented (committed as `maid: refresh types.ts module JSDoc for Slice 2 completion`).

**Flagged for review** (not applied — require author judgment):

- **AS 10.5 spec-text drift (SD-012)** — `smithy-status-skill.spec.md` line 206 still reads `ids: string[]` instead of the canonical `node_ids: string[]`. This is intentionally deferred to Slice 3's audit task per the slice plan ("this task does not silently edit the spec"). Surfaced here per Slice 3 Task 3's PR-description requirement.
- **Data-model §5 missing the new `dangling_refs` field** — `DependencyOrderTable` in the data model lists only `rows`, `id_prefix`, and `format`. The implementation adds a fourth optional field `dangling_refs?: Array<{ source_id, missing_id }>` (required by Slice 2 Task 2 acceptance criteria as the structured replacement for warning-string parsing). The field is documented in `types.ts` and the contracts; data-model §5 should be updated for parity. Recommended for a follow-up doc PR alongside the SD-012 reconciliation.
- **SD-008 vs SD-010 design conflict** — spec SD-008 (filters apply BEFORE layering) and tasks SD-010 (`buildDependencyGraph` is called with the pre-filter record set) read as contradictory. The pure builder in this slice is agnostic; Slice 3's caller wiring needs to pick a winner. Flagged here so the conflict is visible before Slice 3 lands.

## Validation

All commands run on HEAD (`af9283e`, after the maid commit):

| Command | Result |
|---------|--------|
| `npm run build` | ✅ `dist/cli.js` 100.23 KB, `tsup` Build success in 32ms |
| `npm run typecheck` | ✅ Clean (`tsc --noEmit`, no errors) |
| `npm test` | ✅ 636 tests passing across 22 test files (including 9 new graph-builder tests, 5 cycle-detection tests, 2 new parser tests for structured `dangling_refs`) |

## Outstanding

No blockers. Slice 3 (next) wires `buildDependencyGraph` and a new `renderGraph` module into `statusAction` and resolves the SD-008 / SD-010 / SD-012 follow-ups noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
