### PR TITLE
Ship smithy.status shell-delegation skill (US5 Slice 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Smithy provides a collection of workflow prompts, each for a different stage/sty
 - **smithy.fix** — Minimal-diff bug fix from a GitHub issue
 - **smithy.audit** — Audit a Smithy artifact against its checklist
 - **smithy.orders** — Show available Smithy commands and their usage
+- **smithy.status** — Show the current status of every Smithy planning artifact in the repo. Shells out to `smithy status` and returns the CLI output verbatim with no LLM interpretation.
 
 ### Sub-Agents (not user-invocable)
 

--- a/specs/2026-04-12-004-smithy-status-skill/05-invoke-status-via-skill.tasks.md
+++ b/specs/2026-04-12-004-smithy-status-skill/05-invoke-status-via-skill.tasks.md
@@ -27,7 +27,7 @@ intermediate commit.
 
 ### Tasks
 
-- [ ] **Author `smithy.status.prompt` shell-delegation skill template**
+- [x] **Author `smithy.status.prompt` shell-delegation skill template**
 
   Add a new command template at `src/templates/agent-skills/commands/smithy.status.prompt`.
   The YAML frontmatter and Markdown body must implement the thin shell-delegation
@@ -54,7 +54,7 @@ intermediate commit.
     `$ARGUMENTS` is left as a literal token (e.g., under Gemini), consistent
     with the fallback pattern used by sibling command templates.
 
-- [ ] **Extend template-suite assertions to cover the new command**
+- [x] **Extend template-suite assertions to cover the new command**
 
   Update the hardcoded counts and membership lists in `src/templates.test.ts`
   so the composition and categorization tests recognize the new

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -454,11 +454,14 @@ describe('getComposedTemplates', () => {
     expect(status).toBeDefined();
     // AS 5.4: the skill must surface CLI failures verbatim rather than
     // paraphrase them or reconstruct the status view from first principles.
-    // Pair the `verbatim` substring with an Errors-section anchor so the
-    // assertion provably ties verbatim wording to error handling, not to
-    // generic prose elsewhere in the template.
-    expect(status).toContain('verbatim');
+    // Anchor on (a) the Errors heading and (b) the contract-specific phrase
+    // `stderr verbatim`, which appears only inside the Errors section's
+    // non-zero-exit bullet and mirrors the contracts §2 obligation. The
+    // word `verbatim` alone appears in the description, output, and rules
+    // prose, so it would not prove the Errors section enforces verbatim
+    // surfacing.
     expect(status).toContain('## Errors');
+    expect(status).toContain('stderr verbatim');
   });
 
   it('audit template preserves frontmatter after partial resolution', () => {

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -441,9 +441,12 @@ describe('getComposedTemplates', () => {
     // AS 5.1 (shell-out to the CLI subcommand) and AS 5.3 (forward the
     // user's arguments unchanged). AS 5.2 (no-args default to cwd) is
     // implicit in unchanged $ARGUMENTS forwarding — the skill never
-    // synthesizes a default path.
-    expect(status).toContain('smithy status');
-    expect(status).toContain('$ARGUMENTS');
+    // synthesizes a default path. Match on the combined `smithy status
+    // $ARGUMENTS` substring rather than the two tokens independently, so a
+    // regression that drops the argument-forwarding token from the bash
+    // command — but keeps `$ARGUMENTS` in the surrounding prose — still
+    // fails the suite.
+    expect(status).toContain('smithy status $ARGUMENTS');
   });
 
   it('status template surfaces CLI failures verbatim in the Errors section', () => {

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -294,7 +294,7 @@ describe('one-shot-output snippet', () => {
 describe('getTemplateFilesByCategory', () => {
   it('returns the correct number of files per category', () => {
     const byCategory = getTemplateFilesByCategory();
-    expect(byCategory.commands).toHaveLength(10);
+    expect(byCategory.commands).toHaveLength(11);
     expect(byCategory.prompts).toHaveLength(2);
     expect(byCategory.agents).toHaveLength(13);
     expect(byCategory.skills).toHaveLength(1);
@@ -317,6 +317,7 @@ describe('getTemplateFilesByCategory', () => {
     expect(commands).toContain('smithy.fix.md');
     expect(commands).toContain('smithy.orders.md');
     expect(commands).toContain('smithy.spark.md');
+    expect(commands).toContain('smithy.status.md');
   });
 
   it('prompts includes guidance and titles', () => {
@@ -407,6 +408,7 @@ describe('getComposedTemplates', () => {
   it('categorizes templates correctly', () => {
     expect(composed.commands.has('smithy.strike.md')).toBe(true);
     expect(composed.commands.has('smithy.audit.md')).toBe(true);
+    expect(composed.commands.has('smithy.status.md')).toBe(true);
     expect(composed.prompts.has('smithy.guidance.md')).toBe(true);
     expect(composed.prompts.has('smithy.titles.md')).toBe(true);
     expect(composed.agents.has('smithy.clarify.md')).toBe(true);
@@ -426,6 +428,34 @@ describe('getComposedTemplates', () => {
     expect(audit).toContain('Audit Checklist (.spec.md)');
     expect(audit).toContain('Audit Checklist (.tasks.md)');
     expect(audit).toContain('Audit Checklist (.strike.md)');
+  });
+
+  // User Story 5 Slice 1: smithy.status is a thin shell-delegation skill that
+  // shells out to the `smithy status` CLI and surfaces output and errors
+  // verbatim. These assertions back-stop the contract at the template level so
+  // a future regression that drops the shell-out instruction, the argument
+  // forwarding token, or the verbatim-error wording fails the suite.
+  it('status template shells out to `smithy status` and forwards $ARGUMENTS', () => {
+    const status = composed.commands.get('smithy.status.md')!;
+    expect(status).toBeDefined();
+    // AS 5.1 (shell-out to the CLI subcommand) and AS 5.3 (forward the
+    // user's arguments unchanged). AS 5.2 (no-args default to cwd) is
+    // implicit in unchanged $ARGUMENTS forwarding — the skill never
+    // synthesizes a default path.
+    expect(status).toContain('smithy status');
+    expect(status).toContain('$ARGUMENTS');
+  });
+
+  it('status template surfaces CLI failures verbatim in the Errors section', () => {
+    const status = composed.commands.get('smithy.status.md')!;
+    expect(status).toBeDefined();
+    // AS 5.4: the skill must surface CLI failures verbatim rather than
+    // paraphrase them or reconstruct the status view from first principles.
+    // Pair the `verbatim` substring with an Errors-section anchor so the
+    // assertion provably ties verbatim wording to error handling, not to
+    // generic prose elsewhere in the template.
+    expect(status).toContain('verbatim');
+    expect(status).toContain('## Errors');
   });
 
   it('audit template preserves frontmatter after partial resolution', () => {

--- a/src/templates/agent-skills/commands/README.md
+++ b/src/templates/agent-skills/commands/README.md
@@ -19,6 +19,7 @@ Deployed to:
 | `smithy.fix` | Minimal-diff bug fix from a GitHub issue | (none) |
 | `smithy.audit` | Audit a Smithy artifact against its checklist | (none) |
 | `smithy.orders` | Show available Smithy commands and their usage | (none) |
+| `smithy.status` | Show the current status of every Smithy planning artifact in the repo | (none) |
 
 ## Conventions
 

--- a/src/templates/agent-skills/commands/smithy.status.prompt
+++ b/src/templates/agent-skills/commands/smithy.status.prompt
@@ -90,8 +90,7 @@ The three error conditions to expect are:
    meant.
 3. **CLI output is unexpectedly empty** — return the empty output as-is and
    add at most one sentence noting that the repo may contain no Smithy
-   artifacts (the CLI itself prints a hint pointing at `smithy.ignite` /
-   `smithy.mark` in this case; let that hint stand on its own if present).
+   artifacts.
 
 In every error case, the CLI's own message is the authoritative report.
 

--- a/src/templates/agent-skills/commands/smithy.status.prompt
+++ b/src/templates/agent-skills/commands/smithy.status.prompt
@@ -55,10 +55,12 @@ output through any filter.
 
 ## Output
 
-Return the CLI's stdout to the user **as-is, byte-for-byte**, with at most a
-single short framing sentence (for example, "Here is the current status:").
-Any framing must be one sentence at most — never multiple sentences, never a
-summary, never a re-render of the tree.
+Return the CLI's stdout to the user **unmodified** — do not rewrite, summarize,
+re-format, or re-render any part of it. You may optionally precede the stdout
+with a single short framing sentence on its own line (for example, "Here is
+the current status:"), but the framing is additive and must not alter the
+stdout content itself. Never use multiple framing sentences, never replace the
+stdout with a summary, and never re-render the tree.
 
 - Do **not** re-filter the CLI's output. If the user wanted a filter, they
   passed (or should pass) `--status`, `--type`, or `--root` to the CLI; the

--- a/src/templates/agent-skills/commands/smithy.status.prompt
+++ b/src/templates/agent-skills/commands/smithy.status.prompt
@@ -1,0 +1,108 @@
+---
+name: smithy-status
+description: "Show the current status of every Smithy planning artifact in the repo. Thin wrapper around the deterministic `smithy status` CLI — output is returned verbatim with no LLM interpretation."
+---
+# smithy-status
+
+You are the **smithy-status agent**. You are a thin shell-delegation wrapper
+around the `smithy status` CLI subcommand. The CLI does all of the real work
+(scanning, classifying, rendering, suggesting next actions). Your sole
+responsibility is to invoke the CLI, forward the user's arguments unchanged,
+and return the CLI's output verbatim.
+
+**Do not summarize, paraphrase, re-format, re-filter, or "improve" the CLI's
+output. Do not reconstruct any information from first principles.** The CLI is
+the source of truth.
+
+---
+
+## Input
+
+Arguments to forward to the CLI: $ARGUMENTS
+
+If `$ARGUMENTS` is empty (the user invoked `/smithy.status` with no
+arguments), forward no arguments at all — do **not** synthesize a default path
+or any other flag. The CLI uses the current working directory implicitly when
+no `--root` is provided; rely on that behavior rather than computing a path
+yourself.
+
+If `$ARGUMENTS` is left as the literal token `$ARGUMENTS` (for example, when
+running under an agent that does not perform argument substitution, such as
+Gemini), treat it the same as empty input: invoke the CLI with no arguments
+and rely on the CLI's working-directory default.
+
+---
+
+## Action
+
+Run exactly one shell command:
+
+```bash
+smithy status $ARGUMENTS
+```
+
+When `$ARGUMENTS` is empty (or the literal `$ARGUMENTS` token), run instead:
+
+```bash
+smithy status
+```
+
+That is the entire operation. Do not run additional commands to "enrich" the
+output, do not re-invoke the CLI with different flags, and do not pipe the
+output through any filter.
+
+---
+
+## Output
+
+Return the CLI's stdout to the user **as-is, byte-for-byte**, with at most a
+single short framing sentence (for example, "Here is the current status:").
+Any framing must be one sentence at most — never multiple sentences, never a
+summary, never a re-render of the tree.
+
+- Do **not** re-filter the CLI's output. If the user wanted a filter, they
+  passed (or should pass) `--status`, `--type`, or `--root` to the CLI; the
+  CLI applies filters internally.
+- Do **not** reformat the tree, change connector characters, recolor, or
+  re-order rows. The CLI's renderer is authoritative.
+- Do **not** drop or condense the summary header, "Orphaned Specs" group,
+  "Broken Links" group, or any next-action suggestions.
+
+---
+
+## Errors
+
+If the CLI fails or produces unusual output, surface the failure **verbatim**.
+Do not attempt to reconstruct the status view from first principles, do not
+retry with different arguments or heuristics, and do not paraphrase the error
+message.
+
+The three error conditions to expect are:
+
+1. **`smithy` CLI not on `PATH`** — the shell will report a "command not
+   found" (or equivalent) error. Return that error verbatim and add at most
+   one sentence telling the user the Smithy CLI must be installed or rebuilt
+   before `/smithy.status` can run.
+2. **CLI exits non-zero** — capture and return the CLI's stderr verbatim. Do
+   not retry with different arguments. Do not guess what the user "really"
+   meant.
+3. **CLI output is unexpectedly empty** — return the empty output as-is and
+   add at most one sentence noting that the repo may contain no Smithy
+   artifacts (the CLI itself prints a hint pointing at `smithy.ignite` /
+   `smithy.mark` in this case; let that hint stand on its own if present).
+
+In every error case, the CLI's own message is the authoritative report.
+
+---
+
+## Rules
+
+- **One shell call only.** Issue exactly one invocation of `smithy status`
+  per user request.
+- **Verbatim passthrough.** Forward `$ARGUMENTS` unchanged; return stdout and
+  stderr unchanged. The agent's role ends at "run the command and show the
+  output."
+- **No LLM inference.** Do not infer status, dependencies, next actions, or
+  parse warnings. The CLI computes all of these deterministically.
+- **No scope expansion.** Do not modify files, do not create issues, do not
+  run additional smithy commands. `smithy.status` is read-only and on-demand.


### PR DESCRIPTION
## Source

- Spec: [`specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.spec.md`](specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.spec.md) — User Story 5
- Tasks: [`specs/2026-04-12-004-smithy-status-skill/05-invoke-status-via-skill.tasks.md`](specs/2026-04-12-004-smithy-status-skill/05-invoke-status-via-skill.tasks.md)
- Contracts: [`specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.contracts.md`](specs/2026-04-12-004-smithy-status-skill/smithy-status-skill.contracts.md) §2 "smithy.status Agent Skill"

## Slice

**Slice 1: Ship the smithy.status Shell-Delegation Skill** — A working `smithy.status.prompt` template lives in the commands template directory, auto-registers via the existing glob-based composition, and instructs the invoking agent to shell out to `smithy status` with verbatim passthrough of arguments, stdout, and errors. Hardcoded template-count and membership assertions in `src/templates.test.ts` are updated so the suite stays green.

## Addresses

- Functional Requirements: FR-014, FR-015
- Acceptance Scenarios: 5.1 (shell-out + verbatim passthrough), 5.2 (no-args defaults to cwd implicitly), 5.3 (forward arguments unchanged), 5.4 (verbatim error surfacing for the three contracts §2 error conditions)

## Tasks completed

- [x] Author `smithy.status.prompt` shell-delegation skill template
- [x] Extend template-suite assertions to cover the new command

## Review

`smithy-implementation-review` returned **0 Critical, 0 Important, 1 Minor (Low confidence)** findings.

- **Minor (note only)**: The new template's H1 body heading uses `# smithy-status` (hyphenated, matching frontmatter `name`). Most sibling command templates use the dotted form for the body H1 (e.g., `# smithy.orders`). This is a cross-template style nit; the frontmatter `name` field — which is what runtimes consume — correctly uses the hyphenated form per SD-013. Out of scope for this slice; flag for a future template-style cleanup pass.

No auto-fixes were applied from review.

## Documentation

`smithy-maid` returned 2 auto-fixable items, both applied in commit `477ae88`:

- `CLAUDE.md`: Added a `smithy.status` bullet to the "The Smithy Workflow Commands" enumeration so the doc is no longer missing a deployed command.
- `src/templates/agent-skills/commands/README.md`: Added a `smithy.status` row to the "Current Commands" table.

## Validation

All commands run on HEAD `477ae88`:

- `npm run typecheck` → passes (no type errors)
- `npm run build` → passes (`dist/cli.js` 116.30 KB)
- `npm test` → **683/683 tests pass** across 23 files (3 new behavioral assertions for the `smithy.status` template included)

## Out of scope (per slice charter)

- `src/commands/status.ts`, `src/cli.ts`, and the agent deployers are untouched. The CLI was already implemented in User Stories 1–4 (already merged on master).
