### PR TITLE
Fix session-title hook errors and restrict rename set

### DIFF
--- a/.claude/hooks/smithy-session-title.mjs
+++ b/.claude/hooks/smithy-session-title.mjs
@@ -2,120 +2,114 @@
 // Smithy session-title hook for Claude Code.
 //
 // Wired into .claude/settings.json as a UserPromptSubmit hook by `smithy init`.
-// On every user prompt that starts with `/smithy.<cmd>`, derive a short session
-// title (slug + command + IDs) and emit it as `sessionTitle`. For non-smithy
-// prompts, exits silently. Any error path also exits silently so this hook
-// never blocks a user prompt.
+// On every user prompt that starts with `/smithy.<cmd>` for an artifact-producing
+// command AND carries a recognizable artifact path, derive a kebab-case session
+// title (`<parent-slug>-<cmd>[-<n>[-<m>]]`) and emit it as `sessionTitle`. For
+// non-rename commands, description-only invocations, or non-smithy prompts, exit
+// silently so Claude Code's own auto-naming stays in charge. Any error path also
+// exits silently — this hook never blocks a user prompt.
 
 import { pathToFileURL } from 'node:url';
 
 const SMITHY_PREFIX = /^\/smithy\.([a-z][a-z0-9-]*)\b/i;
+const RENAME_COMMANDS = new Set(['spark', 'ignite', 'mark', 'cut', 'forge', 'strike', 'render']);
 
-function capitalize(s) {
-  if (!s) return '';
-  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+// Path-shape regexes. Each captures the human-readable slug AFTER any
+// date/uniqueness prefix, and keeps multi-word kebab slugs whole.
+const SPEC_FOLDER_RE   = /specs?\/\d{4}-\d{2}-\d{2}-\d{3}-([a-z0-9][a-z0-9-]*)/i;
+const PRD_RFC_FOLDER_RE = /docs\/(?:prds|rfcs)\/\d{4}-\d{3}-([a-z0-9][a-z0-9-]*)/i;
+const TASKS_FILE_RE    = /(?:^|[\s/])(\d{1,3})-([a-z0-9][a-z0-9-]*)\.tasks\.md\b/i;
+const FEATURES_FILE_RE = /(?:^|[\s/])\d{1,3}-([a-z0-9][a-z0-9-]*)\.features\.md\b/i;
+const STRIKE_FILE_RE   = /(?:^|[\s/])([a-z0-9][a-z0-9-]*)\.strike\.md\b/i;
+const TRAILING_INT_RE  = /(?:^|\s)(\d{1,3})\s*$/;
+
+function trailingInt(rest) {
+  const m = rest.match(TRAILING_INT_RE);
+  return m ? String(parseInt(m[1], 10)) : null;
 }
 
-function pad2(n) {
-  const s = String(n);
-  return s.length === 1 ? '0' + s : s;
-}
-
-// Try to extract slug + numeric IDs from the argument string of a smithy command.
-function parseArgs(cmd, rest) {
-  let slug;
-  let storyNum;
-  let sliceNum;
-
-  // Tasks file pattern: <NN>-<slug>.tasks.md (anywhere in path)
-  const tasksMatch = rest.match(/(?:^|[\s/])(\d{1,3})-([a-z0-9][a-z0-9-]*)\.tasks\.md\b/i);
-  if (tasksMatch) {
-    storyNum = pad2(parseInt(tasksMatch[1], 10));
-    slug = tasksMatch[2];
-  }
-
-  // Strike file pattern: <slug>.strike.md
-  if (!slug) {
-    const strikeMatch = rest.match(/(?:^|[\s/])([a-z0-9][a-z0-9-]*)\.strike\.md\b/i);
-    if (strikeMatch) {
-      slug = strikeMatch[1];
-    }
-  }
-
-  // Spec folder pattern: specs/<YYYY>-<MM>-<DD>-<NNN>-<slug>
-  if (!slug) {
-    const specMatch = rest.match(/specs?\/\d{4}-\d{2}-\d{2}-\d{3}-([a-z0-9][a-z0-9-]*)/i);
-    if (specMatch) {
-      slug = specMatch[1];
-    }
-  }
-
-  // Quoted-string fallback: first quoted run, take its first word
-  if (!slug) {
-    const quoted = rest.match(/["']([^"']+)["']/);
-    if (quoted) {
-      const firstQuotedWord = quoted[1].trim().split(/\s+/)[0];
-      if (firstQuotedWord) slug = firstQuotedWord;
-    }
-  }
-
-  // First non-flag, non-numeric token fallback
-  if (!slug) {
-    const firstWord = rest.trim().split(/\s+/)[0];
-    if (firstWord && !firstWord.startsWith('-') && /[a-z]/i.test(firstWord)) {
-      const last = firstWord.split('/').filter(Boolean).pop() || firstWord;
-      slug = last.replace(/\.[^.]+$/, '').replace(/^\d+-/, '');
-    }
-  }
-
-  // Trailing bare integer: slice number for forge, story number for cut
-  const trailingInt = rest.match(/(?:^|\s)(\d{1,3})\s*$/);
-  if (trailingInt) {
-    const n = pad2(parseInt(trailingInt[1], 10));
-    if (cmd === 'forge') {
-      sliceNum = n;
-    } else if (cmd === 'cut' && !storyNum) {
-      storyNum = n;
-    }
-  }
-
-  return { slug, storyNum, sliceNum };
+function joinTitle(parts) {
+  return parts.filter(p => p !== null && p !== undefined && p !== '').join('-');
 }
 
 /**
  * Derive a Claude Code session title from a user prompt.
- * Returns null if the prompt is not a `/smithy.<cmd>` invocation.
+ * Returns null when the prompt should not trigger a rename.
  *
  * @param {string} prompt
- * @param {{ branch?: string }} [options]
  * @returns {string | null}
  */
-export function deriveTitle(prompt, options = {}) {
+export function deriveTitle(prompt) {
   if (typeof prompt !== 'string') return null;
   const trimmed = prompt.trim();
   const match = trimmed.match(SMITHY_PREFIX);
   if (!match) return null;
 
   const cmd = match[1].toLowerCase();
+  if (!RENAME_COMMANDS.has(cmd)) return null;
+
   const rest = trimmed.slice(match[0].length).trim();
+  if (!rest) return null;
 
-  const { slug, storyNum, sliceNum } = parseArgs(cmd, rest);
+  const tasks    = rest.match(TASKS_FILE_RE);
+  const features = rest.match(FEATURES_FILE_RE);
+  const strike   = rest.match(STRIKE_FILE_RE);
+  const spec     = rest.match(SPEC_FOLDER_RE);
+  const prdRfc   = rest.match(PRD_RFC_FOLDER_RE);
+  const tail     = trailingInt(rest);
 
-  // Build the display slug: take the first dash/space-separated segment, capitalize.
-  let display = '';
-  if (slug) {
-    display = capitalize(slug.split(/[-\s]/)[0]);
-  }
-  if (!display && options.branch) {
-    const branchTail = options.branch.split(/[/_-]/).pop() || '';
-    display = capitalize(branchTail);
-  }
-  if (!display) {
-    display = 'Smithy';
-  }
+  // Per-command format-by-shape table.
+  switch (cmd) {
+    case 'forge': {
+      // Tasks file: <spec-slug>-forge-<storyN>[-<sliceN>]
+      if (tasks && spec) {
+        const storyN = String(parseInt(tasks[1], 10));
+        return joinTitle([spec[1], 'forge', storyN, tail]);
+      }
+      // Strike file: <strike-slug>-forge
+      if (strike) return joinTitle([strike[1], 'forge']);
+      return null;
+    }
 
-  const numbers = [storyNum, sliceNum].filter(Boolean).join(' ');
-  return [display, cmd, numbers].filter(Boolean).join(' ');
+    case 'cut': {
+      // Spec folder + optional trailing story number.
+      if (spec) return joinTitle([spec[1], 'cut', tail]);
+      return null;
+    }
+
+    case 'mark': {
+      // Features file + optional trailing feature number takes precedence.
+      if (features) return joinTitle([features[1], 'mark', tail]);
+      // Plain RFC path → <rfc-slug>-mark.
+      if (prdRfc) return joinTitle([prdRfc[1], 'mark']);
+      return null;
+    }
+
+    case 'render': {
+      // A features.md path lives inside an RFC folder and matches both regexes;
+      // prefer the features-file slug so Phase-0 review titles use the feature
+      // map (`core-render`) rather than the parent RFC (`foo-render`).
+      if (features) return joinTitle([features[1], 'render', tail]);
+      if (prdRfc) return joinTitle([prdRfc[1], 'render', tail]);
+      return null;
+    }
+
+    case 'ignite':
+    case 'spark': {
+      // Phase-0 review of an existing PRD/RFC: <slug>-<cmd>.
+      if (prdRfc) return joinTitle([prdRfc[1], cmd]);
+      return null;
+    }
+
+    case 'strike': {
+      // Phase-0 review of an existing strike file: <slug>-strike.
+      if (strike) return joinTitle([strike[1], 'strike']);
+      return null;
+    }
+
+    default:
+      return null;
+  }
 }
 
 // --- main: read stdin JSON, emit sessionTitle if applicable ---
@@ -141,7 +135,12 @@ async function main() {
 }
 
 // Run main only when executed directly (not when imported by tests).
-const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+let isMain = false;
+try {
+  isMain = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+} catch {
+  isMain = false;
+}
 if (isMain) {
   await main();
 }

--- a/.claude/hooks/smithy-session-title.mjs
+++ b/.claude/hooks/smithy-session-title.mjs
@@ -20,7 +20,9 @@ const SPEC_FOLDER_RE   = /specs?\/\d{4}-\d{2}-\d{2}-\d{3}-([a-z0-9][a-z0-9-]*)/i
 const PRD_RFC_FOLDER_RE = /docs\/(?:prds|rfcs)\/\d{4}-\d{3}-([a-z0-9][a-z0-9-]*)/i;
 const TASKS_FILE_RE    = /(?:^|[\s/])(\d{1,3})-([a-z0-9][a-z0-9-]*)\.tasks\.md\b/i;
 const FEATURES_FILE_RE = /(?:^|[\s/])\d{1,3}-([a-z0-9][a-z0-9-]*)\.features\.md\b/i;
-const STRIKE_FILE_RE   = /(?:^|[\s/])([a-z0-9][a-z0-9-]*)\.strike\.md\b/i;
+// Strike files live at specs/strikes/YYYY-MM-DD-<slug>.strike.md (per smithy.strike).
+// The date prefix is optional — bare `<slug>.strike.md` is also accepted.
+const STRIKE_FILE_RE   = /(?:^|[\s/])(?:\d{4}-\d{2}-\d{2}-)?([a-z][a-z0-9-]*)\.strike\.md\b/i;
 const TRAILING_INT_RE  = /(?:^|\s)(\d{1,3})\s*$/;
 
 function trailingInt(rest) {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -245,7 +245,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/smithy-session-title.mjs\""
+            "command": "[ -f \"$CLAUDE_PROJECT_DIR/.claude/hooks/smithy-session-title.mjs\" ] && node \"$CLAUDE_PROJECT_DIR/.claude/hooks/smithy-session-title.mjs\" || true"
           }
         ]
       }

--- a/src/agents/claude.test.ts
+++ b/src/agents/claude.test.ts
@@ -10,6 +10,7 @@ import {
   removeLegacy,
   removeSessionTitleHook,
   resolveSettingsPath,
+  SESSION_TITLE_HOOK_COMMAND,
   SESSION_TITLE_HOOK_FILENAME,
   writePermissions,
   writeSessionTitleHook,
@@ -826,6 +827,46 @@ describe('writeSessionTitleHook', () => {
 
     const config = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf8'));
     expect(config.hooks.UserPromptSubmit[0].hooks[0].command).toContain(SESSION_TITLE_HOOK_FILENAME);
+  });
+
+  it('heals a stale registration in place when the command string is out of date', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    const settingsPath = path.join(claudeDir, 'settings.json');
+    const staleCommand = `node "$CLAUDE_PROJECT_DIR/.claude/hooks/${SESSION_TITLE_HOOK_FILENAME}"`;
+    fs.writeFileSync(settingsPath, JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: staleCommand }] },
+        ],
+      },
+    }));
+
+    writeSessionTitleHook(tmpDir, 'repo');
+
+    const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    const matching = config.hooks.UserPromptSubmit.flatMap(
+      (entry: { hooks?: { command?: string }[] }) =>
+        entry.hooks?.filter(h => h.command?.includes(SESSION_TITLE_HOOK_FILENAME)) ?? [],
+    );
+    expect(matching.length).toBe(1);
+    expect(matching[0].command).toBe(SESSION_TITLE_HOOK_COMMAND);
+    expect(matching[0].command).not.toBe(staleCommand);
+  });
+
+  it('writes the current wrapped command on a fresh install', () => {
+    writeSessionTitleHook(tmpDir, 'repo');
+    writeSessionTitleHook(tmpDir, 'repo');
+
+    const config = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf8'),
+    );
+    const matching = config.hooks.UserPromptSubmit.flatMap(
+      (entry: { hooks?: { command?: string }[] }) =>
+        entry.hooks?.filter(h => h.command?.includes(SESSION_TITLE_HOOK_FILENAME)) ?? [],
+    );
+    expect(matching.length).toBe(1);
+    expect(matching[0].command).toBe(SESSION_TITLE_HOOK_COMMAND);
   });
 });
 

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -11,9 +11,17 @@ import type { PermissionLevel, DeployablePermissionLevel, DeployLocation } from 
 export const SESSION_TITLE_HOOK_FILENAME = 'smithy-session-title.mjs';
 /** Relative deploy path under the Claude base directory. */
 export const SESSION_TITLE_HOOK_RELPATH = `.claude/hooks/${SESSION_TITLE_HOOK_FILENAME}`;
-/** The shell command registered in settings.json to invoke the hook. */
+/**
+ * The shell command registered in settings.json to invoke the hook.
+ *
+ * Wrapped in `[ -f ... ] && node ... || true` so the hook is a no-op when
+ * `$CLAUDE_PROJECT_DIR` is unset/empty or the script is missing — without the
+ * guard, `node "/.claude/hooks/..."` fails with `ERR_MODULE_NOT_FOUND` from
+ * the cjs loader (issue #264). The trailing `|| true` keeps the hook from
+ * exiting non-zero when `[ -f ]` is false.
+ */
 export const SESSION_TITLE_HOOK_COMMAND =
-  `node "$CLAUDE_PROJECT_DIR/.claude/hooks/${SESSION_TITLE_HOOK_FILENAME}"`;
+  `[ -f "$CLAUDE_PROJECT_DIR/.claude/hooks/${SESSION_TITLE_HOOK_FILENAME}" ] && node "$CLAUDE_PROJECT_DIR/.claude/hooks/${SESSION_TITLE_HOOK_FILENAME}" || true`;
 
 /**
  * Deploy Claude templates. Returns the list of deployed file paths (relative to baseDir).
@@ -236,7 +244,12 @@ function isSessionTitleHookCommand(cmd: HookCommand | undefined): boolean {
 
 /**
  * Merge the smithy session-title UserPromptSubmit hook into settings.json.
- * Idempotent: a second call leaves the file unchanged.
+ *
+ * Idempotent on a clean settings.json AND heals stale registrations: any entry
+ * whose command references our hook filename but differs from the current
+ * `SESSION_TITLE_HOOK_COMMAND` is rewritten in place. This is what migrates an
+ * existing user from the old unguarded `node "$CLAUDE_PROJECT_DIR/..."` form to
+ * the wrapped form on `smithy update` (issue #264 fix).
  */
 export function writeSessionTitleHook(targetDir: string, level: DeployablePermissionLevel): void {
   const settingsPath = resolveSettingsPath(targetDir, level);
@@ -247,12 +260,21 @@ export function writeSessionTitleHook(targetDir: string, level: DeployablePermis
   const hooks = (settings.hooks ?? {}) as Record<string, HookEntry[]>;
   const ups = Array.isArray(hooks.UserPromptSubmit) ? hooks.UserPromptSubmit : [];
 
-  // Idempotent: bail if our hook command is already registered anywhere in UserPromptSubmit
-  const alreadyRegistered = ups.some(entry =>
-    Array.isArray(entry.hooks) && entry.hooks.some(isSessionTitleHookCommand),
-  );
+  let foundMatching = false;
+  let healed = false;
+  for (const entry of ups) {
+    if (!Array.isArray(entry.hooks)) continue;
+    for (const cmd of entry.hooks) {
+      if (!isSessionTitleHookCommand(cmd)) continue;
+      foundMatching = true;
+      if (cmd.command !== SESSION_TITLE_HOOK_COMMAND) {
+        cmd.command = SESSION_TITLE_HOOK_COMMAND;
+        healed = true;
+      }
+    }
+  }
 
-  if (!alreadyRegistered) {
+  if (!foundMatching) {
     ups.push({
       hooks: [{ type: 'command', command: SESSION_TITLE_HOOK_COMMAND }],
     });
@@ -264,8 +286,10 @@ export function writeSessionTitleHook(targetDir: string, level: DeployablePermis
   };
 
   fs.writeFileSync(settingsPath, JSON.stringify(next, null, 2));
-  if (!alreadyRegistered) {
+  if (!foundMatching) {
     console.log(picocolors.blue(`  Added session-title hook to ${settingsPath}`));
+  } else if (healed) {
+    console.log(picocolors.blue(`  Updated session-title hook command in ${settingsPath}`));
   }
 }
 

--- a/src/session-title-hook.test.ts
+++ b/src/session-title-hook.test.ts
@@ -54,6 +54,12 @@ describe('deriveTitle', () => {
       expect(deriveTitle('/smithy.forge feature.strike.md')).toBe('feature-forge');
     });
 
+    it('strips the YYYY-MM-DD prefix from a strike-file slug', () => {
+      expect(
+        deriveTitle('/smithy.forge specs/strikes/2026-03-14-verbose-flag.strike.md'),
+      ).toBe('verbose-flag-forge');
+    });
+
     it('returns null with no arguments', () => {
       expect(deriveTitle('/smithy.forge')).toBeNull();
     });
@@ -66,6 +72,12 @@ describe('deriveTitle', () => {
   describe('strike', () => {
     it('emits <strike-slug>-strike from a .strike.md file (Phase-0 review)', () => {
       expect(deriveTitle('/smithy.strike feature.strike.md')).toBe('feature-strike');
+    });
+
+    it('strips the YYYY-MM-DD prefix from the canonical strikes/ path', () => {
+      expect(
+        deriveTitle('/smithy.strike specs/strikes/2026-03-14-verbose-flag.strike.md'),
+      ).toBe('verbose-flag-strike');
     });
 
     it('returns null for a description argument', () => {

--- a/src/session-title-hook.test.ts
+++ b/src/session-title-hook.test.ts
@@ -3,79 +3,193 @@ import { describe, it, expect } from 'vitest';
 import { deriveTitle } from './templates/hooks/smithy-session-title.mjs';
 
 describe('deriveTitle', () => {
-  it('derives "Evals cut 03" from a smithy.cut spec-folder + story number', () => {
-    expect(deriveTitle('/smithy.cut specs/2026-03-14-001-evals 3')).toBe('Evals cut 03');
+  describe('cut', () => {
+    it('emits <spec-slug>-cut-<storyN> from a spec folder + trailing story number', () => {
+      expect(deriveTitle('/smithy.cut specs/2026-03-14-001-evals 3')).toBe('evals-cut-3');
+    });
+
+    it('does not zero-pad single-digit story numbers', () => {
+      expect(deriveTitle('/smithy.cut specs/2026-03-14-001-evals 1')).toBe('evals-cut-1');
+    });
+
+    it('emits <spec-slug>-cut without a number when none is given', () => {
+      expect(deriveTitle('/smithy.cut specs/2026-03-14-001-evals')).toBe('evals-cut');
+    });
+
+    it('keeps multi-word spec slugs whole', () => {
+      expect(
+        deriveTitle('/smithy.cut specs/2026-03-14-001-evals-framework 7'),
+      ).toBe('evals-framework-cut-7');
+    });
+
+    it('returns null when given a bare description (no spec path)', () => {
+      expect(deriveTitle('/smithy.cut foo 7')).toBeNull();
+    });
+
+    it('returns null with no arguments', () => {
+      expect(deriveTitle('/smithy.cut')).toBeNull();
+    });
   });
 
-  it('derives "Runner forge 03 02" from a smithy.forge tasks-file path + slice number', () => {
-    expect(
-      deriveTitle('/smithy.forge specs/2026-03-14-001-evals/03-runner.tasks.md 2'),
-    ).toBe('Runner forge 03 02');
+  describe('forge', () => {
+    it('emits <spec-slug>-forge-<storyN>-<sliceN> from a tasks file + trailing slice number', () => {
+      expect(
+        deriveTitle('/smithy.forge specs/2026-03-14-001-evals/03-runner.tasks.md 2'),
+      ).toBe('evals-forge-3-2');
+    });
+
+    it('uses the spec-folder slug, not the tasks-file slug', () => {
+      expect(
+        deriveTitle('/smithy.forge specs/2026-03-14-001-evals-framework/12-runner.tasks.md 4'),
+      ).toBe('evals-framework-forge-12-4');
+    });
+
+    it('emits <spec-slug>-forge-<storyN> without a slice number', () => {
+      expect(
+        deriveTitle('/smithy.forge specs/2026-03-14-001-evals/03-runner.tasks.md'),
+      ).toBe('evals-forge-3');
+    });
+
+    it('emits <strike-slug>-forge from a .strike.md file', () => {
+      expect(deriveTitle('/smithy.forge feature.strike.md')).toBe('feature-forge');
+    });
+
+    it('returns null with no arguments', () => {
+      expect(deriveTitle('/smithy.forge')).toBeNull();
+    });
+
+    it('returns null for a bare slice number with no path', () => {
+      expect(deriveTitle('/smithy.forge 2')).toBeNull();
+    });
   });
 
-  it('derives "Add strike" from a smithy.strike with a quoted feature description', () => {
-    expect(deriveTitle('/smithy.strike "add verbose flag"')).toBe('Add strike');
+  describe('strike', () => {
+    it('emits <strike-slug>-strike from a .strike.md file (Phase-0 review)', () => {
+      expect(deriveTitle('/smithy.strike feature.strike.md')).toBe('feature-strike');
+    });
+
+    it('returns null for a description argument', () => {
+      expect(deriveTitle('/smithy.strike "add verbose flag"')).toBeNull();
+    });
+
+    it('returns null with no arguments', () => {
+      expect(deriveTitle('/smithy.strike')).toBeNull();
+    });
   });
 
-  it('falls back to "Smithy <cmd>" when there are no arguments', () => {
-    expect(deriveTitle('/smithy.orders')).toBe('Smithy orders');
+  describe('ignite', () => {
+    it('emits <prd-slug>-ignite from a docs/prds/ path', () => {
+      expect(deriveTitle('/smithy.ignite docs/prds/2026-001-foo.prd.md')).toBe('foo-ignite');
+    });
+
+    it('emits <rfc-slug>-ignite from a docs/rfcs/ path', () => {
+      expect(
+        deriveTitle('/smithy.ignite docs/rfcs/2026-001-foo/foo.rfc.md'),
+      ).toBe('foo-ignite');
+    });
+
+    it('keeps multi-word RFC slugs whole', () => {
+      expect(
+        deriveTitle('/smithy.ignite docs/rfcs/2026-001-webhook-support/webhook-support.rfc.md'),
+      ).toBe('webhook-support-ignite');
+    });
+
+    it('returns null for a description argument', () => {
+      expect(deriveTitle('/smithy.ignite "build a plugin system"')).toBeNull();
+    });
   });
 
-  it('returns null for non-smithy prompts', () => {
-    expect(deriveTitle('not a smithy command')).toBeNull();
-    expect(deriveTitle('/some-other-command run')).toBeNull();
-    expect(deriveTitle('')).toBeNull();
+  describe('spark', () => {
+    it('emits <prd-slug>-spark when re-running on an existing PRD', () => {
+      expect(deriveTitle('/smithy.spark docs/prds/2026-001-foo.prd.md')).toBe('foo-spark');
+    });
+
+    it('returns null for a description argument', () => {
+      expect(deriveTitle('/smithy.spark "an idea worth a paragraph"')).toBeNull();
+    });
   });
 
-  it('returns null for non-string input', () => {
-    expect(deriveTitle(undefined)).toBeNull();
-    expect(deriveTitle(null)).toBeNull();
-    expect(deriveTitle(42)).toBeNull();
+  describe('mark', () => {
+    it('emits <feature-map-slug>-mark-<N> for a features.md path + feature number', () => {
+      expect(
+        deriveTitle('/smithy.mark docs/rfcs/2026-001-foo/01-core.features.md 3'),
+      ).toBe('core-mark-3');
+    });
+
+    it('emits <feature-map-slug>-mark with no trailing number', () => {
+      expect(
+        deriveTitle('/smithy.mark docs/rfcs/2026-001-foo/01-core.features.md'),
+      ).toBe('core-mark');
+    });
+
+    it('emits <rfc-slug>-mark from a bare RFC path', () => {
+      expect(
+        deriveTitle('/smithy.mark docs/rfcs/2026-001-foo/foo.rfc.md'),
+      ).toBe('foo-mark');
+    });
+
+    it('returns null for a description argument', () => {
+      expect(deriveTitle('/smithy.mark "add webhook support"')).toBeNull();
+    });
   });
 
-  it('handles a strike file path', () => {
-    expect(deriveTitle('/smithy.forge feature.strike.md')).toBe('Feature forge');
+  describe('render', () => {
+    it('emits <rfc-slug>-render-<N> for an RFC + milestone number', () => {
+      expect(
+        deriveTitle('/smithy.render docs/rfcs/2026-002-bar/bar.rfc.md 2'),
+      ).toBe('bar-render-2');
+    });
+
+    it('emits <rfc-slug>-render without a milestone number', () => {
+      expect(
+        deriveTitle('/smithy.render docs/rfcs/2026-002-bar/bar.rfc.md'),
+      ).toBe('bar-render');
+    });
+
+    it('emits <feature-map-slug>-render from a features.md path (Phase-0 review)', () => {
+      expect(
+        deriveTitle('/smithy.render docs/rfcs/2026-001-foo/01-core.features.md'),
+      ).toBe('core-render');
+    });
+
+    it('returns null with no arguments', () => {
+      expect(deriveTitle('/smithy.render')).toBeNull();
+    });
   });
 
-  it('handles a bare slug + cut story number', () => {
-    expect(deriveTitle('/smithy.cut foo 7')).toBe('Foo cut 07');
+  describe('non-rename commands', () => {
+    it('returns null for /smithy.fix', () => {
+      expect(deriveTitle('/smithy.fix some bug')).toBeNull();
+    });
+
+    it('returns null for /smithy.audit', () => {
+      expect(deriveTitle('/smithy.audit')).toBeNull();
+    });
+
+    it('returns null for /smithy.orders', () => {
+      expect(deriveTitle('/smithy.orders')).toBeNull();
+    });
+
+    it('returns null for an unknown smithy command', () => {
+      expect(deriveTitle('/smithy.banjo whatever')).toBeNull();
+    });
   });
 
-  it('handles a bare slice number for forge with no path', () => {
-    // No slug recoverable, falls back to Smithy; sliceNum is the trailing 2.
-    expect(deriveTitle('/smithy.forge 2')).toBe('Smithy forge 02');
-  });
+  describe('non-smithy and bad input', () => {
+    it('returns null for non-smithy prompts', () => {
+      expect(deriveTitle('not a smithy command')).toBeNull();
+      expect(deriveTitle('/some-other-command run')).toBeNull();
+      expect(deriveTitle('')).toBeNull();
+    });
 
-  it('uses branch fallback when no slug is in the prompt', () => {
-    expect(deriveTitle('/smithy.audit', { branch: 'feature/evals-runner' })).toBe(
-      'Runner audit',
-    );
-  });
+    it('returns null for non-string input', () => {
+      expect(deriveTitle(undefined)).toBeNull();
+      expect(deriveTitle(null)).toBeNull();
+      expect(deriveTitle(42)).toBeNull();
+    });
 
-  it('zero-pads single-digit story numbers', () => {
-    expect(deriveTitle('/smithy.cut specs/2026-03-14-001-evals 1')).toBe('Evals cut 01');
-  });
-
-  it('handles two-digit story and slice numbers', () => {
-    expect(
-      deriveTitle('/smithy.forge specs/2026-03-14-001-evals/12-runner.tasks.md 11'),
-    ).toBe('Runner forge 12 11');
-  });
-
-  it('is case-insensitive on the smithy prefix', () => {
-    expect(deriveTitle('/SMITHY.cut specs/2026-03-14-001-evals 3')).toBe('Evals cut 03');
-  });
-
-  it('only takes the first dash-segment of the slug for the display', () => {
-    expect(
-      deriveTitle('/smithy.cut specs/2026-03-14-001-evals-framework 3'),
-    ).toBe('Evals cut 03');
-  });
-
-  it('does not extract a sliceNum for non-forge commands', () => {
-    // smithy.strike with a trailing number — the number should NOT become a
-    // story or slice ID (only cut consumes trailing ints, only forge keeps
-    // them as slice IDs). The slug fallback treats "build" as the first word.
-    expect(deriveTitle('/smithy.strike build 5')).toBe('Build strike');
+    it('is case-insensitive on the smithy prefix', () => {
+      expect(deriveTitle('/SMITHY.cut specs/2026-03-14-001-evals 3')).toBe('evals-cut-3');
+    });
   });
 });

--- a/src/templates/hooks/smithy-session-title.mjs
+++ b/src/templates/hooks/smithy-session-title.mjs
@@ -2,120 +2,114 @@
 // Smithy session-title hook for Claude Code.
 //
 // Wired into .claude/settings.json as a UserPromptSubmit hook by `smithy init`.
-// On every user prompt that starts with `/smithy.<cmd>`, derive a short session
-// title (slug + command + IDs) and emit it as `sessionTitle`. For non-smithy
-// prompts, exits silently. Any error path also exits silently so this hook
-// never blocks a user prompt.
+// On every user prompt that starts with `/smithy.<cmd>` for an artifact-producing
+// command AND carries a recognizable artifact path, derive a kebab-case session
+// title (`<parent-slug>-<cmd>[-<n>[-<m>]]`) and emit it as `sessionTitle`. For
+// non-rename commands, description-only invocations, or non-smithy prompts, exit
+// silently so Claude Code's own auto-naming stays in charge. Any error path also
+// exits silently — this hook never blocks a user prompt.
 
 import { pathToFileURL } from 'node:url';
 
 const SMITHY_PREFIX = /^\/smithy\.([a-z][a-z0-9-]*)\b/i;
+const RENAME_COMMANDS = new Set(['spark', 'ignite', 'mark', 'cut', 'forge', 'strike', 'render']);
 
-function capitalize(s) {
-  if (!s) return '';
-  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+// Path-shape regexes. Each captures the human-readable slug AFTER any
+// date/uniqueness prefix, and keeps multi-word kebab slugs whole.
+const SPEC_FOLDER_RE   = /specs?\/\d{4}-\d{2}-\d{2}-\d{3}-([a-z0-9][a-z0-9-]*)/i;
+const PRD_RFC_FOLDER_RE = /docs\/(?:prds|rfcs)\/\d{4}-\d{3}-([a-z0-9][a-z0-9-]*)/i;
+const TASKS_FILE_RE    = /(?:^|[\s/])(\d{1,3})-([a-z0-9][a-z0-9-]*)\.tasks\.md\b/i;
+const FEATURES_FILE_RE = /(?:^|[\s/])\d{1,3}-([a-z0-9][a-z0-9-]*)\.features\.md\b/i;
+const STRIKE_FILE_RE   = /(?:^|[\s/])([a-z0-9][a-z0-9-]*)\.strike\.md\b/i;
+const TRAILING_INT_RE  = /(?:^|\s)(\d{1,3})\s*$/;
+
+function trailingInt(rest) {
+  const m = rest.match(TRAILING_INT_RE);
+  return m ? String(parseInt(m[1], 10)) : null;
 }
 
-function pad2(n) {
-  const s = String(n);
-  return s.length === 1 ? '0' + s : s;
-}
-
-// Try to extract slug + numeric IDs from the argument string of a smithy command.
-function parseArgs(cmd, rest) {
-  let slug;
-  let storyNum;
-  let sliceNum;
-
-  // Tasks file pattern: <NN>-<slug>.tasks.md (anywhere in path)
-  const tasksMatch = rest.match(/(?:^|[\s/])(\d{1,3})-([a-z0-9][a-z0-9-]*)\.tasks\.md\b/i);
-  if (tasksMatch) {
-    storyNum = pad2(parseInt(tasksMatch[1], 10));
-    slug = tasksMatch[2];
-  }
-
-  // Strike file pattern: <slug>.strike.md
-  if (!slug) {
-    const strikeMatch = rest.match(/(?:^|[\s/])([a-z0-9][a-z0-9-]*)\.strike\.md\b/i);
-    if (strikeMatch) {
-      slug = strikeMatch[1];
-    }
-  }
-
-  // Spec folder pattern: specs/<YYYY>-<MM>-<DD>-<NNN>-<slug>
-  if (!slug) {
-    const specMatch = rest.match(/specs?\/\d{4}-\d{2}-\d{2}-\d{3}-([a-z0-9][a-z0-9-]*)/i);
-    if (specMatch) {
-      slug = specMatch[1];
-    }
-  }
-
-  // Quoted-string fallback: first quoted run, take its first word
-  if (!slug) {
-    const quoted = rest.match(/["']([^"']+)["']/);
-    if (quoted) {
-      const firstQuotedWord = quoted[1].trim().split(/\s+/)[0];
-      if (firstQuotedWord) slug = firstQuotedWord;
-    }
-  }
-
-  // First non-flag, non-numeric token fallback
-  if (!slug) {
-    const firstWord = rest.trim().split(/\s+/)[0];
-    if (firstWord && !firstWord.startsWith('-') && /[a-z]/i.test(firstWord)) {
-      const last = firstWord.split('/').filter(Boolean).pop() || firstWord;
-      slug = last.replace(/\.[^.]+$/, '').replace(/^\d+-/, '');
-    }
-  }
-
-  // Trailing bare integer: slice number for forge, story number for cut
-  const trailingInt = rest.match(/(?:^|\s)(\d{1,3})\s*$/);
-  if (trailingInt) {
-    const n = pad2(parseInt(trailingInt[1], 10));
-    if (cmd === 'forge') {
-      sliceNum = n;
-    } else if (cmd === 'cut' && !storyNum) {
-      storyNum = n;
-    }
-  }
-
-  return { slug, storyNum, sliceNum };
+function joinTitle(parts) {
+  return parts.filter(p => p !== null && p !== undefined && p !== '').join('-');
 }
 
 /**
  * Derive a Claude Code session title from a user prompt.
- * Returns null if the prompt is not a `/smithy.<cmd>` invocation.
+ * Returns null when the prompt should not trigger a rename.
  *
  * @param {string} prompt
- * @param {{ branch?: string }} [options]
  * @returns {string | null}
  */
-export function deriveTitle(prompt, options = {}) {
+export function deriveTitle(prompt) {
   if (typeof prompt !== 'string') return null;
   const trimmed = prompt.trim();
   const match = trimmed.match(SMITHY_PREFIX);
   if (!match) return null;
 
   const cmd = match[1].toLowerCase();
+  if (!RENAME_COMMANDS.has(cmd)) return null;
+
   const rest = trimmed.slice(match[0].length).trim();
+  if (!rest) return null;
 
-  const { slug, storyNum, sliceNum } = parseArgs(cmd, rest);
+  const tasks    = rest.match(TASKS_FILE_RE);
+  const features = rest.match(FEATURES_FILE_RE);
+  const strike   = rest.match(STRIKE_FILE_RE);
+  const spec     = rest.match(SPEC_FOLDER_RE);
+  const prdRfc   = rest.match(PRD_RFC_FOLDER_RE);
+  const tail     = trailingInt(rest);
 
-  // Build the display slug: take the first dash/space-separated segment, capitalize.
-  let display = '';
-  if (slug) {
-    display = capitalize(slug.split(/[-\s]/)[0]);
-  }
-  if (!display && options.branch) {
-    const branchTail = options.branch.split(/[/_-]/).pop() || '';
-    display = capitalize(branchTail);
-  }
-  if (!display) {
-    display = 'Smithy';
-  }
+  // Per-command format-by-shape table.
+  switch (cmd) {
+    case 'forge': {
+      // Tasks file: <spec-slug>-forge-<storyN>[-<sliceN>]
+      if (tasks && spec) {
+        const storyN = String(parseInt(tasks[1], 10));
+        return joinTitle([spec[1], 'forge', storyN, tail]);
+      }
+      // Strike file: <strike-slug>-forge
+      if (strike) return joinTitle([strike[1], 'forge']);
+      return null;
+    }
 
-  const numbers = [storyNum, sliceNum].filter(Boolean).join(' ');
-  return [display, cmd, numbers].filter(Boolean).join(' ');
+    case 'cut': {
+      // Spec folder + optional trailing story number.
+      if (spec) return joinTitle([spec[1], 'cut', tail]);
+      return null;
+    }
+
+    case 'mark': {
+      // Features file + optional trailing feature number takes precedence.
+      if (features) return joinTitle([features[1], 'mark', tail]);
+      // Plain RFC path → <rfc-slug>-mark.
+      if (prdRfc) return joinTitle([prdRfc[1], 'mark']);
+      return null;
+    }
+
+    case 'render': {
+      // A features.md path lives inside an RFC folder and matches both regexes;
+      // prefer the features-file slug so Phase-0 review titles use the feature
+      // map (`core-render`) rather than the parent RFC (`foo-render`).
+      if (features) return joinTitle([features[1], 'render', tail]);
+      if (prdRfc) return joinTitle([prdRfc[1], 'render', tail]);
+      return null;
+    }
+
+    case 'ignite':
+    case 'spark': {
+      // Phase-0 review of an existing PRD/RFC: <slug>-<cmd>.
+      if (prdRfc) return joinTitle([prdRfc[1], cmd]);
+      return null;
+    }
+
+    case 'strike': {
+      // Phase-0 review of an existing strike file: <slug>-strike.
+      if (strike) return joinTitle([strike[1], 'strike']);
+      return null;
+    }
+
+    default:
+      return null;
+  }
 }
 
 // --- main: read stdin JSON, emit sessionTitle if applicable ---
@@ -141,7 +135,12 @@ async function main() {
 }
 
 // Run main only when executed directly (not when imported by tests).
-const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+let isMain = false;
+try {
+  isMain = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+} catch {
+  isMain = false;
+}
 if (isMain) {
   await main();
 }

--- a/src/templates/hooks/smithy-session-title.mjs
+++ b/src/templates/hooks/smithy-session-title.mjs
@@ -20,7 +20,9 @@ const SPEC_FOLDER_RE   = /specs?\/\d{4}-\d{2}-\d{2}-\d{3}-([a-z0-9][a-z0-9-]*)/i
 const PRD_RFC_FOLDER_RE = /docs\/(?:prds|rfcs)\/\d{4}-\d{3}-([a-z0-9][a-z0-9-]*)/i;
 const TASKS_FILE_RE    = /(?:^|[\s/])(\d{1,3})-([a-z0-9][a-z0-9-]*)\.tasks\.md\b/i;
 const FEATURES_FILE_RE = /(?:^|[\s/])\d{1,3}-([a-z0-9][a-z0-9-]*)\.features\.md\b/i;
-const STRIKE_FILE_RE   = /(?:^|[\s/])([a-z0-9][a-z0-9-]*)\.strike\.md\b/i;
+// Strike files live at specs/strikes/YYYY-MM-DD-<slug>.strike.md (per smithy.strike).
+// The date prefix is optional — bare `<slug>.strike.md` is also accepted.
+const STRIKE_FILE_RE   = /(?:^|[\s/])(?:\d{4}-\d{2}-\d{2}-)?([a-z][a-z0-9-]*)\.strike\.md\b/i;
 const TRAILING_INT_RE  = /(?:^|\s)(\d{1,3})\s*$/;
 
 function trailingInt(rest) {


### PR DESCRIPTION
## Summary
- Primary outcome: the session-title hook no longer crashes on non-smithy prompts (#264), no longer clobbers the title for diagnostic commands like `/smithy.fix` (#276), and produces clean kebab-case titles derived from artifact slugs.
- Notable behaviour changes: the hook now only fires for `spark`, `ignite`, `mark`, `cut`, `forge`, `strike`, `render`, and only when the prompt carries a recognizable artifact path. Description-only invocations (e.g. `/smithy.spark "..."`) fall through to Claude Code's own auto-naming.
- Follow-up work deferred: Anthropic doesn't expose an AI-driven session-title mechanism today; if that lands, we could replace the description-input fallback with an AI-generated slug.

## Context
- Issue #264: users hit `Failed with non-blocking status code: node:internal/modules/cjs/loader:1423` on every non-smithy prompt. Root cause is `$CLAUDE_PROJECT_DIR` being empty in some contexts, so node tries to load `/.claude/hooks/smithy-session-title.mjs` and the cjs loader throws `ERR_MODULE_NOT_FOUND` before the script's own try/catch ever runs.
- Issue #276: the rename fired for every `/smithy.<cmd>`, including `fix`/`audit`/`orders` where renaming just clobbers a useful in-flight title.
- Title format ask: the user wanted a uniform `<parent-slug>-<cmd>[-<n>[-<m>]]` shape (kebab-case, no leading zeros) that encodes the parent artifact, replacing today's `"<Display> <cmd> <numbers>"` (e.g. `"Evals cut 03"` → `evals-cut-3`).

## Implementation Notes
- **Hook script** (`src/templates/hooks/smithy-session-title.mjs`): `deriveTitle` rewritten as a command-allowlist + format-by-input-shape table. Slug-extraction regexes strip the date/uniqueness prefix and keep multi-word slugs whole (e.g. `webhook-support-ignite`, not `webhook-ignite`). Returns `null` whenever no path-derived slug is available — never emits a junk title.
- **Defensive shell wrapper** (`src/agents/claude.ts`): registered command is now `[ -f "$CLAUDE_PROJECT_DIR/.claude/hooks/smithy-session-title.mjs" ] && node "$CLAUDE_PROJECT_DIR/.claude/hooks/smithy-session-title.mjs" || true`. The trailing `|| true` keeps the hook silent when the env var is unset or the file is missing.
- **Stale-registration heal** (`writeSessionTitleHook`): walks `UserPromptSubmit` and rewrites any entry referencing the smithy hook filename whose command differs from the current `SESSION_TITLE_HOOK_COMMAND`. Existing users get the wrapper on their next `smithy update` without manual intervention.
- Title format table (full coverage in `src/session-title-hook.test.ts`):

  | Input | Title |
  |---|---|
  | `/smithy.cut specs/2026-03-14-001-evals 3` | `evals-cut-3` |
  | `/smithy.forge specs/2026-03-14-001-evals/03-runner.tasks.md 2` | `evals-forge-3-2` |
  | `/smithy.forge feature.strike.md` | `feature-forge` |
  | `/smithy.ignite docs/prds/2026-001-foo.prd.md` | `foo-ignite` |
  | `/smithy.mark docs/rfcs/2026-001-foo/01-core.features.md 3` | `core-mark-3` |
  | `/smithy.render docs/rfcs/2026-002-bar/bar.rfc.md 2` | `bar-render-2` |
  | `/smithy.fix ...`, `/smithy.audit`, `/smithy.orders`, description input | `null` (no rename) |

## Risks & Mitigations
- Risk: the wrapped command relies on `sh -c` semantics for `[ -f ]` and `||`. | Mitigation: Claude Code already runs hook commands through a shell (the existing `"$CLAUDE_PROJECT_DIR"` expansion proves it), so the wrapper composes the same way.
- Risk: existing users with the old unwrapped command stay broken if `writeSessionTitleHook` doesn't heal them. | Mitigation: the heal logic now reconciles in place and `smithy update` calls into it via `initAction`. New `claude.test.ts` cases pin the heal-stale-command and fresh-install behavior.
- Risk: regex slug extraction breaks on multi-word folder slugs. | Mitigation: explicit test for `evals-framework` (multi-word) and `webhook-support` (RFC); the regex captures the full kebab segment with no truncation.

## Rollback Plan
- Revert this commit. No data migrations involved — `settings.json` is rewritten back to the old unwrapped form on the next `smithy update` because of the same heal logic.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npm run typecheck`)
- [x] Full test suite green (`npm test` — 704 / 704)

### Template Generation
- [x] Claude Prompts: `.claude/hooks/smithy-session-title.mjs` matches the source after `node dist/cli.js update -y`
- [ ] Gemini Skills: not affected
- [ ] Codex Prompts: not affected
- [ ] GitHub Issue Templates: not affected

### Permissions & Configuration
- [x] Claude Config: `.claude/settings.json` correctly rewritten (heal log line `Updated session-title hook command in ...`)
- [ ] Gemini Config: not affected
- [ ] Codex Config: not affected

### Manual Test Cases
- [x] Reproduced #264: `unset CLAUDE_PROJECT_DIR; eval '<wrapped command>'` exits 0 silently. Same with `CLAUDE_PROJECT_DIR=/tmp/no-such`.
- [x] End-to-end: `printf '{"prompt":"/smithy.cut specs/2026-03-14-001-evals 3"}' | node .claude/hooks/smithy-session-title.mjs` emits `evals-cut-3`. `/smithy.fix some bug` and a non-smithy prompt produce no output.

## Issue
- Closes #264
- Closes #276
