### PR TITLE
Restore per-row hints and add row digits to smithy status

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1125,10 +1125,14 @@ describe('CLI status', () => {
     // branch of the renderer is exercised in one invocation:
     //
     // 1. A not-started RFC with a virtual features child. The RFC is a
-    //    root (no ancestors) → un-suppressed → its hint line IS
-    //    emitted. The virtual features record below it inherits
-    //    `suppressed_by_ancestor: true` because its parent (the RFC)
-    //    is not-started → its hint line must NOT be emitted.
+    //    root (no ancestors) → un-suppressed → its hint line is
+    //    emitted. The virtual features record below it carries
+    //    `suppressed_by_ancestor: true` on its `next_action` (the RFC
+    //    parent is not-started), but the renderer no longer treats
+    //    that flag as a gate, so its hint line is also emitted —
+    //    every actionable row stays self-describing in the text view.
+    //    The flag still rides along on the JSON payload for machine
+    //    consumers.
     //
     // 2. An independent spec whose only tasks child is fully checked
     //    off → both records classify as `done` → neither emits a hint

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1205,12 +1205,16 @@ describe('CLI status', () => {
     expect(renderHintLines).toHaveLength(1);
     expect(renderHintLines[0]).toContain('docs/rfcs/active.rfc.md');
 
-    // AS 4.5: the suppressed features record emits NO hint line.
-    // There is only one feature-level hint-worthy command
-    // (`smithy.mark`) in the rule table; it must not appear anywhere
-    // in the text output since the only features record in the
-    // fixture is suppressed.
-    expect(textOutput).not.toContain('smithy.mark');
+    // The suppressed-by-ancestor features record still surfaces its own
+    // hint in the text view: every actionable row must be self-describing
+    // even when its parent is `not-started`. The `suppressed_by_ancestor`
+    // flag remains on the JSON payload (asserted above) for machine
+    // consumers, but the renderer no longer treats it as a gate.
+    const markHintLines = lines.filter(
+      (l) => l.includes('→') && l.includes('smithy.mark'),
+    );
+    expect(markHintLines).toHaveLength(1);
+    expect(markHintLines[0]).toContain('docs/rfcs/active.features.md');
 
     // Done records emit no hint line: the finished tasks file is done
     // and must not have an arrow beneath its rendered line.
@@ -1227,10 +1231,11 @@ describe('CLI status', () => {
       break;
     }
 
-    // There must be exactly one hint line in the entire output — the
-    // un-suppressed RFC's. No other arrow characters should appear.
+    // Two hint lines total: the un-suppressed RFC's and the
+    // suppressed-by-ancestor features map's. The done tasks record
+    // emits nothing.
     const allHintLines = lines.filter((l) => l.includes('\u2192'));
-    expect(allHintLines).toHaveLength(1);
+    expect(allHintLines).toHaveLength(2);
   });
 
   describe('US6 filters (--status, --type, --root)', () => {

--- a/src/status/render.test.ts
+++ b/src/status/render.test.ts
@@ -609,12 +609,14 @@ describe('renderTree — story number prefix', () => {
   });
 });
 
-describe('renderTree — slice rendering for tasks records', () => {
-  it('renders each parsed slice as a nested tree child under its tasks record', () => {
-    // A real tasks record carries per-slice info on `record.slices`.
-    // The renderer surfaces each slice with its `S<N>` id, the
-    // heading title, and a status icon — none of which appears in
-    // the aggregate `<completed>/<total>` counter alone.
+describe('renderTree — slice rows are not rendered', () => {
+  it('omits per-slice tree rows even when the tasks record carries a populated slices array', () => {
+    // The renderer dropped its inline `S<N>` slice rows: the actionable
+    // form of "which slice is next" lives in the parent's
+    // `→ smithy.forge <path> <N>` hint, not in a dedicated row. The
+    // `<completed>/<total>` counter on the tasks marker continues to
+    // surface aggregate slice progress, and the `slices` field stays
+    // on the JSON payload for machine consumers.
     const tasks = makeRecord({
       type: 'tasks',
       path: 'specs/f/01-story.tasks.md',
@@ -635,17 +637,15 @@ describe('renderTree — slice rendering for tasks records', () => {
       { theme: utf8Theme },
     );
     const lines = output.split('\n');
+    expect(lines).toHaveLength(1);
     expect(lines[0]).toBe('01 Story  ◐ 1/3');
-    expect(lines[1]).toBe('├─ S1 Foo  ✓');
-    expect(lines[2]).toBe('├─ S2 Bar  ◐');
-    expect(lines[3]).toBe('└─ S3 Baz  ○');
+    // Slice ids must not appear as their own rows.
+    expect(output).not.toContain('S1 Foo');
+    expect(output).not.toContain('S2 Bar');
+    expect(output).not.toContain('S3 Baz');
   });
 
-  it('omits slice lines when the tasks record has no slices field', () => {
-    // Virtual tasks records emitted by the scanner from a `—` spec
-    // row carry no `slices` field — the underlying tasks file does
-    // not exist yet. The renderer must not synthesize phantom slice
-    // children for them.
+  it('renders virtual tasks records as a single line with no slice rows beneath', () => {
     const virt = makeRecord({
       type: 'tasks',
       path: 'specs/f/04-future.tasks.md',
@@ -660,59 +660,6 @@ describe('renderTree — slice rendering for tasks records', () => {
       { theme: utf8Theme },
     );
     expect(output).toBe('04 Future Story  ○');
-  });
-
-  it('inherits the parent connector spacing for slice connectors', () => {
-    // A spec parent with two children: the first is a tasks record
-    // with slices, the second is another tasks record. The slice
-    // connectors must inherit the vertical-bar spacer from the spec's
-    // first-child column, not the blank-spacer that the spec's
-    // last-child column would imply.
-    const spec = makeRecord({
-      type: 'spec',
-      path: 'specs/f/f.spec.md',
-      title: 'Feature',
-      status: 'in-progress',
-      parent_path: null,
-    });
-    const firstTasks = makeRecord({
-      type: 'tasks',
-      path: 'specs/f/01-a.tasks.md',
-      title: 'A',
-      status: 'in-progress',
-      completed: 1,
-      total: 2,
-      parent_path: 'specs/f/f.spec.md',
-      parent_row_id: 'US1',
-      slices: [
-        { id: 'S1', title: 'first', status: 'done' },
-        { id: 'S2', title: 'second', status: 'in-progress' },
-      ],
-    });
-    const secondTasks = makeRecord({
-      type: 'tasks',
-      path: 'specs/f/02-b.tasks.md',
-      title: 'B',
-      status: 'not-started',
-      completed: 0,
-      total: 0,
-      parent_path: 'specs/f/f.spec.md',
-      parent_row_id: 'US2',
-      slices: [],
-    });
-    const tree = buildTree([spec, firstTasks, secondTasks]);
-    const output = renderTree(tree, { theme: utf8Theme });
-    const lines = output.split('\n');
-    // The first tasks record is a non-last sibling of the spec, so its
-    // slice children carry the vertical-bar spacer (`│  `) inherited
-    // from the spec's first-child column. The orphan-spec heading
-    // wrapping above contributes a leading three-space indent because
-    // the spec's `parent_path` is null. The last slice uses the
-    // last-branch (`└─`) connector and its descendant column would
-    // therefore be blank, but we are at a leaf so no further lines
-    // follow.
-    expect(lines.some((l) => l.endsWith('│  ├─ S1 first  ✓'))).toBe(true);
-    expect(lines.some((l) => l.endsWith('│  └─ S2 second  ◐'))).toBe(true);
   });
 });
 
@@ -801,7 +748,12 @@ describe('renderTree — renderHints option (US4 Slice 2)', () => {
     expect(output).not.toContain('\u2192');
   });
 
-  it('renderHints: true emits no hint line for a suppressed record', () => {
+  it('renderHints: true still emits a hint line for a suppressed-by-ancestor record', () => {
+    // Suppression is preserved on the JSON payload (machine consumers
+    // can tell which hints sit beneath a not-started ancestor) but the
+    // text renderer no longer hides them \u2014 every actionable row carries
+    // its own copy-pasteable hint so nothing reads as a bare `\u25cb` below
+    // a not-started parent.
     const record = makeRecord({
       type: 'tasks',
       path: 'specs/f/01-story.tasks.md',
@@ -810,7 +762,7 @@ describe('renderTree — renderHints option (US4 Slice 2)', () => {
       parent_path: 'specs/f/f.spec.md',
       next_action: {
         command: 'smithy.forge',
-        arguments: ['specs/f/01-story.tasks.md'],
+        arguments: ['specs/f/01-story.tasks.md', '1'],
         reason: 'because',
         suppressed_by_ancestor: true,
       },
@@ -819,9 +771,9 @@ describe('renderTree — renderHints option (US4 Slice 2)', () => {
       { roots: [{ record, children: [] }] },
       { theme: utf8Theme, renderHints: true },
     );
-    expect(output.split('\n')).toHaveLength(1);
-    expect(output).not.toContain('\u2192');
-    expect(output).not.toContain('smithy.forge');
+    const lines = output.split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain('\u2192 smithy.forge specs/f/01-story.tasks.md 1');
   });
 
   it('renderHints: true emits a hint line beneath a nested record with the correct tree-prefix inheritance', () => {
@@ -894,7 +846,12 @@ describe('renderTree — renderHints option (US4 Slice 2)', () => {
     expect(lines[1]).not.toMatch(/^\s*\u2192/);
   });
 
-  it('renderHints: true emits a hint line only for records whose next_action is non-null and not suppressed', () => {
+  it('renderHints: true emits a hint line for every actionable record, including suppressed-by-ancestor children', () => {
+    // Ancestor not-started \u2192 children carry `suppressed_by_ancestor:
+    // true` on the JSON payload, but the text renderer surfaces every
+    // hint regardless. A descendant under a not-started parent must
+    // still display its own copy-pasteable hint; otherwise a wall of
+    // `\u25cb` markers leaves the user with nothing to act on.
     const rfc = makeRecord({
       type: 'rfc',
       path: 'docs/rfcs/demo.rfc.md',
@@ -923,9 +880,9 @@ describe('renderTree — renderHints option (US4 Slice 2)', () => {
     const tree = buildTree([rfc, features]);
     const output = renderTree(tree, { theme: utf8Theme, renderHints: true });
     const arrowLines = output.split('\n').filter((l) => l.includes('\u2192'));
-    expect(arrowLines).toHaveLength(1);
+    expect(arrowLines).toHaveLength(2);
     expect(arrowLines[0]).toContain('smithy.render');
-    expect(output).not.toContain('smithy.mark');
+    expect(arrowLines[1]).toContain('smithy.mark');
   });
 });
 

--- a/src/status/render.ts
+++ b/src/status/render.ts
@@ -74,7 +74,6 @@ import {
 } from './tree.js';
 import type {
   ArtifactRecord,
-  SliceSummary,
   Status,
   StatusTree,
   TreeNode,
@@ -95,16 +94,24 @@ export interface RenderTreeOptions {
   theme?: Theme;
   /**
    * When `true`, append an indented next-action hint line beneath every
-   * real record whose `next_action` is non-null and not suppressed by
-   * an ancestor. Defaults to `false` so existing callers (and legacy
-   * tests) continue to see a pure tree with no hint annotations.
+   * real record whose `next_action` is non-null. Defaults to `false` so
+   * existing callers (and legacy tests) continue to see a pure tree with
+   * no hint annotations.
    *
    * The hint line uses the formatter {@link formatNextAction} and is
    * indented with the same tree-prefix the record's descendants would
    * inherit, plus a two-space pad (SD-016) so the hint visually
    * attaches beneath the record line. Done records (whose `next_action`
-   * is `null`) and records carrying `suppressed_by_ancestor: true` emit
-   * no hint line. Group sentinel nodes never emit a hint line.
+   * is `null`) emit no hint line. Group sentinel nodes never emit a
+   * hint line.
+   *
+   * Records carrying `suppressed_by_ancestor: true` still render their
+   * own hint here so each row is self-describing — the suppression flag
+   * is preserved on the JSON payload for machine consumers but is no
+   * longer used as a render gate. Without per-row hints under a
+   * not-started parent, every child row degrades to a bare `○` marker
+   * with no copy-pasteable command, and users had no way to act on
+   * individual stories without scrolling back up to the parent.
    */
   renderHints?: boolean;
 }
@@ -170,7 +177,6 @@ function renderRoot(
   // A root's descendants inherit no parent spacer, so the hint line
   // (when enabled) is anchored at column 0 plus the two-space hint pad.
   maybePushHint(node.record, '', lines, renderHints, theme);
-  pushSliceLines(node.record, '', lines, theme);
   const { children } = node;
   for (let i = 0; i < children.length; i++) {
     renderChild(
@@ -211,13 +217,6 @@ function renderChild(
   // keeping the hint anchored beneath the record but out of the way of
   // real descendants below it.
   maybePushHint(node.record, nextPrefix, lines, renderHints, theme);
-  // Slices live inline inside a tasks file (not as separate records),
-  // so they cannot reach the tree builder. Render them here as nested
-  // children of their owning tasks record using the same `nextPrefix`
-  // any real child would inherit, so each slice id (`S1`, `S2`, …)
-  // surfaces in the tree view rather than being collapsed into the
-  // tasks record's `<completed>/<total>` counter alone.
-  pushSliceLines(node.record, nextPrefix, lines, theme);
   const { children } = node;
   for (let i = 0; i < children.length; i++) {
     renderChild(
@@ -240,14 +239,17 @@ function renderChild(
  *   "Orphaned Tasks") — these have no lifecycle and no next action.
  * - The record's `next_action` is `null` or omitted (done and
  *   read-error records, respectively).
- * - `next_action.suppressed_by_ancestor === true` — suppressed hints
- *   are intentionally hidden so only the topmost actionable ancestor's
- *   hint surfaces (FR-011).
  *
  * Otherwise emit a single line of the form
  * `<recordPrefix>  → <command> [args…]` where `recordPrefix` is the
  * same prefix the record's descendants would inherit, and the two
  * spaces after it are the SD-016 hint pad.
+ *
+ * `next_action.suppressed_by_ancestor === true` is intentionally not
+ * gated here. The flag still flows through the JSON payload so machine
+ * consumers can tell which hints are downstream of a not-started
+ * ancestor, but in the text view every actionable record renders its
+ * own copy-pasteable hint so each row is self-describing.
  */
 function maybePushHint(
   record: ArtifactRecord,
@@ -260,7 +262,6 @@ function maybePushHint(
   if (isGroupSentinel(record)) return;
   const action = record.next_action;
   if (action === null || action === undefined) return;
-  if (action.suppressed_by_ancestor === true) return;
   lines.push(
     `${recordPrefix}  ${formatNextAction(action, theme.glyphs.arrow)}`,
   );
@@ -315,60 +316,6 @@ function applyStoryNumber(title: string, rowId: string | undefined): string {
   if (digits === undefined) return stripped;
   const nn = digits.padStart(2, '0');
   return `${nn} ${stripped}`;
-}
-
-/**
- * Render the per-slice breakdown of a tasks record as nested tree
- * lines beneath it. Each slice is rendered as a leaf child carrying
- * its canonical `S<N>` id, the heading title, and a status icon
- * mirroring the record-level icons (`✓` / `◐` / `○`). No-op for
- * non-tasks records, for tasks records with no parsed slices, or
- * during the renderer pipeline's collapsed-done branch (the tasks
- * record never reaches this function in that case because
- * `collapseTree` upstream replaces it with a leaf).
- *
- * Slices are deliberately rendered here in the tree-renderer rather
- * than expanded into virtual `ArtifactRecord`s upstream because they
- * live inline inside a tasks file — they have no path of their own,
- * no dependency-order section, and no lifecycle independent of their
- * parent record. Treating them as a renderer-only concern keeps the
- * scanner / classifier / suggester surface unchanged.
- */
-function pushSliceLines(
-  record: ArtifactRecord,
-  recordPrefix: string,
-  lines: string[],
-  theme: Theme,
-): void {
-  if (record.type !== 'tasks') return;
-  const slices = record.slices;
-  if (slices === undefined || slices.length === 0) return;
-  for (let i = 0; i < slices.length; i++) {
-    const slice = slices[i];
-    if (slice === undefined) continue;
-    const isLast = i === slices.length - 1;
-    const connector = isLast ? theme.glyphs.lastBranch : theme.glyphs.branch;
-    const marker = formatSliceMarker(slice, theme);
-    lines.push(
-      `${recordPrefix}${connector}${slice.id} ${slice.title}  ${marker}`,
-    );
-  }
-}
-
-/**
- * Status marker for a {@link SliceSummary} inside the tree view.
- * Mirrors the icon mapping used by real records (`✓` / `◐` / `○`)
- * so a row of slice ids reads as a homogeneous progress strip.
- */
-function formatSliceMarker(slice: SliceSummary, theme: Theme): string {
-  switch (slice.status) {
-    case 'done':
-      return theme.paint.done(theme.icons.done);
-    case 'in-progress':
-      return theme.paint.inProgress(theme.icons.inProgress);
-    case 'not-started':
-      return theme.paint.notStarted(theme.icons.notStarted);
-  }
 }
 
 /**

--- a/src/status/suggester.test.ts
+++ b/src/status/suggester.test.ts
@@ -111,7 +111,11 @@ describe('suggestNextAction — done and unknown short-circuit to null', () => {
 });
 
 describe('suggestNextAction — tasks records', () => {
-  it('suggests smithy.forge for a not-started tasks record', () => {
+  it('suggests smithy.forge with no slice digit when a not-started tasks record has no parsed slices', () => {
+    // Older fixtures (and pathological tasks files with no `## Slice N:`
+    // headings) have no `slices` field on the record, so the suggester
+    // falls back to the legacy single-arg shape rather than fabricate
+    // a `0` digit.
     const record = makeRecord({
       type: 'tasks',
       status: 'not-started',
@@ -126,19 +130,66 @@ describe('suggestNextAction — tasks records', () => {
     expect(action!.suppressed_by_ancestor).toBeUndefined();
   });
 
-  it('suggests smithy.forge for an in-progress tasks record', () => {
+  it('appends the first non-done slice digit on a not-started tasks record with parsed slices', () => {
+    // Real tasks records carry per-slice info (parser populates it from
+    // `## Slice N:` headings). The first non-done slice's digit travels
+    // into `args[1]` so the hint reads `smithy.forge <path> <N>` and
+    // tells the user exactly which slice to pick up next.
+    const record = makeRecord({
+      type: 'tasks',
+      status: 'not-started',
+      path: 'specs/x/01-foo.tasks.md',
+      slices: [
+        { id: 'S1', title: 'Bootstrap', status: 'not-started' },
+        { id: 'S2', title: 'Wire init', status: 'not-started' },
+      ],
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action!.command).toBe('smithy.forge');
+    expect(action!.arguments).toEqual(['specs/x/01-foo.tasks.md', '1']);
+    expect(action!.reason).toContain('S1');
+  });
+
+  it('appends the first non-done slice digit on an in-progress tasks record', () => {
+    // S1 done, S2 in-progress, S3 not-started → next forge target is S2.
+    // The suggester picks the first slice whose status !== 'done', so
+    // an in-progress slice wins over a later not-started one — which
+    // matches "resume mid-flight work" intent.
     const record = makeRecord({
       type: 'tasks',
       status: 'in-progress',
       path: 'specs/x/02-bar.tasks.md',
       completed: 2,
       total: 5,
+      slices: [
+        { id: 'S1', title: 'Foo', status: 'done' },
+        { id: 'S2', title: 'Bar', status: 'in-progress' },
+        { id: 'S3', title: 'Baz', status: 'not-started' },
+      ],
     });
     const action = suggestNextAction(record, [], false);
     expect(action).not.toBeNull();
     expect(action!.command).toBe('smithy.forge');
-    expect(action!.arguments).toEqual(['specs/x/02-bar.tasks.md']);
-    expect(action!.reason.length).toBeGreaterThan(0);
+    expect(action!.arguments).toEqual(['specs/x/02-bar.tasks.md', '2']);
+    expect(action!.reason).toContain('S2');
+  });
+
+  it('falls back to the single-arg shape when every slice is already done', () => {
+    // Pathological for an in-progress/not-started tasks record (would
+    // normally roll up to done), but the suggester must still return
+    // a usable action rather than emit a blank slice digit.
+    const record = makeRecord({
+      type: 'tasks',
+      status: 'in-progress',
+      path: 'specs/x/03-baz.tasks.md',
+      slices: [
+        { id: 'S1', title: 'Foo', status: 'done' },
+        { id: 'S2', title: 'Bar', status: 'done' },
+      ],
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action!.command).toBe('smithy.forge');
+    expect(action!.arguments).toEqual(['specs/x/03-baz.tasks.md']);
   });
 
   it('redirects a virtual tasks record to smithy.cut on its parent spec', () => {
@@ -180,7 +231,37 @@ describe('suggestNextAction — tasks records', () => {
 });
 
 describe('suggestNextAction — rfc records', () => {
-  it('suggests smithy.render for a not-started rfc record', () => {
+  it('suggests smithy.render with the first virtual milestone digit', () => {
+    // M1 already has a feature map (real, in-progress); M2 / M3 do not
+    // (virtual, not-started). The suggester points at M2 — the first
+    // milestone whose feature map has yet to be rendered.
+    const record = makeRecord({
+      type: 'rfc',
+      status: 'in-progress',
+      path: 'docs/rfcs/2026-04-12-foo.rfc.md',
+      dependency_order: {
+        rows: [
+          makeRow('M1', 'docs/rfcs/01-spawn.features.md'),
+          makeRow('M2'),
+          makeRow('M3'),
+        ],
+        id_prefix: 'M',
+        format: 'table',
+      },
+    });
+    const children: ArtifactRecord[] = [
+      makeChild('in-progress', 'features'),
+      makeRecord({ type: 'features', status: 'not-started', virtual: true }),
+      makeRecord({ type: 'features', status: 'not-started', virtual: true }),
+    ];
+    const action = suggestNextAction(record, children, false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.render');
+    expect(action!.arguments).toEqual(['docs/rfcs/2026-04-12-foo.rfc.md', '2']);
+    expect(action!.reason).toContain('M2');
+  });
+
+  it('falls back to single-arg smithy.render when the rfc has zero milestones', () => {
     const record = makeRecord({
       type: 'rfc',
       status: 'not-started',
@@ -193,14 +274,28 @@ describe('suggestNextAction — rfc records', () => {
     expect(action!.reason.length).toBeGreaterThan(0);
   });
 
-  it('suggests smithy.render for an in-progress rfc record', () => {
+  it('falls back to single-arg smithy.render when every milestone already has a feature map', () => {
+    // No virtual children → no "first virtual not-started" candidate.
+    // Suggester degrades to the bare RFC-path hint rather than picking
+    // an arbitrary milestone digit.
     const record = makeRecord({
       type: 'rfc',
       status: 'in-progress',
       path: 'docs/rfcs/2026-04-12-foo.rfc.md',
+      dependency_order: {
+        rows: [
+          makeRow('M1', 'docs/rfcs/01-spawn.features.md'),
+          makeRow('M2', 'docs/rfcs/02-dispatch.features.md'),
+        ],
+        id_prefix: 'M',
+        format: 'table',
+      },
     });
-    const action = suggestNextAction(record, [], false);
-    expect(action).not.toBeNull();
+    const children: ArtifactRecord[] = [
+      makeChild('done', 'features'),
+      makeChild('in-progress', 'features'),
+    ];
+    const action = suggestNextAction(record, children, false);
     expect(action!.command).toBe('smithy.render');
     expect(action!.arguments).toEqual(['docs/rfcs/2026-04-12-foo.rfc.md']);
   });

--- a/src/status/suggester.ts
+++ b/src/status/suggester.ts
@@ -180,7 +180,9 @@ function firstVirtualNotStartedRowDigits(
  * 3. Otherwise the record is `not-started` or `in-progress` and the
  *    deterministic rule table from FR-010 applies, with a
  *    prerequisite check so every suggested command is runnable:
- *    - `rfc` → `smithy.render [record.path]`
+ *    - `rfc` → `smithy.render [record.path, <first-virtual-row-digits>]`
+ *      when a milestone has no feature map yet; `smithy.render [record.path]`
+ *      otherwise (zero rows, or every milestone already rendered).
  *    - `features` → `smithy.mark [record.path, <first-virtual-row-digits>]`
  *      when a feature has no spec file yet; `smithy.mark [record.path]`
  *      only when the record has zero rows but is itself `not-started`;
@@ -191,7 +193,9 @@ function firstVirtualNotStartedRowDigits(
  *      only when the record has zero rows but is itself `not-started`;
  *      `null` otherwise (every declared tasks file already exists, so
  *      the per-task hints cover the remaining work).
- *    - `tasks` → `smithy.forge [record.path]` for a real tasks record;
+ *    - `tasks` → `smithy.forge [record.path, <first-non-done-slice-digits>]`
+ *      for a real tasks record carrying parsed slices (degrades to
+ *      `smithy.forge [record.path]` when no slices are present);
  *      `smithy.cut [dirname(parent_path), <parent_row_id-digits>]` for
  *      a virtual tasks record whose file does not yet exist (falling
  *      back to the `smithy.forge` shape when the scanner did not
@@ -206,10 +210,14 @@ function firstVirtualNotStartedRowDigits(
  * @param record             The already-classified record to evaluate.
  * @param resolvedChildren   Children whose `status` is already
  *                           finalized, in the same order as
- *                           `record.dependency_order.rows`. Ignored
- *                           for `rfc` records; also ignored for `tasks`
- *                           records (their virtual/real state lives on
- *                           the record itself).
+ *                           `record.dependency_order.rows`. Consulted
+ *                           for `rfc` / `features` / `spec` records to
+ *                           pick the first virtual not-started row whose
+ *                           digit anchors the appended `<N>` argument.
+ *                           Ignored for `tasks` records — their slice
+ *                           digit is read off `record.slices`, and their
+ *                           virtual/real state lives on the record
+ *                           itself.
  * @param ancestorNotStarted True when any ancestor in the record's
  *                           parent chain has `status: 'not-started'`.
  *                           Drives `suppressed_by_ancestor`.

--- a/src/status/suggester.ts
+++ b/src/status/suggester.ts
@@ -10,16 +10,22 @@
  *
  * The rule table mirrors FR-010 in `smithy-status-skill.spec.md` and
  * Acceptance Scenarios 4.1–4.5, extended so every hint represents a
- * command whose on-disk prerequisites are satisfied:
+ * command whose on-disk prerequisites are satisfied AND carries a
+ * trailing row digit pointing at the next actionable child whenever one
+ * is available:
  *
- * - `rfc` → `smithy.render <rfc-path>`
+ * - `rfc` → `smithy.render <rfc-path> <first-virtual-M<N>-digits>` when a
+ *   milestone has no feature map yet; `smithy.render <rfc-path>` when the
+ *   RFC has zero rows or every milestone is already rendered
  * - `features` → `smithy.mark <features-path> <first-virtual-F<N>-digits>`
  *   (only when at least one feature row has no spec file on disk; null
  *   otherwise so per-spec hints below the features map drive the work)
  * - `spec` → `smithy.cut <dirname(spec-path)> <first-virtual-US<N>-digits>`
  *   (only when at least one user-story row has no tasks file on disk;
  *   null otherwise so per-task hints below the spec drive the work)
- * - `tasks` → `smithy.forge <tasks-path>` for real tasks files, or
+ * - `tasks` → `smithy.forge <tasks-path> <first-non-done-S<N>-digits>` for
+ *   real tasks files (degrades to `smithy.forge <tasks-path>` when the
+ *   record carries no parsed slices), or
  *   `smithy.cut <spec-folder> <US<N>-digits>` for virtual tasks
  *   records (where the tasks file does not yet exist)
  *
@@ -40,7 +46,7 @@
 
 import path from 'node:path';
 
-import type { ArtifactRecord, NextAction } from './types.js';
+import type { ArtifactRecord, NextAction, SliceSummary } from './types.js';
 
 /**
  * Extract the numeric suffix from a canonical dep-order row id
@@ -101,6 +107,32 @@ function specFolderFromPath(specPath: string): string {
     return specPath.replace(/\/+$/, '');
   }
   return path.dirname(specPath);
+}
+
+/**
+ * Find the first slice on a real tasks record whose status is not `done`
+ * and return its numeric id suffix (e.g. `S2` → `'2'`). Returns
+ * `undefined` if `slices` is missing/empty or no slice qualifies. Used
+ * to compose `smithy.forge <path> <slice-num>` hints so the user knows
+ * exactly which slice the next forge invocation should pick up.
+ *
+ * Slices are emitted by the parser in source order, which matches the
+ * dep-order column inside a tasks file, so a single forward scan finds
+ * the right candidate. We do not prefer in-progress over not-started:
+ * the first slice that is not `done` IS the next thing to forge,
+ * regardless of whether it is mid-flight or yet to start.
+ */
+function firstNonDoneSliceDigits(
+  slices: SliceSummary[] | undefined,
+): string | undefined {
+  if (slices === undefined || slices.length === 0) return undefined;
+  for (const slice of slices) {
+    if (slice.status !== 'done') {
+      const digits = numericIdSuffix(slice.id);
+      if (digits !== undefined) return digits;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -200,8 +232,21 @@ export function suggestNextAction(
   switch (record.type) {
     case 'rfc': {
       command = 'smithy.render';
-      args = [record.path];
-      reason = `RFC ${record.title} is ${record.status}; run smithy.render to continue drafting it.`;
+      // Mirror the features/spec pattern: surface the next not-yet-rendered
+      // milestone digit so `smithy.render <rfc> <N>` is copy-pasteable. If
+      // every milestone already has a feature map (or the RFC has zero
+      // rows) we fall back to the legacy single-arg shape.
+      const milestoneDigits = firstVirtualNotStartedRowDigits(
+        record,
+        resolvedChildren,
+      );
+      if (milestoneDigits !== undefined) {
+        args = [record.path, milestoneDigits];
+        reason = `RFC ${record.title} has a milestone M${milestoneDigits} with no feature map yet; run smithy.render to produce it.`;
+      } else {
+        args = [record.path];
+        reason = `RFC ${record.title} is ${record.status}; run smithy.render to continue drafting it.`;
+      }
       break;
     }
     case 'features': {
@@ -274,8 +319,19 @@ export function suggestNextAction(
         // suggester stays total.
       }
       command = 'smithy.forge';
-      args = [record.path];
-      reason = `Tasks file ${record.title} is ${record.status}; run smithy.forge to implement its next slice.`;
+      // Append the digit of the first non-done slice so the hint reads
+      // `smithy.forge <path> <N>` and the user can pick up exactly where
+      // the work resumes. Records that don't carry parsed slices (older
+      // fixtures, pathological tasks files) keep the legacy one-arg
+      // shape rather than emit a nonsense `0` digit.
+      const sliceDigits = firstNonDoneSliceDigits(record.slices);
+      if (sliceDigits !== undefined) {
+        args = [record.path, sliceDigits];
+        reason = `Tasks file ${record.title} is ${record.status}; run smithy.forge to implement slice S${sliceDigits}.`;
+      } else {
+        args = [record.path];
+        reason = `Tasks file ${record.title} is ${record.status}; run smithy.forge to implement its next slice.`;
+      }
       break;
     }
   }

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -132,9 +132,11 @@ export interface NextAction {
   /** One-line human-readable rationale. */
   reason: string;
   /**
-   * True when an ancestor artifact is itself not-started, meaning this
-   * suggestion was dropped from the rendered output in favor of the
-   * ancestor's suggestion. Retained in the record set for JSON consumers.
+   * True when an ancestor artifact is itself not-started. The text
+   * renderer surfaces the hint regardless — every actionable row stays
+   * self-describing — but this flag remains on the JSON payload so
+   * machine consumers can tell which suggestions sit beneath a
+   * not-started ancestor and treat them as lower priority.
    */
   suppressed_by_ancestor?: boolean;
 }


### PR DESCRIPTION
Three regressions slipped in with the row-id surfacing work in 1a73ee5:

- Per-row `→ smithy.<cmd> … N` hints disappeared whenever an ancestor was not-started, because `maybePushHint` treated `suppressed_by_ancestor` as a render gate. Under a not-started spec, every user-story row read as a bare `○` with no copy-pasteable command.
- `smithy.forge` and `smithy.render` hints carried no trailing row digit even though both commands accept one, so the user couldn't tell which slice or milestone was next without re-reading the parent table.
- Inline `S<N>` slice rows under tasks records added vertical noise without surfacing anything actionable — the slice number that matters is the one inside the parent's hint, not a dedicated row.

Drop the suppression gate in `maybePushHint` (the flag still flows through the JSON payload for machine consumers — only the render gate goes away). Append the first-non-done slice digit to `smithy.forge` via a new `firstNonDoneSliceDigits` helper. Append the first-virtual milestone digit to `smithy.render` via the existing `firstVirtualNotStartedRowDigits` helper. Remove `pushSliceLines` / `formatSliceMarker` and their call sites; the `slices` field stays on `ArtifactRecord` so JSON consumers and the `<completed>/<total>` counter on the tasks marker continue to work.

## Summary
- Primary outcome: 
- Notable behaviour changes: 
- Follow-up work deferred (if any): 

## Context
- Why are we doing this work now? Link to decisions, specs, or incidents.
- What user story or scenario does it unlock or improve?

## Implementation Notes
- Key architectural choices (include trade-offs or alternatives considered).
- Impacted modules or boundaries.
- Template / Agentic CLI specifics.

## Risks & Mitigations
- Risk: | Mitigation:

## Rollback Plan
- Steps to back out the change safely (code and data).

## Testing

### Smithy CLI Core
- [ ] Build succeeds (`npm run build`)
- [ ] Type check succeeds (`npx tsc --noEmit`)
- [ ] CLI `init` smoke test (`node dist/cli.js init`)

### Template Generation
- [ ] Gemini Skills: `.gemini/skills/` folders and `SKILL.md` validity.
- [ ] Codex Prompts: `tools/codex/prompts/` file content.
- [ ] Claude Prompts: `.claude/prompts/` file content.
- [ ] GitHub Issue Templates: `.github/ISSUE_TEMPLATE/` content.

### Permissions & Configuration
- [ ] Gemini Config: `.gemini/config.json` correctly formed and merged.
- [ ] Codex Config: `.codex/config.toml` contains correct `[[approvals.rules]]`.
- [ ] Claude Config: `.claude/settings.json` correctly formed.

### Manual Test Cases
- [ ] Reviewed applicable cases in [`tests/Agent.tests.md`](tests/Agent.tests.md) and [`tests/Manual.tests.md`](tests/Manual.tests.md) (if init/uninit flows changed)

## Issue
<!-- Link the GitHub issue(s) this PR addresses using a closing keyword (Closes, Fixes, Resolves) so they auto-close on merge. One issue per line. If there is no related issue, delete this entire section rather than leaving an unfilled placeholder. -->
- Closes #
