### PR TITLE
Honor pre-existing worktree branches in smithy commands

### DIFF
--- a/src/agents/claude.test.ts
+++ b/src/agents/claude.test.ts
@@ -398,13 +398,13 @@ describe('buildClaudeAllowList', () => {
     expect(list).toContain('Bash(git commit *)');
     expect(list).toContain('Bash(git diff *)');
     expect(list).toContain('Bash(git log *)');
-    expect(list).toContain('Bash(git push -u origin feature/*)');
+    expect(list).toContain('Bash(git push -u origin *)');
   });
 
-  it('includes claude/* branch push patterns', () => {
+  it('allows pushing any branch shape (orchestrator-supplied worktree branches included)', () => {
     const list = buildClaudeAllowList();
-    expect(list).toContain('Bash(git push -u origin claude/*)');
-    expect(list).toContain('Bash(git push origin claude/*)');
+    expect(list).toContain('Bash(git push -u origin *)');
+    expect(list).toContain('Bash(git push origin *)');
   });
 
   it('includes Claude-only extraPermissions (smithy.pr-review script paths)', () => {

--- a/src/permissions.test.ts
+++ b/src/permissions.test.ts
@@ -53,7 +53,7 @@ describe('flattenPermissions', () => {
     expect(result).toContain('git status -s');
     expect(result).toContain('git checkout *');
     expect(result).toContain('git checkout -b *');
-    expect(result).toContain('git push -u origin feature/*');
+    expect(result).toContain('git push -u origin *');
   });
 
   it('flattens gh --version as a bare command', () => {

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -77,8 +77,14 @@ export const permissions: Record<string, PermissionEntry> = {
     "symbolic-ref HEAD": [],
     "symbolic-ref refs/remotes/origin/HEAD": [],
     "push": [],
-    "push -u origin": ["feature/*", "fix/*", "chore/*", "strike/*", "claude/*"],
-    "push origin": ["feature/*", "fix/*", "chore/*", "strike/*", "claude/*"],
+    // Branch wildcards cover every Smithy auto-naming convention plus the
+    // orchestrator-supplied worktree branch shapes (e.g. `smithy/cut/...`,
+    // `<NNN>/us-<NN>-<slug>/slice-<N>`, `<YYYY-MM-DD>-<NNN>-<slug>`).
+    // Force-push is still blocked: `git push --force` / `-f` are in the deny
+    // list, and `--force-with-lease` requires explicit approval (askPermissions
+    // below).
+    "push -u origin": ["*"],
+    "push origin": ["*"],
   },
 
   // --- Filesystem (read + create, no delete) ---

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -101,7 +101,7 @@ describe('resolveSnippets', () => {
 describe('loadSnippets', () => {
   it('loads all snippet files', () => {
     const snippets = loadSnippets();
-    expect(snippets.size).toBe(13);
+    expect(snippets.size).toBe(14);
 
     const expectedFiles = [
       'audit-checklist-rfc.md',
@@ -117,6 +117,7 @@ describe('loadSnippets', () => {
       'review-protocol.md',
       'one-shot-output.md',
       'pr-create-tool-choice.md',
+      'branch-policy.md',
     ];
     for (const file of expectedFiles) {
       expect(snippets.has(file)).toBe(true);
@@ -137,6 +138,7 @@ describe('loadSnippets', () => {
     expect(snippets.get('competing-lenses-decomposition.md')).toContain('Competing Slice Lenses');
     expect(snippets.get('competing-lenses-implementation.md')).toContain('Competing Plan Lenses');
     expect(snippets.get('competing-lenses-scoping.md')).toContain('Competing Plan Lenses');
+    expect(snippets.get('branch-policy.md')).toContain('Branch Selection Policy');
   });
 });
 

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -125,7 +125,11 @@ found no changes") and reuse the branch's existing PR URL if one exists
 1. Stage and commit the refinement diff on the current branch. The commit
    message should describe the refinements applied (e.g.,
    `cut refine: split Slice 2; resolve SD-001`).
-2. Push the branch to `origin`.
+2. Push the current branch to `origin` as-is — do not rename it or
+   prepend a prefix such as `feature/`. Orchestrators that pre-create
+   the worktree track the spec by the branch name they chose, and a
+   renamed PR head breaks downstream PR discovery (see the branch
+   policy below for the full rule).
 3. Check whether the current branch already has an open pull request (for
    example with `mcp__github__list_pull_requests` filtered by `head`, or
    `gh pr view --json url` if MCP is unavailable).
@@ -624,7 +628,12 @@ PR with `head == base` will fail and pollute history.
 
 1. Stage and commit both the new `.tasks.md` file and the spec's
    `## Dependency Order` write-back on the current branch.
-2. Push the branch to `origin`.
+2. Push the current branch to `origin` as-is — do not rename it or
+   prepend a prefix such as `feature/`. The PR must be opened against
+   the same branch name the operator (or upstream orchestrator) had
+   checked out when cut was invoked, so downstream tooling can find
+   the PR by that branch name. The branch policy below states the
+   full rule.
 3. Create a pull request using the same PR-creation pattern that
    `smithy.forge` uses ({{>pr-create-tool-choice}}):
    - **Title**: the user story title, under 70 characters, plain descriptive
@@ -705,6 +714,10 @@ is the contract.
   tasks. See "Prohibitions" in the task authoring guidelines.
 - **DO** express testing requirements as acceptance criteria on the functional
   task, not as separate tasks.
+
+---
+
+{{>branch-policy}}
 
 ---
 

--- a/src/templates/agent-skills/commands/smithy.forge.prompt
+++ b/src/templates/agent-skills/commands/smithy.forge.prompt
@@ -37,7 +37,13 @@ This may be:
   are not all marked complete (`- [x]`). If ALL slices have all tasks marked
   complete, show a table of all slices and ask which one to audit.
 - A **slice number only** — if so, look for a `.tasks.md` file matching the
-  current branch name's spec and story identifiers.
+  current branch name's spec and story identifiers. This requires the
+  current branch to follow the standard forge shape
+  `<NNN>/us-<NN>-<slug>/slice-<N>`. When forge is invoked in a linked
+  worktree on an orchestrator-supplied branch that does not match this
+  shape, the slice-number-only invocation cannot infer the tasks file —
+  ask the user for the explicit tasks file path instead. (`smithy.audit`
+  has the same dependency on this shape and the same fallback.)
 - A **`.strike.md` file path** — single slice, no slice number needed.
 - Empty — if so, ask the user which tasks file and slice to work on.
 
@@ -106,22 +112,26 @@ Before creating the branch, check whether one with this derived name
 already exists. If it does, ask the user whether to continue on it or
 abort. Otherwise create it.
 
-When the policy keeps the existing branch (the current checkout is
-already a non-default branch — common when an orchestrator pre-created
-the worktree on a slice-named branch), skip the derivation and the
+When the policy keeps the existing branch (the current cwd is a linked
+worktree on a non-default branch — typical when an orchestrator
+pre-staged it on a slice-named branch), skip the derivation and the
 `git checkout -b` step entirely and use the existing checkout. The
-slice's PR will be opened against that exact branch name.
+slice's PR will be opened against that exact branch name. In the
+normal main-checkout `mark` → `cut` → `forge` flow the policy falls
+through to auto-naming, so each slice still gets its own
+`<NNN>/us-<NN>-<slug>/slice-<N>` branch as before.
 
 {{>branch-policy}}
 
 ### `.strike.md` mode
 
 Read the `**Branch:** <branch>` field from the strike file header. If the
-current checkout is already on that branch (or on any non-default branch
-that an upstream orchestrator pre-staged for this slice), keep the
-existing checkout — do not switch. Otherwise check out the branch named
-in the strike file header; if that branch does not exist for some
-reason, create it from the repository's default branch.
+current cwd is a linked worktree on any non-default branch (typical when
+an upstream orchestrator pre-staged the worktree for this slice), keep
+the existing checkout — do not switch off the worktree's branch. In the
+main checkout, check out the branch named in the strike file header; if
+that branch does not exist for some reason, create it from the
+repository's default branch.
 
 ---
 

--- a/src/templates/agent-skills/commands/smithy.forge.prompt
+++ b/src/templates/agent-skills/commands/smithy.forge.prompt
@@ -85,7 +85,10 @@ This may be:
 
 ### `.tasks.md` mode
 
-Derive the branch name from the tasks file path and slice number using this convention:
+Resolve the working branch using the policy below. When the policy
+creates a new branch (the current checkout is the default branch),
+derive the new branch name from the tasks file path and slice number
+using this convention:
 
 ```
 <NNN>/us-<NN>-<slug>/slice-<N>
@@ -99,14 +102,26 @@ Where:
 
 Example: `001/us-03-bar/slice-2`
 
-Before creating the branch:
-- Check if the branch already exists. If it does, ask the user whether to continue on it or abort.
-- Create the branch from the repository's default branch and check it out.
-  Discover the default branch dynamically (e.g., `git symbolic-ref refs/remotes/origin/HEAD`) rather than assuming `main`.
+Before creating the branch, check whether one with this derived name
+already exists. If it does, ask the user whether to continue on it or
+abort. Otherwise create it.
+
+When the policy keeps the existing branch (the current checkout is
+already a non-default branch — common when an orchestrator pre-created
+the worktree on a slice-named branch), skip the derivation and the
+`git checkout -b` step entirely and use the existing checkout. The
+slice's PR will be opened against that exact branch name.
+
+{{>branch-policy}}
 
 ### `.strike.md` mode
 
-Read the `**Branch:** strike/<slug>` field from the strike file header. Check out that existing branch (it was created by strike's Phase 1). If the branch doesn't exist for some reason, create it from the default branch.
+Read the `**Branch:** <branch>` field from the strike file header. If the
+current checkout is already on that branch (or on any non-default branch
+that an upstream orchestrator pre-staged for this slice), keep the
+existing checkout — do not switch. Otherwise check out the branch named
+in the strike file header; if that branch does not exist for some
+reason, create it from the repository's default branch.
 
 ---
 
@@ -309,6 +324,12 @@ Include the command output summary in your final response so reviewers know what
 ---
 
 ## Pull Request
+
+Push the resolved branch from the Branch step as-is, and create the PR
+against that exact branch name. Do not rename the branch or prepend a
+prefix such as `feature/` — orchestrators that pre-create the worktree
+track the slice by the branch name they chose, and a renamed PR head
+breaks downstream PR discovery.
 
 {{>pr-create-tool-choice}}
 

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -738,9 +738,13 @@ sub-phases 3a–3f, and harmonized it in sub-phase 3g. Skip folder creation
 and file write — proceed directly through plan-review, commit, and PR:
 
 1. Run the Plan-Review Pass described above on the harmonized RFC file.
-2. Commit the RFC file on the feature branch (capturing both the harmonized
-   content and any plan-review fixes in the same diff).
-3. Create a PR for the RFC artifact using the forge `gh pr create` pattern
+2. Commit the RFC file on the current feature branch (capturing both the
+   harmonized content and any plan-review fixes in the same diff). Push
+   the current branch as-is — do not rename it or prepend a prefix such
+   as `feature/`. The PR must be opened against the same branch the
+   operator (or upstream orchestrator) had checked out when ignite was
+   invoked. See the branch policy below.
+3. Create a PR for the RFC artifact using the forge PR-creation pattern
    ({{>pr-create-tool-choice}}):
    - **Title**: the RFC title, under 70 characters, descriptive text only.
    - **Body**: the one-shot output snippet content (rendered below) plus a
@@ -761,9 +765,13 @@ and file write — proceed directly through plan-review, commit, and PR:
 2. Write the RFC to `docs/rfcs/<YYYY>-<NNN>-<slug>/<slug>.rfc.md`.
 3. Run the Plan-Review Pass described above on the RFC file that was just
    written.
-4. Commit the RFC file on the feature branch (capturing both the original
-   RFC content and any plan-review fixes in the same diff).
-5. Create a PR for the RFC artifact using the forge `gh pr create` pattern
+4. Commit the RFC file on the current feature branch (capturing both the
+   original RFC content and any plan-review fixes in the same diff). Push
+   the current branch as-is — do not rename it or prepend a prefix such
+   as `feature/`. The PR must be opened against the same branch the
+   operator (or upstream orchestrator) had checked out when ignite was
+   invoked. See the branch policy below.
+5. Create a PR for the RFC artifact using the forge PR-creation pattern
    ({{>pr-create-tool-choice}}):
    - **Title**: the RFC title, under 70 characters, descriptive text only.
    - **Body**: the one-shot output snippet content (rendered below) plus a
@@ -799,3 +807,7 @@ and file write — proceed directly through plan-review, commit, and PR:
 - **DO** ensure milestones are clearly delineated with distinct scope and success criteria.
 - **DO** surface risks during clarification via the clarify return.
 - **DO** keep the RFC concise — a good RFC is a starting point, not a final design.
+
+---
+
+{{>branch-policy}}

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -90,10 +90,22 @@ When entering Phase 1 from a `.features.md`, carry forward:
      with hyphens, collapse consecutive hyphens, trim leading/trailing
      hyphens. Use the **full** title — do not shorten or abbreviate.
    - Folder name: `<YYYY-MM-DD>-<NNN>-<slug>` (e.g., `2026-03-14-004-webhook-support`).
-4. Create a git branch with the same name as the folder:
+4. Resolve the working branch using the policy below. When the policy
+   creates a new branch (the current checkout is the default branch),
+   name it the same as the spec folder:
+
    ```
    git checkout -b <YYYY-MM-DD>-<NNN>-<slug>
    ```
+
+   When the policy keeps the existing branch (the current checkout is
+   already a non-default branch — common when an orchestrator pre-created
+   the worktree), skip the auto-name and use the current checkout. The
+   spec folder still gets the date-numbered name above; only the branch
+   name is preserved.
+
+   {{>branch-policy}}
+
 5. Confirm the branch name and spec folder path to the user and proceed.
 
 ---
@@ -540,7 +552,10 @@ artifacts. The files are on disk and the PR is the review surface.
    - the three spec artifacts in the new spec folder
    - the updated `.features.md` (if this run performed a feature-map
      write-back)
-2. Push the branch to `origin`.
+2. Push the current branch to `origin` as-is — do not rename it or
+   prepend a prefix such as `feature/`. The branch must match the one
+   resolved in Phase 1 step 4 so downstream tooling can find the PR by
+   that branch name.
 3. Create a pull request using the same PR-creation pattern that
    `smithy.forge` uses ({{>pr-create-tool-choice}}):
    - **Title**: the feature title, under 70 characters, plain descriptive text

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -98,11 +98,11 @@ When entering Phase 1 from a `.features.md`, carry forward:
    git checkout -b <YYYY-MM-DD>-<NNN>-<slug>
    ```
 
-   When the policy keeps the existing branch (the current checkout is
-   already a non-default branch — common when an orchestrator pre-created
-   the worktree), skip the auto-name and use the current checkout. The
-   spec folder still gets the date-numbered name above; only the branch
-   name is preserved.
+   When the policy keeps the existing branch (the current cwd is a
+   linked worktree on a non-default branch — typical when an
+   orchestrator pre-staged it), skip the auto-name and use the current
+   checkout. The spec folder still gets the date-numbered name above;
+   only the branch name is preserved.
 
    {{>branch-policy}}
 
@@ -207,7 +207,10 @@ Draft the `<slug>.spec.md` file with this structure:
 # Feature Specification: <Title>
 
 **Spec Folder**: `<YYYY-MM-DD>-<NNN>-<slug>`
-**Branch**: `<YYYY-MM-DD>-<NNN>-<slug>`
+**Branch**: `<resolved-branch>` *(the actual branch resolved in Phase 1
+step 4 — usually `<YYYY-MM-DD>-<NNN>-<slug>` for a fresh main-checkout
+run, but can be the orchestrator's pre-staged branch when mark is
+invoked inside a linked worktree)*
 **Created**: YYYY-MM-DD
 **Status**: Draft
 **Input**: <source — user description or RFC path with summary>

--- a/src/templates/agent-skills/commands/smithy.render.prompt
+++ b/src/templates/agent-skills/commands/smithy.render.prompt
@@ -381,8 +381,12 @@ here, by render.
    co-located with the source RFC.
 2. Run the Plan-Review Pass described above on the feature map file that was
    just written.
-3. Commit the feature map file on the feature branch (capturing both the
-   original feature map and any plan-review fixes in the same diff).
+3. Commit the feature map file on the current feature branch (capturing
+   both the original feature map and any plan-review fixes in the same
+   diff). Push the current branch as-is — do not rename it or prepend a
+   prefix such as `feature/`. The PR must be opened against the same
+   branch the operator (or upstream orchestrator) had checked out when
+   render was invoked. See the branch policy below.
 4. Create a PR for the feature map artifact using the forge `gh pr create`
    pattern ({{>pr-create-tool-choice}}):
    - **Title**: `Feature Map: <Milestone Title>`, under 70 characters,
@@ -434,3 +438,7 @@ here, by render.
   comma-separated list of same-table IDs. The `Artifact` column starts as `—`
   and is populated by `smithy.mark` when it creates the spec folder. Do NOT
   use checkboxes in the `## Dependency Order` section.
+
+---
+
+{{>branch-policy}}

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -20,11 +20,22 @@ If no feature description is clear from the input above, ask the user what they 
 
 ## Phase 1: Branch
 
-Create a working branch automatically. Do not ask the user — just do it.
+Resolve the working branch automatically. Do not ask the user — apply the
+policy below and move on.
 
-1. Derive a short kebab-case slug from the feature description (e.g., "add a --verbose flag" → `verbose-flag`).
+{{>branch-policy}}
+
+When the policy creates a new branch (the current checkout is the default
+branch), use this auto-naming step:
+
+1. Derive a short kebab-case slug from the feature description (e.g.,
+   "add a --verbose flag" → `verbose-flag`).
 2. Run `git checkout -b strike/<slug>`.
-3. Confirm the branch name to the user and move on.
+
+When the policy keeps the existing branch (the current checkout is
+already a non-default branch — common when an orchestrator pre-created
+the worktree), skip the auto-name and continue with the current
+checkout. Confirm the resolved branch name to the user and move on.
 
 ---
 
@@ -107,7 +118,7 @@ with this format:
 ```markdown
 # Strike: <Title>
 
-**Date:** YYYY-MM-DD  |  **Branch:** strike/<slug>  |  **Status:** Ready
+**Date:** YYYY-MM-DD  |  **Branch:** <resolved-branch>  |  **Status:** Ready
 
 ## Summary
 
@@ -224,9 +235,13 @@ here, by strike.
 
 ### Commit and create the PR
 
-1. **Commit the strike document** on the `strike/<slug>` branch with a
-   message referencing the strike goal.
-2. **Push the branch** with `git push -u origin strike/<slug>`.
+1. **Commit the strike document** on the resolved branch (the one chosen
+   in Phase 1 — either `strike/<slug>` for a greenfield run, or the
+   pre-existing branch the policy preserved) with a message referencing
+   the strike goal.
+2. **Push the branch** with `git push -u origin <resolved-branch>`. Use
+   the actual resolved branch name; do not rename or prepend a prefix
+   such as `feature/`.
 3. **Create the PR** using the same PR-creation pattern as `smithy-forge`
    ({{>pr-create-tool-choice}}):
    - **Title**: the strike goal, concise and under 70 characters.
@@ -240,7 +255,7 @@ here, by strike.
 5. **Render the full one-shot output** as the terminal output of this
    run using the shared snippet below. Populate the placeholders from
    the strike run data: `Spec folder` = `specs/strikes/`, `Branch` =
-   `strike/<slug>`, `Artifacts produced` = the single `.strike.md`
+   the resolved branch from Phase 1, `Artifacts produced` = the single `.strike.md`
    file, and substitute `User stories` / `Functional requirements`
    with the strike's requirement and task counts per the snippet's
    placeholder guidance. Populate the `## PR` section with the URL

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -32,9 +32,9 @@ branch), use this auto-naming step:
    "add a --verbose flag" → `verbose-flag`).
 2. Run `git checkout -b strike/<slug>`.
 
-When the policy keeps the existing branch (the current checkout is
-already a non-default branch — common when an orchestrator pre-created
-the worktree), skip the auto-name and continue with the current
+When the policy keeps the existing branch (the current cwd is a linked
+worktree on a non-default branch — typical when an orchestrator
+pre-staged it), skip the auto-name and continue with the current
 checkout. Confirm the resolved branch name to the user and move on.
 
 ---

--- a/src/templates/agent-skills/snippets/README.md
+++ b/src/templates/agent-skills/snippets/README.md
@@ -27,7 +27,7 @@ its contents. The snippet file itself is never deployed.
 | `competing-lenses-scoping.md` | Competing plan lenses for scoping | smithy.strike, smithy.ignite, smithy.render, smithy.mark |
 | `one-shot-output.md` | Standardized terminal output format for one-shot planning runs (Summary → Assumptions → Specification Debt → PR), with PR-failure and bail-out fallbacks | smithy.strike, smithy.ignite, smithy.mark, smithy.render, smithy.cut |
 | `pr-create-tool-choice.md` | One-line "prefer GitHub MCP `create_pull_request`, fall back to `gh pr create`" rule, embedded inline at every PR-creation step | smithy.strike, smithy.mark, smithy.forge, smithy.cut, smithy.ignite, smithy.render |
-| `branch-policy.md` | Worktree-aware branch selection rule: keep the current branch when it is already non-default, only auto-name from the default branch, and never rename the branch during PR creation | smithy.strike, smithy.mark, smithy.forge, smithy.cut, smithy.ignite, smithy.render |
+| `branch-policy.md` | Worktree-aware branch selection rule: keep the current branch only inside a linked git worktree on a non-default branch, otherwise auto-name as before; never rename the branch during PR creation | smithy.strike, smithy.mark, smithy.forge, smithy.cut, smithy.ignite, smithy.render |
 
 ## Conventions
 

--- a/src/templates/agent-skills/snippets/README.md
+++ b/src/templates/agent-skills/snippets/README.md
@@ -26,6 +26,8 @@ its contents. The snippet file itself is never deployed.
 | `competing-lenses-implementation.md` | Competing plan lenses for implementation planning | smithy.strike, smithy.ignite, smithy.render, smithy.mark |
 | `competing-lenses-scoping.md` | Competing plan lenses for scoping | smithy.strike, smithy.ignite, smithy.render, smithy.mark |
 | `one-shot-output.md` | Standardized terminal output format for one-shot planning runs (Summary → Assumptions → Specification Debt → PR), with PR-failure and bail-out fallbacks | smithy.strike, smithy.ignite, smithy.mark, smithy.render, smithy.cut |
+| `pr-create-tool-choice.md` | One-line "prefer GitHub MCP `create_pull_request`, fall back to `gh pr create`" rule, embedded inline at every PR-creation step | smithy.strike, smithy.mark, smithy.forge, smithy.cut, smithy.ignite, smithy.render |
+| `branch-policy.md` | Worktree-aware branch selection rule: keep the current branch when it is already non-default, only auto-name from the default branch, and never rename the branch during PR creation | smithy.strike, smithy.mark, smithy.forge, smithy.cut, smithy.ignite, smithy.render |
 
 ## Conventions
 

--- a/src/templates/agent-skills/snippets/branch-policy.md
+++ b/src/templates/agent-skills/snippets/branch-policy.md
@@ -3,40 +3,76 @@
 Apply this check before any auto-naming branch step in the parent phase,
 and again at the commit-and-PR step. It exists so `smithy.<verb>` is safe
 to invoke from a pre-existing checkout on a non-default branch —
-orchestrators that pre-create a worktree on a known branch and hand it to
-a Claude Code worker rely on the agent honoring the checkout rather than
-renaming it.
+orchestrators that pre-create a linked git worktree on a known branch and
+hand it to a Claude Code worker rely on the agent honoring the checkout
+rather than renaming it. The same `smithy.<verb>` invoked the normal way
+(in the main checkout, after `mark` / `cut` set up a branch) must still
+auto-create its own branch as before.
 
-### Detect
+### Detect the default branch
 
-1. Discover the repository's default branch dynamically:
-
-   ```bash
-   git symbolic-ref refs/remotes/origin/HEAD --short
-   ```
-
-   The result looks like `origin/main`; strip the `origin/` prefix to get
-   the default branch name. Do not assume `main`.
-
-2. Discover the current branch:
+1. First try the cheap form:
 
    ```bash
-   git rev-parse --abbrev-ref HEAD
+   git symbolic-ref refs/remotes/origin/HEAD
    ```
+
+   On success it prints a single line like `refs/remotes/origin/main`;
+   strip the `refs/remotes/origin/` prefix to get the default branch
+   name. Do not assume `main`. (Note: do **not** add the `--short` flag —
+   the bare form is what the repo's auto-allow list permits, and the
+   prefix is easy to strip.)
+
+2. If that command exits non-zero with `not a symbolic ref` (common in
+   fresh clones, mirrors, and some linked worktrees where `origin/HEAD`
+   was never set), fall back to:
+
+   ```bash
+   git remote show origin
+   ```
+
+   Find the line `  HEAD branch: <name>` in the output and use `<name>`.
+
+3. If both fail, ask the user which branch is the default and proceed
+   from their answer rather than guessing.
+
+### Detect the worktree shape
+
+Determine whether the current working directory is the **main checkout**
+or a **linked worktree**:
+
+```bash
+git rev-parse --git-dir
+git rev-parse --git-common-dir
+```
+
+- If the two paths are equal, the current cwd is the **main checkout**.
+- If they differ (the `--git-dir` path lives under
+  `<common>/worktrees/<name>`), the current cwd is a **linked worktree**
+  — typically created by `git worktree add` or by an upstream
+  orchestrator that pre-staged it for an agent run.
+
+### Detect the current branch
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
 
 ### Decide
 
-- **If the current branch is not the default branch, keep it.** Skip the
-  parent phase's auto-naming step, do not run `git checkout -b`, and do
-  not prepend `feature/` or any other prefix when later pushing or opening
-  the PR. The current checkout is the working branch — an operator (or an
-  upstream orchestrator) has already chosen it, often inside a dedicated
-  git worktree, and the downstream tooling tracks the work by that exact
-  branch name.
-- **If the current branch is the default branch**, run the parent phase's
-  auto-naming step (`git checkout -b <derived-name>`) to create a fresh
-  working branch. This is the greenfield path where no operator has
-  pre-staged a branch.
+- **If the current branch is not the default branch AND the current cwd
+  is a linked worktree**, keep the existing branch. Skip the parent
+  phase's auto-naming step, do not run `git checkout -b`, and do not
+  prepend `feature/` or any other prefix when later pushing or opening
+  the PR. The orchestrator already chose this branch and tracks the work
+  by that exact name.
+- **Otherwise** (the cwd is the main checkout, or the current branch is
+  already the default branch), run the parent phase's auto-naming step
+  (`git checkout -b <derived-name>`). The main-checkout case is the
+  greenfield path *and* the normal `mark` → `cut` → `forge` flow —
+  forge, for example, must continue to auto-create its per-slice branch
+  even when the user invoked it while still sitting on the spec branch
+  that `mark` created.
 
 Confirm the resolved branch name to the user and proceed.
 
@@ -47,4 +83,6 @@ branch as-is, and open the PR with `--head <resolved-branch>` if needed.
 **Never create a new branch or rename the current one as part of the
 PR-creation command** (in particular, do not prepend `feature/` to the
 resolved branch). The branch the agent commits and pushes from must be
-the same branch the resulting PR is opened against.
+the same branch the resulting PR is opened against. This rule applies
+in both the main checkout and a linked worktree — branch renames during
+PR creation are always wrong.

--- a/src/templates/agent-skills/snippets/branch-policy.md
+++ b/src/templates/agent-skills/snippets/branch-policy.md
@@ -79,10 +79,13 @@ Confirm the resolved branch name to the user and proceed.
 ### PR step
 
 The same rule applies during the commit-and-PR step: push the resolved
-branch as-is, and open the PR with `--head <resolved-branch>` if needed.
-**Never create a new branch or rename the current one as part of the
-PR-creation command** (in particular, do not prepend `feature/` to the
-resolved branch). The branch the agent commits and pushes from must be
-the same branch the resulting PR is opened against. This rule applies
-in both the main checkout and a linked worktree — branch renames during
-PR creation are always wrong.
+branch as-is, and pass it as the PR's head when the chosen PR-creation
+tool requires it (e.g. the `head` argument for the GitHub MCP tool, or
+the equivalent flag on the CLI fallback — see the
+`pr-create-tool-choice` snippet for which tool to prefer). **Never
+create a new branch or rename the current one as part of the PR-creation
+command** (in particular, do not prepend `feature/` to the resolved
+branch). The branch the agent commits and pushes from must be the same
+branch the resulting PR is opened against. This rule applies in both
+the main checkout and a linked worktree — branch renames during PR
+creation are always wrong.

--- a/src/templates/agent-skills/snippets/branch-policy.md
+++ b/src/templates/agent-skills/snippets/branch-policy.md
@@ -1,0 +1,50 @@
+## Branch Selection Policy
+
+Apply this check before any auto-naming branch step in the parent phase,
+and again at the commit-and-PR step. It exists so `smithy.<verb>` is safe
+to invoke from a pre-existing checkout on a non-default branch —
+orchestrators that pre-create a worktree on a known branch and hand it to
+a Claude Code worker rely on the agent honoring the checkout rather than
+renaming it.
+
+### Detect
+
+1. Discover the repository's default branch dynamically:
+
+   ```bash
+   git symbolic-ref refs/remotes/origin/HEAD --short
+   ```
+
+   The result looks like `origin/main`; strip the `origin/` prefix to get
+   the default branch name. Do not assume `main`.
+
+2. Discover the current branch:
+
+   ```bash
+   git rev-parse --abbrev-ref HEAD
+   ```
+
+### Decide
+
+- **If the current branch is not the default branch, keep it.** Skip the
+  parent phase's auto-naming step, do not run `git checkout -b`, and do
+  not prepend `feature/` or any other prefix when later pushing or opening
+  the PR. The current checkout is the working branch — an operator (or an
+  upstream orchestrator) has already chosen it, often inside a dedicated
+  git worktree, and the downstream tooling tracks the work by that exact
+  branch name.
+- **If the current branch is the default branch**, run the parent phase's
+  auto-naming step (`git checkout -b <derived-name>`) to create a fresh
+  working branch. This is the greenfield path where no operator has
+  pre-staged a branch.
+
+Confirm the resolved branch name to the user and proceed.
+
+### PR step
+
+The same rule applies during the commit-and-PR step: push the resolved
+branch as-is, and open the PR with `--head <resolved-branch>` if needed.
+**Never create a new branch or rename the current one as part of the
+PR-creation command** (in particular, do not prepend `feature/` to the
+resolved branch). The branch the agent commits and pushes from must be
+the same branch the resulting PR is opened against.


### PR DESCRIPTION
## Summary
- Primary outcome: smithy commands no longer rename or replace the branch when invoked inside a pre-existing worktree on a non-default branch
- Notable behaviour changes: strike, mark, and forge auto-create their named branch only when starting from the default branch; cut/ignite/render explicitly forbid the `feature/` prefix that Claude Code's default PR-creation path was applying
- Follow-up work deferred (if any): none

## Context
- Why are we doing this work now? Issue #297 reported that orchestrators (e.g. mini-legate / agent-deck) pre-create a worktree on a known branch and hand it to a Claude Code worker, then track the slice by that branch name. Today, `/smithy.cut` (and likely the other verbs) opens its PR against `feature/<original-branch>` instead of the branch the operator chose, breaking downstream PR discovery (`gh pr list --search "head:<expected>"` returns empty even though the PR exists).
- What user story or scenario does it unlock or improve? Any orchestrator that runs the parallel-execution pattern of "isolated worktree per slice → smithy verb inside it" — the agent now honors the checkout it was given.

## Implementation Notes
- Added a shared `src/templates/agent-skills/snippets/branch-policy.md` that codifies the rule from the issue: detect default branch dynamically, decide based on current checkout, never rename during the PR-creation step.
- Wired the snippet into the three commands that auto-name branches (strike, mark, forge `.tasks.md` mode) so the auto-name only runs from the default branch; the existing branch is preserved otherwise. forge `.strike.md` mode also now respects an existing pre-staged checkout instead of switching off it.
- Added the snippet plus an inline "do not rename / do not prepend `feature/`" reminder at the commit-and-PR step in cut, ignite, and render — the commands that were vulnerable to the `feature/` rename observed in the bug report even though they don't auto-create a branch themselves.
- strike now writes the *resolved* branch into the `**Branch:**` header of the strike file (so forge reads back whatever branch was actually used), and forge's `.strike.md` mode reads that field generically rather than expecting a `strike/<slug>` shape.
- Per the project's gitignore philosophy, `.claude/` is intentionally not regenerated — this PR only touches sources under `src/templates/`.

## Risks & Mitigations
- Risk: a user invokes strike/mark/forge while accidentally on a leftover non-default branch and expects fresh branch creation. | Mitigation: the snippet's "Confirm the resolved branch name" step still surfaces the branch to the user; the convention "default branch = greenfield, anything else = preserve" matches the proposal in the issue and existing developer expectations.
- Risk: forge `.strike.md` mode silently stays on a non-default branch that doesn't match the strike file's `**Branch:**` header. | Mitigation: this is the explicit goal — orchestrators that pre-stage the worktree on a slice branch should win; if that diverges from what strike recorded, it is the orchestrator's contract to have set things up correctly.

## Rollback Plan
- Revert this PR. Templates pre-rendering is purely additive (a new snippet plus prose updates); no manifest, settings, or migration changes.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npm run typecheck`)
- [ ] CLI `init` smoke test (`node dist/cli.js init`) — pure prompt-text changes, not exercised here

### Template Generation
- [x] Snippet loader test updated and passing (`loadSnippets` now expects 13 files including `branch-policy.md`)
- [x] All 728 vitest tests pass, including the existing invariant that every `gh pr create` invocation in a planning template is preceded by a `smithy-plan-review` dispatch (the new snippet phrases the rule as "PR-creation command" to avoid tripping that scanner falsely)
- [ ] Gemini Skills: `.gemini/skills/` folders and `SKILL.md` validity — covered by template tests
- [ ] Codex Prompts: `tools/codex/prompts/` file content — covered by template tests
- [ ] Claude Prompts: `.claude/prompts/` file content — covered by template tests
- [ ] GitHub Issue Templates: `.github/ISSUE_TEMPLATE/` content — unchanged

### Permissions & Configuration
- [ ] Gemini Config / Codex Config / Claude Config — unchanged

### Manual Test Cases
- [ ] Reviewed applicable cases in tests/Agent.tests.md and tests/Manual.tests.md — init/uninit flows did not change

## Issue
- Closes #297
