### PR TITLE
Make smithy status --root flexible for non-canonical layouts

### DIFF
--- a/src/status/scanner.test.ts
+++ b/src/status/scanner.test.ts
@@ -144,6 +144,36 @@ describe('scan', () => {
     expect(records.some((r) => r.path === '01-first.tasks.md')).toBe(true);
   });
 
+  it('fast path: does NOT prune subdirectories whose leaf name is in IGNORED_DIR_NAMES', () => {
+    // Regression guard: the IGNORED_DIR_NAMES filter is fallback-only.
+    // A repo with the canonical layout that happens to nest a subdir
+    // named `build/`, `dist/`, `coverage/`, etc. under `specs/` MUST
+    // still surface artifacts under it — those folder names are
+    // legitimate domain words inside spec layouts.
+    write(
+      'specs/build/build-feature.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+    write(
+      'specs/dist/dist-feature.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+    write(
+      'specs/coverage/coverage-feature.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+    const records = scan(root);
+    const paths = records
+      .filter((r) => r.virtual !== true)
+      .map((r) => r.path)
+      .sort();
+    expect(paths).toEqual([
+      'specs/build/build-feature.spec.md',
+      'specs/coverage/coverage-feature.spec.md',
+      'specs/dist/dist-feature.spec.md',
+    ]);
+  });
+
   it('fast path: skips everything outside the canonical scan dirs when they exist', () => {
     // Performance: when `specs/` (or any canonical scan dir) is
     // present, the scanner takes the fast path and never recurses

--- a/src/status/scanner.test.ts
+++ b/src/status/scanner.test.ts
@@ -101,6 +101,114 @@ describe('scan', () => {
     expect(records).toEqual([]);
   });
 
+  it('discovers artifacts under non-canonical layouts (singular spec/, custom dirs)', () => {
+    // Issue #295: a project that uses `spec/` (singular) or any other
+    // custom layout under the resolved --root should still surface its
+    // artifacts. The scanner walks `root` recursively and matches by
+    // suffix, so the directory naming convention does not matter.
+    write(
+      'spec/feature-a.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+    write(
+      'lib-streaming/spec/streaming.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+    write(
+      'docs/rfc/proposal.rfc.md',
+      `# RFC\n\n## Dependency Order\n\n${TABLE_HEADER}\n| M1 | Milestone | — | — |\n`,
+    );
+    const records = scan(root);
+    expect(records.some((r) => r.path === 'spec/feature-a.spec.md')).toBe(true);
+    expect(
+      records.some((r) => r.path === 'lib-streaming/spec/streaming.spec.md'),
+    ).toBe(true);
+    expect(records.some((r) => r.path === 'docs/rfc/proposal.rfc.md')).toBe(true);
+  });
+
+  it('honors --root pointed at a sub-package containing a singular spec/ directory', () => {
+    // Simulates passing `--root lib-streaming/spec` from the issue.
+    // Artifacts that live exactly under that root must be discoverable
+    // even when they don't sit inside the canonical `specs/` /
+    // `docs/rfcs/` / `specs/strikes/` top-level layout.
+    write(
+      'lib-streaming/spec/streaming.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+    write(
+      'lib-streaming/spec/01-first.tasks.md',
+      `# Tasks\n\n## Slice 1: First\n\n- [x] Done\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | First | — | — |\n`,
+    );
+    const records = scan(join(root, 'lib-streaming/spec'));
+    expect(records.some((r) => r.path === 'streaming.spec.md')).toBe(true);
+    expect(records.some((r) => r.path === '01-first.tasks.md')).toBe(true);
+  });
+
+  it('fast path: skips everything outside the canonical scan dirs when they exist', () => {
+    // Performance: when `specs/` (or any canonical scan dir) is
+    // present, the scanner takes the fast path and never recurses
+    // into sibling subtrees — vendored fixtures in `node_modules/`,
+    // build outputs in `dist/`, hooks in `.git/`, etc. are all
+    // bypassed for free regardless of what they contain.
+    write(
+      'node_modules/some-pkg/fixture.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+    write(
+      'dist/build-artifact.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+    write(
+      'lib-streaming/spec/streaming.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+    // A real artifact under the canonical layout pins the fast path.
+    write(
+      'specs/real.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+    const records = scan(root);
+    const paths = records
+      .filter((r) => r.virtual !== true)
+      .map((r) => r.path);
+    expect(paths).toEqual(['specs/real.spec.md']);
+  });
+
+  it('fallback path: skips IGNORED_DIR_NAMES when walking root recursively', () => {
+    // When no canonical scan dir exists, the recursive fallback runs.
+    // It must still skip universally-untouchable dirs (VCS metadata,
+    // dependency caches, build outputs, agent config dirs) so the
+    // fallback stays bounded on a large repo.
+    write(
+      'node_modules/some-pkg/fixture.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+    write(
+      '.git/hooks/sample.tasks.md',
+      `# Tasks\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | x | — | — |\n`,
+    );
+    write(
+      'dist/build-artifact.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+    write(
+      '.smithy/manifest-fixture.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+    // Real artifact in a non-canonical location → triggers fallback.
+    write(
+      'lib-streaming/spec/streaming.spec.md',
+      `# Spec\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Story | — | — |\n`,
+    );
+    const records = scan(root);
+    const paths = records.map((r) => r.path);
+    expect(paths.some((p) => p.startsWith('node_modules/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('.git/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('dist/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('.smithy/'))).toBe(false);
+    expect(paths).toContain('lib-streaming/spec/streaming.spec.md');
+  });
+
   it('AS 1.1: spec with two done tasks children and one — row', () => {
     // Spec references two existing tasks files (both fully checked)
     // and one — row which must emit a virtual not-started tasks record.

--- a/src/status/scanner.ts
+++ b/src/status/scanner.ts
@@ -202,12 +202,12 @@ export function scan(root: string): ArtifactRecord[] {
     if (!isWithinRoot(realStart, realRoot)) continue;
     if (visitedDirs.has(realStart)) continue;
     visitedDirs.add(realStart);
-    walkDir(startDir, realRoot, records, visitedDirs);
+    walkDir(startDir, realRoot, records, visitedDirs, false);
     scannedAnyCanonical = true;
   }
   if (!scannedAnyCanonical) {
     visitedDirs.add(realRoot);
-    walkDir(realRoot, realRoot, records, visitedDirs);
+    walkDir(realRoot, realRoot, records, visitedDirs, true);
   }
 
   // Phase 2: resolve parent/child linkage and emit virtual records.
@@ -400,12 +400,21 @@ export function scan(root: string): ArtifactRecord[] {
  * skipping anything whose real path escapes `realRoot` or that has
  * already been visited (which breaks symlink cycles). Parses every
  * discovered artifact file into `records`.
+ *
+ * `applyIgnoreList` gates the {@link IGNORED_DIR_NAMES} filter and is
+ * the only behavioral difference between the fast path and the
+ * fallback walk. Pass `false` from the canonical-scan-root fast path
+ * so existing `specs/build/`, `specs/dist/`, etc. layouts continue to
+ * surface their artifacts; pass `true` from the recursive fallback so
+ * the scan stays bounded on a non-canonical repo root that may include
+ * VCS metadata, dep caches, build outputs, and agent config dirs.
  */
 function walkDir(
   dir: string,
   realRoot: string,
   records: Map<string, ArtifactRecord>,
   visitedDirs: Set<string>,
+  applyIgnoreList: boolean,
 ): void {
   let entries: string[];
   try {
@@ -432,16 +441,18 @@ function walkDir(
     }
 
     if (stat.isDirectory()) {
-      // Skip universally-untouchable directories (VCS metadata,
-      // dependency caches, build outputs, agent config dirs). Smithy
-      // artifacts never live inside these, and walking them on a
-      // typical repo root would be expensive for no payoff.
-      if (IGNORED_DIR_NAMES.has(name)) continue;
+      // Fallback only: skip universally-untouchable directories (VCS
+      // metadata, dependency caches, build outputs, agent config dirs)
+      // so the recursive walk stays bounded on a non-canonical repo
+      // root. The fast path passes `false` to preserve any legitimate
+      // `specs/build/`, `specs/dist/`, etc. layouts under canonical
+      // scan roots.
+      if (applyIgnoreList && IGNORED_DIR_NAMES.has(name)) continue;
       // Guard against directory cycles introduced by symlinks by
       // tracking canonical real paths we have already walked.
       if (visitedDirs.has(realAbs)) continue;
       visitedDirs.add(realAbs);
-      walkDir(abs, realRoot, records, visitedDirs);
+      walkDir(abs, realRoot, records, visitedDirs, applyIgnoreList);
     } else if (stat.isFile()) {
       handleFile(abs, realRoot, records);
     }

--- a/src/status/scanner.ts
+++ b/src/status/scanner.ts
@@ -6,11 +6,29 @@
  * contract in `smithy-status-skill.data-model.md`. It proceeds in four
  * phases:
  *
- *   1. **Discovery / parse** — walk `specs/`, `docs/rfcs/`, and
- *      `specs/strikes/` under `root`, collect files by suffix
- *      (`.rfc.md`, `.features.md`, `.spec.md`, `.tasks.md`), read their
- *      contents, and call {@link parseArtifact} for each. Symlinks whose
- *      real path escapes `root` are silently skipped.
+ *   1. **Discovery / parse** — collect files by suffix (`.rfc.md`,
+ *      `.features.md`, `.spec.md`, `.tasks.md`), read their contents,
+ *      and call {@link parseArtifact} for each. Discovery uses a
+ *      hybrid strategy:
+ *
+ *        a. **Fast path (canonical layout).** If any of the canonical
+ *           scan dirs (`specs/`, `docs/rfcs/`, `specs/strikes/`) exist
+ *           directly under `root`, walk only those. Conventional repos
+ *           — including monorepos with the canonical layout at their
+ *           top level — pay no scan cost outside those subtrees.
+ *
+ *        b. **Fallback (non-canonical layout).** If none of the
+ *           canonical scan dirs exist under `root`, walk `root`
+ *           recursively. This lets `--root` point at any directory
+ *           containing artifacts — a sub-package, a singular `spec/`
+ *           directory, etc. — without enforcing a fixed top-level
+ *           layout (issue #295). The recursive walker skips
+ *           subdirectories named in {@link IGNORED_DIR_NAMES} (`.git`,
+ *           `node_modules`, build outputs, agent config dirs) so the
+ *           fallback stays bounded even on a large repo.
+ *
+ *      Symlinks whose real path escapes `root` are silently skipped
+ *      under both strategies.
  *
  *   2. **Resolution + virtual emission** — walk every real parent
  *      record's `dependency_order.rows`, match each row to an existing
@@ -70,7 +88,58 @@ import type {
   DependencyRow,
 } from './types.js';
 
+/**
+ * Canonical top-level directories the scanner walks when present.
+ * Conventional repos hit this fast path: walking three known subtrees
+ * is a hard upper bound on scan cost regardless of repo size, so
+ * monorepos with the canonical layout at their top level pay no extra
+ * cost as the repo grows.
+ *
+ * When NONE of these exist directly under `root`, the scanner falls
+ * back to a recursive walk of `root` (filtered by IGNORED_DIR_NAMES)
+ * so non-canonical layouts — a singular `spec/` folder, a sub-package
+ * passed via `--root`, etc. — still surface their artifacts (issue
+ * #295).
+ */
 const SCAN_ROOTS = ['specs', 'docs/rfcs', 'specs/strikes'] as const;
+
+/**
+ * Directory names the recursive fallback refuses to descend into.
+ * Keeps the fallback walk from spelunking into VCS metadata,
+ * dependency caches, build outputs, and agent-config dirs that will
+ * never contain Smithy artifacts. Match is by the leaf directory name
+ * (case-sensitive), applied at every depth — a `node_modules` nested
+ * inside a sub-package is also skipped.
+ *
+ * Only consulted by the fallback (non-canonical layout) walker. The
+ * fast path scans `SCAN_ROOTS` directly and never enters these dirs
+ * to begin with.
+ *
+ * Intentionally narrow: dot-prefixed directories users might actually
+ * keep artifacts in (`.specs/`, `.docs/`) are NOT ignored. The set
+ * covers the universally-untouchable dirs and the agent-config dirs
+ * Smithy itself deploys (`.claude/`, `.gemini/`, `.codex/`).
+ */
+const IGNORED_DIR_NAMES = new Set<string>([
+  '.git',
+  '.hg',
+  '.svn',
+  'node_modules',
+  'dist',
+  'build',
+  'out',
+  'coverage',
+  '.next',
+  '.nuxt',
+  '.cache',
+  '.turbo',
+  '.idea',
+  '.vscode',
+  '.smithy',
+  '.claude',
+  '.gemini',
+  '.codex',
+]);
 
 const SUFFIX_TYPES: Array<readonly [string, ArtifactType]> = [
   ['.rfc.md', 'rfc'],
@@ -100,7 +169,21 @@ export function scan(root: string): ArtifactRecord[] {
   // `specs/` and `specs/strikes/`).
   const visitedDirs = new Set<string>();
 
-  // Phase 1: discover + parse.
+  // Phase 1: discover + parse. Two strategies, chosen by what's
+  // actually present under `realRoot`:
+  //
+  //  - Fast path: walk SCAN_ROOTS that exist. Conventional repos
+  //    (canonical layout at their top level) take this path and pay
+  //    no recursion cost outside the known subtrees, regardless of
+  //    repo size. The fallback walker is never invoked.
+  //
+  //  - Fallback: if NONE of the SCAN_ROOTS exist under `realRoot`,
+  //    walk `realRoot` recursively (skipping IGNORED_DIR_NAMES). This
+  //    is the issue-#295 case — `--root` pointed at a sub-package or
+  //    a layout that doesn't follow the canonical naming, so the
+  //    scanner has to discover artifacts wherever they live under the
+  //    user's chosen root.
+  let scannedAnyCanonical = false;
   for (const scanRoot of SCAN_ROOTS) {
     const startDir = path.join(realRoot, scanRoot);
     let stat: fs.Stats;
@@ -120,6 +203,11 @@ export function scan(root: string): ArtifactRecord[] {
     if (visitedDirs.has(realStart)) continue;
     visitedDirs.add(realStart);
     walkDir(startDir, realRoot, records, visitedDirs);
+    scannedAnyCanonical = true;
+  }
+  if (!scannedAnyCanonical) {
+    visitedDirs.add(realRoot);
+    walkDir(realRoot, realRoot, records, visitedDirs);
   }
 
   // Phase 2: resolve parent/child linkage and emit virtual records.
@@ -344,9 +432,13 @@ function walkDir(
     }
 
     if (stat.isDirectory()) {
-      // Guard against directory cycles introduced by symlinks (and
-      // duplicate descents from overlapping scan roots) by tracking
-      // canonical real paths we have already walked.
+      // Skip universally-untouchable directories (VCS metadata,
+      // dependency caches, build outputs, agent config dirs). Smithy
+      // artifacts never live inside these, and walking them on a
+      // typical repo root would be expensive for no payoff.
+      if (IGNORED_DIR_NAMES.has(name)) continue;
+      // Guard against directory cycles introduced by symlinks by
+      // tracking canonical real paths we have already walked.
       if (visitedDirs.has(realAbs)) continue;
       visitedDirs.add(realAbs);
       walkDir(abs, realRoot, records, visitedDirs);
@@ -386,9 +478,9 @@ function handleFile(
   const type = detectTypeFromSuffix(rel);
   if (type === null) return;
 
-  // Same file visited via two scan roots (e.g., `specs/strikes/` lives
-  // inside `specs/`): the first insert wins and subsequent visits are
-  // no-ops. This keeps the returned record set free of duplicates.
+  // Defensive: if the same repo-relative path is somehow seen twice
+  // (e.g., a symlink that survives the visited-dir cycle guard), the
+  // first insert wins and subsequent visits are no-ops.
   if (records.has(rel)) return;
 
   let content: string;


### PR DESCRIPTION
## Summary
- Primary outcome: `smithy status --root <path>` surfaces artifacts under non-canonical layouts (singular `spec/`, custom sub-packages like `lib-streaming/spec/`, etc.).
- Notable behaviour changes: when none of `specs/`, `docs/rfcs/`, `specs/strikes/` exist under the resolved `--root`, the scanner falls back to a recursive walk (skipping VCS, dep caches, build outputs, agent config dirs). When any of them do exist, the original fast path is preserved unchanged.
- Follow-up work deferred (if any): none.

## Context
- Issue #295 reported that the scanner only walks a hardcoded list of subdirectories. Repos that put their specs in a singular `spec/` directory (or in any sub-package the user passes via `--root`) showed no artifacts even though the files were on disk with the right suffixes.
- The fix needs to add flexibility for non-canonical layouts without regressing performance on conventional repos / monorepos that already use the canonical layout at their top level.

## Implementation Notes
- Hybrid discovery in `src/status/scanner.ts`:
  - Fast path: walk `SCAN_ROOTS` (`specs/`, `docs/rfcs/`, `specs/strikes/`) when any of them exist directly under `realRoot`. Bounded scan cost regardless of repo size — no recursion outside the known subtrees, so monorepos with the canonical layout pay zero extra cost.
  - Fallback path: only triggers when none of `SCAN_ROOTS` exist. Recursively walks `realRoot`, skipping `IGNORED_DIR_NAMES` (`.git`, `.hg`, `.svn`, `node_modules`, `dist`, `build`, `out`, `coverage`, `.next`, `.nuxt`, `.cache`, `.turbo`, `.idea`, `.vscode`, `.smithy`, `.claude`, `.gemini`, `.codex`).
- The ignore list is intentionally narrow: dot-prefixed directories users might keep artifacts in (`.specs/`, `.docs/`) are not ignored. Only universally-untouchable dirs and the agent-config dirs Smithy itself deploys.
- Symlink cycle detection (`visitedDirs`) and root-escape rejection (`isWithinRoot`) are unchanged and apply to both paths.
- No CLI surface change — `--root` already existed.

## Risks & Mitigations
- Risk: Fallback path on a non-canonical repo is more expensive than the original behavior. | Mitigation: Fallback only fires when no canonical scan dir exists, and the ignore list bounds it on typical project trees. Conventional repos take the fast path and are unaffected.
- Risk: Ignore list excludes a dir a user actually wants scanned. | Mitigation: List is restricted to universally-skip directories. Users with artifacts under e.g. `.smithy/` would be a pathological case; can be revisited if reported.

## Rollback Plan
- Revert the commit on this branch. No data migrations, no on-disk format changes.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npm run typecheck`)
- [ ] CLI `init` smoke test (`node dist/cli.js init`) — not relevant; this PR only changes the status scanner.

### Template Generation
- [ ] Gemini Skills: `.gemini/skills/` folders and `SKILL.md` validity. — not touched.
- [ ] Codex Prompts: `tools/codex/prompts/` file content. — not touched.
- [ ] Claude Prompts: `.claude/prompts/` file content. — not touched.
- [ ] GitHub Issue Templates: `.github/ISSUE_TEMPLATE/` content. — not touched.

### Permissions & Configuration
- [ ] Gemini Config: `.gemini/config.json` correctly formed and merged. — not touched.
- [ ] Codex Config: `.codex/config.toml` contains correct `[[approvals.rules]]`. — not touched.
- [ ] Claude Config: `.claude/settings.json` correctly formed. — not touched.

### Manual Test Cases
- [ ] Reviewed applicable cases in `tests/Agent.tests.md` and `tests/Manual.tests.md` (if init/uninit flows changed) — init/uninit flows untouched.

### Automated coverage added
- [x] Singular `spec/` and other custom layouts surface artifacts.
- [x] `--root` pointed at a sub-package (`lib-streaming/spec`) discovers artifacts directly under it.
- [x] Fast path: when canonical scan dirs exist, sibling subtrees (incl. `node_modules/`, `dist/`) are not walked.
- [x] Fallback path: `IGNORED_DIR_NAMES` skips `.git`, `node_modules`, `dist`, `.smithy` while still surfacing real artifacts elsewhere.
- [x] Full suite: 732 tests pass.

## Issue
- Closes #295
