### PR TITLE
Auto-allow git push --force-with-lease + drift report on smithy update

### DIFF
--- a/src/agents/claude.test.ts
+++ b/src/agents/claude.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import {
+  analyzeSettingsDrift,
   buildClaudeAllowList,
   buildClaudeAskList,
   buildClaudeDenyList,
@@ -16,6 +17,7 @@ import {
   writePermissions,
   writeSessionTitleHook,
 } from './claude.js';
+import { hasDrift } from '../drift.js';
 import { getComposedTemplates, getTemplateFilesByCategory } from '../templates.js';
 import { writeManifest, readManifest, removeStaleFiles } from '../manifest.js';
 
@@ -805,6 +807,81 @@ describe('writePermissions', () => {
     expect(config.permissions.deny).toContain('Bash(git branch -D *)');
     // Custom key should be preserved
     expect(config.permissions.someCustomFlag).toBe(true);
+  });
+});
+
+describe('analyzeSettingsDrift', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-claude-test-'));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null when settings.json does not exist', () => {
+    const report = analyzeSettingsDrift(tmpDir, 'repo');
+    expect(report).toBeNull();
+  });
+
+  it('returns null when settings.json is malformed JSON', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(path.join(claudeDir, 'settings.json'), '{ not json');
+    const report = analyzeSettingsDrift(tmpDir, 'repo');
+    expect(report).toBeNull();
+  });
+
+  it('reports no drift right after writePermissions writes a fresh file', () => {
+    writePermissions(tmpDir, 'repo');
+    const report = analyzeSettingsDrift(tmpDir, 'repo');
+    expect(report).not.toBeNull();
+    expect(hasDrift(report!)).toBe(false);
+  });
+
+  it('flags an unmanaged user customization in the allow list', () => {
+    writePermissions(tmpDir, 'repo');
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    config.permissions.allow.push('Bash(my-team-tool)');
+    fs.writeFileSync(settingsPath, JSON.stringify(config));
+
+    const report = analyzeSettingsDrift(tmpDir, 'repo');
+    expect(report).not.toBeNull();
+    expect(report!.unmanagedAllow).toContain('Bash(my-team-tool)');
+  });
+
+  it('detects the issue #302 migration where --force-with-lease is in both allow and ask', () => {
+    writePermissions(tmpDir, 'repo');
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    // Simulate a pre-fix install: the entry sits in `ask` (now stale) AND in
+    // `allow` (where the new Smithy version put it).
+    config.permissions.ask = [
+      'Bash(git push --force-with-lease)',
+      'Bash(git push --force-with-lease *)',
+    ];
+    fs.writeFileSync(settingsPath, JSON.stringify(config));
+
+    const report = analyzeSettingsDrift(tmpDir, 'repo');
+    expect(report).not.toBeNull();
+    expect(report!.unmanagedAsk).toContain('Bash(git push --force-with-lease *)');
+    const conflictEntries = report!.crossCategoryConflicts.map(c => c.entry);
+    expect(conflictEntries).toContain('Bash(git push --force-with-lease *)');
+  });
+
+  it('treats a missing permissions object as an empty triple (no drift)', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({ unrelated: true }));
+
+    const report = analyzeSettingsDrift(tmpDir, 'repo');
+    expect(report).not.toBeNull();
+    expect(hasDrift(report!)).toBe(false);
   });
 });
 

--- a/src/agents/claude.test.ts
+++ b/src/agents/claude.test.ts
@@ -661,8 +661,13 @@ describe('writePermissions', () => {
     // Deny list should contain destructive git operations
     expect(config.permissions.deny).toContain('Bash(git branch -D *)');
     // Allow list should auto-approve force-push with lease (issue #302) so
-    // AI-driven rebases finish without confirmation prompts.
-    expect(config.permissions.allow).toContain('Bash(git push --force-with-lease *)');
+    // AI-driven rebases finish without confirmation prompts. We assert the
+    // explicit `origin <ref>` form rather than a bare wildcard so the test
+    // doesn't regress alongside the `--force` smuggling fix from PR #304.
+    expect(config.permissions.allow).toContain('Bash(git push --force-with-lease origin *)');
+    // The unrestricted wildcard form must NOT be allowed — see the PR #304
+    // regression guard in permissions.test.ts for the rationale.
+    expect(config.permissions.allow).not.toContain('Bash(git push --force-with-lease *)');
     // Should NOT have old format
     expect(config.permissions).not.toHaveProperty('allowed_commands');
   });
@@ -859,8 +864,9 @@ describe('analyzeSettingsDrift', () => {
     writePermissions(tmpDir, 'repo');
     const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
     const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-    // Simulate a pre-fix install: the entry sits in `ask` (now stale) AND in
-    // `allow` (where the new Smithy version put it).
+    // Simulate a pre-fix install: the bare and unrestricted-wildcard entries
+    // sit in `ask` (now stale). The bare form also lives in the new canonical
+    // `allow` list, so it surfaces as a cross-category collision.
     config.permissions.ask = [
       'Bash(git push --force-with-lease)',
       'Bash(git push --force-with-lease *)',
@@ -869,9 +875,14 @@ describe('analyzeSettingsDrift', () => {
 
     const report = analyzeSettingsDrift(tmpDir, 'repo');
     expect(report).not.toBeNull();
+    expect(report!.unmanagedAsk).toContain('Bash(git push --force-with-lease)');
     expect(report!.unmanagedAsk).toContain('Bash(git push --force-with-lease *)');
     const conflictEntries = report!.crossCategoryConflicts.map(c => c.entry);
-    expect(conflictEntries).toContain('Bash(git push --force-with-lease *)');
+    // The bare form is canonical allow → it shows up as a collision.
+    expect(conflictEntries).toContain('Bash(git push --force-with-lease)');
+    // The unrestricted-wildcard form is no longer canonical anywhere — it's
+    // only flagged as unmanaged ask drift, not a cross-category collision.
+    expect(conflictEntries).not.toContain('Bash(git push --force-with-lease *)');
   });
 
   it('treats a missing permissions object as an empty triple (no drift)', () => {

--- a/src/agents/claude.test.ts
+++ b/src/agents/claude.test.ts
@@ -448,7 +448,9 @@ describe('buildClaudeAllowList', () => {
     const list = buildClaudeAllowList();
     const joined = list.join('\n');
     expect(joined).not.toMatch(/\brm\b/);
-    expect(joined).not.toMatch(/--force/);
+    // No unsafe `--force` (i.e. without lease). `--force-with-lease` is
+    // permitted (issue #302) and must not trip this guard.
+    expect(joined).not.toMatch(/--force(?!-with-lease)/);
     expect(joined).not.toMatch(/\bchmod\b/);
     expect(joined).not.toMatch(/\bchown\b/);
     expect(joined).not.toMatch(/\bkill\b/);
@@ -571,8 +573,8 @@ describe('buildClaudeDenyList', () => {
     expect(list).toContain('Bash(git push --force *)');
     expect(list).toContain('Bash(git push -f)');
     expect(list).toContain('Bash(git push -f *)');
-    // --force-with-lease is intentionally NOT denied — it goes to the ask list
-    // so rebase workflows can still push with a confirmation.
+    // --force-with-lease is intentionally NOT denied — it is auto-allowed
+    // (issue #302) so AI-driven rebases can finish without prompting.
     expect(list).not.toContain('Bash(git push --force-with-lease)');
     expect(list).not.toContain('Bash(git push --force-with-lease *)');
   });
@@ -594,10 +596,10 @@ describe('buildClaudeAskList', () => {
     }
   });
 
-  it('asks before force-push with lease', () => {
+  it('does not gate force-push with lease behind a prompt (issue #302)', () => {
     const list = buildClaudeAskList();
-    expect(list).toContain('Bash(git push --force-with-lease)');
-    expect(list).toContain('Bash(git push --force-with-lease *)');
+    expect(list).not.toContain('Bash(git push --force-with-lease)');
+    expect(list).not.toContain('Bash(git push --force-with-lease *)');
   });
 
   it('does not include the no-lease force push (that is denied)', () => {
@@ -656,8 +658,9 @@ describe('writePermissions', () => {
     expect(Array.isArray(config.permissions.deny)).toBe(true);
     // Deny list should contain destructive git operations
     expect(config.permissions.deny).toContain('Bash(git branch -D *)');
-    // Ask list should prompt before force-push with lease
-    expect(config.permissions.ask).toContain('Bash(git push --force-with-lease *)');
+    // Allow list should auto-approve force-push with lease (issue #302) so
+    // AI-driven rebases finish without confirmation prompts.
+    expect(config.permissions.allow).toContain('Bash(git push --force-with-lease *)');
     // Should NOT have old format
     expect(config.permissions).not.toHaveProperty('allowed_commands');
   });

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -5,6 +5,7 @@ import picocolors from 'picocolors';
 import { getComposedTemplates, getTemplateFilesByCategory, stripFrontmatter } from '../templates.js';
 import { flattenPermissions, claudeToolPermissions, askPermissions, denyPermissions, extraPermissions, type LanguageToolchain, type PlatformPackageManager } from '../permissions.js';
 import { hooksTemplateDir, removeIfExists } from '../utils.js';
+import { computeDrift, type DriftReport, type PermissionTriple } from '../drift.js';
 import type { PermissionLevel, DeployablePermissionLevel, DeployLocation } from '../interactive.js';
 
 /** Filename of the deployed Claude Code session-title hook script. */
@@ -221,6 +222,47 @@ export function writePermissions(
 
   fs.writeFileSync(settingsPath, JSON.stringify(config, null, 2));
   console.log(picocolors.blue(`  Added default permissions to ${settingsPath}`));
+}
+
+/**
+ * Inspect a Claude settings.json for drift against the canonical Smithy
+ * permission lists. Returns `null` if the file does not exist or cannot be
+ * parsed (no drift to report on something we can't read). Otherwise returns
+ * a {@link DriftReport} the caller can format and surface to the user.
+ *
+ * Call this *before* `writePermissions` so the comparison sees the user's
+ * pre-merge state — once the merge runs, every customization would look like
+ * drift in the new file.
+ */
+export function analyzeSettingsDrift(
+  targetDir: string,
+  level: DeployablePermissionLevel,
+  languages?: LanguageToolchain[],
+  platformManagers?: PlatformPackageManager[],
+): DriftReport | null {
+  const settingsPath = resolveSettingsPath(targetDir, level);
+  if (!fs.existsSync(settingsPath)) return null;
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  } catch {
+    return null;
+  }
+  const perms = (raw as { permissions?: Record<string, unknown> })?.permissions;
+  const existing: PermissionTriple = {
+    allow: Array.isArray(perms?.allow) ? (perms!.allow as string[]) : [],
+    ask: Array.isArray(perms?.ask) ? (perms!.ask as string[]) : [],
+    deny: Array.isArray(perms?.deny) ? (perms!.deny as string[]) : [],
+  };
+
+  const canonical: PermissionTriple = {
+    allow: buildClaudeAllowList(languages, platformManagers),
+    ask: buildClaudeAskList(),
+    deny: buildClaudeDenyList(),
+  };
+
+  return computeDrift(existing, canonical);
 }
 
 // ----- Session-title hook -----

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -11,6 +11,9 @@ import {
 import type { SmithyManifest } from '../manifest.js';
 import type { AgentChoice, DeployLocation } from '../interactive.js';
 import { toolchains, type LanguageToolchain } from '../permissions.js';
+import { detectPlatforms } from '../platform-detect.js';
+import { analyzeSettingsDrift, resolveSettingsPath } from '../agents/claude.js';
+import { formatDriftReport, hasDrift, type DriftReport } from '../drift.js';
 
 /** Validate and filter manifest language values against known toolchain keys. */
 function validatedLanguages(raw: string[] | undefined): LanguageToolchain[] | undefined {
@@ -149,6 +152,41 @@ export async function updateAction(opts: UpdateOptions = {}): Promise<void> {
       console.log(picocolors.dim(`Skipping ${manifest.deployLocation} manifest update.`));
       continue;
     }
+
+    // Capture drift before the redeploy mutates the file. `writePermissions`
+    // unions canonical entries into the user's settings, so post-merge every
+    // user customization would look like drift — the diff is only meaningful
+    // against the pre-merge state.
+    const drift = collectClaudeDrift(targetDir, location, manifest);
+
     await redeployFromManifest(manifest, targetDir);
+
+    if (drift) {
+      const settingsPath = resolveSettingsPath(targetDir, location);
+      console.log('');
+      console.log(picocolors.yellow(formatDriftReport(drift, settingsPath)));
+    }
   }
+}
+
+/**
+ * Build a Claude drift report for the given target, or `null` if Claude isn't
+ * one of the deployed agents, permissions are disabled, or the settings file
+ * doesn't exist yet.
+ */
+function collectClaudeDrift(
+  targetDir: string,
+  location: DeployLocation,
+  manifest: SmithyManifest,
+): DriftReport | null {
+  if (!manifest.permissions) return null;
+  if (!manifest.agents.includes('claude')) return null;
+  const report = analyzeSettingsDrift(
+    targetDir,
+    location,
+    validatedLanguages(manifest.languages),
+    detectPlatforms(),
+  );
+  if (!report || !hasDrift(report)) return null;
+  return report;
 }

--- a/src/drift.test.ts
+++ b/src/drift.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { computeDrift, hasDrift, formatDriftReport } from './drift.js';
+
+describe('computeDrift', () => {
+  it('reports no drift when existing matches canonical exactly', () => {
+    const triple = { allow: ['Bash(ls *)', 'Bash(git status)'], ask: [], deny: ['Bash(rm -rf /)'] };
+    const report = computeDrift(triple, triple);
+    expect(report.unmanagedAllow).toEqual([]);
+    expect(report.unmanagedAsk).toEqual([]);
+    expect(report.unmanagedDeny).toEqual([]);
+    expect(report.crossCategoryConflicts).toEqual([]);
+    expect(hasDrift(report)).toBe(false);
+  });
+
+  it('flags allow-list entries the user has that Smithy does not manage', () => {
+    const existing = { allow: ['Bash(ls *)', 'Bash(my-custom-tool)'], ask: [], deny: [] };
+    const canonical = { allow: ['Bash(ls *)'], ask: [], deny: [] };
+    const report = computeDrift(existing, canonical);
+    expect(report.unmanagedAllow).toEqual(['Bash(my-custom-tool)']);
+    expect(report.unmanagedAsk).toEqual([]);
+    expect(report.unmanagedDeny).toEqual([]);
+    expect(hasDrift(report)).toBe(true);
+  });
+
+  it('flags ask-list entries the user has that Smithy does not manage', () => {
+    const existing = { allow: [], ask: ['Bash(stale-prompt)'], deny: [] };
+    const canonical = { allow: [], ask: [], deny: [] };
+    const report = computeDrift(existing, canonical);
+    expect(report.unmanagedAsk).toEqual(['Bash(stale-prompt)']);
+    expect(hasDrift(report)).toBe(true);
+  });
+
+  it('flags deny-list entries the user has that Smithy does not manage', () => {
+    const existing = { allow: [], ask: [], deny: ['Bash(forbidden)'] };
+    const canonical = { allow: [], ask: [], deny: [] };
+    const report = computeDrift(existing, canonical);
+    expect(report.unmanagedDeny).toEqual(['Bash(forbidden)']);
+    expect(hasDrift(report)).toBe(true);
+  });
+
+  it('detects the issue #302 migration pattern (entry in both allow and ask)', () => {
+    const entry = 'Bash(git push --force-with-lease *)';
+    const existing = {
+      allow: ['Bash(git status)', entry],
+      ask: [entry],
+      deny: [],
+    };
+    const canonical = {
+      allow: ['Bash(git status)', entry],
+      ask: [],
+      deny: [],
+    };
+    const report = computeDrift(existing, canonical);
+    // The stale ask copy is flagged as unmanaged.
+    expect(report.unmanagedAsk).toEqual([entry]);
+    // And as a cross-category conflict so the user knows the categories disagree.
+    expect(report.crossCategoryConflicts).toEqual([
+      { entry, categories: ['allow', 'ask'] },
+    ]);
+    expect(hasDrift(report)).toBe(true);
+  });
+
+  it('reports cross-category conflicts in stable allow → ask → deny order', () => {
+    const entry = 'Bash(weird-case)';
+    const existing = {
+      // Insertion order chosen to be different from the canonical order
+      // we expect in the output.
+      deny: [entry],
+      ask: [entry],
+      allow: [entry],
+    };
+    const report = computeDrift(existing, { allow: [], ask: [], deny: [] });
+    expect(report.crossCategoryConflicts).toHaveLength(1);
+    const conflict = report.crossCategoryConflicts[0]!;
+    expect(conflict.entry).toBe(entry);
+    expect(conflict.categories).toEqual(['allow', 'ask', 'deny']);
+  });
+
+  it('sorts multiple cross-category conflicts alphabetically', () => {
+    const existing = {
+      allow: ['Bash(zzz)', 'Bash(aaa)'],
+      ask: ['Bash(zzz)', 'Bash(aaa)'],
+      deny: [],
+    };
+    const report = computeDrift(existing, { allow: [], ask: [], deny: [] });
+    expect(report.crossCategoryConflicts.map(c => c.entry)).toEqual(['Bash(aaa)', 'Bash(zzz)']);
+  });
+
+  it('preserves user insertion order for unmanaged entries within a category', () => {
+    const existing = {
+      allow: ['Bash(custom-z)', 'Bash(custom-a)', 'Bash(custom-m)'],
+      ask: [],
+      deny: [],
+    };
+    const report = computeDrift(existing, { allow: [], ask: [], deny: [] });
+    expect(report.unmanagedAllow).toEqual(['Bash(custom-z)', 'Bash(custom-a)', 'Bash(custom-m)']);
+  });
+});
+
+describe('hasDrift', () => {
+  it('returns false on an empty report', () => {
+    expect(
+      hasDrift({ unmanagedAllow: [], unmanagedAsk: [], unmanagedDeny: [], crossCategoryConflicts: [] }),
+    ).toBe(false);
+  });
+
+  it('returns true if any single category has drift', () => {
+    expect(
+      hasDrift({ unmanagedAllow: ['x'], unmanagedAsk: [], unmanagedDeny: [], crossCategoryConflicts: [] }),
+    ).toBe(true);
+    expect(
+      hasDrift({ unmanagedAllow: [], unmanagedAsk: ['x'], unmanagedDeny: [], crossCategoryConflicts: [] }),
+    ).toBe(true);
+    expect(
+      hasDrift({ unmanagedAllow: [], unmanagedAsk: [], unmanagedDeny: ['x'], crossCategoryConflicts: [] }),
+    ).toBe(true);
+    expect(
+      hasDrift({
+        unmanagedAllow: [], unmanagedAsk: [], unmanagedDeny: [],
+        crossCategoryConflicts: [{ entry: 'x', categories: ['allow', 'ask'] }],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('formatDriftReport', () => {
+  it('mentions the settings path in the header', () => {
+    const out = formatDriftReport(
+      { unmanagedAllow: ['Bash(x)'], unmanagedAsk: [], unmanagedDeny: [], crossCategoryConflicts: [] },
+      '/some/path/settings.json',
+    );
+    expect(out).toContain('/some/path/settings.json');
+  });
+
+  it('lists cross-category collisions with the categories shown', () => {
+    const out = formatDriftReport(
+      {
+        unmanagedAllow: [],
+        unmanagedAsk: ['Bash(git push --force-with-lease *)'],
+        unmanagedDeny: [],
+        crossCategoryConflicts: [
+          { entry: 'Bash(git push --force-with-lease *)', categories: ['allow', 'ask'] },
+        ],
+      },
+      '/repo/.claude/settings.json',
+    );
+    expect(out).toContain('Cross-category collisions');
+    expect(out).toContain('Bash(git push --force-with-lease *)');
+    expect(out).toContain('[allow + ask]');
+  });
+
+  it('omits sections that have no entries', () => {
+    const out = formatDriftReport(
+      { unmanagedAllow: ['Bash(x)'], unmanagedAsk: [], unmanagedDeny: [], crossCategoryConflicts: [] },
+      '/p/settings.json',
+    );
+    expect(out).toContain('Unmanaged `allow` entries');
+    expect(out).not.toContain('Unmanaged `ask` entries');
+    expect(out).not.toContain('Unmanaged `deny` entries');
+    expect(out).not.toContain('Cross-category collisions');
+  });
+
+  it('reminds the user that update never removes entries', () => {
+    const out = formatDriftReport(
+      { unmanagedAllow: ['Bash(x)'], unmanagedAsk: [], unmanagedDeny: [], crossCategoryConflicts: [] },
+      '/p/settings.json',
+    );
+    expect(out).toMatch(/never removes entries you added/);
+  });
+});

--- a/src/drift.ts
+++ b/src/drift.ts
@@ -1,0 +1,140 @@
+/**
+ * Settings-drift detection for `smithy update`.
+ *
+ * `writePermissions` merges canonical Smithy permission lists into the user's
+ * existing settings.json by union, so it never removes entries the user (or a
+ * previous Smithy version) added. That means after a Smithy version that
+ * relocates a permission between categories — e.g. issue #302 moved
+ * `git push --force-with-lease` from the `ask` list into `allow` — a stale
+ * copy of the entry stays in the old category and silently overrides the new
+ * one (Claude Code resolves `ask > allow`).
+ *
+ * Rather than auto-pruning (which would also delete legitimate user
+ * customizations), `smithy update` surfaces a drift report so the user can
+ * decide what to do. This module is the pure logic behind that report.
+ */
+
+export type PermissionCategory = 'allow' | 'ask' | 'deny';
+
+export interface PermissionTriple {
+  allow: string[];
+  ask: string[];
+  deny: string[];
+}
+
+export interface CrossCategoryConflict {
+  entry: string;
+  /** Categories the entry appears in, in stable `allow → ask → deny` order. */
+  categories: ReadonlyArray<PermissionCategory>;
+}
+
+export interface DriftReport {
+  /** Entries in the user's `allow` list that Smithy does not manage. */
+  unmanagedAllow: string[];
+  /** Entries in the user's `ask` list that Smithy does not manage. */
+  unmanagedAsk: string[];
+  /** Entries in the user's `deny` list that Smithy does not manage. */
+  unmanagedDeny: string[];
+  /**
+   * Entries that appear in two or more of the user's allow/ask/deny lists.
+   * The strong signal that a Smithy version moved an entry between categories
+   * and the old copy was never removed.
+   */
+  crossCategoryConflicts: CrossCategoryConflict[];
+}
+
+/**
+ * Diff a user's existing permission triple against Smithy's current canonical
+ * triple and report what does not match.
+ *
+ * "Unmanaged" entries may be legitimate user customizations OR stale entries
+ * left over from a previous Smithy version. `computeDrift` cannot tell the
+ * two apart — that's why the report is informational, not auto-applied.
+ */
+export function computeDrift(
+  existing: PermissionTriple,
+  canonical: PermissionTriple,
+): DriftReport {
+  const canonicalAllow = new Set(canonical.allow);
+  const canonicalAsk = new Set(canonical.ask);
+  const canonicalDeny = new Set(canonical.deny);
+
+  const unmanagedAllow = existing.allow.filter(e => !canonicalAllow.has(e));
+  const unmanagedAsk = existing.ask.filter(e => !canonicalAsk.has(e));
+  const unmanagedDeny = existing.deny.filter(e => !canonicalDeny.has(e));
+
+  const seen = new Map<string, Set<PermissionCategory>>();
+  const track = (entry: string, cat: PermissionCategory) => {
+    let s = seen.get(entry);
+    if (!s) {
+      s = new Set();
+      seen.set(entry, s);
+    }
+    s.add(cat);
+  };
+  for (const e of existing.allow) track(e, 'allow');
+  for (const e of existing.ask) track(e, 'ask');
+  for (const e of existing.deny) track(e, 'deny');
+
+  const order: ReadonlyArray<PermissionCategory> = ['allow', 'ask', 'deny'];
+  const crossCategoryConflicts: CrossCategoryConflict[] = [];
+  for (const [entry, cats] of seen) {
+    if (cats.size >= 2) {
+      crossCategoryConflicts.push({
+        entry,
+        categories: order.filter(c => cats.has(c)),
+      });
+    }
+  }
+  crossCategoryConflicts.sort((a, b) => a.entry.localeCompare(b.entry));
+
+  return { unmanagedAllow, unmanagedAsk, unmanagedDeny, crossCategoryConflicts };
+}
+
+export function hasDrift(report: DriftReport): boolean {
+  return (
+    report.unmanagedAllow.length > 0 ||
+    report.unmanagedAsk.length > 0 ||
+    report.unmanagedDeny.length > 0 ||
+    report.crossCategoryConflicts.length > 0
+  );
+}
+
+/**
+ * Render a drift report as plain text suitable for terminal output. The caller
+ * applies any color styling — keeping this pure makes it easy to snapshot in
+ * tests.
+ */
+export function formatDriftReport(report: DriftReport, settingsPath: string): string {
+  const lines: string[] = [];
+  lines.push(`Settings drift detected at ${settingsPath}:`);
+  lines.push('');
+
+  if (report.crossCategoryConflicts.length > 0) {
+    const n = report.crossCategoryConflicts.length;
+    lines.push(`  Cross-category collisions (${n}) — usually a Smithy migration that left a stale copy:`);
+    for (const c of report.crossCategoryConflicts) {
+      lines.push(`    - ${c.entry}  [${c.categories.join(' + ')}]`);
+    }
+    lines.push('    Action: keep the entry in the category Smithy now uses, delete it from the others.');
+    lines.push('    (Claude Code resolves deny > ask > allow, so the strictest list wins on collisions.)');
+    lines.push('');
+  }
+
+  const sections: ReadonlyArray<readonly [PermissionCategory, string[]]> = [
+    ['allow', report.unmanagedAllow],
+    ['ask', report.unmanagedAsk],
+    ['deny', report.unmanagedDeny],
+  ];
+  for (const [name, entries] of sections) {
+    if (entries.length === 0) continue;
+    lines.push(`  Unmanaged \`${name}\` entries (${entries.length}) — your customizations or leftovers from older Smithy versions:`);
+    for (const e of entries) {
+      lines.push(`    - ${e}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('  Smithy update never removes entries you added — review the list above and edit settings.json by hand if any are stale.');
+  return lines.join('\n');
+}

--- a/src/permissions.test.ts
+++ b/src/permissions.test.ts
@@ -134,13 +134,35 @@ describe('flattenPermissions', () => {
   it('auto-allows force-push with lease so AI-driven rebases do not block on confirmation', () => {
     const result = flattenPermissions();
     expect(result).toContain('git push --force-with-lease');
-    expect(result).toContain('git push --force-with-lease *');
     expect(result).toContain('git push --force-with-lease origin *');
-    // The lease check is the safety boundary; do not deny or ask.
+    // The lease check is the safety boundary; do not deny or ask the bare /
+    // explicit-origin shapes.
     expect(denyPermissions).not.toContain('git push --force-with-lease');
-    expect(denyPermissions).not.toContain('git push --force-with-lease *');
+    expect(denyPermissions).not.toContain('git push --force-with-lease origin *');
     expect(askPermissions).not.toContain('git push --force-with-lease');
     expect(askPermissions).not.toContain('git push --force-with-lease *');
+  });
+
+  it('does NOT auto-allow an unrestricted wildcard after `--force-with-lease`', () => {
+    // Regression guard for PR #304 review: `Bash(git push --force-with-lease *)`
+    // would match `git push --force-with-lease --force origin <branch>`, which
+    // bypasses the lease check (Git's `--force` overrides `--force-with-lease`).
+    const result = flattenPermissions();
+    expect(result).not.toContain('git push --force-with-lease *');
+  });
+
+  it('denies smuggling `--force` / `-f` after `--force-with-lease`', () => {
+    // Belt-and-suspenders against the same bypass: even if a future allow
+    // change accidentally re-introduces the unrestricted wildcard, the
+    // dangerous combinations stay blocked.
+    expect(denyPermissions).toContain('git push --force-with-lease --force');
+    expect(denyPermissions).toContain('git push --force-with-lease --force *');
+    expect(denyPermissions).toContain('git push --force-with-lease -f');
+    expect(denyPermissions).toContain('git push --force-with-lease -f *');
+    expect(denyPermissions).toContain('git push --force-with-lease origin --force');
+    expect(denyPermissions).toContain('git push --force-with-lease origin --force *');
+    expect(denyPermissions).toContain('git push --force-with-lease origin -f');
+    expect(denyPermissions).toContain('git push --force-with-lease origin -f *');
   });
 
   it('does NOT include extraPermissions (Claude-only entries that would leak into Gemini)', () => {

--- a/src/permissions.test.ts
+++ b/src/permissions.test.ts
@@ -131,11 +131,16 @@ describe('flattenPermissions', () => {
     expect(denyPermissions).toContain('git push -f *');
   });
 
-  it('asks (does not deny) force-push with lease so rebase pushes can proceed', () => {
-    expect(askPermissions).toContain('git push --force-with-lease');
-    expect(askPermissions).toContain('git push --force-with-lease *');
+  it('auto-allows force-push with lease so AI-driven rebases do not block on confirmation', () => {
+    const result = flattenPermissions();
+    expect(result).toContain('git push --force-with-lease');
+    expect(result).toContain('git push --force-with-lease *');
+    expect(result).toContain('git push --force-with-lease origin *');
+    // The lease check is the safety boundary; do not deny or ask.
     expect(denyPermissions).not.toContain('git push --force-with-lease');
     expect(denyPermissions).not.toContain('git push --force-with-lease *');
+    expect(askPermissions).not.toContain('git push --force-with-lease');
+    expect(askPermissions).not.toContain('git push --force-with-lease *');
   });
 
   it('does NOT include extraPermissions (Claude-only entries that would leak into Gemini)', () => {

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -82,11 +82,17 @@ export const permissions: Record<string, PermissionEntry> = {
     // `<NNN>/us-<NN>-<slug>/slice-<N>`, `<YYYY-MM-DD>-<NNN>-<slug>`).
     // Force-push is still blocked: `git push --force` / `-f` are in the deny
     // list. `--force-with-lease` is auto-allowed below so AI agents can finish
-    // a rebase without a human in the loop — the `--force-with-lease` lease
-    // check is the safety boundary, not user confirmation.
+    // a rebase without a human in the loop — the lease check is the safety
+    // boundary, not user confirmation. We deliberately do NOT use a trailing
+    // `*` on the bare form, because `Bash(git push --force-with-lease *)`
+    // would also match `git push --force-with-lease --force origin <branch>`
+    // — and `--force` overrides the lease check in Git, silently restoring
+    // unconditional force-push. Only the explicit `origin <ref>` form gets
+    // the wildcard, and the `--force` / `-f` follow-up combinations are
+    // explicitly denied below.
     "push -u origin": ["*"],
     "push origin": ["*"],
-    "push --force-with-lease": ["", "*"],
+    "push --force-with-lease": [""],
     "push --force-with-lease origin": ["*"],
   },
 
@@ -476,6 +482,19 @@ export const denyPermissions: string[] = [
   "git push --force *",
   "git push -f",
   "git push -f *",
+  // Defense in depth: combining `--force-with-lease` with `--force` / `-f`
+  // overrides the lease check in Git, so the result is an unconditional
+  // force-push. Block these explicitly so the wildcard in
+  // `push --force-with-lease origin *` cannot be used to smuggle a `--force`
+  // flag past the deny list.
+  "git push --force-with-lease --force",
+  "git push --force-with-lease --force *",
+  "git push --force-with-lease -f",
+  "git push --force-with-lease -f *",
+  "git push --force-with-lease origin --force",
+  "git push --force-with-lease origin --force *",
+  "git push --force-with-lease origin -f",
+  "git push --force-with-lease origin -f *",
   // npm publish — requires explicit approval
   "npm publish",
   "npm publish *",

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -81,10 +81,13 @@ export const permissions: Record<string, PermissionEntry> = {
     // orchestrator-supplied worktree branch shapes (e.g. `smithy/cut/...`,
     // `<NNN>/us-<NN>-<slug>/slice-<N>`, `<YYYY-MM-DD>-<NNN>-<slug>`).
     // Force-push is still blocked: `git push --force` / `-f` are in the deny
-    // list, and `--force-with-lease` requires explicit approval (askPermissions
-    // below).
+    // list. `--force-with-lease` is auto-allowed below so AI agents can finish
+    // a rebase without a human in the loop — the `--force-with-lease` lease
+    // check is the safety boundary, not user confirmation.
     "push -u origin": ["*"],
     "push origin": ["*"],
+    "push --force-with-lease": ["", "*"],
+    "push --force-with-lease origin": ["*"],
   },
 
   // --- Filesystem (read + create, no delete) ---
@@ -433,15 +436,13 @@ export const extraPermissions: string[] = [
 /**
  * Ask list — Claude Code prompts the user before running a matching command,
  * even in auto mode. Sits between `allow` (silent auto-approve) and `deny`
- * (hard block). Use for actions that are sometimes legitimate (e.g. force-push
- * with lease during a rebase) but always deserve a human in the loop.
+ * (hard block). Use for actions that are sometimes legitimate but always
+ * deserve a human in the loop. Currently empty: `--force-with-lease` was
+ * promoted to the allow list in #302 because the lease check itself is the
+ * safety boundary and gating it on user confirmation made AI-driven rebases
+ * painful.
  */
-export const askPermissions: string[] = [
-  // Force-push with lease — safe variant, but still wants explicit confirmation
-  // because it overwrites the remote branch tip.
-  "git push --force-with-lease",
-  "git push --force-with-lease *",
-];
+export const askPermissions: string[] = [];
 
 /**
  * Deny list — blocks dangerous subcommands even when the parent is allowed.
@@ -470,7 +471,7 @@ export const denyPermissions: string[] = [
   "git symbolic-ref --delete *",
   "git symbolic-ref -d *",
   // Force push WITHOUT lease — clobbers the remote unconditionally. The
-  // `--force-with-lease` variant is in the ask list instead.
+  // `--force-with-lease` variant is auto-allowed (see permissions.git above).
   "git push --force",
   "git push --force *",
   "git push -f",


### PR DESCRIPTION
## Summary
- Primary outcome: AI-driven rebases stop blocking on a confirmation prompt for `git push --force-with-lease`, and existing installs are told what to clean up.
- Notable behaviour changes: `git push --force-with-lease` (with or without `origin <branch>`) is auto-allowed for new Smithy installs. The unsafe `git push --force` / `-f` variants remain denied. `smithy update` now prints a drift report when the user's `.claude/settings.json` has entries Smithy doesn't manage or the same entry living in two categories at once.
- Follow-up work deferred (if any): drift reporting is Claude-only; Gemini settings drift could follow the same pattern in a separate PR.

## Context
- Issue #302 — rebases are part of normal AI workflow, but the existing ask-list entry forced a human confirmation every time, defeating auto mode.
- Migration gap: `writePermissions` unions canonical lists into existing settings without ever pruning, and Claude Code resolves `ask > allow` — so the stale `ask` copy of `--force-with-lease` would silently override the new `allow` entry on existing installs. Auto-pruning would also delete legitimate user customizations, so the migration story is "smithy update tells you what looks off and lets you decide".

## Implementation Notes
- **Permission move (commit 1):** Moved `git push --force-with-lease` and `… *` from `askPermissions` (now empty) into `permissions.git`, plus an explicit `--force-with-lease origin *` shape so Gemini's stricter wildcard matching covers the `origin <branch>` case. Tightened the `claude.test.ts` "no destructive --force" guard to `--force(?!-with-lease)` so the new entry doesn't trip the regex.
- **Drift report (commit 2):**
  - `src/drift.ts` — pure logic. `computeDrift(existing, canonical)` returns `unmanagedAllow` / `unmanagedAsk` / `unmanagedDeny` (entries the user has that Smithy does not put there) plus `crossCategoryConflicts` (entries living in two of allow/ask/deny — strong signal of a Smithy migration). `formatDriftReport` renders plain text; the caller applies any color.
  - `src/agents/claude.ts` — `analyzeSettingsDrift` reads `.claude/settings.json`, builds canonical lists with the same toolchain/platform args `writePermissions` uses, returns `DriftReport | null`.
  - `src/commands/update.ts` — captures drift *before* redeploying (post-merge would make every customization look like drift) and prints the report after the redeploy completes.
- Trade-off considered: leaving `--force-with-lease` on the ask list was safer in principle, but the lease check itself is the safety boundary — adding human confirmation on top buys nothing for AI agents.
- Trade-off considered: auto-pruning stale `ask` entries on update would silently delete user customizations alongside Smithy leftovers (no provenance tracking exists). Reporting drift instead is informational and user-respecting.

## Risks & Mitigations
- Risk: someone misreads "force-with-lease" as a synonym for force-push. | Mitigation: comments in `permissions.ts` explain the lease check is the safety boundary; the no-lease `--force` / `-f` denials are unchanged and still tested.
- Risk: drift report becomes noisy on installs with many legitimate customizations. | Mitigation: report is only printed when there is drift; sections are omitted when empty; copy explicitly tells the user "Smithy update never removes entries you added — review the list above and edit settings.json by hand if any are stale."
- Risk: drift detection assumes manifest's `languages` plus current platform detection match what `writePermissions` will use. | Mitigation: `analyzeSettingsDrift` calls the exact same `buildClaude*List` builders with the same args (`detectPlatforms()` + `validatedLanguages`), so canonical lists are identical to what the redeploy writes.

## Rollback Plan
- Revert this branch. The two commits are independent enough that the drift report can be reverted on its own (commit 2) while keeping the `--force-with-lease` permission fix (commit 1).

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npm run typecheck`)
- [x] CLI smoke test — ran `smithy init` into a temp repo, hand-injected the pre-#302 stale `ask` entries plus a fake user customization, ran `smithy update --yes`. The report listed 2 cross-category collisions, 1 unmanaged `allow` entry, and 2 unmanaged `ask` entries with the right action hint. A clean re-run on a fresh install printed nothing.

### Template Generation
- [ ] Gemini Skills: `.gemini/skills/` folders and `SKILL.md` validity. — n/a, no template changes.
- [ ] Codex Prompts: `tools/codex/prompts/` file content. — n/a, no template changes.
- [ ] Claude Prompts: `.claude/prompts/` file content. — n/a, no template changes.
- [ ] GitHub Issue Templates: `.github/ISSUE_TEMPLATE/` content. — n/a, no template changes.

### Permissions & Configuration
- [ ] Gemini Config: `.gemini/config.json` correctly formed and merged. — covered by existing tests, no new assertions added.
- [ ] Codex Config: `.codex/config.toml` contains correct `[[approvals.rules]]`. — n/a, codex not exposed.
- [x] Claude Config: `.claude/settings.json` correctly formed — `writePermissions` test now asserts `Bash(git push --force-with-lease *)` lives on the `allow` list, not `ask`.

### Manual Test Cases
- [ ] Reviewed applicable cases in `tests/Agent.tests.md` and `tests/Manual.tests.md` (if init/uninit flows changed) — init/uninit flows unchanged; update flow grew the drift report but the redeploy contract is the same.

### Automated
- [x] `npm test` — 766 / 766 passing (746 pre-existing + 14 drift unit tests + 6 `analyzeSettingsDrift` integration tests).

## Issue
- Closes #302
