### PR TITLE
Add parallelism lenses to milestone, feature, and slice planning

### DIFF
--- a/src/templates/agent-skills/agents/smithy.reconcile-slices.prompt
+++ b/src/templates/agent-skills/agents/smithy.reconcile-slices.prompt
@@ -74,17 +74,23 @@ ordering.
 
 ### Step 2: Reconcile Tasks Within Slices
 
-Once slice boundaries are established (or for each competing boundary option):
+Once slice boundaries are established (or for each competing boundary option),
+classify each task across the N decompositions you received:
 
-1. **Consensus tasks** — tasks that appear in both decompositions (same
-   substance, possibly different wording). Keep the strongest formulation.
-2. **Unique tasks** — tasks from only one decomposition. Assess whether they
-   represent genuine work the other missed, or lens-specific additions (e.g.,
-   Structural Integrity adding a refactoring task that Minimal Path skipped).
-   Include with a `[via <lens>]` annotation.
-3. **Conflicting tasks** — tasks that address the same concern differently
-   (e.g., one modifies an existing function in-place, another extracts a new
-   module). Present as a conflict with recommendation.
+1. **Consensus tasks** — tasks that appear in **≥2 of N** decompositions (same
+   substance, possibly different wording). Tasks present in all N decompositions
+   are the strongest consensus and should be ordered first; tasks in 2 of N or
+   more are still consensus. Keep the strongest formulation and annotate with
+   the count, e.g. `[consensus: 3/3]` or `[consensus: 2/3 — Minimal Path,
+   Independent Slices]`.
+2. **Unique tasks** — tasks that appear in **exactly 1** decomposition. Assess
+   whether they represent genuine work the others missed, or lens-specific
+   additions (e.g., Structural Integrity adding a refactoring task that the
+   other lenses skipped). Include with a `[via <lens>]` annotation.
+3. **Conflicting tasks** — tasks where two or more decompositions address the
+   same concern differently (e.g., one modifies an existing function in-place,
+   another extracts a new module). Present as a conflict in Step 4 with all
+   competing approaches listed, not just two.
 
 ### Step 3: Validate Task Scoping
 
@@ -129,25 +135,27 @@ For each conflict (slice-level or task-level):
 1. Read the relevant code to assess which approach better fits current
    codebase patterns and conventions.
 2. Consider the tradeoffs each decomposition articulated.
-3. Present **both options** with a recommendation and reasoning. Do not
-   silently drop the losing option — the user benefits from seeing the
-   tradeoff.
+3. Present **all conflicting options** (one per dissenting lens) with a
+   recommendation and reasoning. Do not silently drop any losing option —
+   the user benefits from seeing every tradeoff that surfaced.
 
-Format conflicts as:
+Format conflicts as a bullet list with one entry per dissenting lens — two
+entries when only two lenses disagreed, three when all three did, and so on:
 
 ```
 **Conflict: <topic>**
-- **Option A** (<lens>): <description>
-- **Option B** (<lens>): <description>
-- **Recommendation**: <which option and why>
+- **<Lens A>**: <description of that lens's approach>
+- **<Lens B>**: <description of that lens's approach>
+- **<Lens C>**: <description of that lens's approach>   # only if a third lens dissented
+- **Recommendation**: <which option and why; tie-breaking rationale if applicable>
 ```
 
 ### Step 5: Carry Forward Scout Context
 
 If the competing decompositions referenced a scout report, verify that the
 reconciled output addresses all scout conflicts. If different decompositions
-handled a conflict differently, include both approaches in the conflicts
-section (Step 4).
+handled a conflict differently, include every distinct approach in the
+conflicts section (Step 4) — one entry per dissenting lens.
 
 ---
 
@@ -226,14 +234,17 @@ explanations — omit section if none>
   proposal. If a lens surfaced it, include it — annotated with its source.
   The user and parent agent decide what to act on.
 - **Be transparent about conflicts.** When decompositions disagree on slice
-  boundaries or task approach, show both sides. Make a recommendation but
-  present it as a recommendation, not a decision.
+  boundaries or task approach, show every dissenting side — one entry per
+  lens, not a forced two-way framing. Make a recommendation but present it
+  as a recommendation, not a decision.
 - **Verify against code.** When resolving conflicts, read the actual codebase
   files rather than relying solely on the competing decompositions'
   descriptions. The code is the source of truth.
 - **Enforce task scoping.** Unlike plan reconciliation, you have an additional
   responsibility: validating that every task in the final output complies with
   the scoping rules. This is a hard constraint, not a lens-dependent concern.
-- **Prefer consensus.** When both decompositions agree on a slice boundary or
-  task, that finding gets the highest confidence. Structure the output so
-  consensus items appear first.
+- **Prefer consensus.** A finding is consensus when it appears in **≥2 of N**
+  decompositions; full N/N agreement is the highest confidence and 2/N
+  through (N−1)/N still counts as consensus (with the count noted on the
+  item — see Step 2). Structure the output so consensus items appear first,
+  ordered by their agreement count (N/N before (N−1)/N before 2/N).

--- a/src/templates/agent-skills/agents/smithy.reconcile-slices.prompt
+++ b/src/templates/agent-skills/agents/smithy.reconcile-slices.prompt
@@ -26,9 +26,9 @@ dispatching competing smithy-slice sub-agents.
 
 The parent agent passes you:
 
-1. **Competing decompositions** — the structured outputs from 2 smithy-slice
-   runs, each labeled with the focus lens that produced it (e.g.,
-   "Minimal Path", "Structural Integrity").
+1. **Competing decompositions** — the structured outputs from the parallel
+   smithy-slice runs, each labeled with the focus lens that produced it (e.g.,
+   "Minimal Path", "Structural Integrity", "Independent Slices").
 2. **Context file paths** — the same codebase files that were passed to the
    slice agents, so you can verify findings against actual code.
 3. **User story** — the story title, acceptance scenarios, and traced FRs, for
@@ -42,27 +42,35 @@ The parent agent passes you:
 
 ### Step 1: Compare Slice Strategies
 
-The two decompositions may propose **different slice boundaries** — different
-numbers of slices, different groupings of acceptance scenarios, different
-foundational-vs-additive orderings. This is the most important divergence to
-resolve.
+The competing decompositions may propose **different slice boundaries** —
+different numbers of slices, different groupings of acceptance scenarios,
+different foundational-vs-additive orderings. This is the most important
+divergence to resolve.
 
 1. Map each decomposition's slices to the acceptance scenarios they address.
-2. Identify whether both decompositions cover all acceptance scenarios.
+2. Identify whether all decompositions cover the full set of acceptance
+   scenarios.
 3. Categorize the relationship:
-   - **Same slicing** — both propose the same slice boundaries (possibly with
-     different task details). Proceed to Step 2.
-   - **Different granularity** — one proposes more slices than the other (e.g.,
+   - **Same slicing** — all decompositions propose the same slice boundaries
+     (possibly with different task details). Proceed to Step 2.
+   - **Different granularity** — one proposes more slices than another (e.g.,
      2 vs 3 slices covering the same scenarios). Assess whether the finer
      split produces genuinely independent PRs or just fragments coherent work.
-   - **Different grouping** — both propose the same number of slices but group
-     scenarios differently. Assess which grouping produces more cohesive,
-     independently deliverable PRs.
+   - **Different grouping** — decompositions propose the same number of slices
+     but group scenarios differently. Assess which grouping produces more
+     cohesive, independently deliverable PRs.
 
 For different-granularity or different-grouping cases, read the relevant code
 to assess which slicing better matches the codebase's natural boundaries
 (module structure, test organization, dependency graph). Present the conflict
 with a recommendation (see Step 4).
+
+**Parallelism check.** When one decomposition marks `Depends On = —` and
+another asserts an ordering, verify the dependency exists in the actual data
+or code flow before adopting the ordered version. Convention-driven sequencing
+(e.g., "do scaffolding first, then features") is not a real dependency —
+prefer the parallel-eligible version unless the code or data flow demands
+ordering.
 
 ### Step 2: Reconcile Tasks Within Slices
 

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -583,6 +583,7 @@ Use the **smithy-refine** sub-agent. Pass it:
   |----------|---------------|
   | **Story Completeness** | Does every user story have acceptance scenarios, priority justification, and an independent test? Are there obvious missing stories? |
   | **Priority Ordering** | Are user stories ordered by priority (all P1 first, then P2, then P3)? If priorities have changed since the last revision, do the story numbers still reflect the correct priority order? Flag any out-of-order stories. |
+  | **Story Independence** | Are user stories that touch disjoint code areas or address functionally independent acceptance scenarios marked as such, so they can be cut in parallel? Is the implied "all of P1 before any of P2" sequencing real, or merely conventional? Flag stories where `Depends On` overstates the actual prerequisite. |
   | **Requirement Traceability** | Does every FR trace to at least one user story? Are there user stories with no supporting requirements? |
   | **Cross-Document Consistency** | Do entities in data-model.md match Key Entities in the spec? Do contracts.md interfaces align with integration-related requirements? |
   | **Edge Case Coverage** | Are edge cases from the spec reflected in acceptance scenarios or requirements? Are there unaddressed failure modes? |

--- a/src/templates/agent-skills/commands/smithy.render.prompt
+++ b/src/templates/agent-skills/commands/smithy.render.prompt
@@ -81,6 +81,7 @@ Use the **smithy-refine** sub-agent. Pass it:
   | **Gaps** | Are there milestone goals or success criteria that no feature addresses? |
   | **Overlap** | Are there features with unclear or overlapping boundaries? |
   | **Dependency Clarity** | Are inter-feature dependencies within the milestone evident, or are they hidden? |
+  | **Feature Independence** | Are features that touch disjoint code areas or address functionally independent milestone goals marked as such, so they can be specced and cut in parallel? Is the implied ordering real (data flow / contract dependency), or merely conventional? Flag features whose `Depends On` overstates the actual prerequisite. |
   | **RFC Alignment** | Does the feature map align with the RFC's stated goals and success criteria for this milestone? |
 
 - **Target files**: the `.features.md` file and the source `.rfc.md` file

--- a/src/templates/agent-skills/snippets/audit-checklist-features.md
+++ b/src/templates/agent-skills/snippets/audit-checklist-features.md
@@ -6,6 +6,7 @@
 | **Gaps** | Are there milestone goals or success criteria that no feature addresses? |
 | **Overlap** | Are there features with unclear or overlapping boundaries? |
 | **Dependency Clarity** | Are inter-feature dependencies within the milestone evident, or are they hidden? |
+| **Feature Independence** | Are features that touch disjoint code areas or address functionally independent milestone goals marked as such, so they can be specced and cut in parallel? Is the implied ordering real (data flow / contract dependency), or merely conventional? Flag features whose `Depends On` overstates the actual prerequisite. |
 | **Dependency Order** | If the feature map contains a `## Dependency Order` section: is it a 4-column Markdown table with headers `ID | Title | Depends On | Artifact`? Does every row use an `F<N>` ID (no leading zeros) that is unique within the table? Does each `Depends On` cell list only IDs from the same table (or `—`)? Does every `Artifact` cell contain either `—` or a repo-relative path to an existing spec folder (flag any path that does not resolve)? Is the sequence logically justified? No `[ ]`/`[x]` checkbox syntax is valid here — flag any checkbox markup as a finding. |
 | **RFC Alignment** | Does the feature map align with the RFC's stated goals and success criteria for this milestone? |
 | **Specification Debt** | Does the feature map contain a `## Specification Debt` section? Are debt items structured with required metadata? |

--- a/src/templates/agent-skills/snippets/audit-checklist-spec.md
+++ b/src/templates/agent-skills/snippets/audit-checklist-spec.md
@@ -4,6 +4,7 @@
 |----------|---------------|
 | **Story Completeness** | Does every user story have acceptance scenarios, priority justification, and an independent test? Are there obvious missing stories? |
 | **Priority Ordering** | Are user stories ordered by priority (all P1 first, then P2, then P3)? If any story appears out of priority order, flag it as a finding. |
+| **Story Independence** | Are user stories that touch disjoint code areas or address functionally independent acceptance scenarios marked as such, so they can be cut in parallel? Is the implied "all of P1 before any of P2" sequencing real, or merely conventional? Flag stories where `Depends On` overstates the actual prerequisite. |
 | **Requirement Traceability** | Does every FR trace to at least one user story? Are there user stories with no supporting requirements? |
 | **Cross-Document Consistency** | Do entities in data-model.md match Key Entities in the spec? Do contracts.md interfaces align with integration-related requirements? |
 | **Edge Case Coverage** | Are edge cases from the spec reflected in acceptance scenarios or requirements? Are there unaddressed failure modes? |

--- a/src/templates/agent-skills/snippets/competing-lenses-decomposition.md
+++ b/src/templates/agent-skills/snippets/competing-lenses-decomposition.md
@@ -1,6 +1,6 @@
 ### Competing Slice Lenses
 
-Dispatch 2 competing **smithy-slice** sub-agents in parallel. Each receives the
+Dispatch 3 competing **smithy-slice** sub-agents in parallel. Each receives the
 same user story, spec artifacts, codebase file paths, and scout report — the
 only difference is the **additional planning directives** field.
 
@@ -29,15 +29,29 @@ Use the following lens directives (one per sub-agent):
 > your attention, not your coverage — still flag unnecessary refactoring or
 > scope creep if you find them.
 
+#### Independent Slices
+
+> **Directive:** Bias toward slices whose `Depends On` cell is `—`. When two
+> slices touch the same files but address functionally independent acceptance
+> scenarios, treat them as parallel-eligible rather than fabricating a
+> sequential chain. Avoid front-loading "scaffolding" or "groundwork" slices
+> that exist only to enable later work — if scaffolding is real, fold it into
+> the first slice that needs it. In the Tradeoffs section, surface at least
+> one alternative slicing with greater parallel-execution potential even if
+> you ultimately recommend against it. This directive biases your attention,
+> not your coverage — still flag structural problems, missing tasks, or scope
+> creep if you find them.
+
 ---
 
 Pass the quoted directive text above as the **Additional planning directives**
 field for the corresponding smithy-slice run.
 
-After both return, dispatch the **smithy-reconcile-slices** sub-agent. Pass it:
+After all 3 return, dispatch the **smithy-reconcile-slices** sub-agent. Pass it:
 
-- Both slice decomposition outputs, each labeled with its lens name (e.g.,
-  "**[Minimal Path]** …", "**[Structural Integrity]** …")
+- All 3 slice decomposition outputs, each labeled with its lens name (e.g.,
+  "**[Minimal Path]** …", "**[Structural Integrity]** …",
+  "**[Independent Slices]** …")
 - The same context file paths
 - The user story and spec artifact paths
 

--- a/src/templates/agent-skills/snippets/competing-lenses-scoping.md
+++ b/src/templates/agent-skills/snippets/competing-lenses-scoping.md
@@ -1,6 +1,6 @@
 ### Competing Plan Lenses
 
-Dispatch 3 competing **smithy-plan** sub-agents in parallel. Each receives the
+Dispatch 4 competing **smithy-plan** sub-agents in parallel. Each receives the
 same planning context, feature description, codebase file paths, and scout
 report — the only difference is the **additional planning directives** field.
 
@@ -37,16 +37,29 @@ Use the following lens directives (one per sub-agent):
 > recommend against it. This directive biases your attention, not your
 > coverage — still flag scope bloat or completeness gaps if you find them.
 
+#### Parallelism
+
+> **Directive:** Look for splits that let independent workstreams begin
+> concurrently. Prefer **vertical slices** that span data, logic, and interface
+> over **horizontal phases** that batch all of one layer before any of the
+> next. For each milestone, feature, or user story, ask whether its children
+> could realistically start in parallel without a missing prerequisite — and
+> whether a sequential ordering is truly required by data flow, or merely
+> conventional. In the Tradeoffs section, surface at least one alternative
+> with greater concurrent-execution potential even if you ultimately recommend
+> against it. This directive biases your attention, not your coverage — still
+> flag scope bloat, completeness gaps, or coherence issues if you find them.
+
 ---
 
 Pass the quoted directive text above as the **Additional planning directives**
 field for the corresponding smithy-plan run.
 
-After all 3 return, dispatch the **smithy-reconcile** sub-agent. Pass it:
+After all 4 return, dispatch the **smithy-reconcile** sub-agent. Pass it:
 
-- All 3 plan outputs, each labeled with its lens name (e.g.,
+- All 4 plan outputs, each labeled with its lens name (e.g.,
   "**[Scope Minimalism]** …", "**[Completeness]** …",
-  "**[Coherence]** …")
+  "**[Coherence]** …", "**[Parallelism]** …")
 - The same context file paths
 - The planning context and feature description
 


### PR DESCRIPTION
## Summary
- Primary outcome: planning artifacts decompose with concurrent execution in mind, not just logical grouping.
- Notable behaviour changes: scoping runs now dispatch 4 competing smithy-plan lenses (was 3); slice cuts now dispatch 3 competing smithy-slice lenses (was 2); spec and feature-map audits gain independence checks.
- Follow-up work deferred: none.

## Context
- Why now: issue #283 reports that the RFC → milestones → features → specs → user stories → slices chain produces outputs with low parallelism, turning development into a long sequential pipeline. The hierarchy is logically clean and human-readable, but each level forces "all of parent before any of child," and decomposition tends toward horizontal phases (all schema, then all API, then all UI) rather than vertical slices that could run concurrently.
- The user explicitly framed the fix as a lens-side change ("adjust, refocus, or add a planning lens with a bias toward parallel execution") and warned that vertical slicing must remain the safety mechanism so prerequisite chains do not go astray.

## Implementation Notes
- **Add — don't refocus.** None of the existing five planning lenses (Scope Minimalism / Completeness / Coherence; Minimal Path / Structural Integrity) subsumes parallelism. Each new lens is additive so no existing contrast surface is weakened.
- **Two new lenses.** `Parallelism` joins `competing-lenses-scoping.md` (consumed by ignite, render, mark). `Independent Slices` joins `competing-lenses-decomposition.md` (consumed by cut). Both directives push toward vertical slices and end with the standard "biases your attention, not your coverage" closing so completeness/coherence findings still surface.
- **Audit-checklist mirror.** `audit-checklist-spec.md` gains a `Story Independence` row (mirrored inline in `smithy.mark.prompt`); `audit-checklist-features.md` gains a `Feature Independence` row (mirrored inline in `smithy.render.prompt`). These catch convention-driven sequencing during Phase 0 review.
- **Reconcile guard.** `smithy.reconcile-slices.prompt` Step 1 gains a Parallelism check sentence so the reconciler verifies that ordering claims reflect real data/code dependencies, not "do scaffolding first" convention. Input wording is also generalised from "two decompositions" to "competing decompositions" to match the new 3-way input.
- **Out of scope (per issue framing):** the `## Dependency Order` "same-table-only" schema rule. That is the deeper structural enabler for cross-artifact partial dependencies, but the user scoped this issue to lens adjustments.

## Risks & Mitigations
- Risk: new lens drives reconcile to drop ordering that was actually load-bearing. Mitigation: existing reconcile machinery preserves all unique finds with `[via <lens>]` annotations and surfaces conflicts with both options. Step 1 guard requires verifying ordering against real data/code flow before adopting it.
- Risk: parallelism push erodes correctness/clarity. Mitigation: lens directives explicitly preserve completeness and coherence coverage; smithy-clarify, smithy-refine, smithy-plan-review are untouched; the working-increment rule in `smithy.slice.prompt` Step 4 is reinforced (not weakened) by the Independent Slices "no scaffolding-only slices" guidance.
- Risk: dispatch-count bumps (3→4 scoping, 2→3 decomposition) inflate planning latency or token cost. Mitigation: lenses run in parallel; total wall-clock is bounded by the slowest lens, not the sum.

## Rollback Plan
- Revert this PR. Templates are pure content; no migrations, no manifest changes, no runtime state. After revert, `smithy update` redeploys the prior templates without further action.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npm run typecheck`)
- [x] CLI `init` smoke test (`node dist/cli.js init`)

### Template Generation
- [ ] Gemini Skills: `.gemini/skills/` folders and `SKILL.md` validity.
- [ ] Codex Prompts: `tools/codex/prompts/` file content.
- [x] Claude Prompts: `.claude/prompts/` file content. (Spot-checked deployed `smithy.ignite.md`, `smithy.render.md`, `smithy.mark.md`, `smithy.cut.md`, `smithy.audit.md`, `smithy.reconcile-slices.md`: new lens blocks render with correct dispatch counts (4/4/4/3), audit rows propagate, reconcile guard is present.)
- [ ] GitHub Issue Templates: `.github/ISSUE_TEMPLATE/` content.

### Permissions & Configuration
- [ ] Gemini Config: `.gemini/config.json` correctly formed and merged.
- [ ] Codex Config: `.codex/config.toml` contains correct `[[approvals.rules]]`.
- [ ] Claude Config: `.claude/settings.json` correctly formed.

### Manual Test Cases
- [x] `npm test` — 681 tests pass (`src/templates.test.ts` partial-expansion and lens-heading assertions are lens-name-agnostic, so they continue to pass without modification).

## Issue
- Closes #283
