### PR TITLE
Add spec for expanding evals coverage across planning commands

### DIFF
--- a/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.contracts.md
+++ b/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.contracts.md
@@ -24,7 +24,7 @@ This feature adds **new instances** to two existing contracts (the YAML scenario
 name: <kebab-case-string>             # required, unique across cases
 skill: /<smithy-command>              # required, non-empty
 prompt: <argument-string>             # required
-timeout: <integer-seconds>            # optional; required for mark/cut/render/ignite (FR-010)
+timeout: <seconds>                    # optional; positive finite number of seconds (runner multiplies by 1000); required for mark/cut/render/ignite (FR-010)
 structural_expectations:
   required_headings:                  # required, non-empty array
     - '## ...'
@@ -45,7 +45,7 @@ sub_agent_evidence:                   # required for spark/ignite/render/mark/cu
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `name` | string | Yes | Kebab-case identifier; matches `[a-z0-9-]+`. Unique across `evals/cases/*.yaml`. |
+| `name` | string | Yes | Non-empty unique identifier across `evals/cases/*.yaml` (loader-enforced). Authoring convention: kebab-case `[a-z0-9-]+` for readability and to stay clear of the `--dump` and `loadBaseline` unsafe-name guards. |
 | `skill` | string | Yes | Non-empty slash-command form. The runner's `runScenario` composes the headless invocation as `${skill} ${prompt}` before spawning `claude`. |
 | `prompt` | string | Yes | For scenarios consuming a plant, MUST be an exact repo-relative path; for spark, free-text idea. |
 | `timeout` | number | Conditional | In seconds. Required when the empirical run-time is known to exceed the runner's 120s default. |

--- a/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.contracts.md
+++ b/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.contracts.md
@@ -1,0 +1,213 @@
+# Contracts: Expand Evals Coverage Across Planning Commands
+
+## Overview
+
+This feature adds **new instances** to two existing contracts (the YAML scenario shape consumed by `loadScenarios` and the structural-expectations regex grammar consumed by `validateStructure`) and introduces one **new convention contract** (the planted-artifact fixture layout). No new programmatic interfaces are introduced; no existing interfaces are modified.
+
+## Interfaces
+
+### 1) Scenario YAML File Shape
+
+**Purpose**: A single eval case authored as YAML. Loaded by `loadScenarios(casesDir)` in `evals/lib/scenario-loader.ts`; returns one `EvalScenario` per file.
+
+**Consumers**:
+- `evals/run-evals.ts` (orchestrator iterates loaded scenarios).
+- `evals/lib/runner.ts` (per-scenario `runScenario(scenario, fixtureDir)`).
+- `evals/lib/structural.ts` (`validateStructure(text, scenario.structural_expectations)`).
+- `evals/lib/baseline.ts` (`loadBaseline(scenario.name)`).
+
+**Providers**: this feature authors six new files under `evals/cases/`.
+
+#### Signature (YAML)
+
+```yaml
+name: <kebab-case-string>             # required, unique across cases
+skill: /<smithy-command>              # required, non-empty
+prompt: <argument-string>             # required
+timeout: <integer-seconds>            # optional; required for mark/cut/render/ignite (FR-010)
+structural_expectations:
+  required_headings:                  # required, non-empty array
+    - '## ...'
+  required_patterns:                  # optional regex strings (no flags)
+    - '...'
+  forbidden_patterns:                 # required minimum: refusal phrases + leading frontmatter
+    - "I'd be happy to help"
+    - "Sure, here's"
+    - '^---\r?\n'
+  required_tables:                    # optional
+    - columns: [<col1>, <col2>]
+sub_agent_evidence:                   # required for spark/ignite/render/mark/cut; omitted for audit
+  - agent: <smithy-sub-agent-name>
+    pattern: '<regex>'
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Kebab-case identifier; matches `[a-z0-9-]+`. Unique across `evals/cases/*.yaml`. |
+| `skill` | string | Yes | Non-empty slash-command form. The runner's `runScenario` composes the headless invocation as `${skill} ${prompt}` before spawning `claude`. |
+| `prompt` | string | Yes | For scenarios consuming a plant, MUST be an exact repo-relative path; for spark, free-text idea. |
+| `timeout` | number | Conditional | In seconds. Required when the empirical run-time is known to exceed the runner's 120s default. |
+| `structural_expectations` | object | Yes | See structural-expectations grammar in §2. |
+| `sub_agent_evidence` | array | Conditional | Required for any command that dispatches sub-agents per the Sub-Agent Evidence Matrix. |
+
+#### Outputs
+
+The loader yields an `EvalScenario` (TS interface from `evals/lib/types.ts`); the orchestrator passes that to the runner and validators. No new output shape.
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Duplicate `name` across files | Loader skips the second-loaded file with a stderr note (existing behavior). | Authoring error; the implementer renames one. |
+| Empty `skill` field | Loader rejects the file with a stderr note (existing behavior). | All six new scenarios use non-empty skills. |
+| Invalid regex in `required_patterns` / `forbidden_patterns` | `validateStructure` (in `evals/lib/structural.ts`) throws at run-time. | Authoring error; implementer fixes the YAML. |
+| `sub_agent_evidence[].pattern` does not match canonical text or any dispatch record | The check fails for that scenario; the run reports FAIL for that scenario. | Either a regression in the producing command or expected sub-agent did not dispatch. |
+| Missing or empty `required_headings` | Loader rejects the file (existing behavior). | Authoring error. |
+
+### 2) Structural-Expectations Regex Grammar (existing, used as-is)
+
+**Purpose**: The grammar that `validateStructure` and `verifySubAgents` interpret.
+
+**Consumers**: `evals/lib/structural.ts`.
+
+**Providers**: each scenario YAML authors patterns conforming to this grammar.
+
+#### Signature
+
+- `required_patterns: string[]` — each compiled via `new RegExp(pattern)` (no flags). Pattern must match somewhere in `output` for the check to PASS.
+- `forbidden_patterns: string[]` — each compiled the same way. Pattern MUST NOT match in `output`. Empty `output` ALSO fails the check.
+- `required_headings: string[]` — exact line match against `output.split('\n').map(l => l.trimEnd())`.
+- `required_tables: { columns: string[] }[]` — at least one line containing `|` AND every column substring.
+
+No grammar changes in this feature; new scenarios author patterns within the existing shape.
+
+#### Authoring rules for new scenarios (per FR-014)
+
+- Anchor `required_headings` to the **literal** ATX headings emitted by the producing template's output code-fence, RFC template, spec template, or one-shot snippet. Do not derive headings from prose narration.
+- Anchor `required_patterns` to template-stable markers. Examples: `\*\*Spec folder\*\*`, `\*\*PRD path\*\*`, `\*\*RFC path\*\*`, `^[Cc]larif`, `## Plan\n\n\*\*Directive\*\*`.
+- Single-quote regex strings in YAML so backslash escapes round-trip byte-for-byte.
+
+### 3) Sub-Agent Evidence Per-Command Contract (new authoring contract)
+
+**Purpose**: Documents which sub-agents each new scenario MUST verify and which marker conventions are template-stable.
+
+**Consumers**: scenario authors during initial authoring and during drift refresh.
+
+**Providers**: this spec's `### Sub-Agent Evidence Matrix` (lifted into the eval's authoring conventions).
+
+#### Per-Command Required Sub-Agent Evidence
+
+| Scenario | Required `sub_agent_evidence` agents | Marker conventions |
+|----------|--------------------------------------|---------------------|
+| `audit-flawed-spec` | (none — `sub_agent_evidence` field omitted from YAML) | n/a |
+| `mark-from-features` | smithy-scout, smithy-plan, smithy-clarify, smithy-refine, smithy-plan-review | `## Plan\n\n\*\*Directive\*\*` (plan); `^[Cc]larif` (clarify dispatch description); `^[Ss]cout` or scout's report-stable marker (scout); `## Step \d+:` or refine's stable marker (refine); plan-review's stable marker (plan-review). |
+| `cut-from-spec` | smithy-scout, smithy-clarify, smithy-plan-review | same conventions as mark for the agents listed. |
+| `render-from-rfc` | smithy-scout, smithy-clarify, smithy-plan-review | same. |
+| `ignite-from-prd` | smithy-prose, smithy-plan, smithy-clarify, smithy-plan-review | `## Plan\n\n\*\*Directive\*\*` (plan); `^[Cc]larif` (clarify); prose's stable marker; plan-review's stable marker. |
+| `spark-from-idea` | smithy-survey, smithy-clarify, smithy-prose, smithy-plan-review | `^[Ss]urvey` (survey dispatch description) OR survey's empty-state stub (FR-008 alternation); `^[Cc]larif` (clarify); prose's marker; plan-review's marker. |
+
+#### Error Conditions
+
+| Condition | Response |
+|-----------|----------|
+| The producing template's sub-agent set changes (an agent removed; a new agent added) | Implementer updates this matrix and the affected scenarios in the same PR; otherwise the check fails (false positive) or under-tests (false negative). |
+| A sub-agent's stable marker changes (e.g., `## Plan` heading renamed) | Implementer updates the marker convention here and in every consuming scenario in the same PR. |
+
+### 4) Planted-Artifact Fixture Layout Contract (new convention)
+
+**Purpose**: Specifies the directory layout and naming rules for parent-artifact plants consumed by scenarios.
+
+**Consumers**: scenario YAML files (via exact-path references in `prompt`).
+
+**Providers**: this feature creates the planted artifacts on disk.
+
+#### Layout
+
+```
+evals/fixture/
+  prds/
+    ignite-eval/
+      <slug>.prd.md                        # owned by ignite-from-prd
+  rfcs/
+    render-eval/
+      <slug>.rfc.md                        # owned by render-from-rfc
+    mark-eval/
+      <slug>.rfc.md                        # owned by mark-from-features (RFC for traceability)
+      01-core.features.md                  # owned by mark-from-features (the consumed features-map)
+  specs/
+    cut-eval/
+      <slug>.spec.md                       # owned by cut-from-spec
+      <slug>.data-model.md                 # owned by cut-from-spec
+      <slug>.contracts.md                  # owned by cut-from-spec
+    audit-eval/
+      <slug>.spec.md                       # owned by audit-flawed-spec — DELIBERATELY MISSING `## Dependency Order`
+```
+
+(spark requires no plants; `evals/fixture/prds/spark-eval/` MUST NOT exist.)
+
+#### Inputs (per planted artifact)
+
+| Field | Description |
+|-------|-------------|
+| `path` | Repo-relative path under `evals/fixture/{prds,rfcs,specs}/<scenario-slug>/`. |
+| `scenario_slug` | Matches the consuming scenario's `name` exactly. |
+| `content` | Conforms to the canonical artifact shape (PRD template, RFC template, features-map schema, spec template) so the consuming command's input parsing succeeds; for the audit `flawed-spec`, conforms **except** for the deliberately missing section. |
+| `top-of-file comment` (flawed plants only) | A multi-line comment describing exactly which checklist invariant the flaw violates and why future maintainers should not "fix" it. |
+
+#### Outputs
+
+- The plant is read by exactly one scenario via the runner's invocation `${skill} ${prompt}` where `prompt` is the plant's exact path.
+- `evals/fixture/README.md` documents each plant in a per-row table (path, owner, purpose, flaw description if any).
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| A scenario's prompt references a path outside its own `<scenario-slug>/` subdirectory | Authoring error; reviewer rejects. | Cross-scenario cross-talk forbidden. |
+| A flawed plant has no top-of-file flaw comment | Authoring error; reviewer rejects. | Future maintainers might "fix" the flaw during cleanup. |
+| The planted RFC, features-map, or spec drifts from the producing command's current schema | The consuming command rejects the input or routes incorrectly; scenario fails on next run. | Implementer regenerates the plant and refreshes the scenario's `structural_expectations` together. |
+| A plant references files outside `evals/fixture/<scenario-slug>/` | Authoring error. | Plants are self-contained per scenario. |
+
+### 5) Audit Scenario Detection Contract (new behavioral contract)
+
+**Purpose**: The audit scenario must prove audit *catches the planted flaw*, not just produce a report-shaped document.
+
+**Consumers**: scenario `required_patterns` validate against audit's emitted text.
+
+#### Signature
+
+The planted `evals/fixture/specs/audit-eval/<slug>.spec.md` MUST:
+- Contain all other mandatory spec sections (`# Feature Specification: ...`, `## Clarifications`, `## User Scenarios & Testing`, `## Requirements`, `## Success Criteria`, etc.).
+- **Omit** the `## Dependency Order` section entirely.
+- Carry a top-of-file comment explaining the deliberate omission.
+
+The scenario YAML MUST assert via `required_patterns`:
+- The literal string `Dependency Order` (audit's report references the missing section by name).
+- At least one `Critical` severity label (audit's report categorizes a missing required section as Critical).
+
+#### Error Conditions
+
+| Condition | Response |
+|-----------|----------|
+| Audit's checklist reorganization renames "Dependency Order" → some other phrase | The scenario fails with a missing-pattern error; implementer updates the planted flaw, the checklist, and the scenario together. (Tracked as SD-002.) |
+| Audit's severity grading drifts (e.g., `Critical` → `Blocker`) | The scenario fails with a missing-pattern error; implementer refreshes both the prompt template and the scenario. |
+| The planted spec's flaw is "fixed" by an unrelated cleanup PR | The scenario fails (audit no longer finds the missing section); the file's top-of-file flaw comment exists to prevent this. |
+
+## Events / Hooks
+
+This feature publishes no new events. It consumes the same evaluation flow as existing scenarios:
+
+- Orchestrator startup → `loadScenarios` → per-scenario `runScenario` → `validateStructure` → `verifySubAgents` → `compareToBaseline` (skipped for new scenarios per SD-012) → `scenarioRunToResult` → `buildReport` → `formatReport`.
+
+No webhook publication, no event subscription, no inter-process messaging.
+
+## Integration Boundaries
+
+- **`claude` CLI** (existing boundary): the runner spawns `claude --output-format stream-json --verbose -p <invocation>` per scenario. New scenarios use the same boundary; no auth or invocation surface changes.
+- **Filesystem** (existing boundary): the runner copies `evals/fixture/` to a temp directory before each run; writes by mark/cut/render/ignite happen in the temp copy. The source-fixture checksum invariant (`hashDirectory` before/after) holds for all new scenarios per FR-013.
+- **GitHub `gh` CLI** (new edge case): mark/cut/render/ignite invoke `gh pr create` during their workflows. In the eval execution context `gh` may be unauthenticated; scenarios MUST tolerate the PR-creation-failure branch of the producing command's one-shot snippet (per SD-008).
+- **`git` CLI** (new edge case): mark/cut/render/ignite call `git checkout -b` and `git commit`. The temp fixture copy MUST be a working git repository or the scenarios fail before any output is captured (per SD-001 and SD-007).
+
+No new external system integrations are introduced. The Anthropic Messages Batches API integration is explicitly **out of scope** this round (see spec `## Out of Scope`).

--- a/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.data-model.md
+++ b/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.data-model.md
@@ -20,13 +20,10 @@ Purpose: A single eval case. Defined in `evals/lib/types.ts` as the `EvalScenari
 | `structural_expectations` | StructuralExpectations | Yes | Required headings, patterns, tables, forbidden patterns. Anchored to the producing template's literal output code-fence per FR-014. |
 | `sub_agent_evidence` | SubAgentEvidence[] | No | Per-agent evidence patterns. Required for spark, ignite, render, mark, cut per the Sub-Agent Evidence Matrix in the spec. Omitted for audit. |
 
-Validation rules (existing, unchanged):
+Validation:
 
-- `name` MUST NOT contain path separators or absolute path segments.
-- `skill` MUST be non-empty (audit's slash command satisfies this; scout's TS-shim continues to bypass via `evals/lib/scout-scenario.ts`).
-- `structural_expectations.required_headings` MUST be non-empty.
-- `structural_expectations.required_patterns` and `forbidden_patterns` MUST be valid JavaScript regex strings (compiled via `new RegExp(pattern)` with no flags).
-- `sub_agent_evidence` entries' `pattern` field MUST match either canonical text OR an Agent dispatch's description/resultText (FR-016 of the original evals spec).
+- **Loader-enforced** (existing, unchanged): `name` is a non-empty string and unique across loaded files; `skill` is a non-empty string; `structural_expectations.required_headings` is non-empty; `structural_expectations.required_patterns` / `forbidden_patterns` strings are compiled via `new RegExp(pattern)` (invalid regex throws at run-time inside `validateStructure`).
+- **Authoring conventions** (not loader-enforced): `name` SHOULD NOT contain path separators or absolute path segments (the orchestrator's `--dump` writer rejects unsafe names, and `loadBaseline` independently rejects unsafe names; new scenarios stay clear of those edge cases by following the convention); `sub_agent_evidence[].pattern` SHOULD match either canonical text OR an Agent dispatch's description/resultText (FR-016 of the original evals spec — implementer-side guidance, not a load-time check).
 
 ### 2) PlantedArtifact (new role for an existing artifact type)
 
@@ -53,7 +50,7 @@ Purpose: A scenario-isolated subfolder under `evals/fixture/{prds,rfcs,specs}/`.
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
 | `path` | repo-relative directory path | Yes | One of `evals/fixture/prds/<scenario-slug>/`, `evals/fixture/rfcs/<scenario-slug>/`, `evals/fixture/specs/<scenario-slug>/`. |
-| `scenario_slug` | string | Yes | Matches the consuming scenario's `name`. Examples: `mark-eval/`, `cut-eval/`, `audit-eval/`, `render-eval/`, `ignite-eval/`. (Spark requires no plants; spark's directory MUST NOT exist.) |
+| `scenario_slug` | string | Yes | A short directory-naming label derived from the consuming scenario's command (not equal to the scenario's full `name`). Convention: `<command>-eval`. Examples (with their consuming scenarios): `mark-eval/` ← `mark-from-features`, `cut-eval/` ← `cut-from-spec`, `audit-eval/` ← `audit-flawed-spec`, `render-eval/` ← `render-from-rfc`, `ignite-eval/` ← `ignite-from-prd`. (Spark requires no plants; no `spark-eval/` directory is created.) |
 | `owner` | string | Yes | Single `EvalScenario.name`. |
 
 Validation rules:

--- a/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.data-model.md
+++ b/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.data-model.md
@@ -1,0 +1,101 @@
+# Data Model: Expand Evals Coverage Across Planning Commands
+
+## Overview
+
+This feature adds new instances to existing entities (six `EvalScenario` rows in `evals/cases/`) and introduces a fixture-organization convention for **planted parent artifacts** consumed by those scenarios. No new TypeScript types or persistent runtime entities are introduced; all changes are file-on-disk additions following existing schemas.
+
+## Entities
+
+### 1) EvalScenario (existing — six new instances)
+
+Purpose: A single eval case. Defined in `evals/lib/types.ts` as the `EvalScenario` interface. This feature adds six new YAML files conforming to the existing shape.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | Kebab-case scenario name. Must be unique across all cases. The `--case` filter and baseline filename both key off this. New names: `audit-flawed-spec`, `mark-from-features`, `cut-from-spec`, `render-from-rfc`, `ignite-from-prd`, `spark-from-idea`. |
+| `skill` | string | Yes | Slash-command form (e.g., `/smithy.mark`, `/smithy.audit`). All six new scenarios use a non-empty skill (no TS-shim needed). |
+| `prompt` | string | Yes | The argument string passed after the slash command. For scenarios consuming a planted artifact, this MUST be the exact path to the plant. |
+| `model` | string | No | Optional model override. New scenarios omit this and inherit the runner default. |
+| `timeout` | number | No | Per-scenario timeout in seconds. Mark, cut, render, ignite scenarios MUST set an explicit value calibrated to the producing command's empirical run-time (per FR-010 and SD-006). |
+| `structural_expectations` | StructuralExpectations | Yes | Required headings, patterns, tables, forbidden patterns. Anchored to the producing template's literal output code-fence per FR-014. |
+| `sub_agent_evidence` | SubAgentEvidence[] | No | Per-agent evidence patterns. Required for spark, ignite, render, mark, cut per the Sub-Agent Evidence Matrix in the spec. Omitted for audit. |
+
+Validation rules (existing, unchanged):
+
+- `name` MUST NOT contain path separators or absolute path segments.
+- `skill` MUST be non-empty (audit's slash command satisfies this; scout's TS-shim continues to bypass via `evals/lib/scout-scenario.ts`).
+- `structural_expectations.required_headings` MUST be non-empty.
+- `structural_expectations.required_patterns` and `forbidden_patterns` MUST be valid JavaScript regex strings (compiled via `new RegExp(pattern)` with no flags).
+- `sub_agent_evidence` entries' `pattern` field MUST match either canonical text OR an Agent dispatch's description/resultText (FR-016 of the original evals spec).
+
+### 2) PlantedArtifact (new role for an existing artifact type)
+
+Purpose: A pre-built smithy planning artifact (PRD, RFC, features-map, spec, flawed-spec) committed under `evals/fixture/{prds,rfcs,specs}/<scenario-slug>/`. Each plant is owned by exactly one scenario and is read by that scenario only, via exact path.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `path` | repo-relative file path | Yes | Lives under `evals/fixture/{prds,rfcs,specs}/<scenario-slug>/`. The scenario references this exact path in its `prompt` field. |
+| `artifact_type` | enum (`prd`, `rfc`, `features`, `spec`, `flawed-spec`, `tasks`) | Yes | Determined by file extension and content. Each scenario consumes one or more plants of specific types. |
+| `consumed_by_scenario` | string | Yes | The single `EvalScenario.name` that owns this plant. |
+| `realism` | enum (`minimal`, `representative`, `flawed`) | Yes | `minimal` plants contain just enough structure to pass the consuming command's input validation; `representative` plants exercise realistic content; `flawed` plants (audit only) carry a deliberate, documented anti-pattern. |
+| `documented_in` | string | Yes | The fixture's README must list the plant with a one-line description (purpose + ownership + flaw if any). |
+
+Validation rules:
+
+- The plant's directory MUST follow the `<scenario-slug>/` naming convention; no shared subdirectories.
+- A `flawed` plant MUST carry a comment block at the top describing exactly which checklist invariant it violates and why (so future maintainers do not "fix" it during routine cleanup, mirroring the existing `evals/fixture/src/routes/users.ts` plants).
+- A plant's content MUST NOT reference paths outside its own scenario's plant directory (no cross-scenario cross-talk).
+
+### 3) ScenarioFixtureSubdirectory (new naming convention)
+
+Purpose: A scenario-isolated subfolder under `evals/fixture/{prds,rfcs,specs}/`. Holds the PlantedArtifact entries owned by one scenario.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `path` | repo-relative directory path | Yes | One of `evals/fixture/prds/<scenario-slug>/`, `evals/fixture/rfcs/<scenario-slug>/`, `evals/fixture/specs/<scenario-slug>/`. |
+| `scenario_slug` | string | Yes | Matches the consuming scenario's `name`. Examples: `mark-eval/`, `cut-eval/`, `audit-eval/`, `render-eval/`, `ignite-eval/`. (Spark requires no plants; spark's directory MUST NOT exist.) |
+| `owner` | string | Yes | Single `EvalScenario.name`. |
+
+Validation rules:
+
+- A subdirectory under `evals/fixture/{prds,rfcs,specs}/` MUST be named after exactly one scenario and contain only plants owned by that scenario.
+- The fixture's existing top-level files (`package.json`, `tsconfig.json`, `src/`, `README.md`) MUST remain untouched; this feature is strictly additive at the subdirectory level.
+
+## Relationships
+
+- `EvalScenario` 1:0..N `PlantedArtifact` via `prompt` (exact path reference).
+- `EvalScenario` 1:0..1 `ScenarioFixtureSubdirectory` (a scenario consumes plants from at most one subdirectory; spark consumes zero).
+- `ScenarioFixtureSubdirectory` 1:N `PlantedArtifact` (a subdirectory holds one or more plants for one scenario).
+- `PlantedArtifact` belongs to exactly one `ScenarioFixtureSubdirectory`.
+
+There is no relationship between plants owned by different scenarios; cross-talk is forbidden by the directory-isolation rule (FR-004 of the spec).
+
+## State Transitions
+
+### EvalScenario lifecycle (existing, unchanged)
+
+A scenario file is loaded by `loadScenarios` at orchestrator startup; lifecycle is per-run:
+
+1. `pending` → `running` → `pass` | `fail` | `timeout` | `error`.
+2. Result is recorded in the `EvalReport` and rendered by `formatReport`.
+
+This feature does not modify the lifecycle.
+
+### PlantedArtifact lifecycle (new)
+
+1. **Authoring**: implementer creates the plant file under `evals/fixture/{prds,rfcs,specs}/<scenario-slug>/`.
+2. **Documentation**: implementer adds a row to `evals/fixture/README.md` describing the plant (path, scenario owner, purpose, flaw if any).
+3. **Consumption**: the owning scenario references the plant by exact path in its `prompt` field.
+4. **Refresh**: when a producing command's template drifts (e.g., the spec format adds a new mandatory section), the implementer regenerates the plant from the updated template and updates the corresponding scenario's `structural_expectations` together. Plants and scenarios refresh as a unit.
+
+## Identity & Uniqueness
+
+- Each `EvalScenario` is uniquely identified by its `name` field (loader rejects duplicate names; second-loaded duplicate is skipped with a stderr note).
+- Each `PlantedArtifact` is uniquely identified by its repo-relative `path`.
+- Each `ScenarioFixtureSubdirectory` is uniquely identified by its repo-relative directory path; subdirectory names match the consuming scenario's `name` exactly.
+
+## Notes on the existing data model
+
+- `RunOutput`, `StructuralExpectations`, `SubAgentEvidence`, `Baseline`, `EvalReport`, and `EvalResult` interfaces in `evals/lib/types.ts` remain unchanged. This feature adds **instances**, not new types.
+- `Baseline` files for the six new scenarios are intentionally absent this round; the convention-based loader (`loadBaseline` returns `null` on missing file) makes baselines opt-in per scenario.
+- The fixture's existing `evals/fixture/src/routes/users.ts` planted inconsistencies (used by `scoutScenario`) are preserved unchanged. Adding new plants under `evals/fixture/{prds,rfcs,specs}/` does not interact with the scout fixture.

--- a/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.spec.md
+++ b/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.spec.md
@@ -1,0 +1,245 @@
+# Feature Specification: Expand Evals Coverage Across Planning Commands
+
+**Spec Folder**: `2026-05-03-005-expand-evals-coverage-planning-and-audit`
+**Branch**: `2026-05-03-005-expand-evals-coverage-planning-and-audit`
+**Created**: 2026-05-03
+**Status**: Draft
+**Input**: User description — expand the existing evals framework (currently `strike-health-check` and `scout-fixture-shallow` only) to also cover the smithy planning commands `spark`, `ignite`, `render`, `mark`, `cut`, plus the basic `audit` command. Out of scope this round: `forge`, `fix`, `orders`. The original feature description also asked for a GHA on-demand workflow using the Anthropic Messages Batches API and the deprecation of `tests/Agent.tests.md` — both deferred to a follow-up feature after a Batch-API spike (see `## Out of Scope`).
+
+## Clarifications
+
+### Session 2026-05-03
+
+- Each new scenario lives in `evals/cases/<command>-<descriptor>.yaml` following the existing `strike-health-check.yaml` shape; auto-discovery via `loadScenarios` requires no orchestrator changes. `[Critical Assumption]`
+- Planted parent artifacts (PRD, RFC, features-map, spec, flawed-spec) live under scenario-isolated subdirectories at `evals/fixture/{prds,rfcs,specs}/<scenario-slug>/`. Each plant is owned by exactly one scenario; scenarios reference them by **exact path** in the prompt — no command-side auto-selection. Existing scout plants under `evals/fixture/src/routes/users.ts` are untouched. `[Critical Assumption]`
+- Mark, cut, render scenarios pass exact paths (e.g., `evals/fixture/rfcs/mark-eval/01-core.features.md 1`) so mark's "first unspecced feature" routing rule never crosses into a sibling scenario's plant. `[Critical Assumption]`
+- The audit scenario uses File Argument Mode (`/smithy.audit <exact-path>`) against a planted `.spec.md` whose flaw is **a missing `## Dependency Order` table** — chosen because the canonical 4-column dependency-order schema is locked in `src/templates/agent-skills/README.md` (per CLAUDE.md) and is the most stable invariant the audit checklist asserts against. The scenario asserts audit emits a `Critical` finding plus the literal string `Dependency Order` somewhere in its output. `[Critical Assumption]`
+- Each scenario's `required_headings` is derived from the **template's literal output code-fence** (the `## ...` headings inside the `.prompt` template's Output / RFC template / spec template / one-shot snippet), not from prose narration. Headings sourced from rendered template literals are template-stable; competing-lens prose headings are not. `[Critical Assumption]`
+- Each scenario's `sub_agent_evidence` patterns target template-driven output markers (matching the strike pattern `## Plan\n\n\*\*Directive\*\*` for smithy-plan). Evidence sets per command are documented in `### Sub-Agent Evidence Matrix` below. `[Critical Assumption]`
+- Spark's empty-state survey is matched as a regex alternation in `required_patterns` accepting either the populated `### Alternatives Considered` table header **or** the literal stub string from `smithy.spark.prompt`. Survey error states are intentionally **not** accepted — if survey errors, the scenario fails. `[Critical Assumption]`
+- The strike + scout scenarios continue to pass unchanged; this feature is strictly additive to `evals/cases/`, `evals/fixture/`, and (non-mandatory) `evals/baselines/`.
+- Baselines for the six new scenarios are **deferred** this round. The convention-based loader (`loadBaseline` returns `null` on missing file) makes baselines opt-in per-scenario, so adding scenarios without baselines is a no-op in `run-evals.ts`.
+- Scenarios that exceed the runner's 120s `DEFAULT_TIMEOUT_MS` (ignite, render, mark, cut all dispatch multi-phase sub-agent fan-out) carry an explicit `timeout:` field in their YAML. Concrete timeout values are calibrated empirically during implementation (see SD-006).
+- `forbidden_patterns` for every new scenario reuses the strike convention: `"I'd be happy to help"`, `"Sure, here's"`, and `'^---\r?\n'` (leading YAML frontmatter).
+- Run-time impact for the full `npm run eval` invocation grows from ~10 min (2 scenarios) to ~30-60 min (8 scenarios). The local-on-demand model accepts this; users who need a single scenario use `--case`.
+
+## Artifact Hierarchy
+
+RFC → Milestone → Feature → User Story → Slice → Tasks
+
+This feature lives at the user-story level: it produces a set of additive YAML scenarios + planted fixture artifacts within an existing project (no parent RFC; the originating PRD-equivalent is the user description above).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1: Audit eval validates the audit command catches a planted flaw (Priority: P1)
+
+As a Smithy maintainer, I want an automated eval that exercises `/smithy.audit` against a deliberately-flawed `.spec.md` and confirms audit identifies the flaw, so that a regression in the audit checklist's spec extension is caught locally before release.
+
+**Why this priority**: Audit is the simplest validation surface — single-agent, no sub-agent dispatch, deterministic input/output relationship. It establishes the planted-flaw eval pattern (mirroring scout's existing fixture inconsistencies) that the rest of the suite reuses, and gives the highest signal-per-token of any new scenario.
+
+**Independent Test**: With the planted flawed-spec artifact and the new YAML scenario in place, `npm run eval -- --case audit-flawed-spec` runs to completion and reports PASS. Reverting the planted flaw (adding the missing `## Dependency Order` table) causes the scenario to FAIL on the next run.
+
+**Acceptance Scenarios**:
+
+1. **Given** the planted flawed-spec artifact at `evals/fixture/specs/audit-eval/<slug>.spec.md` (with no `## Dependency Order` section), **When** `npm run eval -- --case audit-flawed-spec` runs, **Then** the scenario PASSES with audit's output containing the literal string `Dependency Order` and at least one `Critical` severity label.
+2. **Given** the planted flawed-spec is repaired (its `## Dependency Order` table is restored), **When** the scenario runs, **Then** it FAILS — proving the eval is gated on audit's detection capability, not on audit running at all.
+3. **Given** the audit prompt template is edited in a way that breaks file-argument mode entirely, **When** the scenario runs, **Then** it FAILS with a `forbidden pattern` or missing-heading error — surfacing the regression to the user.
+
+---
+
+### User Story 2: Mark eval validates the mark command produces a complete spec artifact set (Priority: P1)
+
+As a Smithy maintainer, I want an automated eval that runs `/smithy.mark` against a planted `.features.md` (with an explicit feature number) and confirms mark emits the documented one-shot output snippet plus dispatches the documented sub-agents, so that regressions in mark's specification flow are caught locally before release.
+
+**Why this priority**: Mark is the most-edited planning command in the codebase and the one this feature was authored through. Its output is the most heavily exercised by downstream commands (cut consumes its specs; audit reviews them). Locking mark's terminal-output contract gives high regression coverage per scenario.
+
+**Independent Test**: With the planted features-map at `evals/fixture/rfcs/mark-eval/01-core.features.md`, `npm run eval -- --case mark-from-features` runs to completion and reports PASS, with sub-agent evidence showing smithy-scout, smithy-plan, smithy-clarify, smithy-refine, and smithy-plan-review dispatches.
+
+**Acceptance Scenarios**:
+
+1. **Given** the planted features-map and at least one feature whose `Artifact` cell is `—`, **When** the scenario runs with prompt `evals/fixture/rfcs/mark-eval/01-core.features.md 1`, **Then** mark's terminal output contains the one-shot snippet's mandatory headings (`## Summary`, `## Assumptions`, `## Specification Debt`, `## PR`) and a `**Spec folder**:` bullet pointing into a temp-dir-relative `specs/...` path.
+2. **Given** the scenario's `sub_agent_evidence` lists smithy-scout, smithy-plan, smithy-clarify, smithy-refine, and smithy-plan-review, **When** the run completes, **Then** every listed pattern matches against either the canonical text or a dispatched-agent record.
+3. **Given** the planted features-map references a feature number that is out of range, **When** the prompt is corrected to a valid number, **Then** the scenario PASSES on rerun without source fixture changes (FR-011 source-fixture checksum invariant from the original evals spec is preserved).
+4. **Given** mark dispatches `git checkout -b` and `gh pr create` during its workflow, **When** the scenario runs in the temp fixture copy, **Then** the scenario PASSES even if `gh` authentication is absent — the structural expectations match against either the success or PR-creation-failure branch of the one-shot snippet.
+
+---
+
+### User Story 3: Cut eval validates the cut command produces tasks with inherited spec debt (Priority: P1)
+
+As a Smithy maintainer, I want an automated eval that runs `/smithy.cut` against a planted `.spec.md` (with at least one user story and at least one open `## Specification Debt` row) and confirms cut emits the tasks-file's documented one-shot output snippet plus inherits the debt row, so that regressions in cut's task-decomposition flow are caught locally before release.
+
+**Why this priority**: Cut is the second-most-used planning command and the one the deprecated `tests/Agent.tests.md` A9 was specifically validating (debt inheritance from spec to tasks). Replacing A9's manual procedure with an automated eval is one of the load-bearing motivations for this feature.
+
+**Independent Test**: With the planted spec at `evals/fixture/specs/cut-eval/<slug>.spec.md`, `npm run eval -- --case cut-from-spec` runs to completion and reports PASS, with sub-agent evidence covering smithy-scout, smithy-clarify, and smithy-plan-review.
+
+**Acceptance Scenarios**:
+
+1. **Given** the planted spec contains an `SD-001` row with status `open` in its `## Specification Debt` table, **When** cut runs against it, **Then** the resulting tasks-file output contains a `## Specification Debt` section whose row has Status `inherited` and Description prefixed with `inherited from spec:`.
+2. **Given** the planted spec contains at least one user story with `US1` in `## Dependency Order`, **When** cut runs, **Then** the tasks-file's terminal output contains a `## Dependency Order` table with at least one slice ID (`S1`, `S2`, ...).
+3. **Given** the runner copies the fixture to a temp directory before each run, **When** cut writes its `<NN>-<story-slug>.tasks.md` file, **Then** the source fixture's checksum is unchanged after the scenario completes.
+
+---
+
+### User Story 4: Render eval validates the render command produces a feature map from an RFC (Priority: P2)
+
+As a Smithy maintainer, I want an automated eval that runs `/smithy.render` against a planted `.rfc.md` (with at least one milestone) and confirms render emits the documented features-map structure, so that regressions in render's milestone-to-features decomposition are caught locally before release.
+
+**Why this priority**: Render is less-frequently invoked than mark/cut but produces the load-bearing feature map that mark consumes. Coverage is needed before deprecating Agent.tests.md (a follow-up feature), but lower priority than the commands manipulated daily.
+
+**Independent Test**: With the planted RFC at `evals/fixture/rfcs/render-eval/<slug>.rfc.md` (containing `### Milestone 1: ...`), `npm run eval -- --case render-from-rfc` runs to completion and reports PASS.
+
+**Acceptance Scenarios**:
+
+1. **Given** the planted RFC contains at least one `### Milestone N:` heading, **When** render runs against it (prompt: `evals/fixture/rfcs/render-eval/<slug>.rfc.md`), **Then** render's output contains the one-shot snippet's mandatory headings plus references to the rendered features-map path.
+2. **Given** render dispatches smithy-scout, smithy-clarify, and smithy-plan-review per the template, **When** the run completes, **Then** the scenario's `sub_agent_evidence` patterns match for all three agents.
+
+---
+
+### User Story 5: Ignite eval validates the ignite command produces an RFC from a PRD (Priority: P2)
+
+As a Smithy maintainer, I want an automated eval that runs `/smithy.ignite` against a planted `.prd.md` and confirms ignite emits the documented RFC structure plus dispatches smithy-prose, so that regressions in ignite's PRD-to-RFC workflow are caught locally before release.
+
+**Why this priority**: Ignite is the least-frequently invoked planning command in normal use but the one with the most sub-agent fan-out (3 plan lenses + reconcile + clarify + prose + plan-review). Its scenario doubles as a stress test for sub-agent dispatch verification under heavy fan-out.
+
+**Independent Test**: With the planted PRD at `evals/fixture/prds/ignite-eval/<slug>.prd.md`, `npm run eval -- --case ignite-from-prd` runs to completion and reports PASS within the scenario's calibrated `timeout:`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the planted PRD contains the standard PRD sections, **When** ignite runs against it (prompt: `evals/fixture/prds/ignite-eval/<slug>.prd.md`), **Then** ignite's output contains the one-shot snippet's headings (`## Summary`, `## Assumptions`, `## Specification Debt`, `## PR`) plus a `**RFC path**:` or equivalent terminal marker.
+2. **Given** the scenario's `sub_agent_evidence` covers smithy-prose, smithy-plan, smithy-clarify, and smithy-plan-review, **When** the run completes, **Then** every listed pattern matches.
+3. **Given** ignite's full pipeline routinely takes 5-10 min, **When** the scenario runs with no `timeout:` field, **Then** the scenario fails with `timed_out: true`; **with** the calibrated `timeout:` field, **Then** it completes successfully.
+
+---
+
+### User Story 6: Spark eval validates the spark command produces a PRD from an idea, tolerating empty-state survey output (Priority: P2)
+
+As a Smithy maintainer, I want an automated eval that runs `/smithy.spark` against a one-line idea prompt and confirms spark emits the documented PRD structure, accepting either a populated survey table or the documented empty-state stub, so that regressions in spark's PRD generation are caught locally without coupling to web-research availability.
+
+**Why this priority**: Spark is the upstream entry point of the planning pipeline but produces the smallest artifact and exercises the smallest sub-agent set. The web-research dependency (smithy-survey via WebFetch/WebSearch) makes it the flakiest scenario, justifying a tolerant structural contract.
+
+**Independent Test**: With no fixture plants required (spark's input is the idea text in the prompt), `npm run eval -- --case spark-from-idea` runs to completion and reports PASS regardless of whether smithy-survey returns populated alternatives or the empty-state stub.
+
+**Acceptance Scenarios**:
+
+1. **Given** the scenario prompt is a one-line idea (e.g., `add a CLI flag to dump a scenario's runtime in CSV format`), **When** spark runs against it, **Then** spark's output contains the one-shot snippet's headings plus a `**PRD path**:` or equivalent terminal marker.
+2. **Given** smithy-survey returns a populated `### Alternatives Considered` table, **When** the run completes, **Then** the scenario PASSES via the table-header alternative in `required_patterns`.
+3. **Given** smithy-survey returns the documented empty-state stub (e.g., `No comparable off-the-shelf options identified during survey.`), **When** the run completes, **Then** the scenario PASSES via the stub-string alternative in `required_patterns`.
+4. **Given** smithy-survey errors out (network unavailable, rate limit, or other failure), **When** the run completes, **Then** the scenario FAILS — survey error states are intentional signals.
+
+---
+
+### Edge Cases
+
+- A scenario that requires `git` operations inside the temp fixture copy (mark, cut, render, ignite all run `git checkout -b`) needs a working git repository in the temp copy. Either the fixture is a standalone git repo, or the runner initializes one before deploying skills. (See SD-007.)
+- `gh pr create` fails when no GitHub authentication is available in the eval context. Scenarios must structurally match against the one-shot snippet's PR-creation-failure branch as a valid output, not just the success branch. (See SD-008.)
+- Mark's auto-selection routing ("first unspecced feature") must never pick up a plant intended for a different scenario. Scenarios reference plants by exact path with explicit feature-number qualifiers; planted features-maps live in scenario-isolated subdirectories. (See SD-003.)
+- The audit checklist's exact wording may evolve over time; the scenario's `required_patterns` target the most stable checklist invariant (the missing `## Dependency Order` flaw) but may still drift. (See SD-002.)
+- `evals/baselines/<scenario>.json` is intentionally absent for the six new scenarios this round; `loadBaseline` returns `null` and the orchestrator skips baseline checks per AS 10.3 of the original evals spec.
+- The runner's `DEFAULT_TIMEOUT_MS` of 120s is too short for ignite/mark/render. Each affected scenario carries an explicit `timeout:` field; calibration is empirical (see SD-006).
+
+## Dependency Order
+
+Recommended implementation sequence (priority, then independence):
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| US1 | Audit eval validates the audit command catches a planted flaw | — | — |
+| US2 | Mark eval validates the mark command produces a complete spec artifact set | — | — |
+| US3 | Cut eval validates the cut command produces tasks with inherited spec debt | — | — |
+| US4 | Render eval validates the render command produces a feature map from an RFC | — | — |
+| US5 | Ignite eval validates the ignite command produces an RFC from a PRD | — | — |
+| US6 | Spark eval validates the spark command produces a PRD from an idea, tolerating empty-state survey output | — | — |
+
+All six stories are independently shippable. The fixture-organization rules (scenario-isolated subdirectories under `evals/fixture/{prds,rfcs,specs}/`) are foundation-level guidance applied uniformly across stories rather than a separate dependency.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Each new scenario MUST live as a YAML file under `evals/cases/` and conform to the existing `EvalScenario` shape (`evals/lib/types.ts`).
+- **FR-002**: Each new scenario MUST be auto-discovered by the existing `loadScenarios(casesDir)` call in `evals/run-evals.ts`; the orchestrator MUST require no code changes to incorporate the new scenarios.
+- **FR-003**: Each new scenario MUST execute via the existing `claude` CLI runner (`evals/lib/runner.ts`); no new runner module, no new CLI flag, and no orchestrator-level branching is added by this feature.
+- **FR-004**: Planted parent artifacts (PRDs, RFCs, features-maps, specs) MUST live in scenario-isolated subdirectories under `evals/fixture/{prds,rfcs,specs}/<scenario-slug>/`. Each plant is owned by exactly one scenario.
+- **FR-005**: Each scenario that consumes a planted artifact MUST reference the plant by **exact path** in its `prompt` field (e.g., `evals/fixture/rfcs/mark-eval/01-core.features.md 1`); no command-side auto-selection is permitted.
+- **FR-006**: The audit scenario MUST run in File Argument Mode (`/smithy.audit <exact-path>`) against a planted `.spec.md` whose flaw is the absence of a `## Dependency Order` table.
+- **FR-007**: The audit scenario's `required_patterns` MUST assert the audit output contains the literal string `Dependency Order` AND at least one `Critical` severity label.
+- **FR-008**: The spark scenario's `required_patterns` MUST accept either a populated `### Alternatives Considered` table-header line OR the literal empty-state stub string emitted by smithy-survey.
+- **FR-009**: Each scenario's `sub_agent_evidence` patterns MUST target template-driven output markers that match against either the canonical text or the dispatched-agent record (description / resultText). Agent-name-only matching is insufficient (per FR-016 of the original evals spec).
+- **FR-010**: Scenarios with multi-phase sub-agent fan-out (mark, cut, render, ignite) MUST set explicit per-scenario `timeout:` values calibrated to the empirical run-time of the producing command.
+- **FR-011**: Each scenario's `forbidden_patterns` MUST include at minimum the strike-convention set: `"I'd be happy to help"`, `"Sure, here's"`, and `'^---\r?\n'` (leading YAML frontmatter).
+- **FR-012**: The existing `strike-health-check` and `scout-fixture-shallow` scenarios MUST continue to pass unchanged after the new scenarios and fixture plants are added.
+- **FR-013**: Scenarios MUST NOT modify the source fixture directory; the source-fixture checksum invariant established by the original evals spec MUST continue to hold for every new scenario.
+- **FR-014**: Each new scenario's structural expectations MUST be derivable by inspection from a stable artifact in `src/templates/agent-skills/commands/smithy.<command>.prompt` (the template's literal output code-fence, RFC template, spec template, or one-shot snippet).
+- **FR-015**: The full `npm run eval` invocation MUST complete within the developer's reasonable on-demand patience (target: ≤90 minutes for all 8 scenarios on a typical workstation; observed ~30-60 min). The `--case <name>` filter MUST run only the named scenario.
+
+### Key Entities
+
+- **EvalScenario** *(existing — extended in instances only, not in shape)*: A single eval case loaded from YAML. New scenarios add instances; no fields added to the shape.
+- **PlantedArtifact** *(new role for an existing entity type)*: A pre-built smithy artifact (PRD, RFC, features-map, spec, flawed-spec) committed under `evals/fixture/{prds,rfcs,specs}/<scenario-slug>/`. Each plant is owned by exactly one scenario; plants are read by scenarios via exact path.
+- **ScenarioFixtureSubdirectory** *(new naming convention)*: A scenario-isolated subfolder under `evals/fixture/{prds,rfcs,specs}/`. Naming follows `<scenario-slug>/` where the slug matches the consuming scenario's name (e.g., `mark-eval/`, `cut-eval/`, `audit-eval/`).
+- **Sub-Agent Evidence Matrix** *(new authoring reference)*: Per-command list of expected sub-agent dispatches and their template-stable evidence patterns. See `### Sub-Agent Evidence Matrix` below.
+
+### Sub-Agent Evidence Matrix
+
+Per-command expected dispatches and their evidence-pattern source-of-truth. Each scenario's `sub_agent_evidence` MUST cover the entries listed for its command:
+
+| Command | Sub-Agents (expected dispatches) | Evidence-pattern source |
+|---------|----------------------------------|--------------------------|
+| spark   | smithy-survey, smithy-clarify, smithy-prose, smithy-plan-review | template-stable Markers in each agent's output (e.g., `## Plan\n\n\*\*Directive\*\*` for plan; `^[Cc]larif` for clarify dispatch description) |
+| ignite  | smithy-prose, smithy-plan, smithy-clarify, smithy-plan-review | same conventions as spark |
+| render  | smithy-scout, smithy-clarify, smithy-plan-review | same |
+| mark    | smithy-scout, smithy-plan, smithy-clarify, smithy-refine, smithy-plan-review | same |
+| cut     | smithy-scout, smithy-clarify, smithy-plan-review | same |
+| audit   | (none — audit dispatches no sub-agents) | `sub_agent_evidence` field omitted from YAML |
+
+Implementers refresh patterns when a sub-agent template's stable marker changes; the strike scenario's pattern set in `evals/cases/strike-health-check.yaml` is the canonical reference for marker selection.
+
+## Assumptions
+
+- The runner (`evals/lib/runner.ts`) copies the source fixture to a temp directory before each scenario, so writes performed by mark/cut/render/ignite (new files; `git checkout -b`; `gh pr create`) happen in the temp copy and the source-fixture checksum invariant is preserved.
+- The `claude` CLI's `--output-format stream-json --verbose -p` invocation continues to work for slash-command invocations like `/smithy.mark <path> <feature-number>` and `/smithy.audit <path>`.
+- Smithy-survey returns a stable empty-state stub string when WebFetch/WebSearch cannot find alternatives; the exact stub string is pinned cross-template by FR-008's regex alternation.
+- Each smithy planning command's `## One-Shot Output` snippet remains the canonical terminal-output contract (commands stamp `## Summary`, `## Assumptions`, `## Specification Debt`, `## PR` headings deterministically).
+- Implementers have sufficient access to a Smithy-aware Claude CLI session to capture per-command run-times and calibrate `timeout:` values.
+
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | Mark/cut/render/ignite scenarios all run `git checkout -b` inside the temp fixture copy. The runner's current `fs.cpSync` may not preserve a `.git` directory if the source fixture is not a standalone git repo. Need to confirm the temp copy is git-initialized (or has the source fixture as a git repo) — otherwise the scenarios fail at the branch-creation step before any output is captured. | Edge Cases | Critical | Medium | open | — |
+| SD-002 | The audit scenario's planted flaw (a `.spec.md` missing its `## Dependency Order` table) is tied to one specific checklist invariant in `{{>audit-checklist-spec}}`. If the audit checklist's wording around dependency order changes (e.g., "Dependency Order" → "Implementation Order"), the `required_patterns` literal `Dependency Order` will silently fail. Implementers add an audit-checklist comment cross-referencing the eval scenario, and update both together. | Functional Scope | Critical | Medium | open | — |
+| SD-003 | Cross-talk between mark and cut/render plants. Mark's `.features.md` parser auto-selects "the first `### Feature N` not yet specc'd" when no feature number is given; even with exact-path prompts, a planted features-map referencing another scenario's plant could trip the routing logic. Mitigation: scenario-isolated subdirectories (`evals/fixture/rfcs/mark-eval/`, `.../cut-eval/`, `.../render-eval/`) and planted features-maps reference only their own children. Implementers verify the directory layout before each scenario lands. | Edge Cases | Critical | Medium | open | — |
+| SD-004 | Per-command structural-expectations rigor: for ignite the on-disk RFC contains many mandatory headings (`## Summary` through `## Milestones`), but the **scenario** validates against the **terminal one-shot snippet** (`## Summary` / `## Assumptions` / `## Specification Debt` / `## PR`) — not the on-disk artifact. Implementers confirm at scenario-authoring time whether scenarios assert against the terminal snippet (the simpler, runner-supported path) or read the on-disk RFC (would require runner changes that this feature explicitly does not introduce). | Functional Scope | High | Medium | open | — |
+| SD-005 | Spark's empty-state stub string is currently documented in `smithy.spark.prompt` Phase 2.5 as `No comparable off-the-shelf options identified during survey.`. If smithy-survey's prompt template changes the wording, the eval's regex alternation silently fails. Mitigation: pin the stub string in both the survey template and the eval scenario, with cross-reference comments. | Functional Scope | High | Medium | open | — |
+| SD-006 | Per-scenario `timeout:` calibration. Strike's full pipeline takes ~3-7 min today; ignite (with 3 plan lenses, reconcile, clarify, prose, plan-review) is likely 5-10 min; mark and render with full clarify+plan+refine+plan-review fan-out are similar. The `DEFAULT_TIMEOUT_MS` of 120s is almost certainly too short for ignite/mark/render. Implementers calibrate timeouts empirically during scenario authoring; calibration values land in the YAML scenario's `timeout:` field. | Non-Functional Quality | High | Medium | open | — |
+| SD-007 | Whether the runner's temp-copy includes a `.git` directory or initializes one. `runScenario` in `evals/lib/runner.ts` does `fs.cpSync(fixtureDir, tmpDir, { recursive: true })` — if `evals/fixture/` is not under a separate `.git`, mark/cut/render/ignite scenarios calling `git checkout -b` will fail. The orchestrator may need to `git init` the temp copy before deploying skills. (Closely related to SD-001.) | Integration | High | Medium | open | — |
+| SD-008 | Whether scenarios that create a PR (`gh pr create` in mark/cut/render/ignite) need to be neutralized in the eval environment. Without `gh` auth in CI/local eval context, the one-shot snippet's PR-creation-failure branch will trigger, which still produces output but emits a different terminal contract. Implementers either (a) assert against the failure branch in `required_patterns`, (b) provide stub `gh` credentials, or (c) accept either branch via regex alternation. | Integration | High | Medium | open | — |
+| SD-009 | Per-mode variants for each command (mark with-RFC vs. with-features-map; ignite with-PRD vs. without; render with-RFC vs. with-features.md; cut with explicit story vs. auto-select; audit forge-branch mode) are deferred to follow-up features. This feature ships exactly one canonical scenario per command. | Functional Scope | Medium | High | open | — |
+| SD-010 | Render scenario's structural expectations validate against the terminal one-shot snippet, not the on-disk `.features.md` written by render. The runner only validates `extracted_text` from stream-json, so on-disk validation would require a runner-level enhancement out of scope here. (Same constraint as SD-004; tracked separately because render has the most prominent on-disk-vs-terminal divergence.) | Domain & Data Model | Medium | Medium | open | — |
+| SD-011 | The audit scenario uses `skill: /smithy.audit` and `prompt: <exact-path>`; the runner's `runScenario` composes this as `/smithy.audit <path>`. Implementers verify this composition works for the slash-command-with-path form during scenario authoring; if the runner mishandles the path argument, additional escaping or quoting may be needed. | Interaction & UX | Medium | High | open | — |
+| SD-012 | Baseline files for the six new scenarios (`evals/baselines/<scenario>.json`) are intentionally not authored in this round; baselines for new scenarios are added only after at least two clean runs prove structural stability. The convention-based loader returns `null` on missing files, so this is a no-op for the orchestrator. Follow-up feature(s) snapshot baselines once scenarios are stable. | Functional Scope | Medium | Medium | open | — |
+
+## Out of Scope
+
+- **GHA on-demand evals workflow** (`.github/workflows/evals.yml`): deferred to a follow-up feature pending a Batch-API spike that resolves the upstream wire-shape and sub-agent-dispatch fidelity unknowns.
+- **Anthropic Messages Batches API runner** (`BatchApiRunner`, `--runner batch` flag): deferred. Same reason.
+- **Deprecation of `tests/Agent.tests.md`** and the `agent_tests_passed` → `evals_passed` rename in `.github/workflows/publish.yml`: deferred. Depends on the GHA workflow being operational.
+- **Forge / fix / orders evals**: out of scope for this round; these commands rely more heavily on side effects and external systems and are deliberately excluded.
+- **Per-mode variants** for any command (e.g., mark with-RFC vs. with-features-map; ignite with-PRD vs. without; render with-RFC vs. with-features.md). Single canonical scenario per command this round; alternates captured as SD-009.
+- **Migration of `scoutScenario` from TypeScript to YAML**: not in scope. Continues to live in `evals/lib/scout-scenario.ts`; loader's empty-`skill` rejection rule remains unchanged.
+- **Multi-fixture support** (per-scenario fixture directories): not in scope. Single shared fixture grows additively under scenario-isolated subdirectories.
+- **Scheduled cron evals**: not in scope.
+- **Baseline auto-refresh tooling**: not in scope. Baselines remain manual; new-scenario baselines deferred per SD-012.
+- **Cost dashboards / token-budget surfaces**: not in scope.
+- **Updates to `tests/Agent.tests.md`** (banner, deletion, A-test reorganization): out of scope this round; lands with the deferred GHA/deprecation feature.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Six new YAML scenario files exist under `evals/cases/` (`audit-flawed-spec.yaml`, `mark-from-features.yaml`, `cut-from-spec.yaml`, `render-from-rfc.yaml`, `ignite-from-prd.yaml`, `spark-from-idea.yaml`); `npm run eval` reports a passing run for all six.
+- **SC-002**: `npm run eval -- --case <new-scenario-name>` filters to and runs only that scenario for each of the six new names.
+- **SC-003**: Adding the new scenarios and fixture plants does not change the strike or scout scenario behavior; their Pass/Fail status is identical before and after this feature lands.
+- **SC-004**: Reverting the audit scenario's planted flaw (restoring the missing `## Dependency Order` table to the planted spec) causes `npm run eval -- --case audit-flawed-spec` to report FAIL on the next run — proving the eval is gated on audit's detection capability, not on audit running at all.
+- **SC-005**: The full `npm run eval` invocation (8 scenarios — strike + scout + 6 new) completes within 90 minutes on a typical workstation.
+- **SC-006**: `npm run test:evals` (offline unit tests) continues to pass after the new YAML files and fixture plants land — no test regressions in `evals/lib/*.test.ts`.

--- a/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.spec.md
+++ b/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.spec.md
@@ -59,7 +59,7 @@ As a Smithy maintainer, I want an automated eval that runs `/smithy.mark` agains
 
 1. **Given** the planted features-map and at least one feature whose `Artifact` cell is `—`, **When** the scenario runs with prompt `evals/fixture/rfcs/mark-eval/01-core.features.md 1`, **Then** mark's terminal output contains the one-shot snippet's mandatory headings (`## Summary`, `## Assumptions`, `## Specification Debt`, `## PR`) and a `**Spec folder**:` bullet pointing into a temp-dir-relative `specs/...` path.
 2. **Given** the scenario's `sub_agent_evidence` lists smithy-scout, smithy-plan, smithy-clarify, smithy-refine, and smithy-plan-review, **When** the run completes, **Then** every listed pattern matches against either the canonical text or a dispatched-agent record.
-3. **Given** the planted features-map references a feature number that is out of range, **When** the prompt is corrected to a valid number, **Then** the scenario PASSES on rerun without source fixture changes (FR-011 source-fixture checksum invariant from the original evals spec is preserved).
+3. **Given** the planted features-map references a feature number that is out of range, **When** the prompt is corrected to a valid number, **Then** the scenario PASSES on rerun without source fixture changes (the source-fixture checksum invariant established by the original evals spec is preserved; in this spec see FR-013).
 4. **Given** mark dispatches `git checkout -b` and `gh pr create` during its workflow, **When** the scenario runs in the temp fixture copy, **Then** the scenario PASSES even if `gh` authentication is absent — the structural expectations match against either the success or PR-creation-failure branch of the one-shot snippet.
 
 ---


### PR DESCRIPTION
## Summary

Adds the spec, data-model, and contracts for an **additive expansion of the evals framework** to cover the smithy planning commands `spark`, `ignite`, `render`, `mark`, `cut`, plus the basic `audit` command (existing strike + scout coverage stays). All six new scenarios run under the existing `claude` CLI runner — no new runner module, no orchestrator changes.

The original feature description also asked for a GHA on-demand workflow using the Anthropic Messages Batches API and the deprecation of `tests/Agent.tests.md`. Those were deferred to a follow-up after the initial clarify scan returned `bail_out: true` on two upstream unknowns: the Batches API wire shape, and whether sub-agent dispatch (Task / Agent tool) actually works under raw batches vs. requiring Claude Code's runtime. The narrowed scope ships eval coverage immediately and lets the GHA + Batch-API decision be made on data after a small spike.

## Spec folder

`specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/`

## User stories (6, all independently shippable)

- **US1 (P1)** — Audit eval validates `/smithy.audit` catches a planted flaw (missing `## Dependency Order`).
- **US2 (P1)** — Mark eval against a planted features-map (exact-path; no auto-selection).
- **US3 (P1)** — Cut eval against a planted spec; verifies inherited specification debt.
- **US4 (P2)** — Render eval against a planted RFC.
- **US5 (P2)** — Ignite eval against a planted PRD (largest sub-agent fan-out).
- **US6 (P2)** — Spark eval, tolerant of empty-state survey output.

## Functional requirements

15 FRs; key invariants:

- New scenarios are pure YAML data under `evals/cases/`; auto-discovered by `loadScenarios` (FR-001, FR-002).
- Plants live under scenario-isolated subdirectories: `evals/fixture/{prds,rfcs,specs}/<scenario-slug>/` (FR-004).
- Scenarios reference plants by exact path; mark's "first unspecced feature" auto-selection is short-circuited (FR-005).
- Audit scenario must prove audit *catches* the planted flaw, not just produce a report-shaped document (FR-006, FR-007).
- Spark accepts either populated survey output OR the empty-state stub (FR-008).
- The source-fixture checksum invariant from the original evals spec is preserved (FR-013).

## Key entities

- `EvalScenario` (existing — six new instances, no shape change).
- `PlantedArtifact` (new role for a planted PRD / RFC / features-map / spec / flawed-spec).
- `ScenarioFixtureSubdirectory` (naming convention: `<scenario-slug>/`).
- Sub-Agent Evidence Matrix (per-command expected dispatches with template-stable marker conventions).

## Specification debt (12 items, all open)

Concrete authoring decisions deferred to implementation: temp-copy git initialization (SD-001 / SD-007), audit flaw stability (SD-002), mark-cut cross-talk (SD-003), structural-expectations rigor (SD-004), spark stub-string pinning (SD-005), per-scenario timeout calibration (SD-006), `gh pr create` failure handling (SD-008), per-mode variants follow-up (SD-009), render on-disk-vs-terminal (SD-010), audit slash-command-with-path composition (SD-011), baselines deferral (SD-012).

## Plan-review fixes applied in this PR

- US4 AS2 expanded to include `smithy-scout` (was missing — contradicted the Sub-Agent Evidence Matrix).
- Two brittle line-number references in contracts.md replaced with function-level citations (`runScenario`, `validateStructure`).
- Two brittle line-number references in spec.md (SD-007, SD-011) similarly normalized.

## Plan-review notes (Minor findings, not applied — surface for the reviewer)

- **US5 narrative drift**: "Why this priority" mentions `smithy-reconcile`, but the sub-agent matrix and contracts omit it. Either reconcile is in scope (add it to the matrix) or the narrative should be revised. Implementer's call during US5 authoring.
- **`tasks` enum entry without consumer**: Data-model `PlantedArtifact.artifact_type` includes `tasks`, but no tasks plant is authored this round. Either trim the enum or label it forward-looking.
- **README-update obligation lacks a backing FR**: Data-model and contracts both require `evals/fixture/README.md` rows for each plant; the spec FRs don't mandate it. Consider adding an FR-004a during implementation.
- **`mark-eval/<slug>.rfc.md` plant has no asserted consumer**: Contracts §4 layout shows it "for traceability"; mark-from-features only consumes the features-map. Either remove the RFC plant or document it as optional context.
- **`cut/render` "same conventions as mark" wording**: Contracts §3 says cut and render reuse mark's marker conventions, but neither dispatches `smithy-plan`. Implementer should expand the per-agent marker list explicitly to avoid misapplying a plan marker.
- **Cross-spec FR/AS references** ("AS 10.3 of the original evals spec") lack the spec path; consider adding a "Related Specs" link.
- **SD-001 / SD-007 overlap** on temp-copy git initialization; merging or sharpening the boundary is implementer judgment.

## Next step

Ready for task decomposition with `smithy.cut` against `expand-evals-coverage-planning-and-audit.spec.md`.
