### PR TITLE
Wrap orders gh calls in a smithy.gh-issue skill

### DIFF
--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -297,13 +297,14 @@ describe('getTemplateFilesByCategory', () => {
     expect(byCategory.commands).toHaveLength(10);
     expect(byCategory.prompts).toHaveLength(2);
     expect(byCategory.agents).toHaveLength(13);
-    expect(byCategory.skills).toHaveLength(2);
+    expect(byCategory.skills).toHaveLength(3);
   });
 
-  it('skills includes smithy.pr-review and smithy.status', () => {
+  it('skills includes smithy.pr-review, smithy.status, and smithy.gh-issue', () => {
     const { skills } = getTemplateFilesByCategory();
     expect(skills).toContain('smithy.pr-review');
     expect(skills).toContain('smithy.status');
+    expect(skills).toContain('smithy.gh-issue');
   });
 
   it('commands includes expected template files', () => {
@@ -404,6 +405,74 @@ describe('getComposedTemplates', () => {
     expect(script).toContain('repos/$REPO/pulls/$PR/comments/$COMMENT_ID/replies');
     expect(script).toContain('--method POST');
     expect(script).toContain('--input "$BODY_FILE"');
+  });
+
+  it('skills map includes smithy.gh-issue with the four expected scripts', () => {
+    const skill = composed.skills.get('smithy.gh-issue');
+    expect(skill).toBeDefined();
+    expect(skill!.prompt).toBeTruthy();
+    expect(skill!.scripts.size).toBe(4);
+    expect(skill!.scripts.has('check-env.sh')).toBe(true);
+    expect(skill!.scripts.has('search-issues.sh')).toBe(true);
+    expect(skill!.scripts.has('create-issue.sh')).toBe(true);
+    expect(skill!.scripts.has('link-blocked-by.sh')).toBe(true);
+  });
+
+  it('smithy.gh-issue prompt retains frontmatter with allowed-tools for all scripts', () => {
+    const skill = composed.skills.get('smithy.gh-issue')!;
+    expect(skill.prompt).toMatch(/^---\s*\n/);
+    expect(skill.prompt).toContain('name: smithy.gh-issue');
+    expect(skill.prompt).toContain('Bash(*/smithy.gh-issue/scripts/check-env.sh)');
+    expect(skill.prompt).toContain('Bash(*/smithy.gh-issue/scripts/search-issues.sh *)');
+    expect(skill.prompt).toContain('Bash(*/smithy.gh-issue/scripts/create-issue.sh *)');
+    expect(skill.prompt).toContain('Bash(*/smithy.gh-issue/scripts/link-blocked-by.sh *)');
+  });
+
+  it('smithy.gh-issue scripts start with bash shebang and set strict mode', () => {
+    const skill = composed.skills.get('smithy.gh-issue')!;
+    for (const [, content] of skill.scripts) {
+      expect(content).toMatch(/^#!\/usr\/bin\/env bash/);
+      expect(content).toContain('set -euo pipefail');
+    }
+  });
+
+  it('search-issues.sh accepts state, query, and optional limit', () => {
+    const skill = composed.skills.get('smithy.gh-issue')!;
+    const script = skill.scripts.get('search-issues.sh')!;
+    expect(script).toContain('gh issue list');
+    expect(script).toContain('--state "$STATE"');
+    expect(script).toContain('--search "$QUERY"');
+    expect(script).toContain('--limit "$LIMIT"');
+    expect(script).toContain('--json number,title,state,body');
+  });
+
+  it('create-issue.sh writes via --body-file and emits JSON with number', () => {
+    const skill = composed.skills.get('smithy.gh-issue')!;
+    const script = skill.scripts.get('create-issue.sh')!;
+    expect(script).toContain('gh issue create --title "$TITLE" --body-file "$BODY_FILE"');
+    expect(script).toContain('jq -n');
+    expect(script).toContain('number: $number');
+  });
+
+  it('link-blocked-by.sh uses addBlockedBy GraphQL mutation', () => {
+    const skill = composed.skills.get('smithy.gh-issue')!;
+    const script = skill.scripts.get('link-blocked-by.sh')!;
+    expect(script).toContain('addBlockedBy');
+    expect(script).toContain('blockingIssueId:$blocker');
+    expect(script).toContain('gh api graphql');
+  });
+
+  it('smithy.orders command delegates GitHub ops to smithy.gh-issue scripts', () => {
+    const orders = composed.commands.get('smithy.orders.md')!;
+    expect(orders).toBeDefined();
+    expect(orders).toContain('${CLAUDE_SKILL_DIR}/scripts/check-env.sh');
+    expect(orders).toContain('${CLAUDE_SKILL_DIR}/scripts/search-issues.sh');
+    expect(orders).toContain('${CLAUDE_SKILL_DIR}/scripts/create-issue.sh');
+    expect(orders).toContain('${CLAUDE_SKILL_DIR}/scripts/link-blocked-by.sh');
+    // The old inline gh invocations should be gone — orders no longer calls
+    // gh directly for issue creation, search, or linking.
+    expect(orders).not.toContain('gh issue create --title');
+    expect(orders).not.toContain('gh issue list --search');
   });
 
   it('categorizes templates correctly', () => {

--- a/src/templates/agent-skills/commands/smithy.orders.prompt
+++ b/src/templates/agent-skills/commands/smithy.orders.prompt
@@ -9,7 +9,10 @@ Your job is to take any smithy artifact file and create the appropriate GitHub
 tickets so that planning work is tracked without manual ticket creation.
 
 Before running any shell commands, read and follow the `smithy.guidance` prompt
-for shell best practices.
+for shell best practices. All GitHub operations in this command go through the
+`smithy.gh-issue` skill — use its scripts (`check-env.sh`, `search-issues.sh`,
+`create-issue.sh`, `link-blocked-by.sh`) instead of inline `gh` invocations so
+permissions stay narrow and predictable.
 
 ---
 
@@ -23,13 +26,14 @@ If no file path is provided, ask the user which artifact file to create tickets 
 
 ## Phase 1: Validate Environment
 
-Before doing anything else, verify prerequisites:
+Run the `smithy.gh-issue` skill's environment check before doing anything else:
 
-1. **`gh` CLI available**: Run `gh --version`. If missing, stop with:
-   > `gh` (GitHub CLI) is required but not installed. Install it from https://cli.github.com/
-2. **GitHub remote**: Run `gh repo view --json nameWithOwner -q .nameWithOwner`.
-   If this fails, stop with:
-   > This repository does not have a GitHub remote configured.
+```bash
+${CLAUDE_SKILL_DIR}/scripts/check-env.sh
+```
+
+If it fails, surface the message it printed and stop. On success, capture the
+returned `ownerRepo` for use in the summary.
 
 ---
 
@@ -99,13 +103,10 @@ Parse the tasks file to extract:
 
 ## Phase 4: Duplicate Detection
 
-Before creating any tickets, check for existing duplicates.
-
-For **each ticket** you plan to create, search for existing issues matching the
-title convention:
+For each ticket you plan to create, search for existing matches by title:
 
 ```bash
-gh issue list --search "<title keywords>" --state all --json number,title,state --limit 5
+${CLAUDE_SKILL_DIR}/scripts/search-issues.sh all "<title keywords>" 5
 ```
 
 If matches are found:
@@ -125,8 +126,9 @@ If no matches are found for any tickets, proceed without prompting.
 for canonical ticket title formats and check for repo-level overrides in the
 project's CLAUDE.md. Apply those conventions to all issue titles.
 
-Create GitHub issues using the ticket mappings below. Use `--body-file` with a
-temporary file for issue bodies to avoid shell escaping problems.
+For each ticket, write the body to a temp file with a heredoc, then call
+`create-issue.sh`. The script returns `{"number": N, "url": "..."}` — capture
+the number for parent/child linking and the summary table.
 
 ### Title Conventions
 
@@ -139,10 +141,9 @@ temporary file for issue bodies to avoid shell escaping problems.
 
 ### Ticket mapping: `.rfc.md`
 
-**Parent**: Create one epic/tracking issue for the RFC.
+**Parent**: one epic/tracking issue for the RFC.
 
 ```bash
-# Write body to temp file
 cat > /tmp/orders_body.md << 'BODY'
 ## RFC Tracking Issue
 
@@ -159,10 +160,10 @@ cat > /tmp/orders_body.md << 'BODY'
 **Next step for each milestone**: `smithy.render` to produce a feature map.
 BODY
 
-gh issue create --title "[RFC] <rfc-title>" --body-file /tmp/orders_body.md
+${CLAUDE_SKILL_DIR}/scripts/create-issue.sh "[RFC] <rfc-title>" /tmp/orders_body.md
 ```
 
-**Children**: One issue per milestone, linked to the parent.
+**Children**: one issue per milestone, linked to the parent.
 
 ```bash
 cat > /tmp/orders_body.md << 'BODY'
@@ -178,28 +179,25 @@ cat > /tmp/orders_body.md << 'BODY'
 (where `<N>` is this milestone's number — e.g., `/smithy.render docs/rfcs/2026-001-foo/foo.rfc.md 2`)
 BODY
 
-gh issue create --title "[RFC][Milestone] <milestone-title>" --body-file /tmp/orders_body.md
+${CLAUDE_SKILL_DIR}/scripts/create-issue.sh "[RFC][Milestone] <milestone-title>" /tmp/orders_body.md
 ```
 
 ### Ticket mapping: `.features.md`
 
-**Parent linking**: Search for an existing milestone issue to link to. Feature
-maps include `**Source RFC**` and `**Milestone**` metadata in their header —
-read both to disambiguate across RFCs. First extract the RFC title from the
-source RFC path, then search for a milestone issue that matches **both** the RFC
-title and the milestone title:
+**Parent linking**: Search for an existing milestone issue. Feature maps include
+`**Source RFC**` and `**Milestone**` metadata in their header — read both to
+disambiguate across RFCs. Use both the RFC title and milestone title in the search:
 
 ```bash
-# Use both RFC title and milestone title to avoid matching same-named milestones from different RFCs
-gh issue list --search "[RFC][Milestone] <milestone-title> in:title" --state open --json number,title,body --limit 10
+${CLAUDE_SKILL_DIR}/scripts/search-issues.sh open "[RFC][Milestone] <milestone-title> in:title" 10
 ```
 
-From the results, verify the match by checking that the issue body references
-the same source RFC path. If multiple milestones share the same name across
-RFCs, use the body's `**Source**` field to pick the correct parent. If found,
-reference it in the child ticket body.
+Verify the match by checking that the issue body references the same source RFC
+path. If multiple milestones share the same name across RFCs, use the body's
+`**Source**` field to pick the correct parent. If found, reference it in the
+child ticket body.
 
-**Children**: One issue per feature.
+**Children**: one issue per feature.
 
 ```bash
 cat > /tmp/orders_body.md << 'BODY'
@@ -213,12 +211,12 @@ cat > /tmp/orders_body.md << 'BODY'
 **Next step**: Run `smithy.mark` on this feature to produce a specification.
 BODY
 
-gh issue create --title "[Feature] <feature-title>" --body-file /tmp/orders_body.md
+${CLAUDE_SKILL_DIR}/scripts/create-issue.sh "[Feature] <feature-title>" /tmp/orders_body.md
 ```
 
 ### Ticket mapping: `.spec.md`
 
-**Children**: One issue per user story. No parent ticket is created.
+**Children**: one issue per user story. No parent ticket is created.
 
 ```bash
 cat > /tmp/orders_body.md << 'BODY'
@@ -237,26 +235,27 @@ As a <persona>, I want <goal> so that <benefit>.
 (where `<N>` is this story's number — e.g., `/smithy.cut specs/2026-03-14-001-webhook-support 3`)
 BODY
 
-gh issue create --title "[Story] <story-title>" --body-file /tmp/orders_body.md
+${CLAUDE_SKILL_DIR}/scripts/create-issue.sh "[Story] <story-title>" /tmp/orders_body.md
 ```
 
 ### Ticket mapping: `.tasks.md`
 
-**Parent linking**: Search for an existing user story issue to link to. The
-tasks file header references its source spec — read the spec to find the story
-title that matches this tasks file's story number (`<NN>` from the filename
-`<NN>-<story-slug>.tasks.md` maps to `User Story <NN>` in the spec). Then
-search using the same `[Story]` title prefix used when creating story tickets:
+**Parent linking**: Search for an existing user story issue. The tasks file
+header references its source spec — read the spec to find the story title that
+matches this tasks file's story number (`<NN>` from the filename
+`<NN>-<story-slug>.tasks.md` maps to `User Story <NN>` in the spec). Then search
+using the same `[Story]` title prefix:
 
 ```bash
-gh issue list --search "[Story] <story-title>" --state open --json number,title --limit 10
+${CLAUDE_SKILL_DIR}/scripts/search-issues.sh open "[Story] <story-title>" 10
 ```
 
 Match by story title (the `<story-title>` from `### User Story N: <Title>` —
-or `### User Story N — <Title>` in older specs — the same title used in the `[Story] <story-title>` issue created by
-the `.spec.md` mapping above). If found, reference it in the child ticket body.
+or `### User Story N — <Title>` in older specs — the same title used in the
+`[Story] <story-title>` issue created by the `.spec.md` mapping). If found,
+reference it in the child ticket body.
 
-**Children**: One issue per slice.
+**Children**: one issue per slice.
 
 ```bash
 cat > /tmp/orders_body.md << 'BODY'
@@ -276,7 +275,7 @@ cat > /tmp/orders_body.md << 'BODY'
 **Next step**: Run `smithy.forge` on this slice to implement it.
 BODY
 
-gh issue create --title "[Slice] <slice-title>" --body-file /tmp/orders_body.md
+${CLAUDE_SKILL_DIR}/scripts/create-issue.sh "[Slice] <slice-title>" /tmp/orders_body.md
 ```
 
 ---
@@ -285,34 +284,19 @@ gh issue create --title "[Slice] <slice-title>" --body-file /tmp/orders_body.md
 
 After creating all tickets, establish parent-child relationships:
 
-1. For `.rfc.md`: Link each milestone issue to the RFC tracking issue using
-   GitHub issue references (`#<number>`) in the body (already done during
-   creation).
-2. For `.features.md` and `.tasks.md`: The parent link was added during creation
-   if a matching parent issue was found.
-3. If GitHub sub-issues or project tracking is available, also add `blocked-by`
-   relationships using GraphQL:
+1. For `.rfc.md`: each milestone body already references the RFC tracking
+   issue (`#<parent>`); no extra step needed beyond what was written in Phase 5.
+2. For `.features.md` and `.tasks.md`: the parent reference was added during
+   creation if a matching parent issue was found.
+3. If GitHub sub-issues / `blocked-by` are available in this repo, also add a
+   `blocked-by` link from each child to its parent:
 
 ```bash
-# Fetch issue node IDs
-gh api graphql -f query='query {
-  repository(owner:"OWNER", name:"REPO") {
-    issues(first:20, orderBy:{field:CREATED_AT, direction:DESC}) {
-      nodes { number id title }
-    }
-  }
-}'
-
-# Add blocked-by link (child blocked by parent)
-gh api graphql \
-  -f query='mutation($issue:ID!, $blocker:ID!){
-    addBlockedBy(input:{issueId:$issue, blockingIssueId:$blocker}) {
-      issue { number }
-      blockingIssue { number }
-    }
-  }' \
-  -f issue="$child_id" -f blocker="$parent_id"
+${CLAUDE_SKILL_DIR}/scripts/link-blocked-by.sh <child-number> <parent-number>
 ```
+
+Treat `link-blocked-by` failures as best-effort: print a brief note and continue
+rather than aborting the orders run.
 
 ---
 
@@ -342,12 +326,16 @@ Present a summary table of all created tickets:
 
 ## Rules
 
-- **Do NOT** create tickets without first checking for duplicates.
+- **Do NOT** create tickets without first checking for duplicates via
+  `search-issues.sh`.
 - **Do NOT** accept `.data-model.md` or `.contracts.md` as input — always reject
   with guidance to use the parent `.spec.md`.
 - **Do NOT** require flags or mode arguments — artifact type detection is
   entirely by file extension.
-- **DO** use `--body-file` for issue creation to avoid shell escaping issues.
+- **Do NOT** call `gh` directly for issue creation, search, or linking — go
+  through the `smithy.gh-issue` skill scripts so permissions stay scoped.
+- **DO** write issue bodies to a temp file with a heredoc and pass the file path
+  to `create-issue.sh`, to avoid markdown quoting issues.
 - **DO** link child tickets to parent tickets when parent tickets can be found.
 - **DO** include the next pipeline step in every ticket body.
 - **DO** present duplicate matches to the user before proceeding.

--- a/src/templates/agent-skills/commands/smithy.orders.prompt
+++ b/src/templates/agent-skills/commands/smithy.orders.prompt
@@ -26,7 +26,12 @@ If no file path is provided, ask the user which artifact file to create tickets 
 
 ## Phase 1: Validate Environment
 
-Run the `smithy.gh-issue` skill's environment check before doing anything else:
+**First, load the skill** so its scripts and `${CLAUDE_SKILL_DIR}` are available:
+invoke `Skill("smithy.gh-issue")`. Every `${CLAUDE_SKILL_DIR}/scripts/...` block in
+this command (Phases 1, 4, 5, and 6) requires the skill to be loaded — without
+this step `CLAUDE_SKILL_DIR` is unset and the scripts cannot be located.
+
+Then run the environment check:
 
 ```bash
 ${CLAUDE_SKILL_DIR}/scripts/check-env.sh

--- a/src/templates/agent-skills/skills/smithy.gh-issue/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.gh-issue/SKILL.prompt
@@ -8,8 +8,10 @@ allowed-tools: Bash(*/smithy.gh-issue/scripts/check-env.sh) Bash(*/smithy.gh-iss
 Provides GitHub issue operations via shell scripts bundled in this skill's `scripts/`
 directory. Reference them as `${CLAUDE_SKILL_DIR}/scripts/<script-name>`.
 
-Each script wraps a single, well-understood `gh` API call so the host's permission
-prompt sees one stable command instead of a long, ad-hoc `gh` invocation. This
+Each operation is implemented as a small, stable script with a fixed set of
+`gh` calls (most use one; `link-blocked-by.sh` makes a few — repo lookup, two
+node-id lookups, then the mutation). The host's permission prompt sees one
+stable command per operation instead of a long, ad-hoc `gh` invocation. This
 mirrors the `smithy.pr-review` pattern.
 
 ---

--- a/src/templates/agent-skills/skills/smithy.gh-issue/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.gh-issue/SKILL.prompt
@@ -1,0 +1,90 @@
+---
+name: smithy.gh-issue
+description: "GitHub issue operations: validate environment, search issues, create issues from a body file, and link blocked-by relationships. Use when an agent needs to read or create issues in the current repo."
+allowed-tools: Bash(*/smithy.gh-issue/scripts/check-env.sh) Bash(*/smithy.gh-issue/scripts/search-issues.sh *) Bash(*/smithy.gh-issue/scripts/create-issue.sh *) Bash(*/smithy.gh-issue/scripts/link-blocked-by.sh *)
+---
+# smithy.gh-issue
+
+Provides GitHub issue operations via shell scripts bundled in this skill's `scripts/`
+directory. Reference them as `${CLAUDE_SKILL_DIR}/scripts/<script-name>`.
+
+Each script wraps a single, well-understood `gh` API call so the host's permission
+prompt sees one stable command instead of a long, ad-hoc `gh` invocation. This
+mirrors the `smithy.pr-review` pattern.
+
+---
+
+## Operation: Validate Environment
+
+Verifies the `gh` CLI is installed and the current directory is a GitHub repo.
+Returns JSON with `owner`, `repo`, and `ownerRepo`. Exits non-zero with a
+friendly stderr message on failure.
+
+```bash
+${CLAUDE_SKILL_DIR}/scripts/check-env.sh
+```
+
+Run this **once** at the start of any flow that will create or query issues.
+
+---
+
+## Operation: Search Issues
+
+Searches issues in the current repo. Use this for duplicate detection and for
+locating parent tickets when stitching artifacts together.
+
+```bash
+${CLAUDE_SKILL_DIR}/scripts/search-issues.sh <state> <search-query> [limit]
+```
+
+- `state`: `open`, `closed`, or `all`.
+- `search-query`: any gh-compatible search string. Add `in:title` to restrict
+  the match to titles (e.g. `"[Story] My Title in:title"`).
+- `limit`: optional, defaults to 10.
+
+Output is a JSON array of `{number, title, state, body}`. Empty array (`[]`)
+when nothing matches. The `body` field lets you disambiguate same-named items
+across artifacts (e.g. milestones with the same name in different RFCs — match
+on the `**Source**` line in the body).
+
+---
+
+## Operation: Create Issue
+
+Creates a GitHub issue in the current repo from a title and a body file. Always
+write the body to a temp file first to avoid quoting problems with markdown.
+
+**Step 1 — write the body:**
+```bash
+cat > /tmp/smithy_issue_body.md << 'BODY'
+## Heading
+
+Body content with `code`, **bold**, etc.
+BODY
+```
+
+**Step 2 — create the issue:**
+```bash
+${CLAUDE_SKILL_DIR}/scripts/create-issue.sh "<title>" /tmp/smithy_issue_body.md
+```
+
+Output: JSON `{"number": N, "url": "..."}`. Capture the `number` for parent/child
+linking and for the orders summary table.
+
+Clean up the temp body file after creation.
+
+---
+
+## Operation: Link Blocked-By
+
+Marks one issue as blocked by another via the GitHub `addBlockedBy` GraphQL
+mutation. Use this after both the parent and child issues exist.
+
+```bash
+${CLAUDE_SKILL_DIR}/scripts/link-blocked-by.sh <child-number> <blocker-number>
+```
+
+The script handles node-ID lookup and the mutation itself. Output: JSON
+`{"child": N, "blocker": N}` on success. Errors (e.g. issues not found, repo
+without sub-issue support) surface on stderr — treat them as best-effort and
+continue rather than aborting the parent flow.

--- a/src/templates/agent-skills/skills/smithy.gh-issue/scripts/check-env.sh
+++ b/src/templates/agent-skills/skills/smithy.gh-issue/scripts/check-env.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# check-env.sh — Verify gh CLI is installed and a GitHub remote is configured.
+#
+# Usage: ${CLAUDE_SKILL_DIR}/scripts/check-env.sh
+#
+# Output: JSON {"owner": "...", "repo": "...", "ownerRepo": "owner/repo"}.
+# Exits 1 with a friendly stderr message if gh is missing or no GitHub remote exists.
+
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh (GitHub CLI) is required but not installed. Install it from https://cli.github.com/" >&2
+  exit 1
+fi
+
+if ! REPO_JSON=$(gh repo view --json owner,name 2>/dev/null); then
+  echo "This repository does not have a GitHub remote configured." >&2
+  exit 1
+fi
+
+OWNER=$(echo "$REPO_JSON" | jq -r '.owner.login')
+NAME=$(echo "$REPO_JSON" | jq -r '.name')
+
+jq -n --arg owner "$OWNER" --arg repo "$NAME" \
+  '{owner: $owner, repo: $repo, ownerRepo: "\($owner)/\($repo)"}'

--- a/src/templates/agent-skills/skills/smithy.gh-issue/scripts/check-env.sh
+++ b/src/templates/agent-skills/skills/smithy.gh-issue/scripts/check-env.sh
@@ -13,8 +13,13 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! REPO_JSON=$(gh repo view --json owner,name 2>/dev/null); then
-  echo "This repository does not have a GitHub remote configured." >&2
+# Capture stderr so we can surface gh's real error (auth failure, no remote,
+# rate limit, etc.) instead of always reporting "no GitHub remote configured."
+GH_STDERR=$(mktemp)
+trap 'rm -f "$GH_STDERR"' EXIT
+if ! REPO_JSON=$(gh repo view --json owner,name 2>"$GH_STDERR"); then
+  echo "Could not read GitHub repo info via gh:" >&2
+  cat "$GH_STDERR" >&2
   exit 1
 fi
 

--- a/src/templates/agent-skills/skills/smithy.gh-issue/scripts/create-issue.sh
+++ b/src/templates/agent-skills/skills/smithy.gh-issue/scripts/create-issue.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# create-issue.sh — Create a GitHub issue in the current repo from a body file.
+#
+# Usage: ${CLAUDE_SKILL_DIR}/scripts/create-issue.sh <title> <body-file>
+#
+# Write the body to a temp file with a heredoc before calling, to avoid quoting
+# issues with markdown content:
+#
+#   cat > /tmp/smithy_issue_body.md << 'BODY'
+#   ## My Issue
+#   ...
+#   BODY
+#   ${CLAUDE_SKILL_DIR}/scripts/create-issue.sh "[Story] My Title" /tmp/smithy_issue_body.md
+#
+# Output: JSON {"number": N, "url": "https://github.com/owner/repo/issues/N"}.
+
+set -euo pipefail
+
+TITLE="${1:?title required}"
+BODY_FILE="${2:?body file path required}"
+
+if [ ! -f "$BODY_FILE" ]; then
+  echo "Body file not found: $BODY_FILE" >&2
+  exit 1
+fi
+
+URL=$(gh issue create --title "$TITLE" --body-file "$BODY_FILE")
+NUMBER="${URL##*/}"
+
+jq -n --arg url "$URL" --argjson number "$NUMBER" \
+  '{number: $number, url: $url}'

--- a/src/templates/agent-skills/skills/smithy.gh-issue/scripts/create-issue.sh
+++ b/src/templates/agent-skills/skills/smithy.gh-issue/scripts/create-issue.sh
@@ -24,8 +24,22 @@ if [ ! -f "$BODY_FILE" ]; then
   exit 1
 fi
 
+# Validate jq up front — failing after `gh issue create` would leave an issue
+# behind and a non-zero exit, which callers interpret as failure and may retry,
+# producing duplicate tickets.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to format create-issue output but is not installed." >&2
+  exit 1
+fi
+
 URL=$(gh issue create --title "$TITLE" --body-file "$BODY_FILE")
+URL="${URL//[$'\t\r\n ']/}"
 NUMBER="${URL##*/}"
+
+if ! [[ "$NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "Could not parse issue number from gh output: $URL" >&2
+  exit 1
+fi
 
 jq -n --arg url "$URL" --argjson number "$NUMBER" \
   '{number: $number, url: $url}'

--- a/src/templates/agent-skills/skills/smithy.gh-issue/scripts/link-blocked-by.sh
+++ b/src/templates/agent-skills/skills/smithy.gh-issue/scripts/link-blocked-by.sh
@@ -11,21 +11,40 @@ set -euo pipefail
 CHILD="${1:?child issue number required}"
 BLOCKER="${2:?blocker issue number required}"
 
+# Validate inputs are bare positive integers — leading '#', whitespace, or any
+# non-digit produces a confusing GraphQL Int coercion error or jq parse failure
+# downstream. Catch it here with a clear message instead.
+for arg in "$CHILD" "$BLOCKER"; do
+  if ! [[ "$arg" =~ ^[0-9]+$ ]]; then
+    echo "Issue numbers must be bare positive integers (got: $arg)." >&2
+    exit 1
+  fi
+done
+
 REPO_JSON=$(gh repo view --json owner,name)
 OWNER=$(echo "$REPO_JSON" | jq -r '.owner.login')
 NAME=$(echo "$REPO_JSON" | jq -r '.name')
 
-CHILD_ID=$(gh api graphql \
-  -F owner="$OWNER" -F name="$NAME" -F number="$CHILD" \
-  -f query='query($owner:String!, $name:String!, $number:Int!) {
-    repository(owner:$owner, name:$name) { issue(number:$number) { id } }
-  }' --jq '.data.repository.issue.id')
+# Look up the GraphQL node ID for an issue number; emit a clear stderr error
+# if the issue does not exist in this repo (otherwise we'd pass null to the
+# mutation and get an opaque GraphQL failure).
+lookup_id() {
+  local number="$1"
+  local id
+  id=$(gh api graphql \
+    -F owner="$OWNER" -F name="$NAME" -F number="$number" \
+    -f query='query($owner:String!, $name:String!, $number:Int!) {
+      repository(owner:$owner, name:$name) { issue(number:$number) { id } }
+    }' --jq '.data.repository.issue.id')
+  if [ -z "$id" ] || [ "$id" = "null" ]; then
+    echo "Issue $number not found in $OWNER/$NAME." >&2
+    return 1
+  fi
+  echo "$id"
+}
 
-BLOCKER_ID=$(gh api graphql \
-  -F owner="$OWNER" -F name="$NAME" -F number="$BLOCKER" \
-  -f query='query($owner:String!, $name:String!, $number:Int!) {
-    repository(owner:$owner, name:$name) { issue(number:$number) { id } }
-  }' --jq '.data.repository.issue.id')
+CHILD_ID=$(lookup_id "$CHILD")
+BLOCKER_ID=$(lookup_id "$BLOCKER")
 
 gh api graphql \
   -F issue="$CHILD_ID" -F blocker="$BLOCKER_ID" \

--- a/src/templates/agent-skills/skills/smithy.gh-issue/scripts/link-blocked-by.sh
+++ b/src/templates/agent-skills/skills/smithy.gh-issue/scripts/link-blocked-by.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# link-blocked-by.sh — Mark one issue as blocked-by another via GraphQL.
+#
+# Usage: ${CLAUDE_SKILL_DIR}/scripts/link-blocked-by.sh <child-number> <blocker-number>
+#
+# Looks up node IDs for both issues in the current repo, then posts an
+# addBlockedBy mutation. Output: JSON {"child": N, "blocker": N} on success.
+
+set -euo pipefail
+
+CHILD="${1:?child issue number required}"
+BLOCKER="${2:?blocker issue number required}"
+
+REPO_JSON=$(gh repo view --json owner,name)
+OWNER=$(echo "$REPO_JSON" | jq -r '.owner.login')
+NAME=$(echo "$REPO_JSON" | jq -r '.name')
+
+CHILD_ID=$(gh api graphql \
+  -F owner="$OWNER" -F name="$NAME" -F number="$CHILD" \
+  -f query='query($owner:String!, $name:String!, $number:Int!) {
+    repository(owner:$owner, name:$name) { issue(number:$number) { id } }
+  }' --jq '.data.repository.issue.id')
+
+BLOCKER_ID=$(gh api graphql \
+  -F owner="$OWNER" -F name="$NAME" -F number="$BLOCKER" \
+  -f query='query($owner:String!, $name:String!, $number:Int!) {
+    repository(owner:$owner, name:$name) { issue(number:$number) { id } }
+  }' --jq '.data.repository.issue.id')
+
+gh api graphql \
+  -F issue="$CHILD_ID" -F blocker="$BLOCKER_ID" \
+  -f query='mutation($issue:ID!, $blocker:ID!) {
+    addBlockedBy(input:{issueId:$issue, blockingIssueId:$blocker}) {
+      issue { number } blockingIssue { number }
+    }
+  }' >/dev/null
+
+jq -n --argjson child "$CHILD" --argjson blocker "$BLOCKER" \
+  '{child: $child, blocker: $blocker}'

--- a/src/templates/agent-skills/skills/smithy.gh-issue/scripts/search-issues.sh
+++ b/src/templates/agent-skills/skills/smithy.gh-issue/scripts/search-issues.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# search-issues.sh — Search GitHub issues in the current repo.
+#
+# Usage: ${CLAUDE_SKILL_DIR}/scripts/search-issues.sh <state> <search-query> [limit]
+#
+#   state:        open | closed | all
+#   search-query: any gh-compatible search string (e.g. "[Story] My Title in:title")
+#   limit:        optional, defaults to 10
+#
+# Output: JSON array [{"number": N, "title": "...", "state": "...", "body": "..."}, ...].
+# Returns an empty array ([]) if no issues match.
+
+set -euo pipefail
+
+STATE="${1:?state required (open|closed|all)}"
+QUERY="${2:?search query required}"
+LIMIT="${3:-10}"
+
+gh issue list \
+  --search "$QUERY" \
+  --state "$STATE" \
+  --json number,title,state,body \
+  --limit "$LIMIT"


### PR DESCRIPTION
## Summary
- Primary outcome: extract `smithy.orders`' `gh` issue operations into a reusable `smithy.gh-issue` skill so the host's permission surface for orders collapses from many ad-hoc `gh issue list / create / api graphql` shapes down to four stable script paths.
- Notable behaviour changes: `smithy.orders.prompt` Phases 1, 4, 5, and 6 now call `${CLAUDE_SKILL_DIR}/scripts/{check-env,search-issues,create-issue,link-blocked-by}.sh` instead of inlining `gh`. The added Rules entry forbids direct `gh` calls for issue ops in this command.
- Follow-up work deferred: a parallel `smithy.jira-issue` (or similar) skill following the same shape, mentioned in the issue discussion.

## Context
- Closes #107. The issue called out that orders' `gh api` calls were spread across multi-line shell snippets that produced fiddly permission prompts. Auto-mode masks a lot of that pain at runtime, but the underlying prompt was still long and the per-call shapes were still ad-hoc. The issue comment suggested a `gh-issue` skill that mirrors `smithy.pr-review` / `pr-creation`, which is the path taken here.
- Unblocks future tracker skills (e.g. Jira) that can present the same operation surface to orders.

## Implementation Notes
- New skill at `src/templates/agent-skills/skills/smithy.gh-issue/`:
  - `SKILL.prompt` — frontmatter declares `allowed-tools: Bash(*/smithy.gh-issue/scripts/*.sh ...)` for the four scripts. Body documents each operation as one bash block.
  - `scripts/check-env.sh` — verifies `gh` and a GitHub remote, prints `{owner, repo, ownerRepo}` JSON.
  - `scripts/search-issues.sh <state> <query> [limit]` — single wrapper for both duplicate detection and parent-ticket lookup. Returns `[{number, title, state, body}, ...]`.
  - `scripts/create-issue.sh <title> <body-file>` — preserves the existing heredoc-then-create pattern; emits `{number, url}` JSON so orders can capture the new issue number for parent/child linking.
  - `scripts/link-blocked-by.sh <child> <blocker>` — looks up node IDs by issue number and posts the `addBlockedBy` mutation. Treated as best-effort by orders.
- `smithy.orders.prompt` slimmed: ~25 lines of inline `gh` boilerplate replaced with single-line script invocations; rules updated to forbid direct `gh` for issue ops.
- No changes to deploy code — the existing skill loader and `claude.ts` deploy pipeline pick up the new directory automatically (script execute bits set at deploy time, frontmatter retained for `allowed-tools`).

## Risks & Mitigations
- Risk: existing repos that ran `smithy init` previously will not have the new skill until they re-init / `smithy update`. | Mitigation: orders' prompt explicitly references the skill — if the scripts are missing, the user gets a clear shell error pointing at the skill path, and re-running `smithy init` deploys it.
- Risk: `link-blocked-by` requires the GraphQL `addBlockedBy` mutation, which not every repo has enabled. | Mitigation: orders treats failures from this script as best-effort and continues, matching prior behaviour.

## Rollback Plan
- Revert this commit. The skill directory is purely additive and the orders prompt change is self-contained — no manifests, no schema changes. Existing deployments are unaffected until they re-init.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npm run typecheck`)
- [x] CLI `init` smoke test (`node dist/cli.js init --agent claude --target-dir /tmp/orders-test --yes`) — verified `.claude/skills/smithy.gh-issue/SKILL.md` deploys with frontmatter and all four scripts land as `0755`.

### Template Generation
- [ ] Gemini Skills: not exercised in this PR (skill body is Claude-targeted via `${CLAUDE_SKILL_DIR}`).
- [ ] Codex Prompts: not exercised.
- [x] Claude Prompts: `.claude/skills/smithy.gh-issue/` deploys cleanly; existing `.claude/commands/smithy.orders.md` references the new script paths.
- [ ] GitHub Issue Templates: unchanged.

### Permissions & Configuration
- [ ] Gemini Config: unchanged.
- [ ] Codex Config: unchanged.
- [x] Claude Config: SKILL.md `allowed-tools` lists the four script paths so the host can grant the skill once instead of per-call.

### Manual Test Cases
- [ ] No init/uninit flow changes; A-/H-series cases not re-run.

### Automated
- [x] `npm test` — 688/688 pass, including new assertions in `src/templates.test.ts` covering: skill count, presence of `smithy.gh-issue`, all four script names, frontmatter `allowed-tools` paths, strict-mode shebang on each script, `search-issues.sh` arg shape, `create-issue.sh --body-file` usage, `link-blocked-by.sh` `addBlockedBy` mutation, and that `smithy.orders.md` no longer contains `gh issue create --title` or `gh issue list --search`.

## Issue
- Closes #107
