### PR TITLE
Unblock the evals runner in headless CI mode

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,7 @@
     "allow": [
       "Bash(git status)",
       "Bash(git status -s)",
+      "Bash(git init)",
       "Bash(git fetch *)",
       "Bash(git pull *)",
       "Bash(git pull --rebase *)",
@@ -218,7 +219,7 @@
       "Bash(unzip -l *)",
       "WebSearch",
       "WebFetch",
-      "Write(//tmp/**)",
+      "Write(/tmp/**)",
       "Skill(smithy.*:*)"
     ],
     "deny": [

--- a/evals/lib/runner.test.ts
+++ b/evals/lib/runner.test.ts
@@ -179,7 +179,7 @@ describe('runScenario', () => {
       // Fixture isolation: spawn must target the temp copy, not the source.
       expect(spawn).toHaveBeenCalledWith(
         'claude',
-        ['--output-format', 'stream-json', '--verbose', '-p', '/smithy.strike do something'],
+        ['--output-format', 'stream-json', '--verbose', '--permission-mode', 'bypassPermissions', '-p', '/smithy.strike do something'],
         expect.objectContaining({
           cwd: expect.stringContaining('smithy-eval-'),
           stdio: ['ignore', 'pipe', 'pipe'],

--- a/evals/lib/runner.ts
+++ b/evals/lib/runner.ts
@@ -278,8 +278,21 @@ export async function runScenario(
     // re-confirmed against claude 2.1.121: without it, claude exits 1 with
     // "Error: When using --print, --output-format=stream-json requires --verbose"
     // before emitting any events).
+    //
+    // `--permission-mode bypassPermissions` is required because headless `-p`
+    // mode has no human to approve permission prompts. Without it, any tool
+    // call not covered by the deployed allow-list (e.g. `git init` on a fresh
+    // fixture, or a Write outside an over-narrow glob) silently stalls until
+    // the per-case timeout fires. Each scenario runs in a throwaway temp dir
+    // and the source fixture is checksum-verified before/after (FR-011), so
+    // bypass is appropriate for the eval harness.
     const result = await spawnClaude(
-      ['--output-format', 'stream-json', '--verbose', '-p', invocation],
+      [
+        '--output-format', 'stream-json',
+        '--verbose',
+        '--permission-mode', 'bypassPermissions',
+        '-p', invocation,
+      ],
       tmpDir,
       timeoutMs,
     );

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -29,6 +29,7 @@ export const permissions: Record<string, PermissionEntry> = {
   git: {
     "status": [],
     "status -s": [],
+    "init": [],
     "fetch": ["*"],
     "pull": ["*"],
     "pull --rebase": ["*"],
@@ -432,7 +433,7 @@ export const denyPermissions: string[] = [
 export const claudeToolPermissions: string[] = [
   "WebSearch",
   "WebFetch",
-  "Write(//tmp/**)",
+  "Write(/tmp/**)",
   "Skill(smithy.*:*)",
 ];
 


### PR DESCRIPTION
## Summary
- Primary outcome: unblock the Smithy Evals workflow in headless CI mode so `strike-health-check` actually finishes within the per-case timeout instead of stalling on permission prompts.
- Notable behaviour changes: the eval runner now spawns `claude` with `--permission-mode bypassPermissions`; the deployed Claude permission set adds `Bash(git init)` and fixes the `Write(//tmp/**)` typo to `Write(/tmp/**)`.
- Follow-up work deferred: none.

## Context
- The Smithy Evals workflow added in #281 ran cleanly locally but consistently failed on the GitHub-hosted runner. Run [25357652480](https://github.com/Balexda/SmithyCLI/actions/runs/25357652480) is the canonical failure: `strike-health-check` hit `SIGTERM` at the 600s timeout with only 1535 chars of output, missing every required heading.
- The captured stream events show the agent never got past Phase 1 — it spent the full 10 minutes in a permission-denial loop, repeatedly diagnosing the same blockers in user-visible text:
  - `Write(//tmp/**)` had a literal double slash, so the glob never matched real `/tmp/...` paths and every `Write` was denied.
  - `git init` was missing from the allow-list, so strike could not create a branch on the fresh fixture copy.
  - In headless `claude -p` mode there is no human to approve a prompt, so any tool not covered by the deployed allow-list silently stalls until SIGTERM rather than surfacing as a fast failure.
- Scout passed (it only does Read/Grep/Glob), which is why the failure was strike-specific.

## Implementation Notes
- `evals/lib/runner.ts` — spawn `claude` with `--permission-mode bypassPermissions`. This is the master fix: even after closing the two specific allow-list gaps below, any future tool not on the deployed list would deadlock the same way. Each scenario runs in a fresh `mkdtempSync` copy of the fixture and the source fixture is SHA-256-verified before/after (FR-011), so bypass is appropriate for this harness.
- `src/permissions.ts` — fixed the `Write(//tmp/**)` typo (now `Write(/tmp/**)`) and added `"init": []` to the git block.
- `.claude/settings.json` — synced both fixes into smithy's own deployed allow-list.
- `evals/lib/runner.test.ts` — updated the args-array assertion that pins the spawn call.

## Risks & Mitigations
- Risk: `bypassPermissions` lets the eval agent invoke any tool, including potentially destructive ones. | Mitigation: scoped to the eval harness only (not user-facing); each run executes in a fresh `mkdtempSync` directory under `os.tmpdir()`; the source fixture is checksum-verified before and after each scenario (FR-011); the temp dir is unconditionally cleaned up in a `finally` block (FR-013).
- Risk: adding `Bash(git init)` to the global allow-list lets agents initialize repositories without prompting. | Mitigation: `git init` is idempotent and non-destructive — it only creates `.git/` if it does not already exist and never touches user files.
- Risk: the typo fix changes a permission users may already have approved manually. | Mitigation: the previous form did not match anything, so no behaviour can have come to depend on it; the corrected form is what the comment-of-record always intended.

## Rollback Plan
- Revert this commit. No migrations, no manifest changes; the eval harness reverts to the prior spawn shape and smithy's deployed permissions revert to the prior (broken) form.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build` — runs implicitly via `pretest`)
- [x] Type check succeeds (`npm run typecheck`)
- [ ] CLI `init` smoke test (`node dist/cli.js init`) — not exercised; init code path unchanged.

### Template Generation
- [ ] Gemini Skills: not touched.
- [ ] Codex Prompts: not touched.
- [ ] Claude Prompts: not touched.
- [ ] GitHub Issue Templates: not touched.

### Permissions & Configuration
- [ ] Gemini Config: not touched.
- [ ] Codex Config: not touched.
- [x] Claude Config: `.claude/settings.json` updated to match the new `permissions.ts` shape; covered indirectly by `claude.test.ts` which round-trips the deploy logic.

### Manual Test Cases
- [ ] Init/uninit flows unchanged; A-/H-series cases not re-run.

### Automated
- [x] `npm test` — 685 / 685 pass.
- [x] Re-triggered the Smithy Evals workflow on this branch: [run 25360285498](https://github.com/Balexda/SmithyCLI/actions/runs/25360285498) — **PASS (2/2)** in 8m50s. `strike-health-check` finished in 464s (was: TIMEOUT at 600s) with all required headings, all sub-agent evidence, and the full baseline regression check passing. `scout-fixture-shallow` finished in 47s.
