### PR TITLE
Fix status/--graph disagreement on date-prefixed spec folders

### DIFF
--- a/src/status/scanner.test.ts
+++ b/src/status/scanner.test.ts
@@ -404,6 +404,52 @@ ${TABLE_HEADER}
     expect(virt?.parent_path).toBe('specs/feature-a/feature-a.features.md');
   });
 
+  it('feature-map folder match accepts <slug>.spec.md inside a YYYY-MM-DD-NNN-<slug>/ folder', () => {
+    // Per the smithy.mark convention, spec folders are named
+    // `<YYYY-MM-DD>-<NNN>-<slug>` and the spec file inside is
+    // `<slug>.spec.md` — the bare slug, not the full folder leaf. The
+    // scanner must treat that as a canonical match so the feature row
+    // binds to the real spec instead of emitting a virtual placeholder
+    // at the folder path (which would break parent rollup and make
+    // `smithy status` and `smithy status --graph` disagree on whether
+    // the feature is done).
+    write(
+      'docs/rfcs/demo/01-spawn.features.md',
+      `# Feature Map\n\n## Dependency Order\n\n${TABLE_HEADER}\n| F1 | March CLI Foundation | — | specs/2026-04-05-001-march-cli-foundation/ |\n`,
+    );
+    write(
+      'specs/2026-04-05-001-march-cli-foundation/march-cli-foundation.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Done story | — | specs/2026-04-05-001-march-cli-foundation/01-done.tasks.md |\n`,
+    );
+    write(
+      'specs/2026-04-05-001-march-cli-foundation/01-done.tasks.md',
+      `# Tasks\n\n## Slice 1: Done\n\n- [x] Done task\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Done | — | — |\n`,
+    );
+    const records = scan(root);
+    const real = byPath(
+      records,
+      'specs/2026-04-05-001-march-cli-foundation/march-cli-foundation.spec.md',
+    );
+    expect(real).toBeDefined();
+    expect(real?.virtual).toBeUndefined();
+    expect(real?.parent_path).toBe('docs/rfcs/demo/01-spawn.features.md');
+    expect(real?.parent_row_id).toBe('F1');
+    expect(real?.status).toBe('done');
+    // No virtual placeholder at the folder path should be emitted —
+    // the real spec absorbed the F1 row.
+    const virt = records.find(
+      (r) =>
+        r.type === 'spec' &&
+        r.virtual === true &&
+        r.path === 'specs/2026-04-05-001-march-cli-foundation/',
+    );
+    expect(virt).toBeUndefined();
+    // The feature map rolls up to done because its only child row is
+    // bound to the done spec.
+    const features = byPath(records, 'docs/rfcs/demo/01-spawn.features.md');
+    expect(features?.status).toBe('done');
+  });
+
   it('parent_path collision: a child claimed by two parents keeps the first and warns', () => {
     // Two specs both list the same tasks file in their dep-order
     // tables. The child must keep the first parent_path and append a

--- a/src/status/scanner.ts
+++ b/src/status/scanner.ts
@@ -592,20 +592,43 @@ function findTasksByStoryNumber(
 }
 
 /**
- * Look up the canonical `<folder-leaf>.spec.md` file inside `folder`
- * within the already-discovered record set. Only the canonical filename
- * is accepted; if the folder contains a non-canonical `.spec.md` (or
- * several), this returns `null` and the scanner emits a virtual record
- * at the folder path instead. Falling back to "first .spec.md found"
- * would make parent linkage depend on `readdirSync` order, which is not
- * stable across filesystems.
+ * Look up the canonical `.spec.md` file inside `folder` within the
+ * already-discovered record set. Two filenames count as canonical:
+ *
+ *   - `<folder-leaf>.spec.md` — used when the folder is named after the
+ *     spec slug directly (e.g. `specs/foo/foo.spec.md`).
+ *   - `<slug>.spec.md` where `<slug>` is `<folder-leaf>` with a
+ *     `<YYYY>-<MM>-<DD>-<NNN>-` prefix stripped — the convention emitted
+ *     by `smithy.mark`, which puts spec folders at
+ *     `specs/<YYYY-MM-DD>-<NNN>-<slug>/` but names the spec file after
+ *     the bare slug (e.g. `specs/2026-04-05-001-foo/foo.spec.md`).
+ *
+ * Only canonical filenames are accepted; if the folder contains a
+ * non-canonical `.spec.md`, this returns `null` and the scanner emits a
+ * virtual record at the folder path instead. Falling back to "first
+ * .spec.md found" would make parent linkage depend on `readdirSync`
+ * order, which is not stable across filesystems. When both canonical
+ * filenames are present in the same folder (extremely unusual), the
+ * unprefixed `<folder-leaf>.spec.md` form wins so legacy folders that
+ * happen to start with a date-shaped slug still resolve the way they
+ * always did.
  */
 function findSpecInFolder(
   folder: string,
   records: Map<string, ArtifactRecord>,
 ): string | null {
   const folderLeaf = folder.replace(/\/+$/, '').split('/').pop() ?? '';
-  const canonicalBase = `${folderLeaf}.spec.md`;
+  const canonicalLeafBase = `${folderLeaf}.spec.md`;
+  // The smithy.mark convention strips a `<YYYY>-<MM>-<DD>-<NNN>-` prefix
+  // (e.g. `2026-04-05-001-`) from the folder leaf before naming the
+  // spec file after the bare slug. Only compute a second canonical
+  // base when the folder leaf actually carries that prefix.
+  const datedSlug = folderLeaf.match(/^\d{4}-\d{2}-\d{2}-\d{3}-(.+)$/)?.[1];
+  const canonicalSlugBase =
+    datedSlug !== undefined ? `${datedSlug}.spec.md` : null;
+
+  let leafMatch: string | null = null;
+  let slugMatch: string | null = null;
   for (const [p, rec] of records) {
     if (rec.type !== 'spec') continue;
     if (!p.startsWith(folder)) continue;
@@ -615,11 +638,13 @@ function findSpecInFolder(
     // match a folder query for `specs/`.
     const tail = p.slice(folder.length);
     if (tail.includes('/')) continue;
-    if (tail === canonicalBase) {
-      return p;
+    if (tail === canonicalLeafBase) {
+      leafMatch = p;
+    } else if (canonicalSlugBase !== null && tail === canonicalSlugBase) {
+      slugMatch = p;
     }
   }
-  return null;
+  return leafMatch ?? slugMatch;
 }
 
 function makeVirtualRecord(

--- a/src/status/scanner.ts
+++ b/src/status/scanner.ts
@@ -603,15 +603,15 @@ function findTasksByStoryNumber(
  *     `specs/<YYYY-MM-DD>-<NNN>-<slug>/` but names the spec file after
  *     the bare slug (e.g. `specs/2026-04-05-001-foo/foo.spec.md`).
  *
- * Only canonical filenames are accepted; if the folder contains a
- * non-canonical `.spec.md`, this returns `null` and the scanner emits a
- * virtual record at the folder path instead. Falling back to "first
- * .spec.md found" would make parent linkage depend on `readdirSync`
- * order, which is not stable across filesystems. When both canonical
- * filenames are present in the same folder (extremely unusual), the
- * unprefixed `<folder-leaf>.spec.md` form wins so legacy folders that
- * happen to start with a date-shaped slug still resolve the way they
- * always did.
+ * Only canonical filenames are accepted; if the folder contains no
+ * canonical `.spec.md` (only non-canonical ones, or no `.spec.md` at
+ * all), this returns `null` and the scanner emits a virtual record at
+ * the folder path instead. Falling back to "first .spec.md found"
+ * would make parent linkage depend on `readdirSync` order, which is
+ * not stable across filesystems. When both canonical filenames are
+ * present in the same folder (extremely unusual), the unprefixed
+ * `<folder-leaf>.spec.md` form wins so legacy folders that happen to
+ * start with a date-shaped slug still resolve the way they always did.
  */
 function findSpecInFolder(
   folder: string,
@@ -627,7 +627,6 @@ function findSpecInFolder(
   const canonicalSlugBase =
     datedSlug !== undefined ? `${datedSlug}.spec.md` : null;
 
-  let leafMatch: string | null = null;
   let slugMatch: string | null = null;
   for (const [p, rec] of records) {
     if (rec.type !== 'spec') continue;
@@ -639,12 +638,16 @@ function findSpecInFolder(
     const tail = p.slice(folder.length);
     if (tail.includes('/')) continue;
     if (tail === canonicalLeafBase) {
-      leafMatch = p;
-    } else if (canonicalSlugBase !== null && tail === canonicalSlugBase) {
+      // Leaf form always wins on a tie, so return immediately and skip
+      // the rest of the scan — preserves the early-exit behavior the
+      // function had before slug-form support was added.
+      return p;
+    }
+    if (canonicalSlugBase !== null && tail === canonicalSlugBase) {
       slugMatch = p;
     }
   }
-  return leafMatch ?? slugMatch;
+  return slugMatch;
 }
 
 function makeVirtualRecord(


### PR DESCRIPTION
## Summary
- Primary outcome: `smithy status` and `smithy status --graph` agree on whether a feature/spec is done when the spec folder follows `smithy.mark`'s `YYYY-MM-DD-NNN-<slug>/` convention.
- Notable behaviour changes: feature-map rows pointing at a dated spec folder now bind to the real `<slug>.spec.md` inside instead of producing a phantom `not-started` virtual record at the folder path.
- Follow-up work deferred: none.

## Context
`findSpecInFolder` only matched `<folder-leaf>.spec.md`, but `smithy.mark` writes spec folders as `specs/<YYYY-MM-DD>-<NNN>-<slug>/` and names the spec file after the bare slug (`<slug>.spec.md`). For a feature-map row pointing at such a folder, the scanner could not bind the real spec to its parent, emitted a `not-started` virtual placeholder at the folder path, and bucketed the real spec under "Orphaned Specs".

Both views (`smithy status` and `smithy status --graph`) read the same record set, but the default tree shows orphans in their own group while the layered view rolls up via parent linkage. So a fully-done spec was reported as `✓` under "Orphaned Specs" while simultaneously appearing in Layer 0 of `--graph` as ready-to-work — directly contradicting itself, and pointing at `smithy.cut` for a spec that was already fully decomposed and implemented.

Reproduced against the March repo: "March CLI Foundation" (all 6 user stories complete) appeared as both `Layer 0 — ready to work` and an orphaned `done` spec.

## Implementation Notes
- Extend `findSpecInFolder` (`src/status/scanner.ts`) to compute a second canonical filename when the folder leaf has a `^\d{4}-\d{2}-\d{2}-\d{3}-` prefix: strip that prefix and try `<slug>.spec.md`.
- Iterate every candidate inside the folder (still filtering nested sub-folder matches), capture both the leaf-form and slug-form match if present, and prefer the unprefixed `<folder-leaf>.spec.md` form on a double-match so legacy folders are unaffected.
- Trade-off considered: a permissive "single .spec.md in folder wins" rule. Rejected — the existing module comment is explicit that depending on `readdirSync` order is not stable. Restricting to two well-defined canonical names preserves that determinism.
- Impacted modules: `src/status/scanner.ts` only. No changes to classifier, graph, or renderer — they were already consistent given correct parent linkage.

## Risks & Mitigations
- Risk: a folder containing both a `<folder-leaf>.spec.md` and a `<slug>.spec.md` could newly bind to the leaf form. Mitigation: documented preference order, regression test exercises the date-prefixed branch, and the existing canonical-only test still passes (non-canonical names are still rejected).
- Risk: a date-shaped folder leaf that *isn't* the `mark` convention (e.g. someone manually named a folder `2026-04-05-001-foo` for unrelated reasons). Mitigation: behaviour only changes when a `<slug>.spec.md` actually exists at the stripped-prefix path; otherwise we still fall through to the virtual placeholder.

## Rollback Plan
- Revert this commit. The previous behaviour returns: dated spec folders re-emit virtual placeholders, and `smithy status` / `--graph` again disagree.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npx tsc --noEmit`)
- [ ] CLI `init` smoke test (`node dist/cli.js init`) — not exercised; this PR does not touch init flow.

### Template Generation
- Not applicable — no template changes.

### Permissions & Configuration
- Not applicable — no config changes.

### Manual Test Cases
- [x] Verified against the March repo: with the fix, `smithy status` and `smithy status --graph` agree (`March CLI Foundation` is `✓` in both views; `Snapshot Worktree into Docker Image` is the genuine Layer 0 ready-to-work item; the spurious "March CLI Foundation → smithy.cut" hint is gone).
- [x] Added scanner regression test in `src/status/scanner.test.ts` (`feature-map folder match accepts <slug>.spec.md inside a YYYY-MM-DD-NNN-<slug>/ folder`); full suite passes (682/682).