### PR TITLE
Restore pr-review permission patterns and split force-push by lease

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -216,10 +216,20 @@
       "Bash(zip -r *)",
       "Bash(unzip *)",
       "Bash(unzip -l *)",
+      "Bash(.claude/skills/smithy.pr-review/scripts/find-pr.sh)",
+      "Bash(.claude/skills/smithy.pr-review/scripts/get-comments.sh:*)",
+      "Bash(.claude/skills/smithy.pr-review/scripts/reply-comment.sh:*)",
+      "Bash(*/smithy.pr-review/scripts/find-pr.sh)",
+      "Bash(*/smithy.pr-review/scripts/get-comments.sh:*)",
+      "Bash(*/smithy.pr-review/scripts/reply-comment.sh:*)",
       "WebSearch",
       "WebFetch",
       "Write(//tmp/**)",
       "Skill(smithy.*:*)"
+    ],
+    "ask": [
+      "Bash(git push --force-with-lease)",
+      "Bash(git push --force-with-lease *)"
     ],
     "deny": [
       "Bash(git branch -d *)",
@@ -236,7 +246,13 @@
       "Bash(git symbolic-ref -m *)",
       "Bash(git symbolic-ref --message *)",
       "Bash(git symbolic-ref --delete *)",
-      "Bash(git symbolic-ref -d *)"
+      "Bash(git symbolic-ref -d *)",
+      "Bash(git push --force)",
+      "Bash(git push --force *)",
+      "Bash(git push -f)",
+      "Bash(git push -f *)",
+      "Bash(npm publish)",
+      "Bash(npm publish *)"
     ]
   },
   "hooks": {

--- a/.claude/skills/smithy.pr-review/SKILL.md
+++ b/.claude/skills/smithy.pr-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: smithy.pr-review
 description: "GitHub PR review operations: list inline comments, reply to comments. Use when handling review feedback on an open pull request."
-allowed-tools: Bash(*/smithy.pr-review/scripts/find-pr.sh) Bash(*/smithy.pr-review/scripts/get-comments.sh *) Bash(*/smithy.pr-review/scripts/reply-comment.sh *)
+allowed-tools: Bash(*/smithy.pr-review/scripts/find-pr.sh) Bash(*/smithy.pr-review/scripts/get-comments.sh:*) Bash(*/smithy.pr-review/scripts/reply-comment.sh:*)
 ---
 # smithy.pr-review
 

--- a/src/agents/claude.test.ts
+++ b/src/agents/claude.test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import os from 'os';
 import {
   buildClaudeAllowList,
+  buildClaudeAskList,
   buildClaudeDenyList,
   deploy,
   deploySessionTitleHookScript,
@@ -153,8 +154,8 @@ describe('deploy', () => {
     const content = fs.readFileSync(skillMd, 'utf8');
     expect(content).toContain('allowed-tools:');
     expect(content).toContain('Bash(*/smithy.pr-review/scripts/find-pr.sh)');
-    expect(content).toContain('Bash(*/smithy.pr-review/scripts/get-comments.sh *)');
-    expect(content).toContain('Bash(*/smithy.pr-review/scripts/reply-comment.sh *)');
+    expect(content).toContain('Bash(*/smithy.pr-review/scripts/get-comments.sh:*)');
+    expect(content).toContain('Bash(*/smithy.pr-review/scripts/reply-comment.sh:*)');
   });
 
   it('deploys skill scripts as executable files in scripts/ subdirectory', async () => {
@@ -518,12 +519,17 @@ describe('buildClaudeDenyList', () => {
     expect(list).toContain('Bash(git branch --delete *)');
   });
 
-  it('blocks hard reset but not force push (force push requires approval)', () => {
+  it('blocks hard reset and force push without lease, but not force-with-lease', () => {
     const list = buildClaudeDenyList();
     expect(list).toContain('Bash(git reset --hard *)');
-    // Force push is no longer denied — it triggers a user approval prompt instead
-    expect(list).not.toContain('Bash(git push --force *)');
-    expect(list).not.toContain('Bash(git push -f *)');
+    // Force push without lease clobbers the remote — denied outright.
+    expect(list).toContain('Bash(git push --force)');
+    expect(list).toContain('Bash(git push --force *)');
+    expect(list).toContain('Bash(git push -f)');
+    expect(list).toContain('Bash(git push -f *)');
+    // --force-with-lease is intentionally NOT denied — it goes to the ask list
+    // so rebase workflows can still push with a confirmation.
+    expect(list).not.toContain('Bash(git push --force-with-lease)');
     expect(list).not.toContain('Bash(git push --force-with-lease *)');
   });
 
@@ -533,6 +539,29 @@ describe('buildClaudeDenyList', () => {
     expect(list).toContain('Bash(git checkout .)');
     expect(list).toContain('Bash(git stash drop *)');
     expect(list).toContain('Bash(git stash clear)');
+  });
+});
+
+describe('buildClaudeAskList', () => {
+  it('wraps all ask entries in Bash()', () => {
+    const list = buildClaudeAskList();
+    for (const entry of list) {
+      expect(entry.startsWith('Bash(')).toBe(true);
+    }
+  });
+
+  it('asks before force-push with lease', () => {
+    const list = buildClaudeAskList();
+    expect(list).toContain('Bash(git push --force-with-lease)');
+    expect(list).toContain('Bash(git push --force-with-lease *)');
+  });
+
+  it('does not include the no-lease force push (that is denied)', () => {
+    const list = buildClaudeAskList();
+    expect(list).not.toContain('Bash(git push --force)');
+    expect(list).not.toContain('Bash(git push --force *)');
+    expect(list).not.toContain('Bash(git push -f)');
+    expect(list).not.toContain('Bash(git push -f *)');
   });
 });
 
@@ -568,7 +597,7 @@ describe('writePermissions', () => {
     expect(fs.existsSync(settingsPath)).toBe(true);
   });
 
-  it('uses correct schema with permissions.allow and permissions.deny arrays', () => {
+  it('uses correct schema with permissions.allow, permissions.ask, and permissions.deny arrays', () => {
     writePermissions(tmpDir, 'repo');
 
     const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
@@ -576,13 +605,33 @@ describe('writePermissions', () => {
 
     expect(config).toHaveProperty('permissions');
     expect(config.permissions).toHaveProperty('allow');
+    expect(config.permissions).toHaveProperty('ask');
     expect(config.permissions).toHaveProperty('deny');
     expect(Array.isArray(config.permissions.allow)).toBe(true);
+    expect(Array.isArray(config.permissions.ask)).toBe(true);
     expect(Array.isArray(config.permissions.deny)).toBe(true);
     // Deny list should contain destructive git operations
     expect(config.permissions.deny).toContain('Bash(git branch -D *)');
+    // Ask list should prompt before force-push with lease
+    expect(config.permissions.ask).toContain('Bash(git push --force-with-lease *)');
     // Should NOT have old format
     expect(config.permissions).not.toHaveProperty('allowed_commands');
+  });
+
+  it('seeds the allow list with smithy.pr-review skill script paths', () => {
+    writePermissions(tmpDir, 'repo');
+
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+
+    // Repo-level relative invocation patterns
+    expect(config.permissions.allow).toContain('Bash(.claude/skills/smithy.pr-review/scripts/find-pr.sh)');
+    expect(config.permissions.allow).toContain('Bash(.claude/skills/smithy.pr-review/scripts/get-comments.sh:*)');
+    expect(config.permissions.allow).toContain('Bash(.claude/skills/smithy.pr-review/scripts/reply-comment.sh:*)');
+    // Wildcard fallback for other deploy locations
+    expect(config.permissions.allow).toContain('Bash(*/smithy.pr-review/scripts/find-pr.sh)');
+    expect(config.permissions.allow).toContain('Bash(*/smithy.pr-review/scripts/get-comments.sh:*)');
+    expect(config.permissions.allow).toContain('Bash(*/smithy.pr-review/scripts/reply-comment.sh:*)');
   });
 
   it('entries are Bash()-wrapped or Claude tool names', () => {
@@ -679,6 +728,10 @@ describe('writePermissions', () => {
     // Check that allow list has no duplicates
     const allowSet = new Set(config.permissions.allow);
     expect(config.permissions.allow.length).toBe(allowSet.size);
+
+    // Check that ask list has no duplicates
+    const askSet = new Set(config.permissions.ask);
+    expect(config.permissions.ask.length).toBe(askSet.size);
 
     // Check that deny list has no duplicates
     const denySet = new Set(config.permissions.deny);

--- a/src/agents/claude.test.ts
+++ b/src/agents/claude.test.ts
@@ -375,6 +375,18 @@ describe('buildClaudeAllowList', () => {
     expect(list).toContain('Bash(git push origin claude/*)');
   });
 
+  it('includes Claude-only extraPermissions (smithy.pr-review script paths)', () => {
+    const list = buildClaudeAllowList();
+    // Repo-level relative paths
+    expect(list).toContain('Bash(.claude/skills/smithy.pr-review/scripts/find-pr.sh)');
+    expect(list).toContain('Bash(.claude/skills/smithy.pr-review/scripts/get-comments.sh:*)');
+    expect(list).toContain('Bash(.claude/skills/smithy.pr-review/scripts/reply-comment.sh:*)');
+    // Wildcard fallback for user-level / absolute deploys
+    expect(list).toContain('Bash(*/smithy.pr-review/scripts/find-pr.sh)');
+    expect(list).toContain('Bash(*/smithy.pr-review/scripts/get-comments.sh:*)');
+    expect(list).toContain('Bash(*/smithy.pr-review/scripts/reply-comment.sh:*)');
+  });
+
   it('includes multi-language build tool commands', () => {
     const list = buildClaudeAllowList();
     // npm

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import picocolors from 'picocolors';
 import { getComposedTemplates, getTemplateFilesByCategory, stripFrontmatter } from '../templates.js';
-import { flattenPermissions, claudeToolPermissions, denyPermissions, type LanguageToolchain, type PlatformPackageManager } from '../permissions.js';
+import { flattenPermissions, claudeToolPermissions, askPermissions, denyPermissions, type LanguageToolchain, type PlatformPackageManager } from '../permissions.js';
 import { hooksTemplateDir, removeIfExists } from '../utils.js';
 import type { PermissionLevel, DeployablePermissionLevel, DeployLocation } from '../interactive.js';
 
@@ -144,6 +144,14 @@ export function buildClaudeDenyList(): string[] {
 }
 
 /**
+ * Build the Claude Code ask-list from the shared ask permissions. Claude Code
+ * surfaces these as an explicit prompt even in auto mode.
+ */
+export function buildClaudeAskList(): string[] {
+  return askPermissions.map(cmd => `Bash(${cmd})`);
+}
+
+/**
  * Resolve the settings file path based on the permission level.
  */
 export function resolveSettingsPath(targetDir: string, level: DeployablePermissionLevel): string {
@@ -167,10 +175,11 @@ export function writePermissions(
   const settingsDir = path.dirname(settingsPath);
   if (!fs.existsSync(settingsDir)) fs.mkdirSync(settingsDir, { recursive: true });
   const allowList = buildClaudeAllowList(languages, platformManagers);
+  const askList = buildClaudeAskList();
   const denyList = buildClaudeDenyList();
 
   let config: Record<string, unknown> = {
-    permissions: { allow: allowList, deny: denyList },
+    permissions: { allow: allowList, ask: askList, deny: denyList },
   };
 
   if (fs.existsSync(settingsPath)) {
@@ -178,9 +187,11 @@ export function writePermissions(
       const existing = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
       const existingPerms = existing['permissions'] as Record<string, unknown> | undefined;
       const existingAllow = (existingPerms?.['allow'] ?? []) as string[];
+      const existingAsk = (existingPerms?.['ask'] ?? []) as string[];
       const existingDeny = (existingPerms?.['deny'] ?? []) as string[];
 
       const mergedAllow = [...new Set([...existingAllow, ...allowList])];
+      const mergedAsk = [...new Set([...existingAsk, ...askList])];
       const mergedDeny = [...new Set([...existingDeny, ...denyList])];
 
       config = {
@@ -188,11 +199,12 @@ export function writePermissions(
         permissions: {
           ...(existingPerms ?? {}),
           allow: mergedAllow,
+          ask: mergedAsk,
           deny: mergedDeny,
         },
       };
     } catch {
-      config = { permissions: { allow: allowList, deny: denyList } };
+      config = { permissions: { allow: allowList, ask: askList, deny: denyList } };
     }
   }
 

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import picocolors from 'picocolors';
 import { getComposedTemplates, getTemplateFilesByCategory, stripFrontmatter } from '../templates.js';
-import { flattenPermissions, claudeToolPermissions, askPermissions, denyPermissions, type LanguageToolchain, type PlatformPackageManager } from '../permissions.js';
+import { flattenPermissions, claudeToolPermissions, askPermissions, denyPermissions, extraPermissions, type LanguageToolchain, type PlatformPackageManager } from '../permissions.js';
 import { hooksTemplateDir, removeIfExists } from '../utils.js';
 import type { PermissionLevel, DeployablePermissionLevel, DeployLocation } from '../interactive.js';
 
@@ -127,12 +127,15 @@ export function removeLegacy(targetDir: string): number {
 /**
  * Build the Claude Code allow-list from the shared permissions.
  * Wraps each command in Bash(...) and appends Claude-specific tool permissions.
+ * `extraPermissions` is Claude-only and intentionally lives here rather than
+ * inside `flattenPermissions()` so it doesn't leak into Gemini's allowlist.
  */
 export function buildClaudeAllowList(
   languages?: LanguageToolchain[],
   platformManagers?: PlatformPackageManager[],
 ): string[] {
-  const bashPermissions = flattenPermissions(languages, platformManagers).map(cmd => `Bash(${cmd})`);
+  const flat = [...flattenPermissions(languages, platformManagers), ...extraPermissions];
+  const bashPermissions = flat.map(cmd => `Bash(${cmd})`);
   return [...bashPermissions, ...claudeToolPermissions];
 }
 

--- a/src/agents/gemini.test.ts
+++ b/src/agents/gemini.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { deploy, removeLegacy } from './gemini.js';
+import { buildGeminiAllowList, deploy, removeLegacy } from './gemini.js';
 
 describe('deploy', () => {
   let tmpDir: string;
@@ -94,5 +94,28 @@ describe('removeLegacy', () => {
   it('returns 0 when no skills exist to remove', () => {
     const removedCount = removeLegacy(tmpDir);
     expect(removedCount).toBe(0);
+  });
+});
+
+describe('buildGeminiAllowList', () => {
+  it('wraps every entry in run_shell_command(...)', () => {
+    const list = buildGeminiAllowList();
+    for (const entry of list) {
+      expect(entry.startsWith('run_shell_command(')).toBe(true);
+      expect(entry.endsWith(')')).toBe(true);
+    }
+  });
+
+  it('does not leak Claude-only extraPermissions (smithy.pr-review script paths)', () => {
+    // Regression guard for PR #290 review feedback. The pr-review skill is
+    // Claude-only, and its `:*` argument-suffix patterns are Claude syntax.
+    // Gemini's allowlist must remain free of them.
+    const list = buildGeminiAllowList();
+    const joined = list.join('\n');
+    expect(joined).not.toContain('smithy.pr-review/scripts/find-pr.sh');
+    expect(joined).not.toContain('smithy.pr-review/scripts/get-comments.sh');
+    expect(joined).not.toContain('smithy.pr-review/scripts/reply-comment.sh');
+    expect(joined).not.toContain('.claude/skills/');
+    expect(list.some(e => e.includes(':*'))).toBe(false);
   });
 });

--- a/src/permissions.test.ts
+++ b/src/permissions.test.ts
@@ -138,17 +138,26 @@ describe('flattenPermissions', () => {
     expect(denyPermissions).not.toContain('git push --force-with-lease *');
   });
 
-  it('appends extraPermissions (smithy.pr-review script paths) to the flattened allow list', () => {
+  it('does NOT include extraPermissions (Claude-only entries that would leak into Gemini)', () => {
+    // Regression guard for PR #290 review feedback: extraPermissions used to
+    // be appended inside flattenPermissions(), which Gemini's allowlist also
+    // consumes — leaking `.claude/...` paths and `:*` argument-suffix syntax
+    // into Gemini. They now live in buildClaudeAllowList() instead.
     const result = flattenPermissions();
-    // extraPermissions contents must round-trip through flattenPermissions
     for (const entry of extraPermissions) {
-      expect(result).toContain(entry);
+      expect(result).not.toContain(entry);
     }
-    // Specific entries the user expects
-    expect(result).toContain('.claude/skills/smithy.pr-review/scripts/find-pr.sh');
-    expect(result).toContain('.claude/skills/smithy.pr-review/scripts/get-comments.sh:*');
-    expect(result).toContain('*/smithy.pr-review/scripts/find-pr.sh');
-    expect(result).toContain('*/smithy.pr-review/scripts/reply-comment.sh:*');
+    expect(result).not.toContain('.claude/skills/smithy.pr-review/scripts/find-pr.sh');
+    expect(result).not.toContain('*/smithy.pr-review/scripts/get-comments.sh:*');
+  });
+
+  it('still exports extraPermissions with the smithy.pr-review entries (consumed by buildClaudeAllowList)', () => {
+    expect(extraPermissions).toContain('.claude/skills/smithy.pr-review/scripts/find-pr.sh');
+    expect(extraPermissions).toContain('.claude/skills/smithy.pr-review/scripts/get-comments.sh:*');
+    expect(extraPermissions).toContain('.claude/skills/smithy.pr-review/scripts/reply-comment.sh:*');
+    expect(extraPermissions).toContain('*/smithy.pr-review/scripts/find-pr.sh');
+    expect(extraPermissions).toContain('*/smithy.pr-review/scripts/get-comments.sh:*');
+    expect(extraPermissions).toContain('*/smithy.pr-review/scripts/reply-comment.sh:*');
   });
 
   it('filters to only node toolchain when languages=["node"]', () => {

--- a/src/permissions.test.ts
+++ b/src/permissions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { flattenPermissions, denyPermissions } from './permissions.js';
+import { flattenPermissions, askPermissions, denyPermissions, extraPermissions } from './permissions.js';
 
 describe('flattenPermissions', () => {
   it('returns an array of strings', () => {
@@ -122,6 +122,33 @@ describe('flattenPermissions', () => {
   it('denies npm publish', () => {
     expect(denyPermissions).toContain('npm publish');
     expect(denyPermissions).toContain('npm publish *');
+  });
+
+  it('denies force-push without lease', () => {
+    expect(denyPermissions).toContain('git push --force');
+    expect(denyPermissions).toContain('git push --force *');
+    expect(denyPermissions).toContain('git push -f');
+    expect(denyPermissions).toContain('git push -f *');
+  });
+
+  it('asks (does not deny) force-push with lease so rebase pushes can proceed', () => {
+    expect(askPermissions).toContain('git push --force-with-lease');
+    expect(askPermissions).toContain('git push --force-with-lease *');
+    expect(denyPermissions).not.toContain('git push --force-with-lease');
+    expect(denyPermissions).not.toContain('git push --force-with-lease *');
+  });
+
+  it('appends extraPermissions (smithy.pr-review script paths) to the flattened allow list', () => {
+    const result = flattenPermissions();
+    // extraPermissions contents must round-trip through flattenPermissions
+    for (const entry of extraPermissions) {
+      expect(result).toContain(entry);
+    }
+    // Specific entries the user expects
+    expect(result).toContain('.claude/skills/smithy.pr-review/scripts/find-pr.sh');
+    expect(result).toContain('.claude/skills/smithy.pr-review/scripts/get-comments.sh:*');
+    expect(result).toContain('*/smithy.pr-review/scripts/find-pr.sh');
+    expect(result).toContain('*/smithy.pr-review/scripts/reply-comment.sh:*');
   });
 
   it('filters to only node toolchain when languages=["node"]', () => {

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -395,6 +395,39 @@ export const permissions: Record<string, PermissionEntry> = {
 };
 
 /**
+ * Extra raw permission strings that don't fit the nested `command -> args` shape
+ * of `permissions`. Appended verbatim to the allow list. Use sparingly — most
+ * additions belong in `permissions`.
+ */
+export const extraPermissions: string[] = [
+  // Smithy pr-review skill scripts — belt-and-suspenders for the skill's own
+  // `allowed-tools` frontmatter. We enumerate likely deployment paths because
+  // Claude Code's `*` wildcard doesn't reliably span `/` boundaries.
+  // Repo-level deploy invokes scripts via the relative path; user-level deploy
+  // invokes them via an absolute home path that no single pattern can match
+  // without env-var expansion.
+  ".claude/skills/smithy.pr-review/scripts/find-pr.sh",
+  ".claude/skills/smithy.pr-review/scripts/get-comments.sh:*",
+  ".claude/skills/smithy.pr-review/scripts/reply-comment.sh:*",
+  "*/smithy.pr-review/scripts/find-pr.sh",
+  "*/smithy.pr-review/scripts/get-comments.sh:*",
+  "*/smithy.pr-review/scripts/reply-comment.sh:*",
+];
+
+/**
+ * Ask list — Claude Code prompts the user before running a matching command,
+ * even in auto mode. Sits between `allow` (silent auto-approve) and `deny`
+ * (hard block). Use for actions that are sometimes legitimate (e.g. force-push
+ * with lease during a rebase) but always deserve a human in the loop.
+ */
+export const askPermissions: string[] = [
+  // Force-push with lease — safe variant, but still wants explicit confirmation
+  // because it overwrites the remote branch tip.
+  "git push --force-with-lease",
+  "git push --force-with-lease *",
+];
+
+/**
  * Deny list — blocks dangerous subcommands even when the parent is allowed.
  * In Claude Code, deny takes precedence over allow.
  */
@@ -420,6 +453,12 @@ export const denyPermissions: string[] = [
   "git symbolic-ref --message *",
   "git symbolic-ref --delete *",
   "git symbolic-ref -d *",
+  // Force push WITHOUT lease — clobbers the remote unconditionally. The
+  // `--force-with-lease` variant is in the ask list instead.
+  "git push --force",
+  "git push --force *",
+  "git push -f",
+  "git push -f *",
   // npm publish — requires explicit approval
   "npm publish",
   "npm publish *",
@@ -522,6 +561,10 @@ export function flattenPermissions(
       }
     }
   }
+
+  // Raw entries that don't fit the nested shape (e.g. absolute/relative paths).
+  // Toolchain/platform filters don't apply — these are universal.
+  for (const entry of extraPermissions) result.push(entry);
 
   return result;
 }

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -395,9 +395,13 @@ export const permissions: Record<string, PermissionEntry> = {
 };
 
 /**
- * Extra raw permission strings that don't fit the nested `command -> args` shape
- * of `permissions`. Appended verbatim to the allow list. Use sparingly — most
- * additions belong in `permissions`.
+ * Claude-only raw permission strings that don't fit the nested `command -> args`
+ * shape of `permissions`. Appended verbatim to the Claude allow list by
+ * `buildClaudeAllowList`. **Do not** route through `flattenPermissions()` —
+ * Gemini's `buildGeminiAllowList` also consumes that flattener and would wrap
+ * these in `run_shell_command(...)`, which Gemini neither understands nor
+ * needs (Claude's `:*` argument-suffix syntax is meaningless to Gemini, and
+ * the `.claude/...` paths are Claude assets).
  */
 export const extraPermissions: string[] = [
   // Smithy pr-review skill scripts — belt-and-suspenders for the skill's own
@@ -561,10 +565,6 @@ export function flattenPermissions(
       }
     }
   }
-
-  // Raw entries that don't fit the nested shape (e.g. absolute/relative paths).
-  // Toolchain/platform filters don't apply — these are universal.
-  for (const entry of extraPermissions) result.push(entry);
 
   return result;
 }

--- a/src/templates/agent-skills/skills/smithy.pr-review/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.pr-review/SKILL.prompt
@@ -1,7 +1,7 @@
 ---
 name: smithy.pr-review
 description: "GitHub PR review operations: list inline comments, reply to comments. Use when handling review feedback on an open pull request."
-allowed-tools: Bash(*/smithy.pr-review/scripts/find-pr.sh) Bash(*/smithy.pr-review/scripts/get-comments.sh *) Bash(*/smithy.pr-review/scripts/reply-comment.sh *)
+allowed-tools: Bash(*/smithy.pr-review/scripts/find-pr.sh) Bash(*/smithy.pr-review/scripts/get-comments.sh:*) Bash(*/smithy.pr-review/scripts/reply-comment.sh:*)
 ---
 # smithy.pr-review
 


### PR DESCRIPTION
## Summary
- Primary outcome: stop the smithy.pr-review skill from prompting non-auto-mode users for permission on every script invocation, and split the force-push permission into `--force` (deny) vs `--force-with-lease` (ask) so auto-mode rebases aren't blocked.
- Notable behaviour changes: `permissions.ask` is now written into deployed `settings.json`; force-push without lease is hard-denied; force-with-lease prompts the user; the pr-review skill scripts are seeded into the global allow list under two pattern shapes.
- Follow-up work deferred: none.

## Context
- Issue #226 reported that the pr-review skill kept asking for permission on `Bash(... /smithy.pr-review/scripts/get-comments.sh ...)` invocations. PR #226 originally restored the canonical `:*` argument-suffix form, but PR #259 branched from the same parent and reverted the form back to ` *` on merge, so the fix didn't ship. Auto mode papers over the prompts today, but everyone else still sees them.
- Force-push handling: the user noted that auto-mode trips over force-push during rebases. Without an explicit `ask`, `--force-with-lease` either silently runs or gets blocked depending on the mode. Splitting the two variants (`--force` deny / `--force-with-lease` ask) gives a human-in-the-loop pause exactly when one is wanted, while still blocking the unconditional clobber.

## Implementation Notes
- `src/templates/agent-skills/skills/smithy.pr-review/SKILL.prompt` and the deployed `.claude/skills/smithy.pr-review/SKILL.md` switch back to `Bash(*/smithy.pr-review/scripts/get-comments.sh:*)` and `…reply-comment.sh:*`. The `:*` form is the documented canonical argument-suffix syntax.
- New `extraPermissions: string[]` in `src/permissions.ts` for raw entries that don't fit the nested `command -> args` shape. `flattenPermissions()` appends them to the allow list. Toolchain/platform filters intentionally don't apply — these are universal.
- The pr-review scripts are seeded with two pattern shapes:
  - Relative `.claude/skills/smithy.pr-review/scripts/<script>` for repo-level deploys (matches how Claude Code typically invokes them inside the project).
  - Wildcard `*/smithy.pr-review/scripts/<script>` as a fallback for user-level deploys where the absolute path varies.
- New `askPermissions` array, plumbed through `buildClaudeAskList` in `src/agents/claude.ts` and merged into `permissions.ask` by `writePermissions` (existing settings.json gets the same dedupe + merge treatment as `allow`/`deny`).
- `denyPermissions` gains `git push --force` / `git push --force *` / `git push -f` / `git push -f *`.
- Repo-level `.claude/settings.json` is hand-updated to mirror the deployed shape so smithy's own working copy benefits.

## Risks & Mitigations
- Risk: third-party tools that read `settings.json` may not expect the new `ask` key. | Mitigation: `ask` is part of Claude Code's documented schema; merge logic preserves any existing `ask` entries.
- Risk: someone with a hand-edited `permissions.allow` may end up with both old ` *` and new `:*` forms after `smithy update`. | Mitigation: the merge dedupes by string, so the worst case is two equivalent entries that both auto-approve — no behaviour regression.
- Risk: the `:*` form needs Claude Code's permission matcher to treat it as equivalent to ` *`. | Mitigation: this is documented in the Claude Code permissions reference and was the form chosen by the original PR #226; we're restoring rather than introducing it.

## Rollback Plan
- Revert this commit. The previous behaviour was already broken for non-auto users, and there are no migrations or external state to unwind.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build` — implicitly via `pretest`)
- [x] Type check succeeds (`npm run typecheck`)
- [ ] CLI `init` smoke test (`node dist/cli.js init`) — covered by the `writePermissions` integration tests, not run by hand

### Template Generation
- [ ] Gemini Skills: not touched in this change
- [ ] Codex Prompts: not touched in this change
- [x] Claude Prompts: `.claude/skills/smithy.pr-review/SKILL.md` updated to match the source template
- [ ] GitHub Issue Templates: not touched in this change

### Permissions & Configuration
- [ ] Gemini Config: not touched in this change
- [ ] Codex Config: not touched in this change
- [x] Claude Config: new `permissions.ask` array verified by `claude.test.ts` (schema, idempotency, merge with existing settings) plus repo-level `.claude/settings.json` updated to match

### Automated tests
- [x] `npm test` — 688 passed (23 files), including new coverage for `askPermissions`, force-push deny entries, and `extraPermissions` round-trip through `flattenPermissions`

### Manual Test Cases
- [ ] Manual smoke against an actual PR review flow not run — recommend kicking the tires next time you open a PR with review feedback. The skill prompts should disappear; `git push --force-with-lease` against a rebased branch should produce a single confirmation instead of running silently or being blocked.

## Issue
- Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)
