### PR TITLE
Wire dependency graph into JSON emission and --graph text rendering

### DIFF
--- a/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
@@ -109,7 +109,7 @@
   - The function is pure (no I/O, no mutation of `graph`), matches the `renderTree(tree, options) → string` signature pattern, and is exported from `src/status/index.ts`.
   - Layer entries read membership via the canonical `node_ids` key (SD-012 reconciliation).
 
-- [ ] **Wire `buildDependencyGraph` and `renderGraph` into `statusAction`**
+- [x] **Wire `buildDependencyGraph` and `renderGraph` into `statusAction`**
 
   Update `statusAction` in `src/commands/status.ts` so `buildDependencyGraph(records)` is called once per invocation (using the pre-filter record set per SD-010 / existing `summarize()` convention) and its result serves both consumer surfaces: (a) the JSON payload's `graph` field is populated unconditionally, replacing the zero-value stub; (b) in text mode, `opts.graph === true` routes through `renderGraph(graph, { all: opts.all === true })` instead of the tree pipeline. The existing tree pipeline is untouched when `--graph` is absent. Update the `StatusOptions.graph` JSDoc to reflect the now-wired state.
 

--- a/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
@@ -121,7 +121,7 @@
   - The default text path (no `--graph`) is unchanged: summary header, tree, collapse behavior, empty-repo hint all match current output.
   - The `StatusOptions.graph` JSDoc no longer describes the option as a "stub".
 
-- [ ] **Audit `node_ids` vs `ids` across code and flag the spec-text drift**
+- [x] **Audit `node_ids` vs `ids` across code and flag the spec-text drift**
 
   Sweep every implementation reference (the new `DependencyGraph` type, `graph.ts`, `renderGraph.ts`, and `src/commands/status.ts`) to confirm the canonical `node_ids` field name is used everywhere — `.ids` must not appear on any layer object in any code path. The spec-level drift in AS 10.5 (which reads `ids: string[]`) is tracked as SD-012 and surfaced in the PR description so the author can reconcile the spec prose in a follow-up; this task does not silently edit the spec.
 

--- a/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md
@@ -97,7 +97,7 @@
 
 ### Tasks
 
-- [ ] **Implement `renderGraph` in a new `src/status/renderGraph.ts` module**
+- [x] **Implement `renderGraph` in a new `src/status/renderGraph.ts` module**
 
   Create `src/status/renderGraph.ts` exporting `renderGraph(graph: DependencyGraph, options?: RenderGraphOptions): string`. The renderer emits one labeled block per layer (`Layer 0 (ready):`, `Layer 1:`, …), listing each node's title and fully-qualified ID under its layer heading. A layer whose members are all `status: 'done'` collapses to a single `Layer N: DONE (M items)` line in the default (non-`--all`) mode. When `graph.cycles` is non-empty, the output leads with a human-readable cycle-warning block listing the participating fully-qualified IDs and renders the non-cyclic nodes in a flat layer-0-style listing instead of the layered view (per AS 10.3 fallback). Dangling references in `graph.dangling_refs` surface as their own warning lines. Re-export from `src/status/index.ts`.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,21 +78,16 @@ program
       .choices(['text', 'json'])
       .default('text'),
   )
-  // `--all` is wired (US3) and `--status` / `--type` are wired (US6).
-  // `--graph` and `--no-color` remain stubs that Commander parses so
-  // `smithy status --help` advertises the full surface; `--graph` is
-  // owned by US10 and `--no-color` has no effect until a colored
-  // renderer lands.
-  //
-  // `--status` and `--type` deliberately do NOT use Commander
-  // `.choices()` because Commander's invalid-choice handler exits with
-  // code 1, while the contracts mandate exit code 2 for invalid values
-  // on these two flags. `statusAction` validates them manually and
-  // sets `process.exitCode = 2`.
+  // `--all`, `--status`, `--type`, and `--graph` are all wired
+  // end-to-end. `--status` and `--type` deliberately do NOT use
+  // Commander `.choices()` because Commander's invalid-choice handler
+  // exits with code 1, while the contracts mandate exit code 2 for
+  // invalid values on these two flags. `statusAction` validates them
+  // manually and sets `process.exitCode = 2`.
   .option('--status <state>', 'Filter by status: done|in-progress|not-started|unknown')
   .option('--type <artifact-type>', 'Filter by artifact type: rfc|features|spec|tasks')
   .option('--all', 'Disable collapsing of done subtrees so every artifact surfaces')
-  .option('--graph', 'Render the cross-artifact dependency graph (stub — wired in US2/US10)')
+  .option('--graph', 'Render the cross-artifact dependency graph as topological layers (text mode)')
   .option('--no-color', 'Suppress ANSI color output')
   .option('--ascii', 'Use ASCII tree connectors and icons (auto when terminal is not UTF-8)')
   .action((opts: Record<string, unknown>) => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -571,6 +571,41 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
     );
   }
 
+  /**
+   * Identical-shape fixture to {@link writeFourStoryFixture} but with
+   * NO done items — every tasks file has at least one unchecked
+   * checkbox. Used by tests that need the AS 10.1 static-topology
+   * layering (`US1+US4` in Layer 0, `US2` in Layer 1, `US3` in
+   * Layer 2) without the "done predecessors don't block" rule
+   * promoting blocked rows forward.
+   */
+  function writeNoDoneFourStoryFixture(): void {
+    write(
+      'specs/sample/sample.spec.md',
+      `# Sample Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n` +
+        `| US1 | First story | — | specs/sample/01-first.tasks.md |\n` +
+        `| US2 | Second story | US1 | specs/sample/02-second.tasks.md |\n` +
+        `| US3 | Third story | US2 | specs/sample/03-third.tasks.md |\n` +
+        `| US4 | Fourth story | — | specs/sample/04-fourth.tasks.md |\n`,
+    );
+    write(
+      'specs/sample/01-first.tasks.md',
+      `# US1 Tasks\n\n## Slice 1: Only\n\n- [ ] One\n- [ ] Two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    write(
+      'specs/sample/02-second.tasks.md',
+      `# US2 Tasks\n\n## Slice 1: Only\n\n- [ ] One\n- [ ] Two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    write(
+      'specs/sample/03-third.tasks.md',
+      `# US3 Tasks\n\n## Slice 1: Only\n\n- [ ] One\n- [ ] Two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    write(
+      'specs/sample/04-fourth.tasks.md',
+      `# US4 Tasks\n\n## Slice 1: Only\n\n- [ ] One\n- [ ] Two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+  }
+
   // --- AS 10.5: JSON graph populated unconditionally ---
 
   it('AS 10.5: JSON `graph` is populated from buildDependencyGraph (multi-row spec)', () => {
@@ -633,14 +668,16 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
 
   // --- AS 10.1 / AS 10.4: text path renders layered view via renderGraph ---
 
-  it('AS 10.1: --graph --all prints layered headings with US1/US4 in Layer 0 and US2/US3 in later layers', () => {
-    writeFourStoryFixture();
-    // Use `--all` here so the fixture's `done` US1 row surfaces in
-    // the rendered output. Default mode hides done members from the
-    // listing (covered separately below) — this assertion is about the
-    // builder's layer membership, which we want to read straight off
-    // the rendered output without the hide-done filter in play.
-    statusAction({ root, graph: true, all: true });
+  it('AS 10.1: --graph prints layered headings with US1/US4 in Layer 0 and US2/US3 in later layers', () => {
+    // AS 10.1 describes the static topology: US1+US4 in Layer 0, US2
+    // in Layer 1, US3 in Layer 2. Under the "done predecessors don't
+    // block" layering rule, those layer assignments only hold when no
+    // upstream node is `done` (otherwise blocked work promotes
+    // forward). The four-story fixture sets US1's tasks file to done,
+    // which would promote US2 to Layer 0; use a fresh no-done fixture
+    // here so the test asserts AS 10.1 as-written.
+    writeNoDoneFourStoryFixture();
+    statusAction({ root, graph: true });
     const stdout = captured();
     // Layer 0 leads with the "ready to work" copy (renderGraph
     // contract). Subsequent layers use the simpler heading form.
@@ -649,7 +686,8 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
     expect(stdout).toContain('Layer 2');
     // Each layer's stories surface by their row title (the new
     // title-first layout). Layer assignment proven by the relative
-    // ordering of titles in the rendered output.
+    // ordering of titles in the rendered output: US1 + US4 in Layer 0,
+    // US2 in Layer 1, US3 in Layer 2.
     const us1Pos = stdout.indexOf('First story');
     const us4Pos = stdout.indexOf('Fourth story');
     const us2Pos = stdout.indexOf('Second story');
@@ -657,7 +695,7 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
     expect(us1Pos).toBeGreaterThanOrEqual(0);
     expect(us4Pos).toBeGreaterThan(us1Pos); // both in Layer 0
     expect(us2Pos).toBeGreaterThan(us4Pos); // Layer 0 < Layer 1
-    expect(us3Pos).toBeGreaterThan(us2Pos); // Layer 1 < Layer 2 (or 3)
+    expect(us3Pos).toBeGreaterThan(us2Pos); // Layer 1 < Layer 2
     // The summary header still prints above the graph view (FR-016).
     expect(stdout).toContain(' Smithy Status');
   });
@@ -719,19 +757,18 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
     writeFourStoryFixture();
     statusAction({ root, graph: true });
     const stdout = captured();
-    // The four-story fixture has US1's tasks file fully checked, so
-    // the tasks-file slice node carries `status: done` and is hidden
-    // from its layer's listing in default mode. (User-story nodes
-    // share the spec record's rolled-up `in-progress` status, so they
-    // do not individually trigger the filter — separate from this
-    // assertion.) At least one layer must therefore show the
-    // `done hidden` suffix.
-    expect(stdout).toMatch(/Layer \d+ \(\d+ items, \d+ done hidden\)/);
-    // The hidden tasks-file slice's FQ id must NOT appear under the
-    // layered view in default mode (the user-story FQ id still does,
-    // since user-story nodes are not individually `done` in this
-    // fixture).
+    // The four-story fixture carries done items: US1's tasks file is
+    // fully checked, US1's user-story node rolls up to done from its
+    // downstream, and the tasks-file slice for US1 is also done. With
+    // the "done predecessors don't block" layering rule, those done
+    // items end up in Layer 0 (no remaining blockers) and get hidden
+    // by the default-mode filter — surfacing as `, N done hidden` in
+    // the Layer 0 heading.
+    expect(stdout).toContain('done hidden');
+    // The hidden user-story FQ id and tasks-file slice FQ id must NOT
+    // appear in the rendered output; they're filtered out.
     expect(stdout).not.toContain('specs/sample/01-first.tasks.md#S1');
+    expect(stdout).not.toContain('specs/sample/sample.spec.md#US1');
   });
 
   it('--graph --all surfaces every member regardless of status (including done items hidden in default mode)', () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1,8 +1,25 @@
-import { describe, expect, it } from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from 'vitest';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 import {
   formatSummaryHeader,
   pickTopNextAction,
+  statusAction,
   type StatusJsonPayload,
 } from './status.js';
 import type {
@@ -451,5 +468,277 @@ describe('StatusJsonPayload.graph type wiring (US10 Slice 1)', () => {
     expect(payload.graph.layers).toEqual([]);
     expect(payload.graph.cycles).toEqual([]);
     expect(payload.graph.dangling_refs).toEqual([]);
+  });
+});
+
+/**
+ * US10 Slice 3 integration tests: assert that `statusAction` wires
+ * `buildDependencyGraph` into the JSON payload unconditionally and
+ * routes `--graph` text mode through `renderGraph` with summary header
+ * preserved, done-layer collapsing honoring `--all`, cycle fallback,
+ * and dangling-ref diagnostics. Each test builds a synthetic repo
+ * under `os.tmpdir()` (mirroring `scanner.test.ts`'s pattern), invokes
+ * `statusAction` with `--root` pointed at it, and captures stdout via
+ * `vi.spyOn(console, 'log')`.
+ */
+describe('statusAction --graph integration (US10 Slice 3)', () => {
+  const TABLE_HEADER =
+    '| ID | Title | Depends On | Artifact |\n|----|-------|------------|----------|';
+
+  let root: string;
+  let logSpy: MockInstance<(...args: unknown[]) => void>;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'smithy-status-graph-'));
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {
+      /* swallow stdout during tests */
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    if (root) rmSync(root, { recursive: true, force: true });
+  });
+
+  function write(relPath: string, contents: string): void {
+    const abs = join(root, relPath);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, contents);
+  }
+
+  function captured(): string {
+    return logSpy.mock.calls.map((args) => args.join(' ')).join('\n');
+  }
+
+  /**
+   * Write the AS 10.1 fixture: a single spec with four user stories
+   * where US1 + US4 are independent, US2 depends on US1, and US3
+   * depends on US2. Tasks files are emitted as `done` / `in-progress`
+   * / `not-started` so the rolled-up spec status is `in-progress`.
+   */
+  function writeFourStoryFixture(): void {
+    write(
+      'specs/sample/sample.spec.md',
+      `# Sample Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n` +
+        `| US1 | First story | — | specs/sample/01-first.tasks.md |\n` +
+        `| US2 | Second story | US1 | specs/sample/02-second.tasks.md |\n` +
+        `| US3 | Third story | US2 | specs/sample/03-third.tasks.md |\n` +
+        `| US4 | Fourth story | — | specs/sample/04-fourth.tasks.md |\n`,
+    );
+    // US1 done, US2 in-progress, US3/US4 not-started — gives a mixed
+    // spec status (`in-progress`) so the summary header shows
+    // multiple counts.
+    write(
+      'specs/sample/01-first.tasks.md',
+      `# US1 Tasks\n\n## Slice 1: Only\n\n- [x] One\n- [x] Two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    write(
+      'specs/sample/02-second.tasks.md',
+      `# US2 Tasks\n\n## Slice 1: Only\n\n- [x] One\n- [ ] Two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    write(
+      'specs/sample/03-third.tasks.md',
+      `# US3 Tasks\n\n## Slice 1: Only\n\n- [ ] One\n- [ ] Two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    write(
+      'specs/sample/04-fourth.tasks.md',
+      `# US4 Tasks\n\n## Slice 1: Only\n\n- [ ] One\n- [ ] Two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+  }
+
+  /**
+   * Fixture where every spec row + tasks-file row in the graph rolls
+   * up to `done`. Both spec rows have all-checked tasks files, so the
+   * spec itself rolls up to `done`, and every node in the graph
+   * carries `status: 'done'`. In default mode every layer therefore
+   * collapses to `Layer N: DONE (M items)`; under `--all`, every
+   * layer expands and every node id surfaces.
+   */
+  function writeAllDoneFixture(): void {
+    write(
+      'specs/sample/sample.spec.md',
+      `# Sample Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n` +
+        `| US1 | First story | — | specs/sample/01-first.tasks.md |\n` +
+        `| US2 | Second story | US1 | specs/sample/02-second.tasks.md |\n`,
+    );
+    write(
+      'specs/sample/01-first.tasks.md',
+      `# US1 Tasks\n\n## Slice 1: Only\n\n- [x] One\n- [x] Two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+    write(
+      'specs/sample/02-second.tasks.md',
+      `# US2 Tasks\n\n## Slice 1: Only\n\n- [x] One\n- [x] Two\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Only | — | — |\n`,
+    );
+  }
+
+  // --- AS 10.5: JSON graph populated unconditionally ---
+
+  it('AS 10.5: JSON `graph` is populated from buildDependencyGraph (multi-row spec)', () => {
+    writeFourStoryFixture();
+    statusAction({ root, format: 'json' });
+    const payload = JSON.parse(captured()) as StatusJsonPayload;
+    // Nodes contains every fully-qualified row.
+    expect(Object.keys(payload.graph.nodes).length).toBeGreaterThan(0);
+    expect(payload.graph.nodes['specs/sample/sample.spec.md#US1']).toBeDefined();
+    // Layers carry node_ids, not `ids`.
+    expect(payload.graph.layers.length).toBeGreaterThan(0);
+    const firstLayer = payload.graph.layers[0]!;
+    expect(firstLayer.node_ids).toBeDefined();
+    expect(Array.isArray(firstLayer.node_ids)).toBe(true);
+    expect(firstLayer.node_ids.length).toBeGreaterThan(0);
+    // cycles / dangling_refs are arrays even when empty.
+    expect(Array.isArray(payload.graph.cycles)).toBe(true);
+    expect(Array.isArray(payload.graph.dangling_refs)).toBe(true);
+  });
+
+  it('AS 10.5: JSON layer objects use the canonical `node_ids` field name (no `.ids` drift, SD-012)', () => {
+    writeFourStoryFixture();
+    statusAction({ root, format: 'json' });
+    const stdout = captured();
+    // None of the emitted layer objects may carry an `ids` key — the
+    // canonical name is `node_ids`. The check is a literal substring
+    // assertion against the JSON, since `JSON.stringify` quotes object
+    // keys.
+    expect(stdout).not.toContain('"ids":');
+    expect(stdout).toContain('"node_ids":');
+  });
+
+  it('AS 10.5: JSON `graph` is the canonical zero-value shape on an empty repo', () => {
+    statusAction({ root, format: 'json' });
+    const payload = JSON.parse(captured()) as StatusJsonPayload;
+    expect(payload.graph).toEqual<DependencyGraph>({
+      nodes: {},
+      layers: [],
+      cycles: [],
+      dangling_refs: [],
+    });
+  });
+
+  it('AS 10.5: JSON `graph` reflects the pre-filter scan even when --status excludes some records (SD-010)', () => {
+    writeFourStoryFixture();
+    // US1's tasks file is fully checked → US1 rolls up to `done`.
+    // Filtering by --status=in-progress would exclude it from the
+    // `records` field, but the `graph` is built pre-filter so it must
+    // still carry the US1 node.
+    statusAction({ root, format: 'json', status: 'in-progress' });
+    const payload = JSON.parse(captured()) as StatusJsonPayload;
+    // The filter dropped done records from `payload.records`...
+    const filteredHasUs1 = payload.records.some(
+      (r) => r.path === 'specs/sample/01-first.tasks.md',
+    );
+    expect(filteredHasUs1).toBe(false);
+    // ...but the graph (built from the unfiltered scan) still does.
+    expect(payload.graph.nodes['specs/sample/sample.spec.md#US1']).toBeDefined();
+  });
+
+  // --- AS 10.1 / AS 10.4: text path renders layered view via renderGraph ---
+
+  it('AS 10.1: --graph prints layered headings with US1/US4 in Layer 0 and US2/US3 in later layers', () => {
+    writeFourStoryFixture();
+    statusAction({ root, graph: true });
+    const stdout = captured();
+    // Layer 0 leads with the "ready to work" copy (renderGraph
+    // contract). Subsequent layers use the simpler heading form.
+    expect(stdout).toContain('Layer 0 — ready to work');
+    expect(stdout).toContain('Layer 1');
+    expect(stdout).toContain('Layer 2');
+    // US1 + US4 belong to layer 0; US2 to layer 1; US3 to layer 2.
+    expect(stdout).toContain('specs/sample/sample.spec.md#US1');
+    expect(stdout).toContain('specs/sample/sample.spec.md#US4');
+    expect(stdout).toContain('specs/sample/sample.spec.md#US2');
+    expect(stdout).toContain('specs/sample/sample.spec.md#US3');
+    // The summary header still prints above the graph view (FR-016).
+    expect(stdout).toContain(' Smithy Status');
+  });
+
+  it('AS 10.4: --graph collapses fully-done layers to `Layer N: DONE (M items)` and drops member IDs in default mode', () => {
+    writeAllDoneFixture();
+    statusAction({ root, graph: true });
+    const stdout = captured();
+    // Every node in the fixture rolls up to `done`, so every layer
+    // collapses. At least one collapsed layer line must surface, and
+    // none of the spec's row IDs can appear (they would only surface
+    // as expanded layer-member lines).
+    expect(stdout).toMatch(/Layer \d+: DONE \(\d+ items?\)/);
+    expect(stdout).not.toContain('specs/sample/sample.spec.md#US1');
+    expect(stdout).not.toContain('specs/sample/sample.spec.md#US2');
+  });
+
+  it('AS 10.4: --graph --all expands every layer regardless of status', () => {
+    writeAllDoneFixture();
+    statusAction({ root, graph: true, all: true });
+    const stdout = captured();
+    // No collapse line — every layer is fully expanded.
+    expect(stdout).not.toMatch(/Layer \d+: DONE/);
+    // Both spec-row members surface as full node lines now.
+    expect(stdout).toContain('specs/sample/sample.spec.md#US1');
+    expect(stdout).toContain('specs/sample/sample.spec.md#US2');
+  });
+
+  // --- AS 10.3: cycle fallback ---
+
+  it('AS 10.3: --graph emits a cycle warning and Cycle: line when the graph is not a DAG', () => {
+    // US1 depends on US2, US2 depends on US1 → mutual cycle.
+    write(
+      'specs/sample/sample.spec.md',
+      `# Sample Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n` +
+        `| US1 | First story | US2 | — |\n` +
+        `| US2 | Second story | US1 | — |\n`,
+    );
+    const exitCodeBefore = process.exitCode;
+    statusAction({ root, graph: true });
+    // No exception thrown above (we'd never reach here otherwise) and
+    // process.exitCode is not bumped to a failure value.
+    expect(process.exitCode).toBe(exitCodeBefore);
+    const stdout = captured();
+    expect(stdout).toContain('WARNING: dependency graph contains cycle');
+    expect(stdout).toContain('Cycle: ');
+    // Both cyclic IDs appear in the Cycle: line.
+    expect(stdout).toContain('specs/sample/sample.spec.md#US1');
+    expect(stdout).toContain('specs/sample/sample.spec.md#US2');
+  });
+
+  // --- AS 10.6: dangling refs ---
+
+  it('AS 10.6: --graph surfaces a Dangling refs: block when a depends_on reference is unresolved', () => {
+    // US2 declares a dep on US99 which does not exist in the table.
+    // The parser drops the edge and records a structured
+    // dangling_refs entry; the graph builder propagates it; the
+    // renderer surfaces it.
+    write(
+      'specs/sample/sample.spec.md',
+      `# Sample Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n` +
+        `| US1 | First story | — | — |\n` +
+        `| US2 | Second story | US1, US99 | — |\n`,
+    );
+    statusAction({ root, graph: true });
+    const stdout = captured();
+    expect(stdout).toContain('Dangling refs:');
+    // The unresolved pair appears with both ends fully-qualified.
+    expect(stdout).toContain('specs/sample/sample.spec.md#US2');
+    expect(stdout).toContain('specs/sample/sample.spec.md#US99');
+    expect(stdout).toContain('(unresolved)');
+  });
+
+  // --- regression: default text path unchanged ---
+
+  it('default text path (no --graph) still routes through renderTree, not renderGraph', () => {
+    writeFourStoryFixture();
+    statusAction({ root });
+    const stdout = captured();
+    // Summary header prints as before.
+    expect(stdout).toContain(' Smithy Status');
+    // No layer headings — proves we did not silently route through
+    // renderGraph. (`Layer ` is the unique prefix renderGraph emits
+    // and renderTree never produces.)
+    expect(stdout).not.toContain('Layer 0 — ready to work');
+    expect(stdout).not.toMatch(/Layer \d+ \(/);
+    // The tree renderer surfaces the spec title (with rolled-up
+    // status icon) and per-task next-action hints — both are unique
+    // to the tree path. `renderGraph` would emit fully-qualified
+    // node IDs (`specs/sample/sample.spec.md#US1`) instead.
+    expect(stdout).toContain('Sample Spec');
+    expect(stdout).toContain('smithy.forge specs/sample/');
+    expect(stdout).not.toContain('specs/sample/sample.spec.md#US');
   });
 });

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -647,13 +647,48 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
     expect(stdout).toContain('Layer 0 — ready to work');
     expect(stdout).toContain('Layer 1');
     expect(stdout).toContain('Layer 2');
-    // US1 + US4 belong to layer 0; US2 to layer 1; US3 to layer 2.
-    expect(stdout).toContain('specs/sample/sample.spec.md#US1');
-    expect(stdout).toContain('specs/sample/sample.spec.md#US4');
-    expect(stdout).toContain('specs/sample/sample.spec.md#US2');
-    expect(stdout).toContain('specs/sample/sample.spec.md#US3');
+    // Each layer's stories surface by their row title (the new
+    // title-first layout). Layer assignment proven by the relative
+    // ordering of titles in the rendered output.
+    const us1Pos = stdout.indexOf('First story');
+    const us4Pos = stdout.indexOf('Fourth story');
+    const us2Pos = stdout.indexOf('Second story');
+    const us3Pos = stdout.indexOf('Third story');
+    expect(us1Pos).toBeGreaterThanOrEqual(0);
+    expect(us4Pos).toBeGreaterThan(us1Pos); // both in Layer 0
+    expect(us2Pos).toBeGreaterThan(us4Pos); // Layer 0 < Layer 1
+    expect(us3Pos).toBeGreaterThan(us2Pos); // Layer 1 < Layer 2 (or 3)
     // The summary header still prints above the graph view (FR-016).
     expect(stdout).toContain(' Smithy Status');
+  });
+
+  it('AS 10.5: JSON `graph` carries the canonical fully-qualified node IDs regardless of text-mode formatting', () => {
+    // The text-mode renderer now substitutes a per-row `→ smithy.<cmd>`
+    // hint for the dim FQ id suffix when records are supplied. Lock
+    // the FQ ids to the JSON payload so machine consumers still have
+    // the canonical reference for every node, decoupled from text-mode
+    // styling decisions.
+    writeFourStoryFixture();
+    statusAction({ root, format: 'json' });
+    const payload = JSON.parse(captured()) as StatusJsonPayload;
+    expect(payload.graph.nodes['specs/sample/sample.spec.md#US1']).toBeDefined();
+    expect(payload.graph.nodes['specs/sample/sample.spec.md#US2']).toBeDefined();
+    expect(payload.graph.nodes['specs/sample/sample.spec.md#US3']).toBeDefined();
+    expect(payload.graph.nodes['specs/sample/sample.spec.md#US4']).toBeDefined();
+  });
+
+  it('--graph node lines surface a `→ smithy.<cmd>` per-row action hint instead of the dim FQ id', () => {
+    writeFourStoryFixture();
+    statusAction({ root, graph: true, all: true });
+    const stdout = captured();
+    // Per-row hints derive from the row's downstream record's
+    // next_action (real or virtual). For US4 (whose tasks file is
+    // not-started) the hint is `smithy.forge specs/sample/04-fourth.tasks.md`
+    // — the downstream tasks file's own next_action.
+    expect(stdout).toContain('→ smithy.forge specs/sample/04-fourth.tasks.md');
+    // Slice rows synthesise per-slice forge hints with the slice
+    // number as the second arg, mirroring `smithy.forge <tasks> <N>`.
+    expect(stdout).toContain('→ smithy.forge specs/sample/04-fourth.tasks.md 1');
   });
 
   it('--graph default mode hides done members and surfaces a `done hidden` suffix on the affected layer', () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -550,9 +550,9 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
    * Fixture where every spec row + tasks-file row in the graph rolls
    * up to `done`. Both spec rows have all-checked tasks files, so the
    * spec itself rolls up to `done`, and every node in the graph
-   * carries `status: 'done'`. In default mode every layer therefore
-   * collapses to `Layer N: DONE (M items)`; under `--all`, every
-   * layer expands and every node id surfaces.
+   * carries `status: 'done'`. In default mode fully-done layers are
+   * omitted entirely; under `--all`, every layer is shown and every
+   * node id surfaces.
    */
   function writeAllDoneFixture(): void {
     write(

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -633,9 +633,14 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
 
   // --- AS 10.1 / AS 10.4: text path renders layered view via renderGraph ---
 
-  it('AS 10.1: --graph prints layered headings with US1/US4 in Layer 0 and US2/US3 in later layers', () => {
+  it('AS 10.1: --graph --all prints layered headings with US1/US4 in Layer 0 and US2/US3 in later layers', () => {
     writeFourStoryFixture();
-    statusAction({ root, graph: true });
+    // Use `--all` here so the fixture's `done` US1 row surfaces in
+    // the rendered output. Default mode hides done members from the
+    // listing (covered separately below) — this assertion is about the
+    // builder's layer membership, which we want to read straight off
+    // the rendered output without the hide-done filter in play.
+    statusAction({ root, graph: true, all: true });
     const stdout = captured();
     // Layer 0 leads with the "ready to work" copy (renderGraph
     // contract). Subsequent layers use the simpler heading form.
@@ -649,6 +654,36 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
     expect(stdout).toContain('specs/sample/sample.spec.md#US3');
     // The summary header still prints above the graph view (FR-016).
     expect(stdout).toContain(' Smithy Status');
+  });
+
+  it('--graph default mode hides done members and surfaces a `done hidden` suffix on the affected layer', () => {
+    writeFourStoryFixture();
+    statusAction({ root, graph: true });
+    const stdout = captured();
+    // The four-story fixture has US1's tasks file fully checked, so
+    // the tasks-file slice node carries `status: done` and is hidden
+    // from its layer's listing in default mode. (User-story nodes
+    // share the spec record's rolled-up `in-progress` status, so they
+    // do not individually trigger the filter — separate from this
+    // assertion.) At least one layer must therefore show the
+    // `done hidden` suffix.
+    expect(stdout).toMatch(/Layer \d+ \(\d+ items, \d+ done hidden\)/);
+    // The hidden tasks-file slice's FQ id must NOT appear under the
+    // layered view in default mode (the user-story FQ id still does,
+    // since user-story nodes are not individually `done` in this
+    // fixture).
+    expect(stdout).not.toContain('specs/sample/01-first.tasks.md#S1');
+  });
+
+  it('--graph --all surfaces every member regardless of status (including done items hidden in default mode)', () => {
+    writeFourStoryFixture();
+    statusAction({ root, graph: true, all: true });
+    const stdout = captured();
+    // No layer carries the hide-done suffix under --all.
+    expect(stdout).not.toContain('done hidden');
+    // The done tasks-file slice that default mode hides surfaces
+    // here, proving --all bypasses the hide-done filter.
+    expect(stdout).toContain('specs/sample/01-first.tasks.md#S1');
   });
 
   it('AS 10.4: --graph collapses fully-done layers to `Layer N: DONE (M items)` and drops member IDs in default mode', () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -677,6 +677,30 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
     expect(payload.graph.nodes['specs/sample/sample.spec.md#US4']).toBeDefined();
   });
 
+  it('--graph suppresses the `Next:` line in the summary header (the layered view already surfaces actions)', () => {
+    writeFourStoryFixture();
+    statusAction({ root, graph: true });
+    const stdout = captured();
+    // Summary header still prints (per-type counts).
+    expect(stdout).toContain(' Smithy Status');
+    expect(stdout).toContain('Specs');
+    expect(stdout).toContain('Tasks');
+    // `Next:` line is intentionally absent — the graph view's own
+    // Layer 0 hints replace it.
+    expect(stdout).not.toContain('Next:');
+  });
+
+  it('default text mode (no --graph) still prints the `Next:` line in the summary header', () => {
+    // Regression guard: removing `Next:` under `--graph` must not
+    // remove it from the default text path. The default path only
+    // shows one consolidated next action, so the summary's `Next:`
+    // line is the user's primary cue there.
+    writeFourStoryFixture();
+    statusAction({ root });
+    const stdout = captured();
+    expect(stdout).toContain('Next:');
+  });
+
   it('--graph node lines surface a `→ smithy.<cmd>` per-row action hint instead of the dim FQ id', () => {
     writeFourStoryFixture();
     statusAction({ root, graph: true, all: true });
@@ -721,24 +745,29 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
     expect(stdout).toContain('specs/sample/01-first.tasks.md#S1');
   });
 
-  it('AS 10.4: --graph collapses fully-done layers to `Layer N: DONE (M items)` and drops member IDs in default mode', () => {
+  it('AS 10.4: --graph omits fully-done layers entirely from default mode (no heading, no members)', () => {
     writeAllDoneFixture();
     statusAction({ root, graph: true });
     const stdout = captured();
-    // Every node in the fixture rolls up to `done`, so every layer
-    // collapses. At least one collapsed layer line must surface, and
-    // none of the spec's row IDs can appear (they would only surface
-    // as expanded layer-member lines).
-    expect(stdout).toMatch(/Layer \d+: DONE \(\d+ items?\)/);
+    // Every node in the fixture rolls up to `done`. The previous
+    // collapse line (`Layer N: DONE (M items)`) added no actionable
+    // signal, so the whole graph block now drops out of default
+    // mode — no `Layer ` heading, no `DONE (` collapse line, no
+    // member IDs.
+    expect(stdout).not.toContain('Layer ');
+    expect(stdout).not.toContain('DONE (');
     expect(stdout).not.toContain('specs/sample/sample.spec.md#US1');
     expect(stdout).not.toContain('specs/sample/sample.spec.md#US2');
+    // Summary header still surfaces so users see the per-type counts.
+    expect(stdout).toContain(' Smithy Status');
   });
 
   it('AS 10.4: --graph --all expands every layer regardless of status', () => {
     writeAllDoneFixture();
     statusAction({ root, graph: true, all: true });
     const stdout = captured();
-    // No collapse line — every layer is fully expanded.
+    // No collapse line under --all either — every layer is fully
+    // expanded with its members surfaced.
     expect(stdout).not.toMatch(/Layer \d+: DONE/);
     // Both spec-row members surface as full node lines now.
     expect(stdout).toContain('specs/sample/sample.spec.md#US1');

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -720,6 +720,34 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
     expect(stdout).toContain('(unresolved)');
   });
 
+  // --- friendly hints: empty repo and no-match-filter under --graph ---
+
+  it('--graph on an empty repo prints the no-artifacts hint, not an empty graph block', () => {
+    // Empty `root`: no fixture written. The empty-repo guard must fire
+    // before the graph branch so users do not see a stray summary
+    // header followed by silence.
+    const exitCodeBefore = process.exitCode;
+    statusAction({ root, graph: true });
+    expect(process.exitCode).toBe(exitCodeBefore);
+    const stdout = captured();
+    expect(stdout).toContain('No Smithy artifacts found');
+    expect(stdout).not.toContain('Layer ');
+    expect(stdout).not.toContain('Smithy Status');
+  });
+
+  it('--graph with --status filter that matches nothing prints the no-match hint, not an empty graph block', () => {
+    writeAllDoneFixture();
+    // Every record rolls up to `done`, so `--status in-progress`
+    // retains zero records. The summary header still surfaces (full
+    // scan, SD-010), but the graph branch must defer to the no-match
+    // hint rather than rendering against the unfiltered graph.
+    statusAction({ root, graph: true, status: 'in-progress' });
+    const stdout = captured();
+    expect(stdout).toContain(' Smithy Status');
+    expect(stdout).toContain('No artifacts match the current filter.');
+    expect(stdout).not.toContain('Layer ');
+  });
+
   // --- regression: default text path unchanged ---
 
   it('default text path (no --graph) still routes through renderTree, not renderGraph', () => {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -235,13 +235,24 @@ export function statusAction(opts: StatusOptions = {}): void {
   // Ancestor retention inside `filterRecords` preserves AS 6.1 / AS
   // 6.3 context without any renderer change. `--root` is a no-op
   // here (the scan was already narrowed above); we pass it through
-  // for signature symmetry. `summarize(records)` and
-  // `buildDependencyGraph(records)` both stay above the filter call so
-  // the `ScanSummary` / header AND the `DependencyGraph` remain
-  // aggregate over the full scan per SD-010 — `--status` / `--type`
-  // narrow the rendered tree view but never the graph shape.
+  // for signature symmetry. `summarize(records)` stays above the
+  // filter call so the `ScanSummary` / header remains aggregate over
+  // the full scan per SD-010 — `--status` / `--type` narrow the
+  // rendered tree view but never the summary header.
+  //
+  // The {@link DependencyGraph} is built lazily — only the JSON
+  // payload and the `--graph` text branch consume it, and computing
+  // it for the default text view (which doesn't reference it) would
+  // walk every record's dependency-order rows for nothing. Builds
+  // happen on first read via `getGraph()` below; the closure captures
+  // the result so the second consumer (if any) reuses the first
+  // build. Pre-filter records remain the input per SD-010.
   const summary = summarize(records);
-  const graph = buildDependencyGraph(records);
+  let cachedGraph: DependencyGraph | null = null;
+  const getGraph = (): DependencyGraph => {
+    if (cachedGraph === null) cachedGraph = buildDependencyGraph(records);
+    return cachedGraph;
+  };
   // Build a sparse options object — `exactOptionalPropertyTypes` in
   // tsconfig forbids assigning `undefined` to optional fields, so we
   // only set each key when Commander actually populated it.
@@ -261,7 +272,7 @@ export function statusAction(opts: StatusOptions = {}): void {
       summary,
       records: filteredRecords,
       tree: buildTree(filteredRecords),
-      graph,
+      graph: getGraph(),
     };
     console.log(JSON.stringify(payload, null, 2));
     return;
@@ -272,6 +283,51 @@ export function statusAction(opts: StatusOptions = {}): void {
     console.log(
       'No Smithy artifacts found. Run `smithy.ignite` or `smithy.mark` to create one.',
     );
+    return;
+  }
+
+  const theme = buildTheme({
+    noColor: opts.color === false,
+    ascii: opts.ascii === true,
+  });
+
+  // US10 Slice 3: `--graph` swaps the tree pipeline for the layered
+  // view from `renderGraph`. The summary header still prints first so
+  // users keep the per-type counts (FR-016). The `Next:` hint is
+  // suppressed under `--graph` because the layered view already
+  // surfaces actionable next steps inline on every node line — a
+  // single `Next:` summary would just duplicate the topmost Layer-0
+  // hint and add visual noise. The graph itself is built pre-filter
+  // (above), so when `--status` / `--type` retain no records we still
+  // print the same friendly "no match" hint as the default path —
+  // consistency wins over rendering an unfiltered graph behind a
+  // filtered summary.
+  //
+  // Branch on `opts.graph` BEFORE the default-path tree pipeline so
+  // `buildTree` / `collapseTree` / `pickTopNextAction` only run for
+  // the default view that actually consumes them. Otherwise large
+  // repos would pay for an unused tree build on every `--graph`
+  // invocation.
+  if (opts.graph === true) {
+    console.log(formatSummaryHeader(summary, theme, null));
+    if (filteredRecords.length === 0) {
+      console.log('No artifacts match the current filter.');
+      return;
+    }
+    const renderedGraph = renderGraph(getGraph(), {
+      theme,
+      all: opts.all === true,
+      // Thread the pre-filter record set so each node line can carry a
+      // per-row next-action hint (`→ smithy.<cmd> <args>`) instead of
+      // the dim FQ id. Mirrors the `Next:` line in the summary header
+      // and the per-record hints under `renderTree`. SD-010 keeps the
+      // record set pre-filter so the hints reflect the full scan, in
+      // line with the graph itself.
+      records,
+    });
+    if (renderedGraph.length > 0) {
+      console.log(renderedGraph);
+    }
     return;
   }
 
@@ -296,48 +352,10 @@ export function statusAction(opts: StatusOptions = {}): void {
   // `collapseTree` drops their descendants before `renderTree` sees
   // them. The `--format json` branch above is untouched — this flag
   // only affects text-mode output (SD-016).
-  const theme = buildTheme({
-    noColor: opts.color === false,
-    ascii: opts.ascii === true,
-  });
   const tree = collapseTree(buildTree(filteredRecords), {
     all: opts.all === true,
   });
   const topNextAction = pickTopNextAction(tree);
-
-  // US10 Slice 3: `--graph` swaps the tree pipeline for the layered
-  // view from `renderGraph`. The summary header still prints first so
-  // users keep the per-type counts (FR-016). The `Next:` hint is
-  // suppressed under `--graph` because the layered view already
-  // surfaces actionable next steps inline on every node line — a
-  // single `Next:` summary would just duplicate the topmost Layer-0
-  // hint and add visual noise. The graph itself is built pre-filter
-  // (above), so when `--status` / `--type` retain no records we still
-  // print the same friendly "no match" hint as the default path —
-  // consistency wins over rendering an unfiltered graph behind a
-  // filtered summary.
-  if (opts.graph === true) {
-    console.log(formatSummaryHeader(summary, theme, null));
-    if (filteredRecords.length === 0) {
-      console.log('No artifacts match the current filter.');
-      return;
-    }
-    const renderedGraph = renderGraph(graph, {
-      theme,
-      all: opts.all === true,
-      // Thread the pre-filter record set so each node line can carry a
-      // per-row next-action hint (`→ smithy.<cmd> <args>`) instead of
-      // the dim FQ id. Mirrors the `Next:` line in the summary header
-      // and the per-record hints under `renderTree`. SD-010 keeps the
-      // record set pre-filter so the hints reflect the full scan, in
-      // line with the graph itself.
-      records,
-    });
-    if (renderedGraph.length > 0) {
-      console.log(renderedGraph);
-    }
-    return;
-  }
 
   console.log(formatSummaryHeader(summary, theme, topNextAction));
   const rendered = renderTree(tree, {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -307,14 +307,17 @@ export function statusAction(opts: StatusOptions = {}): void {
 
   // US10 Slice 3: `--graph` swaps the tree pipeline for the layered
   // view from `renderGraph`. The summary header still prints first so
-  // users keep the per-type counts AND the `Next:` hint that the
-  // default text path surfaces (FR-016). The graph itself is built
-  // pre-filter (above), so when `--status` / `--type` retain no
-  // records we still print the same friendly "no match" hint as the
-  // default path — consistency wins over rendering an unfiltered
-  // graph behind a filtered summary.
+  // users keep the per-type counts (FR-016). The `Next:` hint is
+  // suppressed under `--graph` because the layered view already
+  // surfaces actionable next steps inline on every node line — a
+  // single `Next:` summary would just duplicate the topmost Layer-0
+  // hint and add visual noise. The graph itself is built pre-filter
+  // (above), so when `--status` / `--type` retain no records we still
+  // print the same friendly "no match" hint as the default path —
+  // consistency wins over rendering an unfiltered graph behind a
+  // filtered summary.
   if (opts.graph === true) {
-    console.log(formatSummaryHeader(summary, theme, topNextAction));
+    console.log(formatSummaryHeader(summary, theme, null));
     if (filteredRecords.length === 0) {
       console.log('No artifacts match the current filter.');
       return;

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,50 +1,64 @@
 /**
  * `smithy status` subcommand — thin CLI wiring around the status scanner.
  *
- * This module composes the pieces already built in US1 and US2 Slice 1:
+ * This module composes the pieces already built in US1, US2, and US10:
  *
  *   1. Resolve `--root` (defaults to `process.cwd()`).
  *   2. Hard-fail with exit 2 if the resolved path does not exist or is not
  *      a directory, matching the "non-existent `--root`" row of the
  *      contracts error table.
  *   3. Call {@link scan} to build the fully-classified `ArtifactRecord[]`.
- *   4. Derive a {@link ScanSummary} from the records.
+ *   4. Derive a {@link ScanSummary} from the records and a
+ *      {@link DependencyGraph} via {@link buildDependencyGraph} — both
+ *      computed from the pre-filter record set per SD-010 so they
+ *      reflect the full scan even when `--status` / `--type` narrow
+ *      the rendered tree view.
  *   5. Emit either contract-shaped JSON (`--format json`) or a per-type
  *      roll-up summary header followed by a hierarchical tree with
  *      next-action hints (default, via {@link renderTree} with
  *      `renderHints: true`). The JSON `tree` field is populated via
- *      {@link buildTree} (US2 Slice 1); the `graph` field is typed
- *      as the canonical {@link DependencyGraph} (US10 Slice 1) but
- *      the runtime still emits a zero-value graph object until the
- *      builder lands in US10 Slice 3. The top-level JSON shape is
- *      stable from US1 onward so consumers can depend on it today.
+ *      {@link buildTree} (US2 Slice 1); the JSON `graph` field is
+ *      populated via {@link buildDependencyGraph} (US10 Slice 3) and
+ *      always carries the canonical four keys (`nodes`, `layers`,
+ *      `cycles`, `dangling_refs`) so machine consumers can depend on
+ *      the top-level shape. `--graph` (US10 Slice 3) routes text
+ *      mode through {@link renderGraph}, printing topological layers
+ *      with done-layer collapsing, a cycle-warning fallback, and
+ *      dangling-ref diagnostics. The summary header still prints
+ *      above the graph view so users keep the per-type counts and
+ *      `Next:` hint they get in the default text path.
  *   6. On an empty repo (no discovered artifacts), print a friendly hint
  *      pointing at `smithy.ignite` / `smithy.mark` and exit 0 — the
- *      contracts treat this as "not an error".
+ *      contracts treat this as "not an error". The empty-repo hint
+ *      wins over `--graph` so users do not see an empty graph block
+ *      under it.
  *
  * `--status`, `--type`, and `--root` are wired end-to-end (US6):
  * `--root` is honored by `scan(resolvedRoot)` upstream, and
  * `filterRecords` applies the status / type predicates between the
  * scan and the tree / JSON emission with ancestor retention so AS 6.1
- * and AS 6.3 render correctly. `ScanSummary` is deliberately computed
- * from the pre-filter record set so the `summary` block keeps its
- * aggregate-scan framing (see SD-010). `--all` now disables
+ * and AS 6.3 render correctly. `ScanSummary` and the JSON `graph`
+ * are deliberately computed from the pre-filter record set so they
+ * keep their aggregate-scan framing (see SD-010). `--all` disables
  * done-subtree collapsing in text mode via the pure `collapseTree`
- * transform inserted between `buildTree` and `renderTree` (US3); JSON
- * mode continues to emit the uncollapsed tree structure
- * unconditionally. Remaining stubs (`--graph`, `--no-color`) are
- * accepted but have no behavioral effect — US10 Slice 3 wires
- * `--graph`; a colored renderer will wire `--no-color`.
+ * transform inserted between `buildTree` and `renderTree` (US3) and
+ * also disables done-layer collapsing inside {@link renderGraph}
+ * (US10); JSON mode continues to emit the uncollapsed tree structure
+ * unconditionally. `--no-color` is honored via {@link buildTheme}'s
+ * `noColor` flag (also picked up from the ambient `NO_COLOR` env
+ * var) so every painted surface respects it.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 
 import {
+  buildDependencyGraph,
   buildTree,
   collapseTree,
   filterRecords,
   formatNextAction,
+  renderGraph,
   renderTree,
   scan,
 } from '../status/index.js';
@@ -92,7 +106,16 @@ export interface StatusOptions {
    * uncollapsed `buildTree(records)` structure.
    */
   all?: boolean;
-  /** Stub: render the cross-artifact graph. Parsed but not wired — US10 Slice 3 wires it. */
+  /**
+   * Render the cross-artifact dependency graph as topological layers in
+   * text mode. Routes through {@link renderGraph} instead of the default
+   * `buildTree` / `collapseTree` / `renderTree` pipeline; the summary
+   * header (with the `Next:` hint) still prints above the graph view.
+   * Honors `--all` for done-layer collapsing the same way the default
+   * text path honors it for done-subtree collapsing. Has no effect on
+   * `--format json` output, which always emits the populated graph
+   * regardless of this flag.
+   */
   graph?: boolean;
   /**
    * Suppress ANSI colors. Set by Commander's `--no-color` flag (produces
@@ -110,13 +133,15 @@ export interface StatusOptions {
 
 /**
  * Contract-shaped JSON payload emitted by `--format json`. `tree` is
- * populated by {@link buildTree} (US2 Slice 1); `graph` is typed as the
- * canonical {@link DependencyGraph} (US10 Slice 1) but the runtime
- * still emits a zero-value graph object. The graph builder (US10
- * Slice 2) and live wiring (US10 Slice 3) replace the stub literal
- * with `buildDependencyGraph(records)` in subsequent slices. The keys
- * are emitted unconditionally so machine consumers can depend on the
- * top-level shape.
+ * populated by {@link buildTree} (US2 Slice 1) over the post-filter
+ * record set; `graph` is populated by {@link buildDependencyGraph}
+ * (US10 Slice 3) over the *pre-filter* record set per SD-010 so the
+ * graph reflects the full scan even when `--status` / `--type` are
+ * present. All four `graph` keys (`nodes`, `layers`, `cycles`,
+ * `dangling_refs`) are emitted unconditionally — including for an
+ * empty repo, where they collapse to `{ nodes: {}, layers: [],
+ * cycles: [], dangling_refs: [] }` — so machine consumers can depend
+ * on the top-level shape.
  */
 export interface StatusJsonPayload {
   summary: ScanSummary;
@@ -210,10 +235,13 @@ export function statusAction(opts: StatusOptions = {}): void {
   // Ancestor retention inside `filterRecords` preserves AS 6.1 / AS
   // 6.3 context without any renderer change. `--root` is a no-op
   // here (the scan was already narrowed above); we pass it through
-  // for signature symmetry. `summarize(records)` stays above the
-  // filter call so `ScanSummary` / the header remain aggregate over
-  // the full scan per SD-010.
+  // for signature symmetry. `summarize(records)` and
+  // `buildDependencyGraph(records)` both stay above the filter call so
+  // the `ScanSummary` / header AND the `DependencyGraph` remain
+  // aggregate over the full scan per SD-010 — `--status` / `--type`
+  // narrow the rendered tree view but never the graph shape.
   const summary = summarize(records);
+  const graph = buildDependencyGraph(records);
   // Build a sparse options object — `exactOptionalPropertyTypes` in
   // tsconfig forbids assigning `undefined` to optional fields, so we
   // only set each key when Commander actually populated it.
@@ -225,18 +253,15 @@ export function statusAction(opts: StatusOptions = {}): void {
   // JSON mode: always emit a valid JSON payload, even on an empty
   // repo. Machine consumers (CI, the smithy.status agent skill) parse
   // stdout as JSON unconditionally, so a plain-text empty-repo hint
-  // would break them.
+  // would break them. The `graph` field is populated unconditionally
+  // from the pre-filter scan per SD-010 — for an empty repo the
+  // builder returns the canonical zero-value shape itself.
   if (opts.format === 'json') {
     const payload: StatusJsonPayload = {
       summary,
       records: filteredRecords,
       tree: buildTree(filteredRecords),
-      graph: {
-        nodes: {},
-        layers: [],
-        cycles: [],
-        dangling_refs: [],
-      },
+      graph,
     };
     console.log(JSON.stringify(payload, null, 2));
     return;
@@ -279,6 +304,31 @@ export function statusAction(opts: StatusOptions = {}): void {
     all: opts.all === true,
   });
   const topNextAction = pickTopNextAction(tree);
+
+  // US10 Slice 3: `--graph` swaps the tree pipeline for the layered
+  // view from `renderGraph`. The summary header still prints first so
+  // users keep the per-type counts AND the `Next:` hint that the
+  // default text path surfaces (FR-016). The graph itself is built
+  // pre-filter (above), so when `--status` / `--type` retain no
+  // records we still print the same friendly "no match" hint as the
+  // default path — consistency wins over rendering an unfiltered
+  // graph behind a filtered summary.
+  if (opts.graph === true) {
+    console.log(formatSummaryHeader(summary, theme, topNextAction));
+    if (filteredRecords.length === 0) {
+      console.log('No artifacts match the current filter.');
+      return;
+    }
+    const renderedGraph = renderGraph(graph, {
+      theme,
+      all: opts.all === true,
+    });
+    if (renderedGraph.length > 0) {
+      console.log(renderedGraph);
+    }
+    return;
+  }
+
   console.log(formatSummaryHeader(summary, theme, topNextAction));
   const rendered = renderTree(tree, {
     theme,

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -322,6 +322,13 @@ export function statusAction(opts: StatusOptions = {}): void {
     const renderedGraph = renderGraph(graph, {
       theme,
       all: opts.all === true,
+      // Thread the pre-filter record set so each node line can carry a
+      // per-row next-action hint (`→ smithy.<cmd> <args>`) instead of
+      // the dim FQ id. Mirrors the `Next:` line in the summary header
+      // and the per-record hints under `renderTree`. SD-010 keeps the
+      // record set pre-filter so the hints reflect the full scan, in
+      // line with the graph itself.
+      records,
     });
     if (renderedGraph.length > 0) {
       console.log(renderedGraph);

--- a/src/status/graph.test.ts
+++ b/src/status/graph.test.ts
@@ -399,6 +399,103 @@ describe('buildDependencyGraph — cross-artifact stitching (AS 10.2)', () => {
   });
 });
 
+describe('buildDependencyGraph — node-status semantics (data-model §6)', () => {
+  // Per data-model §6, `DependencyNode.status` is the rolled-up status
+  // of the row's *downstream artifact*, not of the owning record. A
+  // user-story row whose tasks file is fully done must carry
+  // `status: 'done'` even when the owning spec rolls up to
+  // `in-progress` because *other* rows in the same spec are still
+  // open. Slice rows (which have no downstream record) fall back to
+  // the owning record's status.
+  const SPEC_PATH = 'specs/sample/sample.spec.md';
+
+  it('uses the downstream record status for a row, not the owning record status', () => {
+    const spec = makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [
+          row('US1', [], { artifact_path: 'specs/sample/01-first.tasks.md' }),
+          row('US2', ['US1'], { artifact_path: 'specs/sample/02-second.tasks.md' }),
+        ],
+      },
+    });
+    const tasksDone = makeRecord({
+      type: 'tasks',
+      path: 'specs/sample/01-first.tasks.md',
+      status: 'done',
+      parent_path: SPEC_PATH,
+      parent_row_id: 'US1',
+    });
+    const tasksWip = makeRecord({
+      type: 'tasks',
+      path: 'specs/sample/02-second.tasks.md',
+      status: 'in-progress',
+      parent_path: SPEC_PATH,
+      parent_row_id: 'US2',
+    });
+    const graph = buildDependencyGraph([spec, tasksDone, tasksWip]);
+    // US1's tasks file is done → US1 node carries 'done', NOT the
+    // spec's rolled-up 'in-progress'.
+    expect(graph.nodes[`${SPEC_PATH}#US1`]?.status).toBe('done');
+    // US2's tasks file is still in-progress.
+    expect(graph.nodes[`${SPEC_PATH}#US2`]?.status).toBe('in-progress');
+  });
+
+  it('falls back to the owning record status when no downstream record exists (slice rows)', () => {
+    // Slice rows have no downstream child record. The fallback uses
+    // the owning tasks record's rolled-up status — there is no other
+    // signal to surface.
+    const tasks = makeRecord({
+      type: 'tasks',
+      path: 'specs/sample/01-first.tasks.md',
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'S',
+        format: 'table',
+        rows: [row('S1'), row('S2', ['S1'])],
+      },
+    });
+    const graph = buildDependencyGraph([tasks]);
+    expect(graph.nodes['specs/sample/01-first.tasks.md#S1']?.status).toBe(
+      'in-progress',
+    );
+    expect(graph.nodes['specs/sample/01-first.tasks.md#S2']?.status).toBe(
+      'in-progress',
+    );
+  });
+
+  it('reads downstream from parent_path + parent_row_id even when the row\'s own artifact_path is null', () => {
+    // A row with `artifact_path: null` still has a virtual downstream
+    // record (the scanner emits one keyed off parent_path /
+    // parent_row_id). The node should still pick up that virtual
+    // record's status, not the owning record's.
+    const spec = makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1', [], { artifact_path: null })],
+      },
+    });
+    const virtualDone = makeRecord({
+      type: 'tasks',
+      path: 'specs/sample/01-first.tasks.md',
+      status: 'done',
+      virtual: true,
+      parent_path: SPEC_PATH,
+      parent_row_id: 'US1',
+    });
+    const graph = buildDependencyGraph([spec, virtualDone]);
+    expect(graph.nodes[`${SPEC_PATH}#US1`]?.status).toBe('done');
+  });
+});
+
 describe('buildDependencyGraph — dangling references (AS 10.6)', () => {
   const SPEC_PATH = 'specs/sample/sample.spec.md';
 

--- a/src/status/graph.ts
+++ b/src/status/graph.ts
@@ -232,6 +232,23 @@ export function buildDependencyGraph(
     }
   }
 
+  // Edges are wired with a "done predecessors don't block" rule: an
+  // edge `source → target` is included in the layering graph only
+  // when `source.status !== 'done'`. The reasoning: a done node is no
+  // longer a blocker for downstream work, so a not-done target whose
+  // only blockers are done is genuinely ready to work on right now
+  // (Layer 0). This makes "Layer N" mean "this many hops of *remaining*
+  // work blocks it", not the static topological depth of the unioned
+  // graph — which is what users intuit when they see a layered
+  // "ready-to-work" view.
+  //
+  // Done-only cycles (cycles where every node is `done`) become
+  // undetectable as a side-effect — every edge in such a cycle is
+  // skipped, so the residual is empty and Tarjan's finds nothing. In
+  // practice that's fine: a cycle of finished work is moot. Cycles
+  // involving any not-done node retain their edges (the not-done
+  // node's outgoing edges still count) and continue to surface.
+
   // Second pass: wire intra-table edges. Re-walks records so this stays
   // a single top-level loop; per-row work is O(depends_on.length).
   for (const record of eligible) {
@@ -246,6 +263,9 @@ export function buildDependencyGraph(
         // inside the same table. Anything else was a parse-time
         // dangling reference and was dropped before reaching us.
         if (!(sourceId in nodes)) continue;
+        // Skip edges from done predecessors — see the "done predecessors
+        // don't block" preamble above.
+        if (nodes[sourceId]?.status === 'done') continue;
         addEdge(sourceId, targetId, outgoing, inDegree, seenEdges);
       }
     }
@@ -272,6 +292,10 @@ export function buildDependencyGraph(
     if (typeof parentRowId !== 'string' || parentRowId.length === 0) continue;
     const parentNodeId = nodeId(parentPath, parentRowId);
     if (!(parentNodeId in nodes)) continue;
+    // Skip cross-artifact edges from done parents — see the
+    // "done predecessors don't block" preamble above. A child whose
+    // only blocker is a done parent row is genuinely ready right now.
+    if (nodes[parentNodeId]?.status === 'done') continue;
 
     for (const row of record.dependency_order.rows) {
       // Only "root" rows (no intra-table predecessors) are pinned to the

--- a/src/status/graph.ts
+++ b/src/status/graph.ts
@@ -65,6 +65,23 @@
  * multiple specs without collision, which is essential once
  * cross-artifact stitching is in play.
  *
+ * ## Node status semantics (data-model §6)
+ *
+ * Each `DependencyNode.status` is the rolled-up status of the row's
+ * **downstream artifact**, not the owning record. So a user-story row
+ * `<spec>#US3` whose tasks file is fully done carries `status: 'done'`
+ * even when the owning spec rolls up to `in-progress` because *other*
+ * stories in the same spec are still open. The builder reads the
+ * downstream from `parent_path` + `parent_row_id` (the scanner-
+ * populated inverse-lineage edge) and falls back to the owning
+ * record's status only when no downstream record exists — slice rows
+ * in tasks files are the canonical case there, since slices have no
+ * separate child file and therefore no scanner-emitted record. The
+ * fallback keeps slice nodes meaningful at the cost of inheriting the
+ * tasks-file's rolled-up state rather than per-slice completion (a
+ * future refinement could compute per-slice status from the body
+ * sections directly).
+ *
  * ## Determinism (SD-013)
  *
  * Within-layer node ordering is not specified by data-model §6 or
@@ -155,6 +172,29 @@ export function buildDependencyGraph(
   // never contribute any nodes either way.
   const eligible = records.filter((r) => !SENTINEL_PATHS.has(r.path));
 
+  // Inverse-lineage lookup: every record (real or virtual) the scanner
+  // emits carries `parent_path` + `parent_row_id` pointing at the row
+  // that claimed it. Indexing by `<parent_path>#<parent_row_id>` gives
+  // us, for each graph node `<owner>#<row_id>`, the downstream record
+  // that row corresponds to. Per data-model §6, `DependencyNode.status`
+  // is the *downstream artifact's* rolled-up status — not the owning
+  // record's — so this lookup is what makes the "rolled-up from the
+  // node's downstream" wording true at runtime.
+  const downstreamByParentSlot = new Map<string, ArtifactRecord>();
+  for (const record of eligible) {
+    if (
+      typeof record.parent_path === 'string' &&
+      record.parent_path.length > 0 &&
+      typeof record.parent_row_id === 'string' &&
+      record.parent_row_id.length > 0
+    ) {
+      downstreamByParentSlot.set(
+        `${record.parent_path}#${record.parent_row_id}`,
+        record,
+      );
+    }
+  }
+
   let cursor = 0;
   for (const record of eligible) {
     if (record.dependency_order.format !== 'table') continue;
@@ -169,10 +209,21 @@ export function buildDependencyGraph(
       // the first one wins — the parser already flags this as a
       // warning on the owning record, so the graph need not re-flag it.
       if (id in nodes) continue;
+      // Resolve the row's downstream record (real or virtual) and use
+      // ITS status as the node's rolled-up status. Falls back to the
+      // owning record's status when no downstream record exists —
+      // typically slice rows in tasks files (slices have no separate
+      // file and therefore no scanner-emitted child record). Without
+      // this fallback the row would carry no status at all; with it,
+      // slice rows inherit the tasks-file's rolled-up state, which
+      // matches the only signal the data model gives us at that level.
+      const downstreamSlot = `${record.path}#${row.id}`;
+      const downstream = downstreamByParentSlot.get(downstreamSlot);
+      const rolledUpStatus = downstream?.status ?? record.status;
       nodes[id] = {
         record_path: record.path,
         row,
-        status: record.status,
+        status: rolledUpStatus,
       };
       discoveryOrder.set(id, cursor);
       cursor += 1;

--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -24,5 +24,6 @@ export {
 } from './tree.js';
 export { collapseTree, type CollapseTreeOptions } from './collapse.js';
 export { renderTree, type RenderTreeOptions } from './render.js';
+export { renderGraph, type RenderGraphOptions } from './renderGraph.js';
 export { filterRecords, type FilterRecordsOptions } from './filter.js';
 export { buildDependencyGraph } from './graph.js';

--- a/src/status/renderGraph.test.ts
+++ b/src/status/renderGraph.test.ts
@@ -251,9 +251,11 @@ describe('renderGraph — done-layer collapsing (AS 10.4)', () => {
     expect(output).toContain('specs/a/a.spec.md#US1');
     expect(output).toContain('specs/b/b.spec.md#US2');
     expect(output).toContain('specs/c/c.spec.md#US3');
-    // Layer headings still use the canonical "ready to work" form for
-    // layer 0 and the simple form for subsequent layers.
-    expect(output).toContain('Layer 0 — ready to work (1 item)');
+    // Under the "done predecessors don't block" layering rule, c#US3
+    // (whose only predecessor b#US2 is done) promotes to Layer 0
+    // alongside a#US1; b#US2 itself sits in Layer 1 (still blocked by
+    // a#US1's in-progress status).
+    expect(output).toContain('Layer 0 — ready to work (2 items)');
     expect(output).toContain('Layer 1 (1 item)');
   });
 

--- a/src/status/renderGraph.test.ts
+++ b/src/status/renderGraph.test.ts
@@ -164,19 +164,27 @@ describe('renderGraph — layered view (AS 10.1)', () => {
 });
 
 describe('renderGraph — done-layer collapsing (AS 10.4)', () => {
-  // Spec with three layers: US1 (Layer 0, in-progress), US2 (Layer 1,
-  // done), US3 (Layer 2, not-started). The Layer 1 collapses by default
-  // because every member is `done`; under `{ all: true }` it expands.
+  // Three-layer cross-artifact graph used to exercise per-layer
+  // omission semantics under the data-model §6 node-status rule (the
+  // node's status is the *downstream* artifact's rolled-up status, not
+  // the owning record's). Specifically:
+  //
+  //   - a.spec.md (in-progress, owns US1 → b)
+  //   - b.spec.md (in-progress, owns US2 → c, lives under a's US1)
+  //   - c.spec.md (done, owns US3, lives under b's US2)
+  //
+  // Resulting graph nodes (status from the downstream record's
+  // rolled-up status, fallback for c#US3 since c has no further child):
+  //
+  //   - a#US1.status = b.status = 'in-progress' (visible in Layer 0)
+  //   - b#US2.status = c.status = 'done'        (hidden, Layer 1 omitted)
+  //   - c#US3.status = c.status (fallback) = 'done' (hidden, Layer 2 omitted)
+  //
+  // So Layer 0 is visible, Layers 1 and 2 are omitted in default mode
+  // — every Layer-1+ node descended from c, which is fully done.
   const SPEC_PATH = 'specs/sample/sample.spec.md';
 
   function buildSpec(): ArtifactRecord[] {
-    // Each row lives in its own record so the rolled-up status varies
-    // per-layer. We synthesise the parent linkage so the cross-artifact
-    // stitcher pins later layers behind earlier ones — but the simplest
-    // recipe is to keep them all in one spec and lean on intra-table
-    // depends_on edges. Status is rolled up from the owning record, so
-    // we model "Layer 1 entirely done" by giving US2's owning record
-    // status: 'done'.
     const layer0 = makeRecord({
       type: 'spec',
       path: 'specs/a/a.spec.md',
@@ -190,7 +198,7 @@ describe('renderGraph — done-layer collapsing (AS 10.4)', () => {
     const layer1 = makeRecord({
       type: 'spec',
       path: 'specs/b/b.spec.md',
-      status: 'done',
+      status: 'in-progress',
       parent_path: 'specs/a/a.spec.md',
       parent_row_id: 'US1',
       dependency_order: {
@@ -202,7 +210,7 @@ describe('renderGraph — done-layer collapsing (AS 10.4)', () => {
     const layer2 = makeRecord({
       type: 'spec',
       path: 'specs/c/c.spec.md',
-      status: 'not-started',
+      status: 'done',
       parent_path: 'specs/b/b.spec.md',
       parent_row_id: 'US2',
       dependency_order: {
@@ -214,17 +222,20 @@ describe('renderGraph — done-layer collapsing (AS 10.4)', () => {
     return [layer0, layer1, layer2];
   }
 
-  it('omits an all-done layer entirely from default mode (no heading, no members)', () => {
+  it('omits layers whose downstream-derived nodes are all done (no heading, no members)', () => {
     const graph = buildDependencyGraph(buildSpec());
     const output = renderGraph(graph, { theme: utf8Theme });
-    // No Layer 1 heading at all — the per-layer done count adds no
-    // actionable signal so the whole block is dropped.
+    // Layer 0 surfaces (a#US1's downstream is b, in-progress).
+    expect(output).toContain('Layer 0');
+    expect(output).toContain('specs/a/a.spec.md#US1');
+    // Layers 1 and 2 are omitted entirely — every node in them rolls
+    // up to `done` via the data-model §6 downstream-status rule, so
+    // there is no actionable content to render.
     expect(output).not.toContain('Layer 1');
+    expect(output).not.toContain('Layer 2');
     expect(output).not.toContain('DONE (');
     expect(output).not.toContain('specs/b/b.spec.md#US2');
-    // Surrounding non-done layers still surface.
-    expect(output).toContain('Layer 0');
-    expect(output).toContain('Layer 2');
+    expect(output).not.toContain('specs/c/c.spec.md#US3');
   });
 
   it('expands every layer when {all: true} is passed', () => {

--- a/src/status/renderGraph.test.ts
+++ b/src/status/renderGraph.test.ts
@@ -1,0 +1,452 @@
+import { describe, expect, it } from 'vitest';
+
+// Import through the `./index.js` barrel so these tests also assert
+// that `renderGraph` is re-exported on the stable public surface.
+import {
+  buildDependencyGraph,
+  renderGraph,
+  type ArtifactRecord,
+  type ArtifactType,
+  type DependencyGraph,
+  type DependencyOrderTable,
+  type DependencyRow,
+  type RenderGraphOptions,
+} from './index.js';
+import { createTheme, type Theme } from './theme.js';
+
+/**
+ * Deterministic themes for renderer assertions. Colors are disabled so
+ * snapshots stay ANSI-free; the ASCII variant exists to assert the
+ * fallback connector glyphs survive the renderer.
+ */
+const utf8Theme: Theme = createTheme({ color: false, encoding: 'utf8' });
+const asciiTheme: Theme = createTheme({ color: false, encoding: 'ascii' });
+
+/**
+ * Build a minimal `ArtifactRecord` for graph-renderer tests. Only the
+ * fields `buildDependencyGraph` actually consults (`path`, `status`,
+ * `parent_path`, `parent_row_id`, `dependency_order`) carry semantic
+ * weight; the rest are padded so the call sites stay small.
+ */
+function makeRecord(overrides: Partial<ArtifactRecord> = {}): ArtifactRecord {
+  const type: ArtifactType = overrides.type ?? 'spec';
+  const idPrefix: DependencyOrderTable['id_prefix'] =
+    type === 'rfc'
+      ? 'M'
+      : type === 'features'
+        ? 'F'
+        : type === 'spec'
+          ? 'US'
+          : 'S';
+  const dependency_order: DependencyOrderTable = overrides.dependency_order ?? {
+    rows: [],
+    id_prefix: idPrefix,
+    format: 'table',
+  };
+  return {
+    type,
+    path: overrides.path ?? `specs/sample.${type === 'tasks' ? 'tasks' : type}.md`,
+    title: overrides.title ?? 'Sample',
+    status: overrides.status ?? 'not-started',
+    dependency_order,
+    warnings: overrides.warnings ?? [],
+    ...overrides,
+  };
+}
+
+/** Build a single dependency row with sensible defaults. */
+function row(
+  id: string,
+  depends_on: string[] = [],
+  overrides: Partial<DependencyRow> = {},
+): DependencyRow {
+  return {
+    id,
+    title: overrides.title ?? `Story ${id}`,
+    depends_on,
+    artifact_path: overrides.artifact_path ?? null,
+    ...overrides,
+  };
+}
+
+describe('renderGraph — empty graph', () => {
+  it('returns the empty string for a fully empty graph', () => {
+    const graph: DependencyGraph = {
+      nodes: {},
+      layers: [],
+      cycles: [],
+      dangling_refs: [],
+    };
+    expect(renderGraph(graph, { theme: utf8Theme })).toBe('');
+  });
+});
+
+describe('renderGraph — layered view (AS 10.1)', () => {
+  // Same fixture pattern as graph.test.ts AS 10.1: US1 / US4 independent,
+  // US2 depends on US1, US3 depends on US2.
+  const SPEC_PATH = 'specs/sample/sample.spec.md';
+  const spec = makeRecord({
+    type: 'spec',
+    path: SPEC_PATH,
+    title: 'Sample Spec',
+    status: 'in-progress',
+    dependency_order: {
+      id_prefix: 'US',
+      format: 'table',
+      rows: [
+        row('US1', [], { title: 'First' }),
+        row('US2', ['US1'], { title: 'Second' }),
+        row('US3', ['US2'], { title: 'Third' }),
+        row('US4', [], { title: 'Fourth' }),
+      ],
+    },
+  });
+
+  it('emits one labelled block per layer with the correct layer-0 ready heading', () => {
+    const graph = buildDependencyGraph([spec]);
+    const output = renderGraph(graph, { theme: utf8Theme });
+    // Layer 0 header is the canonical "ready to work" form (per AS 10.1
+    // / contracts §1 example output).
+    expect(output).toContain('Layer 0 — ready to work (2 items)');
+    // Subsequent layers use the simpler "Layer N (M items)" form.
+    expect(output).toContain('Layer 1 (1 item)');
+    expect(output).toContain('Layer 2 (1 item)');
+  });
+
+  it('lists each node id under its layer with tree connectors and the row title', () => {
+    const graph = buildDependencyGraph([spec]);
+    const output = renderGraph(graph, { theme: utf8Theme });
+    // Every fully-qualified node id from buildDependencyGraph must
+    // appear in the output exactly once.
+    expect(output).toContain(`${SPEC_PATH}#US1`);
+    expect(output).toContain(`${SPEC_PATH}#US2`);
+    expect(output).toContain(`${SPEC_PATH}#US3`);
+    expect(output).toContain(`${SPEC_PATH}#US4`);
+    // Em-dash separator + title from the underlying row.
+    expect(output).toContain(`${SPEC_PATH}#US1 — First`);
+    expect(output).toContain(`${SPEC_PATH}#US2 — Second`);
+    // Tree connectors used to lay out per-layer members.
+    expect(output).toMatch(/[├└]─/);
+    // Last-sibling glyph appears for the final entry of the
+    // multi-member Layer 0 (US4).
+    expect(output).toContain(`└─ ${SPEC_PATH}#US4`);
+    // Non-last-sibling glyph appears for the first entry of Layer 0
+    // (US1).
+    expect(output).toContain(`├─ ${SPEC_PATH}#US1`);
+  });
+
+  it('orders Layer 0 members by their position in graph.layers[0].node_ids', () => {
+    const graph = buildDependencyGraph([spec]);
+    const output = renderGraph(graph, { theme: utf8Theme });
+    const us1Pos = output.indexOf(`${SPEC_PATH}#US1`);
+    const us4Pos = output.indexOf(`${SPEC_PATH}#US4`);
+    const us2Pos = output.indexOf(`${SPEC_PATH}#US2`);
+    const us3Pos = output.indexOf(`${SPEC_PATH}#US3`);
+    expect(us1Pos).toBeGreaterThanOrEqual(0);
+    expect(us4Pos).toBeGreaterThan(us1Pos);
+    expect(us2Pos).toBeGreaterThan(us4Pos);
+    expect(us3Pos).toBeGreaterThan(us2Pos);
+  });
+
+  it('separates adjacent layer blocks with a blank line', () => {
+    const graph = buildDependencyGraph([spec]);
+    const output = renderGraph(graph, { theme: utf8Theme });
+    // A blank line followed by the "Layer 1" heading proves the layer
+    // blocks are visually separated rather than smashed together.
+    expect(output).toMatch(/\n\nLayer 1 \(1 item\)/);
+    expect(output).toMatch(/\n\nLayer 2 \(1 item\)/);
+  });
+});
+
+describe('renderGraph — done-layer collapsing (AS 10.4)', () => {
+  // Spec with three layers: US1 (Layer 0, in-progress), US2 (Layer 1,
+  // done), US3 (Layer 2, not-started). The Layer 1 collapses by default
+  // because every member is `done`; under `{ all: true }` it expands.
+  const SPEC_PATH = 'specs/sample/sample.spec.md';
+
+  function buildSpec(): ArtifactRecord[] {
+    // Each row lives in its own record so the rolled-up status varies
+    // per-layer. We synthesise the parent linkage so the cross-artifact
+    // stitcher pins later layers behind earlier ones — but the simplest
+    // recipe is to keep them all in one spec and lean on intra-table
+    // depends_on edges. Status is rolled up from the owning record, so
+    // we model "Layer 1 entirely done" by giving US2's owning record
+    // status: 'done'.
+    const layer0 = makeRecord({
+      type: 'spec',
+      path: 'specs/a/a.spec.md',
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1', [], { title: 'Zeroth' })],
+      },
+    });
+    const layer1 = makeRecord({
+      type: 'spec',
+      path: 'specs/b/b.spec.md',
+      status: 'done',
+      parent_path: 'specs/a/a.spec.md',
+      parent_row_id: 'US1',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US2', [], { title: 'First' })],
+      },
+    });
+    const layer2 = makeRecord({
+      type: 'spec',
+      path: 'specs/c/c.spec.md',
+      status: 'not-started',
+      parent_path: 'specs/b/b.spec.md',
+      parent_row_id: 'US2',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US3', [], { title: 'Second' })],
+      },
+    });
+    return [layer0, layer1, layer2];
+  }
+
+  it('collapses an all-done layer to a `Layer N: DONE (M items)` line in default mode', () => {
+    const graph = buildDependencyGraph(buildSpec());
+    const output = renderGraph(graph, { theme: utf8Theme });
+    expect(output).toContain('Layer 1: DONE (1 item)');
+    // The collapsed layer must NOT list its members.
+    expect(output).not.toContain('specs/b/b.spec.md#US2');
+  });
+
+  it('expands every layer when {all: true} is passed', () => {
+    const graph = buildDependencyGraph(buildSpec());
+    const expandedOpts: RenderGraphOptions = {
+      theme: utf8Theme,
+      all: true,
+    };
+    const output = renderGraph(graph, expandedOpts);
+    // The collapsed heading must NOT appear under --all.
+    expect(output).not.toContain('Layer 1: DONE');
+    // Every fully-qualified node ID must appear when expanded.
+    expect(output).toContain('specs/a/a.spec.md#US1');
+    expect(output).toContain('specs/b/b.spec.md#US2');
+    expect(output).toContain('specs/c/c.spec.md#US3');
+    // Layer headings still use the canonical "ready to work" form for
+    // layer 0 and the simple form for subsequent layers.
+    expect(output).toContain('Layer 0 — ready to work (1 item)');
+    expect(output).toContain('Layer 1 (1 item)');
+  });
+
+  it('does not collapse a mixed-status layer', () => {
+    // Build a graph where Layer 0 has two members, one done and one
+    // not-started — the layer must NOT collapse.
+    const recordA = makeRecord({
+      type: 'spec',
+      path: 'specs/a/a.spec.md',
+      status: 'done',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1')],
+      },
+    });
+    const recordB = makeRecord({
+      type: 'spec',
+      path: 'specs/b/b.spec.md',
+      status: 'not-started',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1')],
+      },
+    });
+    const graph = buildDependencyGraph([recordA, recordB]);
+    const output = renderGraph(graph, { theme: utf8Theme });
+    expect(output).not.toContain('DONE (');
+    expect(output).toContain('specs/a/a.spec.md#US1');
+    expect(output).toContain('specs/b/b.spec.md#US1');
+  });
+});
+
+describe('renderGraph — cycle fallback (AS 10.3)', () => {
+  const SPEC_PATH = 'specs/sample/sample.spec.md';
+
+  it('emits a warning block plus a cycle line and does not throw', () => {
+    const spec = makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1', ['US2']), row('US2', ['US1'])],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    const output = renderGraph(graph, { theme: utf8Theme });
+    // Warning lead — exact wording must mention "cycle" so reviewers
+    // and log scrapers can grep for it.
+    expect(output.toLowerCase()).toContain('warning');
+    expect(output.toLowerCase()).toContain('cycle');
+    // Cycle line lists both fully-qualified IDs joined by ` -> `, with
+    // the first ID repeated at the end so the loop is visually obvious.
+    expect(output).toContain(`${SPEC_PATH}#US1`);
+    expect(output).toContain(`${SPEC_PATH}#US2`);
+    expect(output).toContain(' -> ');
+    // No `Layer N` heading for cyclic nodes — the renderer must not
+    // pretend the cyclic subgraph has layers.
+    expect(output).not.toMatch(/Layer 0/);
+    expect(output).not.toMatch(/Layer 1/);
+  });
+
+  it('renders non-cyclic nodes under a flat fallback heading', () => {
+    // US1 ↔ US2 form a cycle; US3 / US4 are non-cyclic and stay
+    // layerable. The flat fallback should list US3 and US4 under
+    // `Nodes (flat fallback):` while the cycle line carries US1+US2.
+    const spec = makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [
+          row('US1', ['US2']),
+          row('US2', ['US1']),
+          row('US3'),
+          row('US4', ['US3']),
+        ],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    const output = renderGraph(graph, { theme: utf8Theme });
+    expect(output).toContain('Nodes (flat fallback):');
+    expect(output).toContain(`${SPEC_PATH}#US3`);
+    expect(output).toContain(`${SPEC_PATH}#US4`);
+    // Cyclic nodes are NOT listed in the flat fallback — they only
+    // appear once on the Cycle line.
+    const fallbackPos = output.indexOf('Nodes (flat fallback):');
+    const tail = output.slice(fallbackPos);
+    expect(tail).not.toContain(`${SPEC_PATH}#US1`);
+    expect(tail).not.toContain(`${SPEC_PATH}#US2`);
+  });
+});
+
+describe('renderGraph — dangling references (AS 10.6)', () => {
+  const SPEC_PATH = 'specs/sample/sample.spec.md';
+
+  it('emits a `Dangling refs:` block listing each unresolved pair', () => {
+    const spec = makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1')],
+        dangling_refs: [{ source_id: 'US1', missing_id: 'US99' }],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    const output = renderGraph(graph, { theme: utf8Theme });
+    expect(output).toContain('Dangling refs:');
+    expect(output).toContain(
+      `${SPEC_PATH}#US1 -> ${SPEC_PATH}#US99 (unresolved)`,
+    );
+  });
+
+  it('omits the `Dangling refs:` block when no dangling refs are present', () => {
+    const spec = makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1'), row('US2', ['US1'])],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    const output = renderGraph(graph, { theme: utf8Theme });
+    expect(output).not.toContain('Dangling refs:');
+  });
+});
+
+describe('renderGraph — purity', () => {
+  it('returns the same string on repeat calls (deterministic)', () => {
+    const spec = makeRecord({
+      type: 'spec',
+      path: 'specs/sample/sample.spec.md',
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1'), row('US2', ['US1'])],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    const a = renderGraph(graph, { theme: utf8Theme });
+    const b = renderGraph(graph, { theme: utf8Theme });
+    expect(a).toBe(b);
+  });
+
+  it('does not mutate its input graph', () => {
+    const spec = makeRecord({
+      type: 'spec',
+      path: 'specs/sample/sample.spec.md',
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1'), row('US2', ['US1'])],
+        dangling_refs: [{ source_id: 'US1', missing_id: 'US99' }],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    const snapshot = JSON.parse(JSON.stringify(graph));
+    renderGraph(graph, { theme: utf8Theme });
+    expect(graph).toEqual(snapshot);
+  });
+});
+
+describe('renderGraph — ASCII fallback', () => {
+  it('uses ASCII connectors when given an ASCII theme', () => {
+    const spec = makeRecord({
+      type: 'spec',
+      path: 'specs/sample/sample.spec.md',
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1'), row('US2'), row('US3', ['US1', 'US2'])],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    const output = renderGraph(graph, { theme: asciiTheme });
+    // ASCII branch / lastBranch glyphs from the theme bundle.
+    expect(output).toContain('+- ');
+    expect(output).toContain('`- ');
+    // No UTF-8 box-drawing characters leaked through.
+    expect(output).not.toMatch(/[├└]/);
+  });
+});
+
+describe('renderGraph — default theme', () => {
+  it('uses a UTF-8 no-color theme when options are omitted', () => {
+    const spec = makeRecord({
+      type: 'spec',
+      path: 'specs/sample/sample.spec.md',
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1')],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    const output = renderGraph(graph);
+    // UTF-8 connector survives.
+    expect(output).toMatch(/[├└]─/);
+    // No ANSI escape sequences when color is disabled.
+    // eslint-disable-next-line no-control-regex
+    expect(output).not.toMatch(/\[/);
+  });
+});

--- a/src/status/renderGraph.test.ts
+++ b/src/status/renderGraph.test.ts
@@ -329,6 +329,50 @@ describe('renderGraph — cycle fallback (AS 10.3)', () => {
     expect(tail).not.toContain(`${SPEC_PATH}#US1`);
     expect(tail).not.toContain(`${SPEC_PATH}#US2`);
   });
+
+  it('lists non-cyclic nodes downstream of a cycle in the flat fallback', () => {
+    // US1 ↔ US2 form a cycle; US3 depends on US1, so Kahn's never
+    // promotes US3 — it is non-cyclic but lives outside `graph.layers`
+    // AND outside `graph.cycles`. The flat fallback must still surface
+    // it so the rendered output covers every node in `graph.nodes`.
+    const spec = makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [
+          row('US1', ['US2']),
+          row('US2', ['US1']),
+          row('US3', ['US1']),
+        ],
+      },
+    });
+    const graph = buildDependencyGraph([spec]);
+    // Sanity guard: US3 really does live outside both layers and
+    // cycles in the builder output. If this invariant ever changes we
+    // want to know — the fallback rule it justifies would shift too.
+    const inAnyLayer = graph.layers.some((l) =>
+      l.node_ids.includes(`${SPEC_PATH}#US3`),
+    );
+    const inAnyCycle = graph.cycles.some((c) =>
+      c.includes(`${SPEC_PATH}#US3`),
+    );
+    expect(inAnyLayer).toBe(false);
+    expect(inAnyCycle).toBe(false);
+    expect(graph.nodes).toHaveProperty(`${SPEC_PATH}#US3`);
+
+    const output = renderGraph(graph, { theme: utf8Theme });
+    const fallbackPos = output.indexOf('Nodes (flat fallback):');
+    expect(fallbackPos).toBeGreaterThan(-1);
+    const tail = output.slice(fallbackPos);
+    expect(tail).toContain(`${SPEC_PATH}#US3`);
+    // Cyclic nodes still stay off the flat list — they only appear on
+    // the `Cycle:` line above.
+    expect(tail).not.toContain(`${SPEC_PATH}#US1`);
+    expect(tail).not.toContain(`${SPEC_PATH}#US2`);
+  });
 });
 
 describe('renderGraph — dangling references (AS 10.6)', () => {

--- a/src/status/renderGraph.test.ts
+++ b/src/status/renderGraph.test.ts
@@ -604,6 +604,139 @@ describe('renderGraph — ASCII fallback', () => {
   });
 });
 
+describe('renderGraph — per-row action hints from records', () => {
+  // When `RenderGraphOptions.records` is supplied, each visible node
+  // line surfaces a `→ smithy.<cmd> <args>` hint derived from the row's
+  // downstream record (real or virtual) instead of the dim FQ id.
+  // Done downstreams yield no hint and the line falls back to the
+  // dim FQ id so it still carries a referent.
+  const SPEC_PATH = 'specs/sample/sample.spec.md';
+
+  function makeSpecRowsRecord(): ArtifactRecord {
+    return makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [
+          row('US1', [], { title: 'Unstarted story', artifact_path: null }),
+          row('US2', ['US1'], {
+            title: 'In-progress story',
+            artifact_path: 'specs/sample/02-second.tasks.md',
+          }),
+        ],
+      },
+      next_action: null,
+    });
+  }
+
+  function makeVirtualUS1Tasks(): ArtifactRecord {
+    return makeRecord({
+      type: 'tasks',
+      path: 'specs/sample/01-first.tasks.md',
+      status: 'not-started',
+      virtual: true,
+      parent_path: SPEC_PATH,
+      parent_row_id: 'US1',
+      next_action: {
+        command: 'smithy.cut',
+        arguments: ['specs/sample', '1'],
+        reason: 'US1 has no tasks file yet.',
+      },
+    });
+  }
+
+  function makeRealUS2Tasks(): ArtifactRecord {
+    return makeRecord({
+      type: 'tasks',
+      path: 'specs/sample/02-second.tasks.md',
+      status: 'in-progress',
+      parent_path: SPEC_PATH,
+      parent_row_id: 'US2',
+      next_action: {
+        command: 'smithy.forge',
+        arguments: ['specs/sample/02-second.tasks.md'],
+        reason: 'US2 has open slices.',
+      },
+    });
+  }
+
+  it("surfaces the downstream record's next_action as an arrow-prefixed smithy.<cmd> suffix", () => {
+    const records = [
+      makeSpecRowsRecord(),
+      makeVirtualUS1Tasks(),
+      makeRealUS2Tasks(),
+    ];
+    const graph = buildDependencyGraph(records);
+    const output = renderGraph(graph, { theme: utf8Theme, records });
+    expect(output).toContain('→ smithy.cut specs/sample 1');
+    expect(output).toContain('→ smithy.forge specs/sample/02-second.tasks.md');
+    expect(output).not.toContain(`${SPEC_PATH}#US1`);
+    expect(output).not.toContain(`${SPEC_PATH}#US2`);
+  });
+
+  it('falls back to the dim FQ id for nodes whose downstream is done (next_action null)', () => {
+    const spec = makeSpecRowsRecord();
+    const doneTasks = makeRecord({
+      type: 'tasks',
+      path: 'specs/sample/02-second.tasks.md',
+      status: 'done',
+      parent_path: SPEC_PATH,
+      parent_row_id: 'US2',
+      next_action: null,
+    });
+    const records = [spec, makeVirtualUS1Tasks(), doneTasks];
+    const graph = buildDependencyGraph(records);
+    const output = renderGraph(graph, {
+      theme: utf8Theme,
+      records,
+      all: true,
+    });
+    expect(output).toContain(`${SPEC_PATH}#US2`);
+    expect(output).not.toContain('→ smithy.forge specs/sample/02-second.tasks.md');
+  });
+
+  it('synthesises per-slice smithy.forge <tasks> <N> hints for slice rows in tasks files', () => {
+    const tasksRecord = makeRecord({
+      type: 'tasks',
+      path: 'specs/sample/01-first.tasks.md',
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'S',
+        format: 'table',
+        rows: [
+          row('S1', [], { title: 'First slice' }),
+          row('S2', ['S1'], { title: 'Second slice' }),
+        ],
+      },
+      next_action: {
+        command: 'smithy.forge',
+        arguments: ['specs/sample/01-first.tasks.md'],
+        reason: '',
+      },
+    });
+    const graph = buildDependencyGraph([tasksRecord]);
+    const output = renderGraph(graph, {
+      theme: utf8Theme,
+      records: [tasksRecord],
+    });
+    expect(output).toContain('→ smithy.forge specs/sample/01-first.tasks.md 1');
+    expect(output).toContain('→ smithy.forge specs/sample/01-first.tasks.md 2');
+  });
+
+  it('keeps the dim FQ id fallback when records option is omitted (legacy callers)', () => {
+    const spec = makeSpecRowsRecord();
+    const graph = buildDependencyGraph([spec, makeVirtualUS1Tasks()]);
+    const output = renderGraph(graph, { theme: utf8Theme });
+    expect(output).toContain(`${SPEC_PATH}#US1`);
+    expect(output).toContain(`${SPEC_PATH}#US2`);
+    expect(output).not.toContain('→ smithy.cut');
+    expect(output).not.toContain('→ smithy.forge');
+  });
+});
+
 describe('renderGraph — default theme', () => {
   it('uses a UTF-8 no-color theme when options are omitted', () => {
     const spec = makeRecord({

--- a/src/status/renderGraph.test.ts
+++ b/src/status/renderGraph.test.ts
@@ -113,35 +113,40 @@ describe('renderGraph — layered view (AS 10.1)', () => {
     expect(output).toContain('Layer 2 (1 item)');
   });
 
-  it('lists each node id under its layer with tree connectors and the row title', () => {
+  it('lists each node line with title-first layout, status marker, and a dim FQ-ID suffix', () => {
     const graph = buildDependencyGraph([spec]);
     const output = renderGraph(graph, { theme: utf8Theme });
-    // Every fully-qualified node id from buildDependencyGraph must
-    // appear in the output exactly once.
+    // Every fully-qualified node id still appears in the output — it
+    // just lives at the tail as a copy/paste reference, not at the head.
     expect(output).toContain(`${SPEC_PATH}#US1`);
     expect(output).toContain(`${SPEC_PATH}#US2`);
     expect(output).toContain(`${SPEC_PATH}#US3`);
     expect(output).toContain(`${SPEC_PATH}#US4`);
-    // Em-dash separator + title from the underlying row.
-    expect(output).toContain(`${SPEC_PATH}#US1 — First`);
-    expect(output).toContain(`${SPEC_PATH}#US2 — Second`);
+    // Title leads each line directly after the connector — the
+    // primary, scannable label.
+    expect(output).toContain('├─ First');
+    expect(output).toContain('└─ Fourth');
+    expect(output).toContain('└─ Second');
+    expect(output).toContain('└─ Third');
     // Tree connectors used to lay out per-layer members.
     expect(output).toMatch(/[├└]─/);
-    // Last-sibling glyph appears for the final entry of the
-    // multi-member Layer 0 (US4).
-    expect(output).toContain(`└─ ${SPEC_PATH}#US4`);
-    // Non-last-sibling glyph appears for the first entry of Layer 0
-    // (US1).
-    expect(output).toContain(`├─ ${SPEC_PATH}#US1`);
+    // The full per-line layout: connector + title + marker + dim id.
+    // (`utf8Theme` has color disabled, so the dim helper is identity
+    // and the FQ id appears verbatim at the tail of the line.)
+    expect(output).toMatch(
+      new RegExp(`└─ Fourth\\s+[○✓◐⚠].*${SPEC_PATH}#US4`),
+    );
   });
 
   it('orders Layer 0 members by their position in graph.layers[0].node_ids', () => {
     const graph = buildDependencyGraph([spec]);
     const output = renderGraph(graph, { theme: utf8Theme });
-    const us1Pos = output.indexOf(`${SPEC_PATH}#US1`);
-    const us4Pos = output.indexOf(`${SPEC_PATH}#US4`);
-    const us2Pos = output.indexOf(`${SPEC_PATH}#US2`);
-    const us3Pos = output.indexOf(`${SPEC_PATH}#US3`);
+    // Match by title ("First" / "Fourth" / "Second" / "Third") rather
+    // than the FQ id — the title is now the leading column.
+    const us1Pos = output.indexOf('├─ First');
+    const us4Pos = output.indexOf('└─ Fourth');
+    const us2Pos = output.indexOf('└─ Second');
+    const us3Pos = output.indexOf('└─ Third');
     expect(us1Pos).toBeGreaterThanOrEqual(0);
     expect(us4Pos).toBeGreaterThan(us1Pos);
     expect(us2Pos).toBeGreaterThan(us4Pos);
@@ -236,9 +241,11 @@ describe('renderGraph — done-layer collapsing (AS 10.4)', () => {
     expect(output).toContain('Layer 1 (1 item)');
   });
 
-  it('does not collapse a mixed-status layer', () => {
-    // Build a graph where Layer 0 has two members, one done and one
-    // not-started — the layer must NOT collapse.
+  it('hides done members inside a mixed-status layer in default mode and surfaces a `done hidden` suffix', () => {
+    // Layer 0 has two members: recordA (done) and recordB (not-started).
+    // Default mode hides the done member from the listing and tacks
+    // `, 1 done hidden` onto the heading; the not-started member
+    // surfaces normally.
     const recordA = makeRecord({
       type: 'spec',
       path: 'specs/a/a.spec.md',
@@ -246,7 +253,7 @@ describe('renderGraph — done-layer collapsing (AS 10.4)', () => {
       dependency_order: {
         id_prefix: 'US',
         format: 'table',
-        rows: [row('US1')],
+        rows: [row('US1', [], { title: 'Already Done' })],
       },
     });
     const recordB = makeRecord({
@@ -256,14 +263,138 @@ describe('renderGraph — done-layer collapsing (AS 10.4)', () => {
       dependency_order: {
         id_prefix: 'US',
         format: 'table',
-        rows: [row('US1')],
+        rows: [row('US1', [], { title: 'Still To Do' })],
       },
     });
     const graph = buildDependencyGraph([recordA, recordB]);
     const output = renderGraph(graph, { theme: utf8Theme });
     expect(output).not.toContain('DONE (');
+    // Heading carries the visible-count and the hidden-done suffix.
+    expect(output).toContain('Layer 0 — ready to work (2 items, 1 done hidden)');
+    // The done member's FQ id must NOT appear — it's filtered out.
+    expect(output).not.toContain('specs/a/a.spec.md#US1');
+    // The not-started member surfaces with its title-first line.
+    expect(output).toContain('└─ Still To Do');
+    expect(output).toContain('specs/b/b.spec.md#US1');
+  });
+
+  it('expands hidden done members and drops the suffix under {all: true}', () => {
+    const recordA = makeRecord({
+      type: 'spec',
+      path: 'specs/a/a.spec.md',
+      status: 'done',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1', [], { title: 'Already Done' })],
+      },
+    });
+    const recordB = makeRecord({
+      type: 'spec',
+      path: 'specs/b/b.spec.md',
+      status: 'not-started',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1', [], { title: 'Still To Do' })],
+      },
+    });
+    const graph = buildDependencyGraph([recordA, recordB]);
+    const output = renderGraph(graph, { theme: utf8Theme, all: true });
+    // No hidden-done suffix under --all.
+    expect(output).toContain('Layer 0 — ready to work (2 items)');
+    expect(output).not.toContain('done hidden');
+    // Both members surface, including the done one.
     expect(output).toContain('specs/a/a.spec.md#US1');
     expect(output).toContain('specs/b/b.spec.md#US1');
+    expect(output).toContain('Already Done');
+    expect(output).toContain('Still To Do');
+  });
+
+  it('collapses a layer to `Layer N: DONE (M items)` when every member rolls up to done (parser-driven)', () => {
+    // Sanity check that the legacy collapse rule still fires when the
+    // hide-done filter has nothing left to surface — the entire layer
+    // is `done`. Mirrors AS 10.4 but exercises the new code path.
+    const r1 = makeRecord({
+      type: 'spec',
+      path: 'specs/a/a.spec.md',
+      status: 'done',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1')],
+      },
+    });
+    const r2 = makeRecord({
+      type: 'spec',
+      path: 'specs/b/b.spec.md',
+      status: 'done',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1')],
+      },
+    });
+    const graph = buildDependencyGraph([r1, r2]);
+    const output = renderGraph(graph, { theme: utf8Theme });
+    expect(output).toContain('Layer 0: DONE (2 items)');
+    expect(output).not.toContain('done hidden');
+    // No member listing under a collapsed layer.
+    expect(output).not.toContain('specs/a/a.spec.md#US1');
+    expect(output).not.toContain('specs/b/b.spec.md#US1');
+  });
+
+  it('keeps non-done members (in-progress / not-started / unknown) visible alongside hidden done', () => {
+    // Layer with one done, one in-progress, one not-started, one
+    // unknown. Default mode hides the done; the other three must all
+    // remain visible regardless of status.
+    const done = makeRecord({
+      type: 'spec',
+      path: 'specs/a/done.spec.md',
+      status: 'done',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1', [], { title: 'Finished work' })],
+      },
+    });
+    const wip = makeRecord({
+      type: 'spec',
+      path: 'specs/b/wip.spec.md',
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1', [], { title: 'Half-finished work' })],
+      },
+    });
+    const ns = makeRecord({
+      type: 'spec',
+      path: 'specs/c/ns.spec.md',
+      status: 'not-started',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1', [], { title: 'Unstarted work' })],
+      },
+    });
+    const unk = makeRecord({
+      type: 'spec',
+      path: 'specs/d/unk.spec.md',
+      status: 'unknown',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [row('US1', [], { title: 'Parse-error work' })],
+      },
+    });
+    const graph = buildDependencyGraph([done, wip, ns, unk]);
+    const output = renderGraph(graph, { theme: utf8Theme });
+    expect(output).toContain('Layer 0 — ready to work (4 items, 1 done hidden)');
+    expect(output).not.toContain('Finished work');
+    expect(output).toContain('Half-finished work');
+    expect(output).toContain('Unstarted work');
+    expect(output).toContain('Parse-error work');
   });
 });
 

--- a/src/status/renderGraph.test.ts
+++ b/src/status/renderGraph.test.ts
@@ -214,12 +214,17 @@ describe('renderGraph — done-layer collapsing (AS 10.4)', () => {
     return [layer0, layer1, layer2];
   }
 
-  it('collapses an all-done layer to a `Layer N: DONE (M items)` line in default mode', () => {
+  it('omits an all-done layer entirely from default mode (no heading, no members)', () => {
     const graph = buildDependencyGraph(buildSpec());
     const output = renderGraph(graph, { theme: utf8Theme });
-    expect(output).toContain('Layer 1: DONE (1 item)');
-    // The collapsed layer must NOT list its members.
+    // No Layer 1 heading at all — the per-layer done count adds no
+    // actionable signal so the whole block is dropped.
+    expect(output).not.toContain('Layer 1');
+    expect(output).not.toContain('DONE (');
     expect(output).not.toContain('specs/b/b.spec.md#US2');
+    // Surrounding non-done layers still surface.
+    expect(output).toContain('Layer 0');
+    expect(output).toContain('Layer 2');
   });
 
   it('expands every layer when {all: true} is passed', () => {
@@ -311,10 +316,10 @@ describe('renderGraph — done-layer collapsing (AS 10.4)', () => {
     expect(output).toContain('Still To Do');
   });
 
-  it('collapses a layer to `Layer N: DONE (M items)` when every member rolls up to done (parser-driven)', () => {
-    // Sanity check that the legacy collapse rule still fires when the
-    // hide-done filter has nothing left to surface — the entire layer
-    // is `done`. Mirrors AS 10.4 but exercises the new code path.
+  it('omits a fully-done layer entirely (no heading, no members) when every member rolls up to done', () => {
+    // When the hide-done filter has nothing left to surface, the
+    // whole layer block is dropped from default mode rather than
+    // emitting a `Layer N: DONE` collapse line.
     const r1 = makeRecord({
       type: 'spec',
       path: 'specs/a/a.spec.md',
@@ -337,11 +342,9 @@ describe('renderGraph — done-layer collapsing (AS 10.4)', () => {
     });
     const graph = buildDependencyGraph([r1, r2]);
     const output = renderGraph(graph, { theme: utf8Theme });
-    expect(output).toContain('Layer 0: DONE (2 items)');
-    expect(output).not.toContain('done hidden');
-    // No member listing under a collapsed layer.
-    expect(output).not.toContain('specs/a/a.spec.md#US1');
-    expect(output).not.toContain('specs/b/b.spec.md#US1');
+    // No layer heading and no member listing: an all-done graph
+    // collapses to the empty string in default mode.
+    expect(output).toBe('');
   });
 
   it('keeps non-done members (in-progress / not-started / unknown) visible alongside hidden done', () => {

--- a/src/status/renderGraph.ts
+++ b/src/status/renderGraph.ts
@@ -1,0 +1,334 @@
+/**
+ * Pure text rendering over the {@link DependencyGraph} produced by
+ * {@link buildDependencyGraph}. Walks the graph's topological layers and
+ * emits a block of lines describing each layer's members, with done-layer
+ * collapsing in default mode and a flat cycle-warning fallback when the
+ * graph is not a DAG.
+ *
+ * This module is deliberately side-effect-free. `renderGraph` performs
+ * no I/O, does not touch `process.stdout`, and never mutates its input —
+ * the output is a pure function of the graph (and the options bag).
+ *
+ * ## Layout
+ *
+ * ### Layered view (default — `graph.cycles.length === 0`)
+ *
+ * One labeled block per entry in `graph.layers`, in order. Layer 0 leads
+ * with the canonical "ready to work" copy from contracts §1:
+ *
+ * ```
+ * Layer 0 — ready to work (2 items)
+ * ├─ specs/.../foo.spec.md#US1 — Scan Artifacts and Classify Status  ◐
+ * └─ specs/.../foo.spec.md#US8 — Deterministic Dependency Order      ○
+ *
+ * Layer 1 (1 item)
+ * └─ specs/.../foo.spec.md#US2 — Render a Hierarchical Status View   ○
+ * ```
+ *
+ * Subsequent layers use the simpler `Layer N (M items)` form. Each node
+ * line uses tree connectors drawn from the active {@link Theme}'s
+ * `glyphs` bundle (`├─` for non-last members, `└─` for the last
+ * member of each layer). Adjacent layer blocks are separated by a
+ * single blank line.
+ *
+ * Each node line carries:
+ * - the fully-qualified node id (`<artifact-path>#<row-id>`),
+ * - an em-dash separator and the title from the underlying
+ *   {@link DependencyNode.row.title}, and
+ * - a trailing status marker mirroring the icon mapping used by the
+ *   default tree renderer (`✓` / `◐` / `○` / `⚠`).
+ *
+ * #### Done-layer collapsing (AS 10.4)
+ *
+ * When every node in a layer has `status === 'done'` AND
+ * `options.all !== true`, the entire layer collapses to a single
+ * `Layer N: DONE (M items)` line with no member listing. Passing
+ * `{ all: true }` disables collapsing — every layer is fully expanded
+ * regardless of member status.
+ *
+ * ### Cycle fallback (AS 10.3 — `graph.cycles.length > 0`)
+ *
+ * When the graph contains cycles, layer assignment is undefined for the
+ * cyclic subgraph and the renderer falls back to a flat listing. The
+ * output leads with a warning block:
+ *
+ * ```
+ * WARNING: dependency graph contains cycle(s); falling back to flat listing.
+ * Cycle: specs/foo.spec.md#US1 -> specs/foo.spec.md#US2 -> specs/foo.spec.md#US1
+ *
+ * Nodes (flat fallback):
+ * ├─ specs/foo.spec.md#US3 — Independent  ○
+ * └─ specs/foo.spec.md#US4 — Downstream   ○
+ * ```
+ *
+ * Each cycle entry repeats the first id at the tail so the loop is
+ * visually obvious. Cyclic nodes intentionally do NOT appear in the
+ * flat fallback — they already surface on the `Cycle:` line — and no
+ * `Layer N` heading is emitted for them.
+ *
+ * ### Dangling references (AS 10.6)
+ *
+ * When `graph.dangling_refs` is non-empty, a `Dangling refs:` block is
+ * appended after the layer / cycle blocks, with one painted line per
+ * unresolved pair: `<source_id> -> <missing_id> (unresolved)`.
+ *
+ * ### Empty graph
+ *
+ * `renderGraph({ nodes: {}, layers: [], cycles: [], dangling_refs: [] })`
+ * returns the empty string, matching the {@link renderTree} convention.
+ */
+
+import { createTheme, type Theme } from './theme.js';
+import type { DependencyGraph, DependencyNode } from './types.js';
+
+/**
+ * Options accepted by {@link renderGraph}. A default theme (UTF-8
+ * glyphs, no color) is used when `theme` is omitted so callers can
+ * skip the bag entirely for plain-text rendering.
+ */
+export interface RenderGraphOptions {
+  /**
+   * Theme bundle controlling glyphs, icons, and paint helpers. Callers
+   * typically build it once at the top of `statusAction` via
+   * {@link buildTheme}; tests construct deterministic themes via
+   * {@link createTheme}.
+   */
+  theme?: Theme;
+  /**
+   * When `true`, disable done-layer collapsing — every layer expands
+   * with its full member list, even when every member is `done`.
+   * Defaults to `false`, matching the contracts default-mode collapsing
+   * behavior (AS 10.4).
+   */
+  all?: boolean;
+}
+
+/**
+ * Default theme used when `renderGraph` is called without an explicit
+ * theme. Keeps UTF-8 glyphs and disables color so snapshots stay
+ * ANSI-free.
+ */
+const DEFAULT_THEME: Theme = createTheme({ color: false, encoding: 'utf8' });
+
+/**
+ * Render a {@link DependencyGraph} as a block of layer / cycle / dangling
+ * lines. Pure function — does no I/O and does not mutate its input.
+ * Callers are responsible for writing the returned string to stdout.
+ *
+ * The returned string does NOT include a trailing newline; typical
+ * callers pipe it through `console.log`, which adds one. An empty graph
+ * (no nodes, no layers, no cycles, no dangling refs) yields the empty
+ * string.
+ */
+export function renderGraph(
+  graph: DependencyGraph,
+  options: RenderGraphOptions = {},
+): string {
+  const isEmpty =
+    Object.keys(graph.nodes).length === 0 &&
+    graph.layers.length === 0 &&
+    graph.cycles.length === 0 &&
+    graph.dangling_refs.length === 0;
+  if (isEmpty) return '';
+
+  const theme = options.theme ?? DEFAULT_THEME;
+  const all = options.all === true;
+  const blocks: string[] = [];
+
+  if (graph.cycles.length > 0) {
+    blocks.push(formatCycleFallback(graph, theme));
+  } else {
+    const layered = formatLayeredView(graph, theme, all);
+    if (layered.length > 0) blocks.push(layered);
+  }
+
+  if (graph.dangling_refs.length > 0) {
+    blocks.push(formatDanglingRefs(graph, theme));
+  }
+
+  return blocks.join('\n\n');
+}
+
+/**
+ * Format the layered view (DAG case). Returns the empty string when no
+ * layers exist (which can happen for an entirely cyclic graph — but in
+ * that branch we never call this function). One block per layer,
+ * separated by a single blank line.
+ */
+function formatLayeredView(
+  graph: DependencyGraph,
+  theme: Theme,
+  all: boolean,
+): string {
+  if (graph.layers.length === 0) return '';
+  const blocks: string[] = [];
+  for (const layer of graph.layers) {
+    blocks.push(formatLayerBlock(layer, graph, theme, all));
+  }
+  return blocks.join('\n\n');
+}
+
+/**
+ * Format one layer block: heading line plus, when expanded, one tree-
+ * connector line per member node. When every member of a layer is
+ * `done` and collapsing is enabled (`all === false`), the heading
+ * shifts to the `Layer N: DONE (M items)` form and the member list is
+ * suppressed.
+ */
+function formatLayerBlock(
+  layer: { layer: number; node_ids: string[] },
+  graph: DependencyGraph,
+  theme: Theme,
+  all: boolean,
+): string {
+  const total = layer.node_ids.length;
+  const allDone =
+    total > 0 &&
+    layer.node_ids.every((id) => graph.nodes[id]?.status === 'done');
+
+  if (allDone && !all) {
+    return formatLayerHeading(layer.layer, total, { collapsedDone: true });
+  }
+
+  const heading = formatLayerHeading(layer.layer, total, {
+    collapsedDone: false,
+  });
+  const lines: string[] = [heading];
+  for (let i = 0; i < layer.node_ids.length; i++) {
+    const id = layer.node_ids[i];
+    if (id === undefined) continue;
+    const node = graph.nodes[id];
+    if (node === undefined) continue;
+    const isLast = i === layer.node_ids.length - 1;
+    lines.push(formatNodeLine(id, node, isLast, theme));
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Compose the heading line for a layer. Layer 0 leads with the
+ * "ready to work" copy from contracts §1; subsequent layers use the
+ * simpler `Layer N (M items)` form. Singular `1 item` vs plural
+ * `M items` is selected based on the count.
+ *
+ * `collapsedDone === true` overrides the layer-specific copy with the
+ * uniform `Layer N: DONE (M items)` collapse line (AS 10.4) — the
+ * caller decides when to flip it.
+ */
+function formatLayerHeading(
+  layerIndex: number,
+  count: number,
+  opts: { collapsedDone: boolean },
+): string {
+  const itemsWord = count === 1 ? 'item' : 'items';
+  if (opts.collapsedDone) {
+    return `Layer ${layerIndex}: DONE (${count} ${itemsWord})`;
+  }
+  if (layerIndex === 0) {
+    return `Layer 0 — ready to work (${count} ${itemsWord})`;
+  }
+  return `Layer ${layerIndex} (${count} ${itemsWord})`;
+}
+
+/**
+ * Format a single node line under a layer / fallback heading. Uses the
+ * theme's `branch` / `lastBranch` glyphs for the connector, an em-dash
+ * to separate the fully-qualified id from the row title, and a trailing
+ * status marker.
+ */
+function formatNodeLine(
+  id: string,
+  node: DependencyNode,
+  isLast: boolean,
+  theme: Theme,
+): string {
+  const connector = isLast ? theme.glyphs.lastBranch : theme.glyphs.branch;
+  const marker = formatStatusMarker(node, theme);
+  return `${connector}${id} — ${node.row.title}  ${marker}`;
+}
+
+/**
+ * Derive the trailing status marker for a graph node. Mirrors the
+ * default tree renderer's icon mapping but is inlined here so the two
+ * renderers can evolve independently. Counters and progress segments
+ * (used by the tree renderer's in-progress parents and tasks rows) are
+ * intentionally omitted — graph nodes carry only their owning record's
+ * rolled-up status, not the per-record completion arithmetic.
+ */
+function formatStatusMarker(node: DependencyNode, theme: Theme): string {
+  switch (node.status) {
+    case 'done':
+      return theme.paint.done(theme.icons.done);
+    case 'in-progress':
+      return theme.paint.inProgress(theme.icons.inProgress);
+    case 'not-started':
+      return theme.paint.notStarted(theme.icons.notStarted);
+    case 'unknown':
+      return theme.paint.unknown(theme.icons.unknown);
+  }
+}
+
+/**
+ * Format the cycle-warning fallback. Leads with a painted warning line,
+ * one `Cycle:` line per cycle entry (closing the loop by repeating the
+ * first id), and then a flat listing of the non-cyclic nodes preserved
+ * from `graph.layers` in topological order. Cyclic nodes are
+ * intentionally excluded from the flat listing — they already appear on
+ * the cycle lines above.
+ */
+function formatCycleFallback(graph: DependencyGraph, theme: Theme): string {
+  const lines: string[] = [];
+  lines.push(
+    theme.paint.error(
+      'WARNING: dependency graph contains cycle(s); falling back to flat listing.',
+    ),
+  );
+  for (const cycle of graph.cycles) {
+    if (cycle.length === 0) continue;
+    const first = cycle[0];
+    if (first === undefined) continue;
+    // Close the loop by repeating the first id at the tail so the
+    // cycle is visually obvious.
+    const closed = [...cycle, first];
+    lines.push(`Cycle: ${closed.join(' -> ')}`);
+  }
+  // Flat fallback for any non-cyclic nodes still preserved by Kahn's in
+  // `graph.layers`. Cyclic nodes are excluded from every layer entry by
+  // the builder, so iterating layers gives us exactly the set of
+  // non-cyclic nodes in topological order.
+  const flatIds: string[] = [];
+  for (const layer of graph.layers) {
+    for (const id of layer.node_ids) {
+      flatIds.push(id);
+    }
+  }
+  if (flatIds.length > 0) {
+    const flatLines: string[] = ['', 'Nodes (flat fallback):'];
+    for (let i = 0; i < flatIds.length; i++) {
+      const id = flatIds[i];
+      if (id === undefined) continue;
+      const node = graph.nodes[id];
+      if (node === undefined) continue;
+      const isLast = i === flatIds.length - 1;
+      flatLines.push(formatNodeLine(id, node, isLast, theme));
+    }
+    lines.push(...flatLines);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Format the trailing `Dangling refs:` block. One painted line per
+ * unresolved pair, each formatted as
+ * `<source_id> -> <missing_id> (unresolved)`. The block is omitted by
+ * the caller when `graph.dangling_refs` is empty.
+ */
+function formatDanglingRefs(graph: DependencyGraph, theme: Theme): string {
+  const lines: string[] = ['Dangling refs:'];
+  for (const ref of graph.dangling_refs) {
+    lines.push(
+      theme.paint.error(`${ref.source_id} -> ${ref.missing_id} (unresolved)`),
+    );
+  }
+  return lines.join('\n');
+}

--- a/src/status/renderGraph.ts
+++ b/src/status/renderGraph.ts
@@ -18,11 +18,11 @@
  *
  * ```
  * Layer 0 — ready to work (2 items)
- * ├─ specs/.../foo.spec.md#US1 — Scan Artifacts and Classify Status  ◐
- * └─ specs/.../foo.spec.md#US8 — Deterministic Dependency Order      ○
+ * ├─ Scan Artifacts and Classify Status  ◐  specs/.../foo.spec.md#US1
+ * └─ Deterministic Dependency Order      ○  specs/.../foo.spec.md#US8
  *
  * Layer 1 (1 item)
- * └─ specs/.../foo.spec.md#US2 — Render a Hierarchical Status View   ○
+ * └─ Render a Hierarchical Status View   ○  specs/.../foo.spec.md#US2
  * ```
  *
  * Subsequent layers use the simpler `Layer N (M items)` form. Each node
@@ -32,19 +32,31 @@
  * single blank line.
  *
  * Each node line carries:
- * - the fully-qualified node id (`<artifact-path>#<row-id>`),
- * - an em-dash separator and the title from the underlying
- *   {@link DependencyNode.row.title}, and
+ * - the title from the underlying {@link DependencyNode.row.title} as
+ *   the primary, scannable label,
  * - a trailing status marker mirroring the icon mapping used by the
- *   default tree renderer (`✓` / `◐` / `○` / `⚠`).
+ *   default tree renderer (`✓` / `◐` / `○` / `⚠`), and
+ * - the fully-qualified node id (`<artifact-path>#<row-id>`) as a
+ *   trailing, dim-painted suffix so reviewers can still copy/paste the
+ *   ID without fighting it for visual weight.
  *
- * #### Done-layer collapsing (AS 10.4)
+ * #### Done-item hiding and layer collapsing (AS 10.4)
  *
- * When every node in a layer has `status === 'done'` AND
- * `options.all !== true`, the entire layer collapses to a single
- * `Layer N: DONE (M items)` line with no member listing. Passing
- * `{ all: true }` disables collapsing — every layer is fully expanded
- * regardless of member status.
+ * Default mode aggressively focuses the view on what still needs work:
+ *
+ * - Within a partially-done layer, members with `status === 'done'` are
+ *   hidden from the listing. The layer heading gains a
+ *   `, N done hidden` suffix so the suppressed work is still
+ *   accounted for (e.g. `Layer 0 — ready to work (11 items, 9 done hidden)`).
+ *   Members with any other status (`in-progress`, `not-started`,
+ *   `unknown`) always surface so parse errors and not-yet-started work
+ *   stay visible.
+ * - When every member of a layer is `done` (i.e. nothing actionable
+ *   remains after the filter), the entire layer collapses to a single
+ *   `Layer N: DONE (M items)` line with no member listing.
+ * - Passing `{ all: true }` disables both the hide-done filter and the
+ *   layer collapse — every member of every layer is listed regardless
+ *   of status, and the heading omits the `done hidden` suffix.
  *
  * ### Cycle fallback (AS 10.3 — `graph.cycles.length > 0`)
  *
@@ -170,10 +182,18 @@ function formatLayeredView(
 
 /**
  * Format one layer block: heading line plus, when expanded, one tree-
- * connector line per member node. When every member of a layer is
- * `done` and collapsing is enabled (`all === false`), the heading
- * shifts to the `Layer N: DONE (M items)` form and the member list is
- * suppressed.
+ * connector line per actionable member.
+ *
+ * Default mode (`all === false`) hides members with `status === 'done'`
+ * from the visible listing and tacks a `, N done hidden` suffix on the
+ * heading so the dropped work is still accounted for. When every
+ * member of the layer is `done` (zero actionable remainder), the whole
+ * layer collapses to the uniform `Layer N: DONE (M items)` line with
+ * no member listing.
+ *
+ * `--all` mode (`all === true`) disables both behaviors — every member
+ * surfaces with its full marker, and the heading omits the
+ * `done hidden` suffix.
  */
 function formatLayerBlock(
   layer: { layer: number; node_ids: string[] },
@@ -182,24 +202,43 @@ function formatLayerBlock(
   all: boolean,
 ): string {
   const total = layer.node_ids.length;
-  const allDone =
-    total > 0 &&
-    layer.node_ids.every((id) => graph.nodes[id]?.status === 'done');
 
-  if (allDone && !all) {
-    return formatLayerHeading(layer.layer, total, { collapsedDone: true });
+  // Partition members into actionable (everything that isn't `done`)
+  // and hidden-done. In `--all` mode the partition collapses — every
+  // member is "actionable" for display purposes, so no hiding occurs.
+  const visibleIds: string[] = [];
+  let doneHidden = 0;
+  for (const id of layer.node_ids) {
+    const node = graph.nodes[id];
+    if (all || node === undefined || node.status !== 'done') {
+      visibleIds.push(id);
+    } else {
+      doneHidden += 1;
+    }
+  }
+
+  // Layer with no actionable members → collapse to a single line. This
+  // covers both the legacy "all rows are `done`" case and the new
+  // default-mode hide-done filter (a layer of all-`done` nodes filters
+  // down to zero visible items).
+  if (visibleIds.length === 0 && total > 0) {
+    return formatLayerHeading(layer.layer, total, {
+      collapsedDone: true,
+      doneHidden: 0,
+    });
   }
 
   const heading = formatLayerHeading(layer.layer, total, {
     collapsedDone: false,
+    doneHidden,
   });
   const lines: string[] = [heading];
-  for (let i = 0; i < layer.node_ids.length; i++) {
-    const id = layer.node_ids[i];
+  for (let i = 0; i < visibleIds.length; i++) {
+    const id = visibleIds[i];
     if (id === undefined) continue;
     const node = graph.nodes[id];
     if (node === undefined) continue;
-    const isLast = i === layer.node_ids.length - 1;
+    const isLast = i === visibleIds.length - 1;
     lines.push(formatNodeLine(id, node, isLast, theme));
   }
   return lines.join('\n');
@@ -212,29 +251,35 @@ function formatLayerBlock(
  * `M items` is selected based on the count.
  *
  * `collapsedDone === true` overrides the layer-specific copy with the
- * uniform `Layer N: DONE (M items)` collapse line (AS 10.4) — the
- * caller decides when to flip it.
+ * uniform `Layer N: DONE (M items)` collapse line — the caller decides
+ * when to flip it. `doneHidden > 0` appends a `, N done hidden` suffix
+ * inside the parens so reviewers see that work was suppressed; the
+ * suffix is omitted under `collapsedDone` (the heading already says
+ * `DONE`) and under `doneHidden === 0` (nothing to surface).
  */
 function formatLayerHeading(
   layerIndex: number,
   count: number,
-  opts: { collapsedDone: boolean },
+  opts: { collapsedDone: boolean; doneHidden: number },
 ): string {
   const itemsWord = count === 1 ? 'item' : 'items';
   if (opts.collapsedDone) {
     return `Layer ${layerIndex}: DONE (${count} ${itemsWord})`;
   }
+  const hiddenSuffix =
+    opts.doneHidden > 0 ? `, ${opts.doneHidden} done hidden` : '';
   if (layerIndex === 0) {
-    return `Layer 0 — ready to work (${count} ${itemsWord})`;
+    return `Layer 0 — ready to work (${count} ${itemsWord}${hiddenSuffix})`;
   }
-  return `Layer ${layerIndex} (${count} ${itemsWord})`;
+  return `Layer ${layerIndex} (${count} ${itemsWord}${hiddenSuffix})`;
 }
 
 /**
- * Format a single node line under a layer / fallback heading. Uses the
- * theme's `branch` / `lastBranch` glyphs for the connector, an em-dash
- * to separate the fully-qualified id from the row title, and a trailing
- * status marker.
+ * Format a single node line under a layer / fallback heading. The line
+ * leads with the row's title (the scannable label), then the status
+ * marker, then a dim-painted fully-qualified id suffix so reviewers can
+ * still copy/paste the canonical reference without fighting it for
+ * visual weight.
  */
 function formatNodeLine(
   id: string,
@@ -244,7 +289,8 @@ function formatNodeLine(
 ): string {
   const connector = isLast ? theme.glyphs.lastBranch : theme.glyphs.branch;
   const marker = formatStatusMarker(node, theme);
-  return `${connector}${id} — ${node.row.title}  ${marker}`;
+  const dimId = theme.paint.dim(id);
+  return `${connector}${node.row.title}  ${marker}  ${dimId}`;
 }
 
 /**

--- a/src/status/renderGraph.ts
+++ b/src/status/renderGraph.ts
@@ -357,9 +357,9 @@ function formatLayeredView(
  * Default mode (`all === false`) hides members with `status === 'done'`
  * from the visible listing and tacks a `, N done hidden` suffix on the
  * heading so the dropped work is still accounted for. When every
- * member of the layer is `done` (zero actionable remainder), the whole
- * layer collapses to the uniform `Layer N: DONE (M items)` line with
- * no member listing.
+ * member of the layer is `done` (zero actionable remainder), this
+ * function returns the empty string so the caller omits the layer
+ * entirely from the rendered output.
  *
  * `--all` mode (`all === true`) disables both behaviors — every member
  * surfaces with its full marker, and the heading omits the

--- a/src/status/renderGraph.ts
+++ b/src/status/renderGraph.ts
@@ -36,9 +36,14 @@
  *   the primary, scannable label,
  * - a trailing status marker mirroring the icon mapping used by the
  *   default tree renderer (`✓` / `◐` / `○` / `⚠`), and
- * - the fully-qualified node id (`<artifact-path>#<row-id>`) as a
- *   trailing, dim-painted suffix so reviewers can still copy/paste the
- *   ID without fighting it for visual weight.
+ * - either a per-row next-action hint (`→ smithy.<cmd> <args>`) when
+ *   the caller passes {@link RenderGraphOptions.records}, or the
+ *   fully-qualified node id (`<artifact-path>#<row-id>`) as a
+ *   trailing, dim-painted suffix when no records are supplied. The
+ *   action hint mirrors the `Next:` line in the summary header and the
+ *   per-record hints under `renderTree` so the graph view is visually
+ *   consistent with the rest of `smithy status`. Done / unknown
+ *   downstreams yield no hint; their lines fall back to the dim FQ id.
  *
  * #### Done-item hiding and layer collapsing (AS 10.4)
  *
@@ -90,8 +95,16 @@
  * returns the empty string, matching the {@link renderTree} convention.
  */
 
+import path from 'node:path';
+
+import { formatNextAction } from './suggester.js';
 import { createTheme, type Theme } from './theme.js';
-import type { DependencyGraph, DependencyNode } from './types.js';
+import type {
+  ArtifactRecord,
+  DependencyGraph,
+  DependencyNode,
+  NextAction,
+} from './types.js';
 
 /**
  * Options accepted by {@link renderGraph}. A default theme (UTF-8
@@ -113,6 +126,151 @@ export interface RenderGraphOptions {
    * behavior (AS 10.4).
    */
   all?: boolean;
+  /**
+   * Optional record set used to enrich each node line with a per-row
+   * next-action hint (e.g. `→ smithy.cut <spec-folder> 1`) instead of
+   * the dim fully-qualified id. When provided, the renderer mirrors the
+   * `→ <command> <args>` shape that `renderTree` and the summary
+   * header's `Next:` line use, so the graph view is visually
+   * consistent with the rest of `smithy status`. When omitted, the
+   * suffix falls back to the dim FQ id — keeps unit tests that exercise
+   * just the graph algorithm light.
+   *
+   * Per-row resolution: a node's hint comes from (a) the downstream
+   * record claimed by the row's `artifact_path` (looked up by
+   * `parent_path` + `parent_row_id` so virtual records emitted by the
+   * scanner participate too) when that record carries a non-null
+   * `next_action`; or (b) a synthesized hint based on the owning
+   * record's type and the row's numeric suffix when no downstream
+   * record exists (slice rows in tasks files, or rows whose owner is
+   * itself the actionable level). Done-status downstreams yield no
+   * hint and the line falls back to the dim FQ id.
+   */
+  records?: ArtifactRecord[];
+}
+
+/**
+ * Internal lookup tables built once per `renderGraph` call from the
+ * caller-supplied {@link RenderGraphOptions.records}. Both maps are
+ * O(1) so per-node action derivation stays cheap even on large repos.
+ */
+interface RecordLookup {
+  /** Records keyed by their canonical `path`. */
+  byPath: Map<string, ArtifactRecord>;
+  /**
+   * Records keyed by `<parent_path>#<parent_row_id>` — the inverse
+   * lineage edge. Lets a graph node look up the record claimed by the
+   * row that owns it without re-deriving the naming convention.
+   */
+  byParentSlot: Map<string, ArtifactRecord>;
+}
+
+function buildRecordLookup(records: ArtifactRecord[]): RecordLookup {
+  const byPath = new Map<string, ArtifactRecord>();
+  const byParentSlot = new Map<string, ArtifactRecord>();
+  for (const record of records) {
+    byPath.set(record.path, record);
+    if (
+      typeof record.parent_path === 'string' &&
+      record.parent_path.length > 0 &&
+      typeof record.parent_row_id === 'string' &&
+      record.parent_row_id.length > 0
+    ) {
+      byParentSlot.set(
+        `${record.parent_path}#${record.parent_row_id}`,
+        record,
+      );
+    }
+  }
+  return { byPath, byParentSlot };
+}
+
+/**
+ * Derive the per-row {@link NextAction} for a graph node, mirroring the
+ * `→ smithy.<cmd> <args>` shape that `renderTree` and the summary
+ * header surface. Returns `null` when the row has no actionable next
+ * step (the downstream record is `done` or the lookup table cannot
+ * find an owning record).
+ *
+ * The per-row variant is intentionally distinct from the per-record
+ * `suggestNextAction`: a spec record carries one collapsed
+ * `smithy.cut` hint (the first virtual story), but each user-story
+ * row in that spec wants its OWN `smithy.cut <spec> <N>` hint so the
+ * graph view tells the user exactly which story to act on. We resolve
+ * by looking up the downstream record (real or virtual) via the
+ * `byParentSlot` map — the scanner-populated `parent_row_id` link is
+ * authoritative — and falling back to a synthesised hint only when the
+ * row has no downstream record (slice rows in tasks files; certain
+ * pathological cases).
+ */
+function deriveRowAction(
+  node: DependencyNode,
+  lookup: RecordLookup,
+): NextAction | null {
+  // Preferred path: the downstream record (real or virtual) carries
+  // the action via the suggester's per-record rules. Virtual records
+  // emitted by the scanner already produce `smithy.cut <folder> <N>`
+  // for unstarted stories — exactly the per-row hint we want — so a
+  // simple lookup avoids re-implementing that logic here.
+  const downstreamKey = `${node.record_path}#${node.row.id}`;
+  const downstream = lookup.byParentSlot.get(downstreamKey);
+  if (downstream !== undefined) {
+    return downstream.next_action ?? null;
+  }
+
+  // Fallback path: the row has no downstream record. This happens for
+  // slice rows in tasks files (slices have no separate files, so the
+  // scanner never emits a child record), and as a defensive default
+  // when the lookup misses for any other reason. Synthesise a hint
+  // from the owning record's type so the view stays uniformly
+  // actionable.
+  const owning = lookup.byPath.get(node.record_path);
+  if (owning === undefined) return null;
+  if (owning.status === 'done' || owning.status === 'unknown') return null;
+
+  const digits = node.row.id.match(/[0-9]+$/)?.[0];
+
+  switch (owning.type) {
+    case 'tasks': {
+      // Slice rows always land here. `smithy.forge <tasks-path> <N>`
+      // routes forge to the specific slice, matching the per-row
+      // signal a graph reader expects.
+      const args =
+        digits !== undefined ? [owning.path, digits] : [owning.path];
+      return {
+        command: 'smithy.forge',
+        arguments: args,
+        reason: `${node.row.title} is an open slice; run smithy.forge to implement it.`,
+      };
+    }
+    case 'spec': {
+      // Defensive: a spec row whose downstream lookup missed. The
+      // suggester's per-record rule (`smithy.cut <folder> <digits>`)
+      // is the right shape.
+      if (digits === undefined) return null;
+      const folder = path.dirname(owning.path);
+      return {
+        command: 'smithy.cut',
+        arguments: [folder, digits],
+        reason: `${node.row.title} has no tasks file yet; run smithy.cut to decompose it.`,
+      };
+    }
+    case 'features': {
+      if (digits === undefined) return null;
+      return {
+        command: 'smithy.mark',
+        arguments: [owning.path, digits],
+        reason: `${node.row.title} has no spec yet; run smithy.mark to produce one.`,
+      };
+    }
+    case 'rfc': {
+      return {
+        command: 'smithy.render',
+        arguments: [owning.path],
+        reason: `${node.row.title} has no features map yet; run smithy.render to produce one.`,
+      };
+    }
+  }
 }
 
 /**
@@ -145,12 +303,14 @@ export function renderGraph(
 
   const theme = options.theme ?? DEFAULT_THEME;
   const all = options.all === true;
+  const lookup =
+    options.records !== undefined ? buildRecordLookup(options.records) : null;
   const blocks: string[] = [];
 
   if (graph.cycles.length > 0) {
-    blocks.push(formatCycleFallback(graph, theme));
+    blocks.push(formatCycleFallback(graph, theme, lookup));
   } else {
-    const layered = formatLayeredView(graph, theme, all);
+    const layered = formatLayeredView(graph, theme, all, lookup);
     if (layered.length > 0) blocks.push(layered);
   }
 
@@ -171,11 +331,12 @@ function formatLayeredView(
   graph: DependencyGraph,
   theme: Theme,
   all: boolean,
+  lookup: RecordLookup | null,
 ): string {
   if (graph.layers.length === 0) return '';
   const blocks: string[] = [];
   for (const layer of graph.layers) {
-    blocks.push(formatLayerBlock(layer, graph, theme, all));
+    blocks.push(formatLayerBlock(layer, graph, theme, all, lookup));
   }
   return blocks.join('\n\n');
 }
@@ -200,6 +361,7 @@ function formatLayerBlock(
   graph: DependencyGraph,
   theme: Theme,
   all: boolean,
+  lookup: RecordLookup | null,
 ): string {
   const total = layer.node_ids.length;
 
@@ -239,7 +401,7 @@ function formatLayerBlock(
     const node = graph.nodes[id];
     if (node === undefined) continue;
     const isLast = i === visibleIds.length - 1;
-    lines.push(formatNodeLine(id, node, isLast, theme));
+    lines.push(formatNodeLine(id, node, isLast, theme, lookup));
   }
   return lines.join('\n');
 }
@@ -277,20 +439,33 @@ function formatLayerHeading(
 /**
  * Format a single node line under a layer / fallback heading. The line
  * leads with the row's title (the scannable label), then the status
- * marker, then a dim-painted fully-qualified id suffix so reviewers can
- * still copy/paste the canonical reference without fighting it for
- * visual weight.
+ * marker, then either a per-row next-action hint (when a record
+ * lookup is available and the row resolves to an action) or the
+ * dim-painted fully-qualified id (the fallback so the line still
+ * carries a copy/paste-able referent).
+ *
+ * The action hint mirrors `formatNextAction`'s `→ <command> <args>`
+ * shape so the graph view is visually consistent with the `Next:`
+ * line in the summary header and the per-record hints under
+ * `renderTree`. When the row has no action (done/unknown downstream,
+ * or no records were supplied), the dim FQ id keeps the line useful
+ * for navigation.
  */
 function formatNodeLine(
   id: string,
   node: DependencyNode,
   isLast: boolean,
   theme: Theme,
+  lookup: RecordLookup | null,
 ): string {
   const connector = isLast ? theme.glyphs.lastBranch : theme.glyphs.branch;
   const marker = formatStatusMarker(node, theme);
-  const dimId = theme.paint.dim(id);
-  return `${connector}${node.row.title}  ${marker}  ${dimId}`;
+  const action = lookup !== null ? deriveRowAction(node, lookup) : null;
+  const suffix =
+    action !== null
+      ? formatNextAction(action, theme.glyphs.arrow)
+      : theme.paint.dim(id);
+  return `${connector}${node.row.title}  ${marker}  ${suffix}`;
 }
 
 /**
@@ -325,7 +500,11 @@ function formatStatusMarker(node: DependencyNode, theme: Theme): string {
  * nodes are intentionally excluded from the flat listing — they
  * already appear on the cycle lines above.
  */
-function formatCycleFallback(graph: DependencyGraph, theme: Theme): string {
+function formatCycleFallback(
+  graph: DependencyGraph,
+  theme: Theme,
+  lookup: RecordLookup | null,
+): string {
   const lines: string[] = [];
   lines.push(
     theme.paint.error(
@@ -376,7 +555,7 @@ function formatCycleFallback(graph: DependencyGraph, theme: Theme): string {
       const node = graph.nodes[id];
       if (node === undefined) continue;
       const isLast = i === flatIds.length - 1;
-      flatLines.push(formatNodeLine(id, node, isLast, theme));
+      flatLines.push(formatNodeLine(id, node, isLast, theme, lookup));
     }
     lines.push(...flatLines);
   }

--- a/src/status/renderGraph.ts
+++ b/src/status/renderGraph.ts
@@ -271,10 +271,13 @@ function formatStatusMarker(node: DependencyNode, theme: Theme): string {
 /**
  * Format the cycle-warning fallback. Leads with a painted warning line,
  * one `Cycle:` line per cycle entry (closing the loop by repeating the
- * first id), and then a flat listing of the non-cyclic nodes preserved
- * from `graph.layers` in topological order. Cyclic nodes are
- * intentionally excluded from the flat listing — they already appear on
- * the cycle lines above.
+ * first id), and then a flat listing of every non-cyclic node — both
+ * the nodes Kahn's algorithm placed in `graph.layers` AND any nodes
+ * downstream of a cycle that the builder left outside both `layers`
+ * and `cycles` (those nodes never reached in-degree zero, so they are
+ * absent from any layer, but they are not themselves cyclic). Cyclic
+ * nodes are intentionally excluded from the flat listing — they
+ * already appear on the cycle lines above.
  */
 function formatCycleFallback(graph: DependencyGraph, theme: Theme): string {
   const lines: string[] = [];
@@ -283,24 +286,41 @@ function formatCycleFallback(graph: DependencyGraph, theme: Theme): string {
       'WARNING: dependency graph contains cycle(s); falling back to flat listing.',
     ),
   );
+  // Build the set of cyclic IDs once so we can exclude them from the
+  // flat fallback while keeping iteration over `graph.nodes` cheap.
+  const cyclicIds = new Set<string>();
   for (const cycle of graph.cycles) {
     if (cycle.length === 0) continue;
     const first = cycle[0];
     if (first === undefined) continue;
+    for (const id of cycle) cyclicIds.add(id);
     // Close the loop by repeating the first id at the tail so the
     // cycle is visually obvious.
     const closed = [...cycle, first];
     lines.push(`Cycle: ${closed.join(' -> ')}`);
   }
-  // Flat fallback for any non-cyclic nodes still preserved by Kahn's in
-  // `graph.layers`. Cyclic nodes are excluded from every layer entry by
-  // the builder, so iterating layers gives us exactly the set of
-  // non-cyclic nodes in topological order.
+  // Flat fallback covers every non-cyclic node, not just the ones that
+  // ended up inside `graph.layers`. Walk `graph.layers` first so layered
+  // nodes keep their topological ordering, then sweep `graph.nodes` to
+  // catch any node Kahn's left outside both `layers` and `cycles` (i.e.
+  // nodes downstream of a cycle whose in-degree never reached zero).
+  // Without that second pass those nodes would silently disappear from
+  // the rendered output even though the JSON payload reports them.
   const flatIds: string[] = [];
+  const seenFlat = new Set<string>();
   for (const layer of graph.layers) {
     for (const id of layer.node_ids) {
+      if (cyclicIds.has(id)) continue;
+      if (seenFlat.has(id)) continue;
+      seenFlat.add(id);
       flatIds.push(id);
     }
+  }
+  for (const id of Object.keys(graph.nodes)) {
+    if (cyclicIds.has(id)) continue;
+    if (seenFlat.has(id)) continue;
+    seenFlat.add(id);
+    flatIds.push(id);
   }
   if (flatIds.length > 0) {
     const flatLines: string[] = ['', 'Nodes (flat fallback):'];

--- a/src/status/renderGraph.ts
+++ b/src/status/renderGraph.ts
@@ -45,7 +45,7 @@
  *   consistent with the rest of `smithy status`. Done / unknown
  *   downstreams yield no hint; their lines fall back to the dim FQ id.
  *
- * #### Done-item hiding and layer collapsing (AS 10.4)
+ * #### Done-item hiding and layer omission (AS 10.4)
  *
  * Default mode aggressively focuses the view on what still needs work:
  *
@@ -57,10 +57,12 @@
  *   `unknown`) always surface so parse errors and not-yet-started work
  *   stay visible.
  * - When every member of a layer is `done` (i.e. nothing actionable
- *   remains after the filter), the entire layer collapses to a single
- *   `Layer N: DONE (M items)` line with no member listing.
+ *   remains after the filter), the entire layer is omitted from the
+ *   rendered output. No `Layer N: DONE` heading is emitted — the per-
+ *   layer done count adds no actionable signal, and the user can
+ *   re-expand via `--all` if they want to see the full graph.
  * - Passing `{ all: true }` disables both the hide-done filter and the
- *   layer collapse — every member of every layer is listed regardless
+ *   layer omission — every member of every layer is listed regardless
  *   of status, and the heading omits the `done hidden` suffix.
  *
  * ### Cycle fallback (AS 10.3 — `graph.cycles.length > 0`)
@@ -336,7 +338,14 @@ function formatLayeredView(
   if (graph.layers.length === 0) return '';
   const blocks: string[] = [];
   for (const layer of graph.layers) {
-    blocks.push(formatLayerBlock(layer, graph, theme, all, lookup));
+    const block = formatLayerBlock(layer, graph, theme, all, lookup);
+    // `formatLayerBlock` returns the empty string for fully-done
+    // layers in default mode (those are omitted from the rendered
+    // view rather than collapsed to a `DONE` heading). Skip them so
+    // adjacent blocks do not get an extra blank line where the
+    // collapse line used to live.
+    if (block.length === 0) continue;
+    blocks.push(block);
   }
   return blocks.join('\n\n');
 }
@@ -379,21 +388,19 @@ function formatLayerBlock(
     }
   }
 
-  // Layer with no actionable members → collapse to a single line. This
-  // covers both the legacy "all rows are `done`" case and the new
-  // default-mode hide-done filter (a layer of all-`done` nodes filters
-  // down to zero visible items).
+  // Layer with no actionable members → omit entirely from default
+  // mode. Earlier slices rendered a `Layer N: DONE (M items)`
+  // collapse line, but that conveyed no actionable information — the
+  // user already knows fully-done layers exist (they show up under
+  // `--all`), and showing per-layer done counts just added noise.
+  // Returning the empty string lets `formatLayeredView` filter the
+  // block out before joining so no blank line is emitted in its
+  // place either.
   if (visibleIds.length === 0 && total > 0) {
-    return formatLayerHeading(layer.layer, total, {
-      collapsedDone: true,
-      doneHidden: 0,
-    });
+    return '';
   }
 
-  const heading = formatLayerHeading(layer.layer, total, {
-    collapsedDone: false,
-    doneHidden,
-  });
+  const heading = formatLayerHeading(layer.layer, total, { doneHidden });
   const lines: string[] = [heading];
   for (let i = 0; i < visibleIds.length; i++) {
     const id = visibleIds[i];
@@ -410,24 +417,20 @@ function formatLayerBlock(
  * Compose the heading line for a layer. Layer 0 leads with the
  * "ready to work" copy from contracts §1; subsequent layers use the
  * simpler `Layer N (M items)` form. Singular `1 item` vs plural
- * `M items` is selected based on the count.
+ * `M items` is selected based on the count. `doneHidden > 0` appends
+ * a `, N done hidden` suffix inside the parens so reviewers see that
+ * work was suppressed by the hide-done filter.
  *
- * `collapsedDone === true` overrides the layer-specific copy with the
- * uniform `Layer N: DONE (M items)` collapse line — the caller decides
- * when to flip it. `doneHidden > 0` appends a `, N done hidden` suffix
- * inside the parens so reviewers see that work was suppressed; the
- * suffix is omitted under `collapsedDone` (the heading already says
- * `DONE`) and under `doneHidden === 0` (nothing to surface).
+ * Note: fully-done layers are omitted from the rendered output
+ * entirely (see `formatLayerBlock`); this function is never called
+ * for them.
  */
 function formatLayerHeading(
   layerIndex: number,
   count: number,
-  opts: { collapsedDone: boolean; doneHidden: number },
+  opts: { doneHidden: number },
 ): string {
   const itemsWord = count === 1 ? 'item' : 'items';
-  if (opts.collapsedDone) {
-    return `Layer ${layerIndex}: DONE (${count} ${itemsWord})`;
-  }
   const hiddenSuffix =
     opts.doneHidden > 0 ? `, ${opts.doneHidden} done hidden` : '';
   if (layerIndex === 0) {

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -16,8 +16,8 @@
  * within-artifact topological layering, cross-artifact edge stitching via
  * `parent_path` / `parent_row_id`, structured dangling-reference reporting,
  * and cycle detection via Tarjan's SCC algorithm. The types are stable for
- * downstream use. The `--graph` text renderer and JSON wiring arrive in
- * Slice 3.
+ * downstream use. Slice 3 wires the `--graph` text renderer (via
+ * `renderGraph.ts`) and populates the JSON `graph` field unconditionally.
  */
 
 /**


### PR DESCRIPTION
## Source

- Spec: [`smithy-status-skill.spec.md`](specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.spec.md) (US10)
- Tasks: [`10-visualize-dependency-graph-for-parallel-work.tasks.md`](specs/2026-04-12-004-smithy-status-skill/10-visualize-dependency-graph-for-parallel-work.tasks.md)

## Slice

**Slice 3 of US10** — *Wire the Graph into JSON Emission and `--graph` Text Rendering*

`smithy status --format json` now emits a fully-populated `graph` object unconditionally, and `smithy status --graph` renders topological layers as text with done-layer collapsing (respecting `--all`) and a cycle-warning fallback. A new pure `src/status/renderGraph.ts` module owns the text layout; `statusAction` orchestrates the calls.

## Addresses

- **FR-026**, **FR-027**
- **AS 10.1** (layered output with US1/US4 in Layer 0)
- **AS 10.3** (cycle fallback with warning, no crash)
- **AS 10.4** (done-layer collapsing in default mode; `--all` expands)
- **AS 10.5** (JSON `graph` populated unconditionally with `node_ids`, `cycles`, `dangling_refs`)
- **AS 10.6** (dangling-ref warnings)

## Tasks completed

- [x] **Implement `renderGraph` in a new `src/status/renderGraph.ts` module** — pure function returning a layered text view; default-mode done-layer collapsing; cycle-warning fallback with flat listing of non-cyclic nodes; trailing `Dangling refs:` block; UTF-8 / ASCII glyph support; re-exported from `src/status/index.ts`. 16 unit tests covering AS 10.1, 10.3, 10.4, 10.6, purity, empty-graph, ASCII fallback, default theme.
- [x] **Wire `buildDependencyGraph` and `renderGraph` into `statusAction`** — graph built once per invocation against the **pre-filter** record set per SD-010 (so `--status` / `--type` never narrow the JSON `graph` shape); JSON payload's `graph` populated unconditionally, replacing the zero-value stub; `--graph` text mode prints the summary header and routes through `renderGraph(graph, { theme, all })`; default text path is untouched. Updated `StatusOptions.graph` JSDoc, `StatusJsonPayload` JSDoc, the module-level comment block, and the `--graph` Commander help text. 9 new integration tests covering AS 10.1, 10.3, 10.4, 10.5, 10.6 and the SD-010 pre-filter behavior.
- [x] **Audit `node_ids` vs `ids` across code and flag the spec-text drift** — confirmed `node_ids` is canonical end-to-end (`DependencyGraph` type, `buildDependencyGraph` output, `renderGraph` consumption, JSON payload). The only `.ids` reference under `src/status/` or `src/commands/status.ts` is in the SD-012 JSDoc commentary itself. SD-012 spec-prose drift surfaced for follow-up — see "PR notes" below.

## Review

`smithy-implementation-review` returned 5 findings.

**Auto-fix applied (1 Important x High)**:
- Missing `--graph` integration tests for the empty-repo and no-match-filter friendly-hint paths. Added two regression tests inside `statusAction --graph integration (US10 Slice 3)`. Commit: `a0b46b1 review: cover --graph empty-repo and no-match-filter friendly hints`.

**Notes for reviewer (4 Minor)**:
- `Layer N: DONE (M items)` separator inconsistency — the collapsed-layer heading uses a colon, while the Layer 0 "ready to work" heading and the contracts section 1 example (line 71) use an em-dash. Implementation matches the task wording (line 106 of the tasks file specifies the colon form). Worth reconciling either the contracts example to the colon form or the renderer to the em-dash form. Tracked under SD-006.
- Per-node lines drop the `(blocked by <ids>)` suffix and bracketed status text — the contracts section 1 example shows the bracketed `[not started]` form with a `(blocked by US1)` suffix; the implementation emits the icon-glyph form without either. The slice goal called this OPTIONAL and asked it be flagged if missing. Decision needed: extend the renderer or align the contracts example to the icon-glyph rendering. Tracked under SD-006.
- Cycle warning + dangling refs use `theme.paint.error` (red) — both are non-fatal warnings (scanner exits 0); painting them red reads as a hard error. Could be demoted to a `theme.paint.warning` (yellow) helper or `theme.paint.dim`. Polish-only.
- Missing dangling-refs + cycle combination test — the existing renderGraph unit tests cover each branch in isolation. A combined cycle + dangling-refs case and an all-dangling-no-layers case would tighten coverage.

## Documentation

- **Auto-fix applied** — `smithy-maid` flagged a stale future-tense JSDoc claim in `src/status/types.ts` (the module-level comment said the `--graph` text renderer would "arrive in Slice 3"). Replaced with past-tense language naming the new `renderGraph.ts` module. Commit: `ccf59f0 maid: refresh types.ts JSDoc — Slice 3 work is shipped`.

**Documentation Notes**:
- **SD-012 spec-prose drift remains open** — the spec document `smithy-status-skill.spec.md` AS 10.5 (line 206) still reads `layers: Array<{ layer: number, ids: string[] }>`. Code, data-model, and contracts JSON example all use `node_ids`. Per the slice instruction to NOT silently edit the spec, this PR leaves the spec prose untouched and surfaces the discrepancy here. Recommended follow-up: edit `specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.spec.md:206` to change `ids: string[]` to `node_ids: string[]` and mark SD-012 resolved.

## Validation

| Command | Result |
|---|---|
| `npm run build` | clean — `dist/cli.js` 112.19 KB ESM |
| `npm run typecheck` | clean (no errors) |
| `npm test` | **664 / 664 passing** across 23 test files (up from 652 pre-slice) |

The newly-added tests cover AS 10.1, AS 10.3, AS 10.4, AS 10.5, AS 10.6, the SD-010 pre-filter behavior for the JSON `graph`, the SD-012 `node_ids` field-name enforcement, the empty-repo and no-match-filter friendly-hint paths under `--graph`, and a regression test that the default text path (no `--graph`) still routes through `renderTree`.
