### PR TITLE
Surface slice, milestone, and feature row ids in smithy status

### DIFF
--- a/src/status/parser.test.ts
+++ b/src/status/parser.test.ts
@@ -645,6 +645,29 @@ Just prose.
     ]);
   });
 
+  it('normalizes zero-padded slice headings to the canonical `S<N>` id', () => {
+    // `## Slice 01: …` would naively emit `S01`, but the canonical id
+    // form is `S1` (matches the dep-order `ID_REGEX` of
+    // `^(M|F|US|S)[1-9][0-9]*$`). Keep the parsed id consistent with
+    // the dep-order rows that reference it so renderers can join the
+    // two without a normalization step.
+    const markdown = `# Tasks
+
+## Slice 01: Foo
+
+- [x] a
+
+## Slice 002: Bar
+
+- [ ] b
+`;
+    const record = parseArtifact('specs/foo/a.tasks.md', markdown);
+    expect(record.slices).toEqual([
+      { id: 'S1', title: 'Foo', status: 'done' },
+      { id: 'S2', title: 'Bar', status: 'not-started' },
+    ]);
+  });
+
   it('emits an empty slices array when a tasks file has no slice headings', () => {
     const record = parseArtifact('specs/foo/a.tasks.md', '# Empty\n');
     expect(record.slices).toEqual([]);

--- a/src/status/parser.test.ts
+++ b/src/status/parser.test.ts
@@ -614,4 +614,44 @@ Just prose.
     expect(record.completed).toBe(1);
     expect(record.total).toBe(1);
   });
+
+  it('captures per-slice id, title, and status on tasks records', () => {
+    // Mixed slice statuses exercise every branch of the per-slice
+    // status derivation: all-checked → done, partially-checked →
+    // in-progress, none-checked → not-started. The renderer surfaces
+    // each entry with its `S<N>` id so the issue-296 visibility gap
+    // (slice numbers missing from `smithy status`) cannot regress.
+    const markdown = `# Tasks
+
+## Slice 1: Foo
+
+- [x] a
+- [x] b
+
+## Slice 2: Bar
+
+- [x] c
+- [ ] d
+
+## Slice 3: Baz
+
+- [ ] e
+`;
+    const record = parseArtifact('specs/foo/a.tasks.md', markdown);
+    expect(record.slices).toEqual([
+      { id: 'S1', title: 'Foo', status: 'done' },
+      { id: 'S2', title: 'Bar', status: 'in-progress' },
+      { id: 'S3', title: 'Baz', status: 'not-started' },
+    ]);
+  });
+
+  it('emits an empty slices array when a tasks file has no slice headings', () => {
+    const record = parseArtifact('specs/foo/a.tasks.md', '# Empty\n');
+    expect(record.slices).toEqual([]);
+  });
+
+  it('omits slices on non-tasks records', () => {
+    const record = parseArtifact('specs/foo/a.spec.md', '# Spec\n');
+    expect(record.slices).toBeUndefined();
+  });
 });

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -409,8 +409,17 @@ function countSlices(content: string): {
       sliceCheckboxTotal = 0;
       sliceCheckboxCompleted = 0;
       if (match !== null) {
-        currentSliceId = `S${match[1]}`;
+        // Normalize through `parseInt` so a zero-padded heading
+        // (`## Slice 01: …`) still yields the canonical `S<N>` form
+        // (`S1`) the rest of the system expects. `SliceSummary.id`
+        // documents the no-leading-zeros invariant and the dep-order
+        // `ID_REGEX` rejects `S01`, so emitting `S01` here would have
+        // hidden every `01`-prefixed slice from any view that joins
+        // slices with dep-order rows.
+        const n = Number.parseInt(match[1] ?? '', 10);
+        currentSliceId = Number.isNaN(n) ? null : `S${n}`;
         currentSliceTitle = (match[2] ?? '').trim();
+        if (currentSliceId === null) insideSlice = false;
       } else {
         currentSliceId = null;
         currentSliceTitle = '';

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -11,6 +11,7 @@ import type {
   ArtifactType,
   DependencyOrderTable,
   DependencyRow,
+  SliceSummary,
 } from './types.js';
 
 /**
@@ -292,6 +293,7 @@ export function parseArtifact(
       const counts = countSlices(content);
       record.completed = counts.completed;
       record.total = counts.total;
+      record.slices = counts.slices;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       warnings.push(
@@ -299,6 +301,7 @@ export function parseArtifact(
       );
       record.completed = 0;
       record.total = 0;
+      record.slices = [];
     }
   }
 
@@ -343,22 +346,25 @@ function filenameStem(filePath: string): string {
 }
 
 /**
- * Count slices in a tasks file. Returns `{ total, completed }` where
- * `total` is the number of `## Slice <N>:` H2 sections and `completed`
- * is the number of those slices in which at least one task checkbox
- * exists and every checkbox is ticked. A slice with no checkboxes is
- * never counted as done — a well-formed slice body always lists at
- * least one task, so an empty slice is treated as in-progress/malformed
- * rather than complete. Checkboxes outside a `## Slice <N>:` section
- * (e.g., `## Dependency Order`, appendices) are ignored when resolving
- * per-slice completion.
+ * Count slices in a tasks file. Returns `{ total, completed, slices }`
+ * where `total` is the number of `## Slice <N>:` H2 sections,
+ * `completed` is the number of those slices in which at least one task
+ * checkbox exists and every checkbox is ticked, and `slices` is a
+ * per-slice summary list (canonical id, heading title, derived status)
+ * in source order so renderers can surface slice ids alongside the
+ * aggregate counter. A slice with no checkboxes is never counted as
+ * done — a well-formed slice body always lists at least one task, so
+ * an empty slice is treated as `not-started` rather than complete.
+ * Checkboxes outside a `## Slice <N>:` section (e.g., `## Dependency
+ * Order`, appendices) are ignored when resolving per-slice completion.
  */
 function countSlices(content: string): {
   completed: number;
   total: number;
+  slices: SliceSummary[];
 } {
   const lines = content.split('\n');
-  const sliceHeadingRegex = /^##\s+Slice\s+\d+:/;
+  const sliceHeadingRegex = /^##\s+Slice\s+(\d+):\s*(.*)$/;
   const h2Regex = /^##\s/;
   const checkboxRegex = /^\s*-\s*\[([ xX])\]\s/;
 
@@ -367,24 +373,48 @@ function countSlices(content: string): {
   let insideSlice = false;
   let sliceCheckboxTotal = 0;
   let sliceCheckboxCompleted = 0;
+  let currentSliceId: string | null = null;
+  let currentSliceTitle = '';
+  const slices: SliceSummary[] = [];
 
   const finalizeSlice = (): void => {
     if (!insideSlice) return;
     total += 1;
+    let status: SliceSummary['status'];
     if (
       sliceCheckboxTotal > 0 &&
       sliceCheckboxCompleted === sliceCheckboxTotal
     ) {
       completed += 1;
+      status = 'done';
+    } else if (sliceCheckboxCompleted > 0) {
+      status = 'in-progress';
+    } else {
+      status = 'not-started';
+    }
+    if (currentSliceId !== null) {
+      slices.push({
+        id: currentSliceId,
+        title: currentSliceTitle,
+        status,
+      });
     }
   };
 
   for (const line of lines) {
     if (h2Regex.test(line)) {
       finalizeSlice();
-      insideSlice = sliceHeadingRegex.test(line);
+      const match = sliceHeadingRegex.exec(line);
+      insideSlice = match !== null;
       sliceCheckboxTotal = 0;
       sliceCheckboxCompleted = 0;
+      if (match !== null) {
+        currentSliceId = `S${match[1]}`;
+        currentSliceTitle = (match[2] ?? '').trim();
+      } else {
+        currentSliceId = null;
+        currentSliceTitle = '';
+      }
       continue;
     }
     if (!insideSlice) continue;
@@ -398,7 +428,7 @@ function countSlices(content: string): {
   }
   finalizeSlice();
 
-  return { completed, total };
+  return { completed, total, slices };
 }
 
 /**

--- a/src/status/render.test.ts
+++ b/src/status/render.test.ts
@@ -609,6 +609,113 @@ describe('renderTree — story number prefix', () => {
   });
 });
 
+describe('renderTree — slice rendering for tasks records', () => {
+  it('renders each parsed slice as a nested tree child under its tasks record', () => {
+    // A real tasks record carries per-slice info on `record.slices`.
+    // The renderer surfaces each slice with its `S<N>` id, the
+    // heading title, and a status icon — none of which appears in
+    // the aggregate `<completed>/<total>` counter alone.
+    const tasks = makeRecord({
+      type: 'tasks',
+      path: 'specs/f/01-story.tasks.md',
+      title: 'Story',
+      status: 'in-progress',
+      completed: 1,
+      total: 3,
+      parent_path: 'specs/f/f.spec.md',
+      parent_row_id: 'US1',
+      slices: [
+        { id: 'S1', title: 'Foo', status: 'done' },
+        { id: 'S2', title: 'Bar', status: 'in-progress' },
+        { id: 'S3', title: 'Baz', status: 'not-started' },
+      ],
+    });
+    const output = renderTree(
+      { roots: [{ record: tasks, children: [] }] },
+      { theme: utf8Theme },
+    );
+    const lines = output.split('\n');
+    expect(lines[0]).toBe('01 Story  ◐ 1/3');
+    expect(lines[1]).toBe('├─ S1 Foo  ✓');
+    expect(lines[2]).toBe('├─ S2 Bar  ◐');
+    expect(lines[3]).toBe('└─ S3 Baz  ○');
+  });
+
+  it('omits slice lines when the tasks record has no slices field', () => {
+    // Virtual tasks records emitted by the scanner from a `—` spec
+    // row carry no `slices` field — the underlying tasks file does
+    // not exist yet. The renderer must not synthesize phantom slice
+    // children for them.
+    const virt = makeRecord({
+      type: 'tasks',
+      path: 'specs/f/04-future.tasks.md',
+      title: 'Future Story',
+      status: 'not-started',
+      virtual: true,
+      parent_path: 'specs/f/f.spec.md',
+      parent_row_id: 'US4',
+    });
+    const output = renderTree(
+      { roots: [{ record: virt, children: [] }] },
+      { theme: utf8Theme },
+    );
+    expect(output).toBe('04 Future Story  ○');
+  });
+
+  it('inherits the parent connector spacing for slice connectors', () => {
+    // A spec parent with two children: the first is a tasks record
+    // with slices, the second is another tasks record. The slice
+    // connectors must inherit the vertical-bar spacer from the spec's
+    // first-child column, not the blank-spacer that the spec's
+    // last-child column would imply.
+    const spec = makeRecord({
+      type: 'spec',
+      path: 'specs/f/f.spec.md',
+      title: 'Feature',
+      status: 'in-progress',
+      parent_path: null,
+    });
+    const firstTasks = makeRecord({
+      type: 'tasks',
+      path: 'specs/f/01-a.tasks.md',
+      title: 'A',
+      status: 'in-progress',
+      completed: 1,
+      total: 2,
+      parent_path: 'specs/f/f.spec.md',
+      parent_row_id: 'US1',
+      slices: [
+        { id: 'S1', title: 'first', status: 'done' },
+        { id: 'S2', title: 'second', status: 'in-progress' },
+      ],
+    });
+    const secondTasks = makeRecord({
+      type: 'tasks',
+      path: 'specs/f/02-b.tasks.md',
+      title: 'B',
+      status: 'not-started',
+      completed: 0,
+      total: 0,
+      parent_path: 'specs/f/f.spec.md',
+      parent_row_id: 'US2',
+      slices: [],
+    });
+    const tree = buildTree([spec, firstTasks, secondTasks]);
+    const output = renderTree(tree, { theme: utf8Theme });
+    const lines = output.split('\n');
+    // The first tasks record is a non-last sibling of the spec, so its
+    // slice children carry the vertical-bar spacer (`│  `) inherited
+    // from the spec's first-child column. The orphan-spec heading
+    // wrapping above contributes a leading three-space indent because
+    // the spec's `parent_path` is null. The last slice uses the
+    // last-branch (`└─`) connector and its descendant column would
+    // therefore be blank, but we are at a leaf so no further lines
+    // follow.
+    expect(lines.some((l) => l.endsWith('│  ├─ S1 first  ✓'))).toBe(true);
+    expect(lines.some((l) => l.endsWith('│  └─ S2 second  ◐'))).toBe(true);
+  });
+});
+
 describe('renderTree — renderHints option (US4 Slice 2)', () => {
   it('default (no renderHints) emits no hint line even when records carry next_action', () => {
     const record = makeRecord({

--- a/src/status/render.ts
+++ b/src/status/render.ts
@@ -72,7 +72,13 @@ import {
   ORPHANED_SPECS_PATH,
   ORPHANED_TASKS_PATH,
 } from './tree.js';
-import type { ArtifactRecord, Status, StatusTree, TreeNode } from './types.js';
+import type {
+  ArtifactRecord,
+  SliceSummary,
+  Status,
+  StatusTree,
+  TreeNode,
+} from './types.js';
 
 /**
  * Options accepted by {@link renderTree}. A default theme (UTF-8 glyphs,
@@ -164,6 +170,7 @@ function renderRoot(
   // A root's descendants inherit no parent spacer, so the hint line
   // (when enabled) is anchored at column 0 plus the two-space hint pad.
   maybePushHint(node.record, '', lines, renderHints, theme);
+  pushSliceLines(node.record, '', lines, theme);
   const { children } = node;
   for (let i = 0; i < children.length; i++) {
     renderChild(
@@ -204,6 +211,13 @@ function renderChild(
   // keeping the hint anchored beneath the record but out of the way of
   // real descendants below it.
   maybePushHint(node.record, nextPrefix, lines, renderHints, theme);
+  // Slices live inline inside a tasks file (not as separate records),
+  // so they cannot reach the tree builder. Render them here as nested
+  // children of their owning tasks record using the same `nextPrefix`
+  // any real child would inherit, so each slice id (`S1`, `S2`, …)
+  // surfaces in the tree view rather than being collapsed into the
+  // tasks record's `<completed>/<total>` counter alone.
+  pushSliceLines(node.record, nextPrefix, lines, theme);
   const { children } = node;
   for (let i = 0; i < children.length; i++) {
     renderChild(
@@ -301,6 +315,60 @@ function applyStoryNumber(title: string, rowId: string | undefined): string {
   if (digits === undefined) return stripped;
   const nn = digits.padStart(2, '0');
   return `${nn} ${stripped}`;
+}
+
+/**
+ * Render the per-slice breakdown of a tasks record as nested tree
+ * lines beneath it. Each slice is rendered as a leaf child carrying
+ * its canonical `S<N>` id, the heading title, and a status icon
+ * mirroring the record-level icons (`✓` / `◐` / `○`). No-op for
+ * non-tasks records, for tasks records with no parsed slices, or
+ * during the renderer pipeline's collapsed-done branch (the tasks
+ * record never reaches this function in that case because
+ * `collapseTree` upstream replaces it with a leaf).
+ *
+ * Slices are deliberately rendered here in the tree-renderer rather
+ * than expanded into virtual `ArtifactRecord`s upstream because they
+ * live inline inside a tasks file — they have no path of their own,
+ * no dependency-order section, and no lifecycle independent of their
+ * parent record. Treating them as a renderer-only concern keeps the
+ * scanner / classifier / suggester surface unchanged.
+ */
+function pushSliceLines(
+  record: ArtifactRecord,
+  recordPrefix: string,
+  lines: string[],
+  theme: Theme,
+): void {
+  if (record.type !== 'tasks') return;
+  const slices = record.slices;
+  if (slices === undefined || slices.length === 0) return;
+  for (let i = 0; i < slices.length; i++) {
+    const slice = slices[i];
+    if (slice === undefined) continue;
+    const isLast = i === slices.length - 1;
+    const connector = isLast ? theme.glyphs.lastBranch : theme.glyphs.branch;
+    const marker = formatSliceMarker(slice, theme);
+    lines.push(
+      `${recordPrefix}${connector}${slice.id} ${slice.title}  ${marker}`,
+    );
+  }
+}
+
+/**
+ * Status marker for a {@link SliceSummary} inside the tree view.
+ * Mirrors the icon mapping used by real records (`✓` / `◐` / `○`)
+ * so a row of slice ids reads as a homogeneous progress strip.
+ */
+function formatSliceMarker(slice: SliceSummary, theme: Theme): string {
+  switch (slice.status) {
+    case 'done':
+      return theme.paint.done(theme.icons.done);
+    case 'in-progress':
+      return theme.paint.inProgress(theme.icons.inProgress);
+    case 'not-started':
+      return theme.paint.notStarted(theme.icons.notStarted);
+  }
 }
 
 /**

--- a/src/status/renderGraph.test.ts
+++ b/src/status/renderGraph.test.ts
@@ -122,31 +122,33 @@ describe('renderGraph — layered view (AS 10.1)', () => {
     expect(output).toContain(`${SPEC_PATH}#US2`);
     expect(output).toContain(`${SPEC_PATH}#US3`);
     expect(output).toContain(`${SPEC_PATH}#US4`);
-    // Title leads each line directly after the connector — the
-    // primary, scannable label.
-    expect(output).toContain('├─ First');
-    expect(output).toContain('└─ Fourth');
-    expect(output).toContain('└─ Second');
-    expect(output).toContain('└─ Third');
+    // The row id (`US1`, `US2`, …) leads each line directly after the
+    // connector so slice / milestone / feature / user-story numbers are
+    // visible at a glance, with the title following.
+    expect(output).toContain('├─ US1 First');
+    expect(output).toContain('└─ US4 Fourth');
+    expect(output).toContain('└─ US2 Second');
+    expect(output).toContain('└─ US3 Third');
     // Tree connectors used to lay out per-layer members.
     expect(output).toMatch(/[├└]─/);
-    // The full per-line layout: connector + title + marker + dim id.
-    // (`utf8Theme` has color disabled, so the dim helper is identity
-    // and the FQ id appears verbatim at the tail of the line.)
+    // The full per-line layout: connector + row id + title + marker +
+    // dim id. (`utf8Theme` has color disabled, so the dim helper is
+    // identity and both the row-id prefix and the FQ id appear
+    // verbatim.)
     expect(output).toMatch(
-      new RegExp(`└─ Fourth\\s+[○✓◐⚠].*${SPEC_PATH}#US4`),
+      new RegExp(`└─ US4 Fourth\\s+[○✓◐⚠].*${SPEC_PATH}#US4`),
     );
   });
 
   it('orders Layer 0 members by their position in graph.layers[0].node_ids', () => {
     const graph = buildDependencyGraph([spec]);
     const output = renderGraph(graph, { theme: utf8Theme });
-    // Match by title ("First" / "Fourth" / "Second" / "Third") rather
-    // than the FQ id — the title is now the leading column.
-    const us1Pos = output.indexOf('├─ First');
-    const us4Pos = output.indexOf('└─ Fourth');
-    const us2Pos = output.indexOf('└─ Second');
-    const us3Pos = output.indexOf('└─ Third');
+    // Match by id+title prefix ("US1 First" / "US4 Fourth" / …) rather
+    // than the FQ id — the row id leads each line, then the title.
+    const us1Pos = output.indexOf('├─ US1 First');
+    const us4Pos = output.indexOf('└─ US4 Fourth');
+    const us2Pos = output.indexOf('└─ US2 Second');
+    const us3Pos = output.indexOf('└─ US3 Third');
     expect(us1Pos).toBeGreaterThanOrEqual(0);
     expect(us4Pos).toBeGreaterThan(us1Pos);
     expect(us2Pos).toBeGreaterThan(us4Pos);
@@ -160,6 +162,36 @@ describe('renderGraph — layered view (AS 10.1)', () => {
     // blocks are visually separated rather than smashed together.
     expect(output).toMatch(/\n\nLayer 1 \(1 item\)/);
     expect(output).toMatch(/\n\nLayer 2 \(1 item\)/);
+  });
+
+  it('prefixes every node line with the row id (issue #296)', () => {
+    // Slice / milestone / feature / user-story numbers must appear at
+    // the head of every node line. Regression guard for the issue-296
+    // visibility gap — if the prefix is dropped, the number disappears
+    // entirely on actionable rows (the action hint replaces the dim FQ
+    // id) and is buried at the tail on done rows.
+    const tasksPath = 'specs/sample/sample.tasks.md';
+    const tasks = makeRecord({
+      type: 'tasks',
+      path: tasksPath,
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'S',
+        format: 'table',
+        rows: [
+          row('S1', [], { title: 'Migrate Templates' }),
+          row('S2', ['S1'], { title: 'Wire It Up' }),
+        ],
+      },
+    });
+    const graph = buildDependencyGraph([tasks]);
+    const output = renderGraph(graph, { theme: utf8Theme });
+    // The graph builder puts S1 in Layer 0 (no incoming edges) and S2
+    // in Layer 1 (depends on S1). Each layer has a single member, so
+    // both members render with the last-branch connector — but the row
+    // id always leads the title regardless of position.
+    expect(output).toContain('└─ S1 Migrate Templates');
+    expect(output).toContain('└─ S2 Wire It Up');
   });
 });
 
@@ -291,8 +323,8 @@ describe('renderGraph — done-layer collapsing (AS 10.4)', () => {
     expect(output).toContain('Layer 0 — ready to work (2 items, 1 done hidden)');
     // The done member's FQ id must NOT appear — it's filtered out.
     expect(output).not.toContain('specs/a/a.spec.md#US1');
-    // The not-started member surfaces with its title-first line.
-    expect(output).toContain('└─ Still To Do');
+    // The not-started member surfaces with its row-id-first line.
+    expect(output).toContain('└─ US1 Still To Do');
     expect(output).toContain('specs/b/b.spec.md#US1');
   });
 

--- a/src/status/renderGraph.ts
+++ b/src/status/renderGraph.ts
@@ -468,7 +468,15 @@ function formatNodeLine(
     action !== null
       ? formatNextAction(action, theme.glyphs.arrow)
       : theme.paint.dim(id);
-  return `${connector}${node.row.title}  ${marker}  ${suffix}`;
+  // Prefix the title with the row's canonical id (`S1`, `M1`, `F1`,
+  // `US1`) so slice / milestone / feature / user-story numbers are
+  // visible at a glance instead of buried in the dim FQ-id suffix
+  // (when the suffix even shows — the action-hint branch above
+  // replaces the FQ id, which would otherwise hide the row id
+  // entirely for any actionable row). The id paints dim so the title
+  // stays the dominant visual element.
+  const idPrefix = theme.paint.dim(`${node.row.id} `);
+  return `${connector}${idPrefix}${node.row.title}  ${marker}  ${suffix}`;
 }
 
 /**

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -178,6 +178,18 @@ export interface ArtifactRecord {
    */
   total?: number;
   /**
+   * Per-slice breakdown for tasks files. One entry per `## Slice N:`
+   * H2 in the file, in source order. Each entry carries the canonical
+   * `S<N>` id, the title from the heading, and a status derived from
+   * the section's task checkboxes: `done` when every checkbox is
+   * ticked (and at least one exists), `not-started` when no checkbox
+   * is ticked (or the section is empty), `in-progress` for anything in
+   * between. Renderers consume this to surface individual slice ids in
+   * the tree view rather than aggregating them into a `<completed>/<total>`
+   * counter alone. Omitted on non-tasks records.
+   */
+  slices?: SliceSummary[];
+  /**
    * Repo-relative path to the parent artifact. `null` means "no parent"
    * (top-level RFCs, orphans); an omitted field means "unknown".
    */
@@ -218,6 +230,26 @@ export interface ArtifactRecord {
    * array when clean.
    */
   warnings: string[];
+}
+
+/**
+ * Per-slice summary captured from a tasks file's `## Slice N:` H2
+ * sections. The renderer surfaces these as nested children below their
+ * owning tasks record so the slice ids (`S1`, `S2`, …) are visible in
+ * the tree view rather than collapsed into a single counter.
+ */
+export interface SliceSummary {
+  /** Canonical slice id (`S<N>`, no leading zeros) parsed from the H2. */
+  id: string;
+  /** Title text after `## Slice <N>:` on the heading line. */
+  title: string;
+  /**
+   * Status derived from the slice section's task checkboxes. `done` when
+   * every checkbox is ticked and at least one exists; `not-started` when
+   * no checkbox is ticked (or the section has no checkboxes); otherwise
+   * `in-progress`.
+   */
+  status: 'done' | 'in-progress' | 'not-started';
 }
 
 /**


### PR DESCRIPTION
## Summary
- Primary outcome: row ids (slice / milestone / feature / user-story) now surface in `smithy status` and `smithy status --graph` instead of being aggregated away or buried.
- Notable behaviour changes: default tree adds nested `S<N>` slice children under tasks records; graph view prefixes every node line with its dim-painted row id.
- Follow-up work deferred: none.

## Context
- The `smithy status` views were dropping the very identifiers users referred to when discussing work — slices were collapsed into a `1/3` counter, and `--graph` either buried the row id in the dim FQ-id tail (done rows) or hid it entirely behind the action hint (actionable rows).
- Improves the experience of asking "which slice is in progress?" or "which milestone does this features map satisfy?" without opening files.

## Implementation Notes
- `parser.ts`: extended `countSlices` to capture per-slice id / title / status; populated via a new `slices?: SliceSummary[]` field on tasks records.
- `render.ts`: new `pushSliceLines` helper renders slices as nested children using the same connector-prefix discipline as real tree children. Slices are deliberately not promoted to virtual `ArtifactRecord`s — they have no path, no dependency-order section, and no lifecycle of their own, so keeping them renderer-only avoids churn in the scanner / classifier / suggester surface.
- `renderGraph.ts`: `formatNodeLine` prepends `${node.row.id} ` (dim) before the title. The id paints dim so the title remains the dominant visual element while still being scannable.
- `types.ts`: introduces `SliceSummary` and the optional `slices` field on `ArtifactRecord` (omitted on non-tasks records).

## Risks & Mitigations
- Risk: existing snapshot-style tests that assert on graph node lines or tree slice rows. Mitigation: updated three tests in `renderGraph.test.ts`; full 735-test suite passes after the new tests were added.
- Risk: slice rendering noise on done tasks records under `--all`. Mitigation: collapsed-done subtrees never reach the renderer in default mode (`collapseTree` strips them upstream), so the noise is confined to `--all`, which is the explicit "show everything" view.

## Rollback Plan
- Revert this commit. No data migrations, manifest changes, or template regeneration involved — the change is confined to `src/status/`.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npm run typecheck`)
- [ ] CLI `init` smoke test (`node dist/cli.js init`) — not exercised; change does not touch deployment.

### Template Generation
- [ ] Gemini Skills: not touched.
- [ ] Codex Prompts: not touched.
- [ ] Claude Prompts: not touched.
- [ ] GitHub Issue Templates: not touched.

### Permissions & Configuration
- [ ] Gemini Config: not touched.
- [ ] Codex Config: not touched.
- [ ] Claude Config: not touched.

### Manual Test Cases
- [x] Verified output of `smithy status` and `smithy status --graph` against this repo: slice ids (`S1`, `S2`) now appear as nested children under tasks records, and graph nodes lead with `US1` / `S1` / etc.

## Issue
- Closes #296
