### PR TITLE
Add smithy update --reset-permissions to restore canonical permissions

### DIFF
--- a/src/agents/claude.test.ts
+++ b/src/agents/claude.test.ts
@@ -912,6 +912,25 @@ describe('resetPermissions', () => {
     expect(config.permissions.allow).not.toContain('Bash(stale)');
   });
 
+  it('rebuilds permissions cleanly when existing.permissions is an array', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    const settingsPath = path.join(claudeDir, 'settings.json');
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({ model: 'sonnet', permissions: ['Bash(rm -rf /)'] }),
+    );
+
+    resetPermissions(tmpDir, 'repo');
+
+    const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    expect(config.model).toBe('sonnet');
+    expect(Array.isArray(config.permissions)).toBe(false);
+    expect(config.permissions.allow).toEqual(buildClaudeAllowList());
+    // No leaked array indices ("0", "length", etc.) on the permissions object.
+    expect(Object.keys(config.permissions).sort()).toEqual(['allow', 'ask', 'deny']);
+  });
+
   it('falls back to a fresh baseline when settings.json is malformed JSON', () => {
     const claudeDir = path.join(tmpDir, '.claude');
     fs.mkdirSync(claudeDir, { recursive: true });

--- a/src/agents/claude.test.ts
+++ b/src/agents/claude.test.ts
@@ -11,6 +11,7 @@ import {
   deploySessionTitleHookScript,
   removeLegacy,
   removeSessionTitleHook,
+  resetPermissions,
   resolveSettingsPath,
   SESSION_TITLE_HOOK_COMMAND,
   SESSION_TITLE_HOOK_FILENAME,
@@ -812,6 +813,149 @@ describe('writePermissions', () => {
     expect(config.permissions.deny).toContain('Bash(git branch -D *)');
     // Custom key should be preserved
     expect(config.permissions.someCustomFlag).toBe(true);
+  });
+});
+
+describe('resetPermissions', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-claude-test-'));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes the canonical baseline when settings.json does not exist', () => {
+    resetPermissions(tmpDir, 'repo');
+
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    expect(fs.existsSync(settingsPath)).toBe(true);
+    const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    expect(config.permissions.allow).toEqual(buildClaudeAllowList());
+    expect(config.permissions.ask).toEqual(buildClaudeAskList());
+    expect(config.permissions.deny).toEqual(buildClaudeDenyList());
+  });
+
+  it('overwrites existing allow/ask/deny with the canonical baseline (no merge)', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    const settingsPath = path.join(claudeDir, 'settings.json');
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        permissions: {
+          allow: ['Bash(custom-allow)', 'Bash(git status)'],
+          ask: ['Bash(custom-ask)'],
+          deny: ['Bash(custom-deny)'],
+        },
+      }),
+    );
+
+    resetPermissions(tmpDir, 'repo');
+
+    const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    expect(config.permissions.allow).not.toContain('Bash(custom-allow)');
+    expect(config.permissions.ask).not.toContain('Bash(custom-ask)');
+    expect(config.permissions.deny).not.toContain('Bash(custom-deny)');
+    expect(config.permissions.allow).toEqual(buildClaudeAllowList());
+    expect(config.permissions.ask).toEqual(buildClaudeAskList());
+    expect(config.permissions.deny).toEqual(buildClaudeDenyList());
+  });
+
+  it('preserves non-permissions top-level keys (e.g. model, hooks)', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    const settingsPath = path.join(claudeDir, 'settings.json');
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        model: 'claude-sonnet-4-6',
+        hooks: { UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'echo hi' }] }] },
+        permissions: { allow: ['Bash(custom)'], ask: [], deny: [] },
+      }),
+    );
+
+    resetPermissions(tmpDir, 'repo');
+
+    const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    expect(config.model).toBe('claude-sonnet-4-6');
+    expect(config.hooks).toEqual({
+      UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'echo hi' }] }],
+    });
+    expect(config.permissions.allow).not.toContain('Bash(custom)');
+  });
+
+  it('preserves other keys inside permissions (e.g. defaultMode)', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    const settingsPath = path.join(claudeDir, 'settings.json');
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        permissions: {
+          defaultMode: 'plan',
+          allow: ['Bash(stale)'],
+          ask: [],
+          deny: [],
+        },
+      }),
+    );
+
+    resetPermissions(tmpDir, 'repo');
+
+    const config = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    expect(config.permissions.defaultMode).toBe('plan');
+    expect(config.permissions.allow).not.toContain('Bash(stale)');
+  });
+
+  it('falls back to a fresh baseline when settings.json is malformed JSON', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(path.join(claudeDir, 'settings.json'), '{ not valid json');
+
+    resetPermissions(tmpDir, 'repo');
+
+    const config = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf8'));
+    expect(config.permissions.allow).toEqual(buildClaudeAllowList());
+  });
+
+  it('writes to user-level path for "user" level', () => {
+    const fakeHome = path.join(tmpDir, 'fakehome');
+    fs.mkdirSync(fakeHome, { recursive: true });
+    vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+
+    resetPermissions(tmpDir, 'user');
+
+    const settingsPath = path.join(fakeHome, '.claude', 'settings.json');
+    expect(fs.existsSync(settingsPath)).toBe(true);
+    const repoSettingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    expect(fs.existsSync(repoSettingsPath)).toBe(false);
+  });
+
+  it('clears drift after a reset', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    const settingsPath = path.join(claudeDir, 'settings.json');
+    // Cross-category collision — strong drift signal
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        permissions: {
+          allow: ['Bash(git push --force-with-lease origin *)'],
+          ask: ['Bash(git push --force-with-lease origin *)'],
+          deny: [],
+        },
+      }),
+    );
+    expect(hasDrift(analyzeSettingsDrift(tmpDir, 'repo')!)).toBe(true);
+
+    resetPermissions(tmpDir, 'repo');
+
+    expect(hasDrift(analyzeSettingsDrift(tmpDir, 'repo')!)).toBe(false);
   });
 });
 

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -225,6 +225,60 @@ export function writePermissions(
 }
 
 /**
+ * Replace the `allow`/`ask`/`deny` lists in Claude's settings.json with the
+ * canonical Smithy baseline, dropping any user customizations or stale entries
+ * left over from previous Smithy versions.
+ *
+ * Unlike {@link writePermissions}, this does NOT merge — it overwrites the
+ * three permission arrays. Other top-level keys (e.g. `model`, `hooks`) and
+ * any other keys inside `permissions` (e.g. `defaultMode`) are preserved, so
+ * an unrelated config survives the reset.
+ *
+ * Used by `smithy update --reset-permissions` to clear accumulated drift after
+ * a Smithy version that relocated entries between categories.
+ */
+export function resetPermissions(
+  targetDir: string,
+  level: DeployablePermissionLevel,
+  languages?: LanguageToolchain[],
+  platformManagers?: PlatformPackageManager[],
+): void {
+  const settingsPath = resolveSettingsPath(targetDir, level);
+  const settingsDir = path.dirname(settingsPath);
+  if (!fs.existsSync(settingsDir)) fs.mkdirSync(settingsDir, { recursive: true });
+  const allowList = buildClaudeAllowList(languages, platformManagers);
+  const askList = buildClaudeAskList();
+  const denyList = buildClaudeDenyList();
+
+  let config: Record<string, unknown> = {
+    permissions: { allow: allowList, ask: askList, deny: denyList },
+  };
+
+  if (fs.existsSync(settingsPath)) {
+    try {
+      const existing = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
+      const existingPerms = (existing['permissions'] as Record<string, unknown> | undefined) ?? {};
+      const { allow: _a, ask: _k, deny: _d, ...preservedPerms } = existingPerms;
+      void _a; void _k; void _d;
+      config = {
+        ...existing,
+        permissions: {
+          ...preservedPerms,
+          allow: allowList,
+          ask: askList,
+          deny: denyList,
+        },
+      };
+    } catch {
+      config = { permissions: { allow: allowList, ask: askList, deny: denyList } };
+    }
+  }
+
+  fs.writeFileSync(settingsPath, JSON.stringify(config, null, 2));
+  console.log(picocolors.blue(`  Reset permissions to Smithy baseline in ${settingsPath}`));
+}
+
+/**
  * Inspect a Claude settings.json for drift against the canonical Smithy
  * permission lists. Returns `null` if the file does not exist or cannot be
  * parsed (no drift to report on something we can't read). Otherwise returns

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -257,7 +257,11 @@ export function resetPermissions(
   if (fs.existsSync(settingsPath)) {
     try {
       const existing = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
-      const existingPerms = (existing['permissions'] as Record<string, unknown> | undefined) ?? {};
+      const rawPerms = existing['permissions'];
+      const existingPerms: Record<string, unknown> =
+        typeof rawPerms === 'object' && rawPerms !== null && !Array.isArray(rawPerms)
+          ? (rawPerms as Record<string, unknown>)
+          : {};
       const { allow: _a, ask: _k, deny: _d, ...preservedPerms } = existingPerms;
       void _a; void _k; void _d;
       config = {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -361,6 +361,53 @@ describe('CLI update (non-interactive)', () => {
     const updated = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
     expect(updated.smithyVersion).toBe(pkg.version);
   });
+
+  it('--reset-permissions overwrites stale entries with the canonical baseline', () => {
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+
+    // Inject a fake stale entry into settings.json that the canonical
+    // baseline does not include. Without --reset-permissions, the merge in
+    // writePermissions would preserve it.
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    settings.permissions.allow.push('Bash(stale-custom-entry)');
+    settings.permissions.ask.push('Bash(stale-ask-entry)');
+    settings.model = 'claude-sonnet-4-6';
+    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+
+    const output = execFileSync(
+      'node',
+      [CLI, 'update', '-y', '--reset-permissions'],
+      { encoding: 'utf-8', cwd: tmpDir },
+    );
+    expect(output).toContain('Reset permissions to Smithy baseline');
+
+    const after = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    expect(after.permissions.allow).not.toContain('Bash(stale-custom-entry)');
+    expect(after.permissions.ask).not.toContain('Bash(stale-ask-entry)');
+    // Canonical entries are still present
+    expect(after.permissions.allow).toContain('Bash(git status)');
+    // Non-permissions keys preserved
+    expect(after.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('--reset-permissions is a no-op when manifest does not manage permissions', () => {
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '-y', '--no-permissions'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+
+    const output = execFileSync(
+      'node',
+      [CLI, 'update', '-y', '--reset-permissions'],
+      { encoding: 'utf-8', cwd: tmpDir },
+    );
+    expect(output).toContain('does not manage Claude permissions');
+    expect(output).not.toContain('Reset permissions to Smithy baseline');
+  });
 });
 
 describe('CLI init lifecycle and idempotency', () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -394,6 +394,31 @@ describe('CLI update (non-interactive)', () => {
     expect(after.model).toBe('claude-sonnet-4-6');
   });
 
+  it('refuses to update when manifest deployLocation does not match where it was found', () => {
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+
+    // Simulate a manifest that was hand-copied from another location: it
+    // lives at the repo path but its inner deployLocation says "user".
+    const manifestPath = path.join(tmpDir, '.smithy', 'smithy-manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    manifest.deployLocation = 'user';
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+    const result = spawnSync(
+      'node',
+      [CLI, 'update', '-y', '--reset-permissions'],
+      { encoding: 'utf-8', cwd: tmpDir },
+    );
+    const output = result.stdout + result.stderr;
+    expect(output).toContain('manifest declares deployLocation="user"');
+    expect(output).toContain('refusing to update');
+    expect(output).not.toContain('Reset permissions to Smithy baseline');
+    expect(output).not.toContain('Upgrade complete');
+  });
+
   it('--reset-permissions is a no-op when manifest does not manage permissions', () => {
     execFileSync('node', [CLI, 'init', '-a', 'claude', '-y', '--no-permissions'], {
       encoding: 'utf-8',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { Command, Option } from 'commander';
 import { initAction, type InitOptions } from './commands/init.js';
 import { toolchains, type LanguageToolchain } from './permissions.js';
 import { uninitAction } from './commands/uninit.js';
-import { updateAction } from './commands/update.js';
+import { updateAction, type UpdateOptions } from './commands/update.js';
 import { statusAction, type StatusOptions } from './commands/status.js';
 
 const require = createRequire(import.meta.url);
@@ -67,7 +67,11 @@ program
   .description('Update deployed smithy templates to the current CLI version')
   .option('-d, --target-dir <path>', 'Target directory')
   .option('-y, --yes', 'Accept defaults (non-interactive)')
-  .action(updateAction);
+  .option(
+    '--reset-permissions',
+    'Replace Claude permissions in settings.json with the canonical Smithy baseline (drops user customizations and stale entries)',
+  )
+  .action((opts: Record<string, unknown>) => updateAction(opts as UpdateOptions));
 
 program
   .command('status')

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -160,6 +160,21 @@ export async function updateAction(opts: UpdateOptions = {}): Promise<void> {
   // 3. For each target, check version and redeploy
   const resetRequested = opts.resetPermissions ?? false;
   for (const { location, manifest } of targets) {
+    // The manifest's stored deployLocation must match where we read it from.
+    // They diverge only when a manifest is hand-copied between repo/user, in
+    // which case `--reset-permissions` and the drift report would act on
+    // `location`'s settings.json while `redeployFromManifest` would write to
+    // `manifest.deployLocation`'s — two different files. Bail loudly instead
+    // of silently picking one.
+    if (manifest.deployLocation !== location) {
+      console.log(
+        picocolors.yellow(
+          `  ${location} manifest declares deployLocation="${manifest.deployLocation}"; refusing to update — fix the manifest or rerun \`smithy init\`.`,
+        ),
+      );
+      continue;
+    }
+
     const proceed = await confirmVersionChange(manifest, nonInteractive, location);
     if (!proceed) {
       console.log(picocolors.dim(`Skipping ${manifest.deployLocation} manifest update.`));

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -7,12 +7,17 @@ import {
   promptConfirmOverwrite,
   promptConfirmDowngrade,
   promptConfirmInit,
+  promptConfirmResetPermissions,
 } from '../interactive.js';
 import type { SmithyManifest } from '../manifest.js';
 import type { AgentChoice, DeployLocation } from '../interactive.js';
 import { toolchains, type LanguageToolchain } from '../permissions.js';
 import { detectPlatforms } from '../platform-detect.js';
-import { analyzeSettingsDrift, resolveSettingsPath } from '../agents/claude.js';
+import {
+  analyzeSettingsDrift,
+  resolveSettingsPath,
+  resetPermissions as resetClaudePermissions,
+} from '../agents/claude.js';
 import { formatDriftReport, hasDrift, type DriftReport } from '../drift.js';
 
 /** Validate and filter manifest language values against known toolchain keys. */
@@ -26,6 +31,13 @@ function validatedLanguages(raw: string[] | undefined): LanguageToolchain[] | un
 export interface UpdateOptions {
   targetDir?: string;
   yes?: boolean;
+  /**
+   * When true, replace the `allow`/`ask`/`deny` arrays in Claude's
+   * settings.json with the canonical Smithy baseline before redeploying.
+   * Drops user customizations and stale entries. No-op for manifests that
+   * don't manage Claude permissions.
+   */
+  resetPermissions?: boolean;
 }
 
 /** Map a manifest's agents array back to an AgentChoice for initAction. */
@@ -146,6 +158,7 @@ export async function updateAction(opts: UpdateOptions = {}): Promise<void> {
   }
 
   // 3. For each target, check version and redeploy
+  const resetRequested = opts.resetPermissions ?? false;
   for (const { location, manifest } of targets) {
     const proceed = await confirmVersionChange(manifest, nonInteractive, location);
     if (!proceed) {
@@ -153,11 +166,20 @@ export async function updateAction(opts: UpdateOptions = {}): Promise<void> {
       continue;
     }
 
+    const reset = await maybeResetClaudePermissions(
+      targetDir,
+      location,
+      manifest,
+      resetRequested,
+      nonInteractive,
+    );
+
     // Capture drift before the redeploy mutates the file. `writePermissions`
     // unions canonical entries into the user's settings, so post-merge every
     // user customization would look like drift — the diff is only meaningful
-    // against the pre-merge state.
-    const drift = collectClaudeDrift(targetDir, location, manifest);
+    // against the pre-merge state. Skip when we just reset; the diff is moot
+    // because the file already matches the baseline.
+    const drift = reset ? null : collectClaudeDrift(targetDir, location, manifest);
 
     await redeployFromManifest(manifest, targetDir);
 
@@ -167,6 +189,48 @@ export async function updateAction(opts: UpdateOptions = {}): Promise<void> {
       console.log(picocolors.yellow(formatDriftReport(drift, settingsPath)));
     }
   }
+}
+
+/**
+ * Honor `--reset-permissions` for a single update target. Returns true when a
+ * reset was actually performed (so the caller can skip the drift report).
+ *
+ * No-op when:
+ *   - the flag wasn't passed,
+ *   - the manifest does not manage Claude permissions, or
+ *   - the user declines the interactive confirmation.
+ */
+async function maybeResetClaudePermissions(
+  targetDir: string,
+  location: DeployLocation,
+  manifest: SmithyManifest,
+  resetRequested: boolean,
+  nonInteractive: boolean,
+): Promise<boolean> {
+  if (!resetRequested) return false;
+
+  if (!manifest.permissions || !manifest.agents.includes('claude')) {
+    console.log(
+      picocolors.dim(
+        `  --reset-permissions: ${location} manifest does not manage Claude permissions; nothing to reset.`,
+      ),
+    );
+    return false;
+  }
+
+  const ok = nonInteractive || (await promptConfirmResetPermissions(location));
+  if (!ok) {
+    console.log(picocolors.dim(`  Skipping permission reset for ${location} manifest.`));
+    return false;
+  }
+
+  resetClaudePermissions(
+    targetDir,
+    location,
+    validatedLanguages(manifest.languages),
+    detectPlatforms(),
+  );
+  return true;
 }
 
 /**

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -149,3 +149,12 @@ export async function promptConfirmDowngrade(
     default: false,
   });
 }
+
+export async function promptConfirmResetPermissions(location: DeployLocation): Promise<boolean> {
+  return await confirm({
+    message:
+      `Reset ${location} Claude permissions to the Smithy baseline? ` +
+      'This will overwrite the allow/ask/deny lists in settings.json — any custom entries you added will be removed.',
+    default: false,
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `smithy update --reset-permissions` to overwrite Claude `settings.json` `allow`/`ask`/`deny` with the canonical Smithy baseline, complementing the existing drift report
- Preserves unrelated top-level keys (`model`, `hooks`) and other keys inside `permissions` (e.g. `defaultMode`); skips with an informative message when the manifest doesn't manage Claude permissions
- Interactive confirmation by default (destructive — drops user customizations); auto-confirms under `-y`. Drift report is suppressed after a successful reset since the file matches baseline

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (779 passing, 24 files)
- [x] `npm run build` produces `dist/cli.js`
- [x] New unit tests cover `resetPermissions`: missing file, overwrite-not-merge, key preservation, malformed JSON fallback, user-level path, drift-cleared
- [x] New CLI integration tests cover the flag end-to-end and the no-op path when the manifest doesn't manage Claude permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
