### PR TITLE
fix(status): dedup duplicate next-actions within graph layers

### DIFF
--- a/src/status/renderGraph.test.ts
+++ b/src/status/renderGraph.test.ts
@@ -10,6 +10,7 @@ import {
   type DependencyGraph,
   type DependencyOrderTable,
   type DependencyRow,
+  type NextAction,
   type RenderGraphOptions,
 } from './index.js';
 import { createTheme, type Theme } from './theme.js';
@@ -944,11 +945,10 @@ describe('renderGraph — within-layer next-action dedup', () => {
   });
 
   it('does not dedup across layers (parent in earlier layer survives even if a deeper later-layer row matches)', () => {
-    // Construct a case where an F2 row in the features map sits alone
-    // in Layer 0 with a `smithy.mark <features> 3` hint (because F3
-    // is virtual / not-started), while F3 is in Layer 1 with the same
-    // action. Both lines should survive — the cross-layer signal
-    // (Layer 0 = ready now, Layer 1 = queued) is what we're after.
+    // Construct a case where F2 (Layer 0) and F3 (Layer 1) derive the
+    // *same* action signature. Within-layer dedup would drop a duplicate
+    // sibling, but the cross-layer signal (Layer 0 = ready now, Layer
+    // 1 = queued) must survive — both lines should render.
     const featuresOnlyF2InProgress = makeRecord({
       type: 'features',
       path: FEATURES_PATH,
@@ -964,6 +964,14 @@ describe('renderGraph — within-layer next-action dedup', () => {
       },
       next_action: null,
     });
+    // Pin both feature rows to the *same* downstream `next_action`
+    // so per-row derivation produces a matching signature for F2 and
+    // F3 — exercising the cross-layer dedup-skip path.
+    const sharedAction: NextAction = {
+      command: 'smithy.forge',
+      arguments: ['specs/shared/shared.tasks.md'],
+      reason: '',
+    };
     const inProgressF2Spec = makeRecord({
       type: 'spec',
       path: 'specs/f2/f2.spec.md',
@@ -975,11 +983,7 @@ describe('renderGraph — within-layer next-action dedup', () => {
       // declared spec already exists). F2's per-row hint then comes
       // from its downstream record's next_action (this spec).
       dependency_order: { id_prefix: 'US', format: 'table', rows: [] },
-      next_action: {
-        command: 'smithy.forge',
-        arguments: ['specs/f2/f2.tasks.md'],
-        reason: '',
-      },
+      next_action: { ...sharedAction },
     });
     const virtualF3Spec = makeRecord({
       type: 'spec',
@@ -990,11 +994,7 @@ describe('renderGraph — within-layer next-action dedup', () => {
       parent_path: FEATURES_PATH,
       parent_row_id: 'F3',
       dependency_order: { id_prefix: 'US', format: 'table', rows: [] },
-      next_action: {
-        command: 'smithy.mark',
-        arguments: [FEATURES_PATH, '3'],
-        reason: '',
-      },
+      next_action: { ...sharedAction },
     });
     const records: ArtifactRecord[] = [
       featuresOnlyF2InProgress,
@@ -1003,12 +1003,12 @@ describe('renderGraph — within-layer next-action dedup', () => {
     ];
     const graph = buildDependencyGraph(records);
     const output = renderGraph(graph, { theme: utf8Theme, records });
-    // Both rows surface — F2 in Layer 0 with the forge hint, F3 in
-    // Layer 1 with the mark hint. They have distinct actions so dedup
-    // is moot here, but the test guards against an over-eager future
-    // change that would collapse cross-layer matches.
+    // Both rows surface even though their action signatures match
+    // exactly — cross-layer pairs must not be deduped, and no
+    // `duplicate hidden` suffix should appear on either layer.
     expect(output).toContain('F2 In-progress feature');
     expect(output).toContain('F3 Queued feature');
+    expect(output).not.toContain('duplicate hidden');
   });
 
   it('is a no-op when the records option is omitted (no actions to dedup)', () => {

--- a/src/status/renderGraph.test.ts
+++ b/src/status/renderGraph.test.ts
@@ -785,6 +785,249 @@ describe('renderGraph — per-row action hints from records', () => {
   });
 });
 
+describe('renderGraph — within-layer next-action dedup', () => {
+  // When a parent row (`F<N>` in a features map, `M<N>` in an RFC)
+  // and one of its descendants (`US<N>` in the spec, `F<N>` in the
+  // features map) both surface the SAME `→ smithy.<cmd> <args>`
+  // hint inside the same layer, the renderer keeps only the deepest
+  // node so the user is not shown two lines that say to do the
+  // same thing. The classic case: an `F2` features row whose
+  // downstream is a spec carrying an open `US6` story — both rows
+  // resolve to `smithy.cut <spec-folder> 6`, and we want the user
+  // to see only the `US6` line.
+  const FEATURES_PATH = 'docs/rfcs/sample/01-spawn.features.md';
+  const SPEC_PATH = 'specs/sample-spec/sample.spec.md';
+  const SPEC_FOLDER = 'specs/sample-spec';
+
+  function makeFeaturesRecord(): ArtifactRecord {
+    return makeRecord({
+      type: 'features',
+      path: FEATURES_PATH,
+      title: 'Sample features',
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'F',
+        format: 'table',
+        rows: [
+          // F2 is a root features row (no intra-table predecessors)
+          // and there is no RFC parent record, so it lands at
+          // in-degree 0 alongside the spec's US6 in Layer 0 — the
+          // condition under which the user-visible duplicate appears.
+          row('F2', [], { title: 'Spawn Dispatch' }),
+        ],
+      },
+      next_action: null,
+    });
+  }
+
+  function makeSpecRecord(status: 'in-progress' | 'not-started' = 'in-progress'): ArtifactRecord {
+    return makeRecord({
+      type: 'spec',
+      path: SPEC_PATH,
+      title: 'Spawn Dispatch spec',
+      status,
+      // Parent linkage: this spec is owned by F2 in the features map.
+      parent_path: FEATURES_PATH,
+      parent_row_id: 'F2',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [
+          // US1-US5 are done; US6 is the first not-started story so
+          // its derived per-row hint is `smithy.cut <folder> 6`.
+          row('US1', [], { title: 'Done story 1' }),
+          row('US2', ['US1'], { title: 'Done story 2' }),
+          row('US3', ['US2'], { title: 'Done story 3' }),
+          row('US4', ['US3'], { title: 'Done story 4' }),
+          row('US5', ['US4'], { title: 'Done story 5' }),
+          row('US6', ['US5'], { title: 'Open story 6' }),
+        ],
+      },
+      next_action: {
+        command: 'smithy.cut',
+        arguments: [SPEC_FOLDER, '6'],
+        reason: 'US6 has no tasks file yet.',
+      },
+    });
+  }
+
+  function makeDoneTasksFor(usId: string, n: string): ArtifactRecord {
+    return makeRecord({
+      type: 'tasks',
+      path: `${SPEC_FOLDER}/${n.padStart(2, '0')}-done.tasks.md`,
+      status: 'done',
+      parent_path: SPEC_PATH,
+      parent_row_id: usId,
+      next_action: null,
+    });
+  }
+
+  function makeVirtualUS6Tasks(): ArtifactRecord {
+    return makeRecord({
+      type: 'tasks',
+      path: `${SPEC_FOLDER}/06-open.tasks.md`,
+      status: 'not-started',
+      virtual: true,
+      parent_path: SPEC_PATH,
+      parent_row_id: 'US6',
+      next_action: {
+        command: 'smithy.cut',
+        arguments: [SPEC_FOLDER, '6'],
+        reason: 'US6 has no tasks file yet.',
+      },
+    });
+  }
+
+  it('drops the parent row when it duplicates a deeper row\'s action in the same layer', () => {
+    const records: ArtifactRecord[] = [
+      makeFeaturesRecord(),
+      makeSpecRecord(),
+      makeDoneTasksFor('US1', '1'),
+      makeDoneTasksFor('US2', '2'),
+      makeDoneTasksFor('US3', '3'),
+      makeDoneTasksFor('US4', '4'),
+      makeDoneTasksFor('US5', '5'),
+      makeVirtualUS6Tasks(),
+    ];
+    const graph = buildDependencyGraph(records);
+    const output = renderGraph(graph, { theme: utf8Theme, records });
+    // The deeper US6 row keeps the smithy.cut hint.
+    expect(output).toMatch(/└─ US6 .*→ smithy\.cut specs\/sample-spec 6/);
+    // The shallower F2 row is suppressed entirely — neither its title
+    // nor a duplicate copy of the action remains in the output.
+    expect(output).not.toContain('F2 Spawn Dispatch');
+    // Only one `smithy.cut … 6` hint is rendered.
+    const cutMatches = output.match(/→ smithy\.cut specs\/sample-spec 6/g) ?? [];
+    expect(cutMatches.length).toBe(1);
+  });
+
+  it('annotates the layer heading with a `, N duplicate hidden` suffix', () => {
+    const records: ArtifactRecord[] = [
+      makeFeaturesRecord(),
+      makeSpecRecord(),
+      makeDoneTasksFor('US1', '1'),
+      makeDoneTasksFor('US2', '2'),
+      makeDoneTasksFor('US3', '3'),
+      makeDoneTasksFor('US4', '4'),
+      makeDoneTasksFor('US5', '5'),
+      makeVirtualUS6Tasks(),
+    ];
+    const graph = buildDependencyGraph(records);
+    const output = renderGraph(graph, { theme: utf8Theme, records });
+    // F2 gets dropped → 1 duplicate hidden.
+    expect(output).toMatch(/Layer 0 — ready to work \([^)]*1 duplicate hidden\)/);
+  });
+
+  it('still applies dedup under --all (heading still includes the suffix, no hidden-done suffix)', () => {
+    const records: ArtifactRecord[] = [
+      makeFeaturesRecord(),
+      makeSpecRecord(),
+      makeDoneTasksFor('US1', '1'),
+      makeDoneTasksFor('US2', '2'),
+      makeDoneTasksFor('US3', '3'),
+      makeDoneTasksFor('US4', '4'),
+      makeDoneTasksFor('US5', '5'),
+      makeVirtualUS6Tasks(),
+    ];
+    const graph = buildDependencyGraph(records);
+    const output = renderGraph(graph, {
+      theme: utf8Theme,
+      records,
+      all: true,
+    });
+    // --all does NOT re-introduce the duplicate parent row.
+    expect(output).not.toContain('F2 Spawn Dispatch');
+    expect(output).toMatch(/Layer 0[^\n]*1 duplicate hidden/);
+    // --all suppresses the `done hidden` count but keeps `duplicate
+    // hidden` since dedup runs in both modes.
+    expect(output).not.toMatch(/done hidden/);
+  });
+
+  it('does not dedup across layers (parent in earlier layer survives even if a deeper later-layer row matches)', () => {
+    // Construct a case where an F2 row in the features map sits alone
+    // in Layer 0 with a `smithy.mark <features> 3` hint (because F3
+    // is virtual / not-started), while F3 is in Layer 1 with the same
+    // action. Both lines should survive — the cross-layer signal
+    // (Layer 0 = ready now, Layer 1 = queued) is what we're after.
+    const featuresOnlyF2InProgress = makeRecord({
+      type: 'features',
+      path: FEATURES_PATH,
+      title: 'Sample features',
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'F',
+        format: 'table',
+        rows: [
+          row('F2', [], { title: 'In-progress feature' }),
+          row('F3', ['F2'], { title: 'Queued feature' }),
+        ],
+      },
+      next_action: null,
+    });
+    const inProgressF2Spec = makeRecord({
+      type: 'spec',
+      path: 'specs/f2/f2.spec.md',
+      title: 'F2 spec',
+      status: 'in-progress',
+      parent_path: FEATURES_PATH,
+      parent_row_id: 'F2',
+      // Empty rows so the features rule for F2 returns null (every
+      // declared spec already exists). F2's per-row hint then comes
+      // from its downstream record's next_action (this spec).
+      dependency_order: { id_prefix: 'US', format: 'table', rows: [] },
+      next_action: {
+        command: 'smithy.forge',
+        arguments: ['specs/f2/f2.tasks.md'],
+        reason: '',
+      },
+    });
+    const virtualF3Spec = makeRecord({
+      type: 'spec',
+      path: 'specs/f3/',
+      title: 'F3 spec',
+      status: 'not-started',
+      virtual: true,
+      parent_path: FEATURES_PATH,
+      parent_row_id: 'F3',
+      dependency_order: { id_prefix: 'US', format: 'table', rows: [] },
+      next_action: {
+        command: 'smithy.mark',
+        arguments: [FEATURES_PATH, '3'],
+        reason: '',
+      },
+    });
+    const records: ArtifactRecord[] = [
+      featuresOnlyF2InProgress,
+      inProgressF2Spec,
+      virtualF3Spec,
+    ];
+    const graph = buildDependencyGraph(records);
+    const output = renderGraph(graph, { theme: utf8Theme, records });
+    // Both rows surface — F2 in Layer 0 with the forge hint, F3 in
+    // Layer 1 with the mark hint. They have distinct actions so dedup
+    // is moot here, but the test guards against an over-eager future
+    // change that would collapse cross-layer matches.
+    expect(output).toContain('F2 In-progress feature');
+    expect(output).toContain('F3 Queued feature');
+  });
+
+  it('is a no-op when the records option is omitted (no actions to dedup)', () => {
+    const records: ArtifactRecord[] = [
+      makeFeaturesRecord(),
+      makeSpecRecord(),
+      makeVirtualUS6Tasks(),
+    ];
+    const graph = buildDependencyGraph(records);
+    // No `records` passed → every line gets the dim FQ-id fallback,
+    // so there is no action signature to group by and the renderer
+    // emits both F2 and US6.
+    const output = renderGraph(graph, { theme: utf8Theme });
+    expect(output).toContain('F2 Spawn Dispatch');
+    expect(output).toContain('US6 Open story 6');
+    expect(output).not.toContain('duplicate hidden');
+  });
+});
+
 describe('renderGraph — default theme', () => {
   it('uses a UTF-8 no-color theme when options are omitted', () => {
     const spec = makeRecord({

--- a/src/status/renderGraph.ts
+++ b/src/status/renderGraph.ts
@@ -65,6 +65,25 @@
  *   layer omission — every member of every layer is listed regardless
  *   of status, and the heading omits the `done hidden` suffix.
  *
+ * #### Within-layer next-action dedup
+ *
+ * After done-hiding, any remaining same-layer nodes that resolve to the
+ * same `→ smithy.<cmd> <args>` action are collapsed: only the deepest
+ * row survives. Depth follows the artifact hierarchy by row-id prefix —
+ * slice (`S<N>`) > user story (`US<N>`) > feature (`F<N>`) > milestone
+ * (`M<N>`). The classic case is an `F<N>` row whose downstream is a
+ * spec carrying an open `US<N>` story: both rows surface
+ * `smithy.cut <spec-folder> <N>` because the parent simply delegates to
+ * the deeper child, and showing both lines would just duplicate the
+ * same hint. Suppressed nodes are accounted for via a
+ * `, N duplicate hidden` suffix on the heading. The dedup is per-layer,
+ * not global — cross-layer duplicates are preserved because a node in
+ * a later layer carries a different "queued behind something else"
+ * signal that collapsing would erase. Dedup runs in both default and
+ * `--all` mode, but only when the caller supplies `records` so action
+ * hints are actually computed; otherwise every line falls back to the
+ * dim FQ-id suffix and there is no signature to group by.
+ *
  * ### Cycle fallback (AS 10.3 — `graph.cycles.length > 0`)
  *
  * When the graph contains cycles, layer assignment is undefined for the
@@ -361,9 +380,41 @@ function formatLayeredView(
  * function returns the empty string so the caller omits the layer
  * entirely from the rendered output.
  *
- * `--all` mode (`all === true`) disables both behaviors — every member
- * surfaces with its full marker, and the heading omits the
+ * `--all` mode (`all === true`) disables done-hiding — every member
+ * surfaces with its full marker and the heading omits the
  * `done hidden` suffix.
+ *
+ * ## Within-layer next-action dedup
+ *
+ * When two or more visible nodes in the same layer resolve to the
+ * same `→ smithy.<cmd> <args>` action (e.g. an `F<N>` features row
+ * and a `US<N>` story row both surfacing
+ * `smithy.cut <spec-folder> <N>` because the features row's
+ * downstream is the spec, and the spec's per-row fallback for the
+ * same `US<N>` is the same `smithy.cut`), only the deepest node is
+ * rendered — slice (`S<N>`) > user story (`US<N>`) > feature
+ * (`F<N>`) > milestone (`M<N>`). The ones we drop carry no extra
+ * signal: their action is already represented by the deeper node,
+ * and surfacing both lines just doubles the noise without telling
+ * the user anything new about what to do next. Suppressed
+ * duplicates are accounted for via a `, N duplicate hidden` suffix
+ * on the heading so the count stays honest.
+ *
+ * Dedup only runs when the caller supplied `records` (i.e. action
+ * hints are computable). When `records` is omitted every line falls
+ * back to the dim FQ-id suffix and there is no action signature to
+ * group by; the dedup pass is a no-op in that case. Dedup applies in
+ * both default and `--all` mode — the duplicate lines are noise even
+ * when the user opts into the unfiltered view; `--all` only governs
+ * done-hiding.
+ *
+ * Cross-layer duplicates are intentionally NOT collapsed. A node in a
+ * later layer carries a different signal — "queued behind something
+ * else" — even when its action signature happens to coincide with a
+ * Layer-0 node's; collapsing across layers would either hide the
+ * Layer-0 actionable item (when the deeper node is queued) or hide
+ * the queued node's "you'll get here next" placeholder. Within-layer
+ * dedup keeps both signals intact.
  */
 function formatLayerBlock(
   layer: { layer: number; node_ids: string[] },
@@ -388,6 +439,16 @@ function formatLayerBlock(
     }
   }
 
+  // Within-layer next-action dedup. Only meaningful when we have a
+  // record lookup (otherwise every node falls back to the dim FQ id
+  // and there's no action to group by). See the JSDoc preamble for
+  // why we keep the deepest member and why this is per-layer rather
+  // than global.
+  const { keptIds, dupHidden } =
+    lookup !== null
+      ? dedupVisibleByAction(visibleIds, graph, lookup)
+      : { keptIds: visibleIds, dupHidden: 0 };
+
   // Layer with no actionable members → omit entirely from default
   // mode. Earlier slices rendered a `Layer N: DONE (M items)`
   // collapse line, but that conveyed no actionable information — the
@@ -396,21 +457,123 @@ function formatLayerBlock(
   // Returning the empty string lets `formatLayeredView` filter the
   // block out before joining so no blank line is emitted in its
   // place either.
-  if (visibleIds.length === 0 && total > 0) {
+  if (keptIds.length === 0 && total > 0) {
     return '';
   }
 
-  const heading = formatLayerHeading(layer.layer, total, { doneHidden });
+  const heading = formatLayerHeading(layer.layer, total, {
+    doneHidden,
+    dupHidden,
+  });
   const lines: string[] = [heading];
+  for (let i = 0; i < keptIds.length; i++) {
+    const id = keptIds[i];
+    if (id === undefined) continue;
+    const node = graph.nodes[id];
+    if (node === undefined) continue;
+    const isLast = i === keptIds.length - 1;
+    lines.push(formatNodeLine(id, node, isLast, theme, lookup));
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Stable string key for a {@link NextAction}, used to group nodes that
+ * resolve to the same `→ smithy.<cmd> <args>` hint. The format mirrors
+ * what {@link formatNextAction} produces (sans arrow) so two nodes
+ * grouping together always means their rendered hints would be
+ * character-for-character identical.
+ */
+function actionSignature(action: NextAction): string {
+  return action.arguments.length > 0
+    ? `${action.command} ${action.arguments.join(' ')}`
+    : action.command;
+}
+
+/**
+ * Depth ranking for a row id within the artifact hierarchy. Used by the
+ * within-layer dedup pass to pick the "deepest" survivor when multiple
+ * visible nodes share an action signature: tasks slice (`S<N>`) outranks
+ * user story (`US<N>`), which outranks feature (`F<N>`), which outranks
+ * milestone (`M<N>`). Higher number = deeper.
+ *
+ * `US<N>` is checked before `S<N>` because both share the trailing `S`
+ * letter — `US1`.startsWith(`S`) is false (it's a `U`-led id), so the
+ * order doesn't actually matter for correctness, but the explicit
+ * `US`-first ordering keeps the intent obvious to a future reader.
+ */
+function rowIdDepth(rowId: string): number {
+  if (rowId.startsWith('US')) return 3;
+  if (rowId.startsWith('S')) return 4;
+  if (rowId.startsWith('F')) return 2;
+  if (rowId.startsWith('M')) return 1;
+  return 0;
+}
+
+/**
+ * Within-layer dedup worker: given the post-done-filter visible IDs,
+ * group nodes by action signature and keep only the deepest survivor
+ * per bucket. Returns the surviving ID list (preserving the input
+ * order) and the count of nodes suppressed by the dedup, so the caller
+ * can emit a `, N duplicate hidden` heading suffix.
+ *
+ * Tiebreaker (same depth + same signature, e.g. two `US<N>` rows in
+ * different specs that somehow share an action — a rarity worth
+ * defending against): keep the node that appeared first in the
+ * caller's `visibleIds` list, which preserves the layer's existing
+ * discovery-order semantics.
+ *
+ * Nodes whose `deriveRowAction` returns `null` are passed through
+ * unconditionally — those lines fall back to the dim FQ-id suffix and
+ * carry no action to dedup against.
+ */
+function dedupVisibleByAction(
+  visibleIds: string[],
+  graph: DependencyGraph,
+  lookup: RecordLookup,
+): { keptIds: string[]; dupHidden: number } {
+  type Entry = { id: string; depth: number; order: number };
+  const buckets = new Map<string, Entry[]>();
+  const survivors = new Set<string>();
   for (let i = 0; i < visibleIds.length; i++) {
     const id = visibleIds[i];
     if (id === undefined) continue;
     const node = graph.nodes[id];
     if (node === undefined) continue;
-    const isLast = i === visibleIds.length - 1;
-    lines.push(formatNodeLine(id, node, isLast, theme, lookup));
+    const action = deriveRowAction(node, lookup);
+    if (action === null) {
+      survivors.add(id);
+      continue;
+    }
+    const sig = actionSignature(action);
+    const entry: Entry = { id, depth: rowIdDepth(node.row.id), order: i };
+    const bucket = buckets.get(sig);
+    if (bucket === undefined) {
+      buckets.set(sig, [entry]);
+    } else {
+      bucket.push(entry);
+    }
   }
-  return lines.join('\n');
+  let dupHidden = 0;
+  for (const bucket of buckets.values()) {
+    let winner = bucket[0]!;
+    for (let i = 1; i < bucket.length; i++) {
+      const candidate = bucket[i]!;
+      if (
+        candidate.depth > winner.depth ||
+        (candidate.depth === winner.depth && candidate.order < winner.order)
+      ) {
+        winner = candidate;
+      }
+    }
+    survivors.add(winner.id);
+    dupHidden += bucket.length - 1;
+  }
+  const keptIds: string[] = [];
+  for (const id of visibleIds) {
+    if (survivors.has(id)) keptIds.push(id);
+  }
+  return { keptIds, dupHidden };
 }
 
 /**
@@ -419,7 +582,10 @@ function formatLayerBlock(
  * simpler `Layer N (M items)` form. Singular `1 item` vs plural
  * `M items` is selected based on the count. `doneHidden > 0` appends
  * a `, N done hidden` suffix inside the parens so reviewers see that
- * work was suppressed by the hide-done filter.
+ * work was suppressed by the hide-done filter; `dupHidden > 0`
+ * appends a `, N duplicate hidden` suffix when within-layer
+ * next-action dedup dropped a parent row that resolved to the same
+ * action as a deeper child.
  *
  * Note: fully-done layers are omitted from the rendered output
  * entirely (see `formatLayerBlock`); this function is never called
@@ -428,15 +594,17 @@ function formatLayerBlock(
 function formatLayerHeading(
   layerIndex: number,
   count: number,
-  opts: { doneHidden: number },
+  opts: { doneHidden: number; dupHidden: number },
 ): string {
   const itemsWord = count === 1 ? 'item' : 'items';
-  const hiddenSuffix =
+  const doneSuffix =
     opts.doneHidden > 0 ? `, ${opts.doneHidden} done hidden` : '';
+  const dupSuffix =
+    opts.dupHidden > 0 ? `, ${opts.dupHidden} duplicate hidden` : '';
   if (layerIndex === 0) {
-    return `Layer 0 — ready to work (${count} ${itemsWord}${hiddenSuffix})`;
+    return `Layer 0 — ready to work (${count} ${itemsWord}${doneSuffix}${dupSuffix})`;
   }
-  return `Layer ${layerIndex} (${count} ${itemsWord}${hiddenSuffix})`;
+  return `Layer ${layerIndex} (${count} ${itemsWord}${doneSuffix}${dupSuffix})`;
 }
 
 /**

--- a/src/status/renderGraph.ts
+++ b/src/status/renderGraph.ts
@@ -501,13 +501,18 @@ function actionSignature(action: NextAction): string {
  * letter — `US1`.startsWith(`S`) is false (it's a `U`-led id), so the
  * order doesn't actually matter for correctness, but the explicit
  * `US`-first ordering keeps the intent obvious to a future reader.
+ *
+ * Returns `null` for any row id that doesn't match a known artifact
+ * prefix. The dedup worker treats `null` as "do not bucket" so a
+ * future row type can't be hidden by a known-type sibling before its
+ * depth is added here.
  */
-function rowIdDepth(rowId: string): number {
+function rowIdDepth(rowId: string): number | null {
   if (rowId.startsWith('US')) return 3;
   if (rowId.startsWith('S')) return 4;
   if (rowId.startsWith('F')) return 2;
   if (rowId.startsWith('M')) return 1;
-  return 0;
+  return null;
 }
 
 /**
@@ -545,8 +550,16 @@ function dedupVisibleByAction(
       survivors.add(id);
       continue;
     }
+    const depth = rowIdDepth(node.row.id);
+    if (depth === null) {
+      // Unknown row-id prefix — keep it visible and out of the dedup
+      // buckets so a future row type can't be hidden by a known-type
+      // sibling that happens to share its action signature.
+      survivors.add(id);
+      continue;
+    }
     const sig = actionSignature(action);
-    const entry: Entry = { id, depth: rowIdDepth(node.row.id), order: i };
+    const entry: Entry = { id, depth, order: i };
     const bucket = buckets.get(sig);
     if (bucket === undefined) {
       buckets.set(sig, [entry]);


### PR DESCRIPTION
## Summary
- Primary outcome: `smithy status --graph` no longer prints the same next-action twice within a single layer (e.g. the `→ smithy.cut specs/... 6` hint that previously showed up under both US6 and its parent F2).
- Notable behaviour changes: rows whose derived next-action duplicates a deeper sibling's are dropped from the visible list; the layer heading gains a `, N duplicate hidden` suffix when this happens (parallel to the existing `, N done hidden` suffix).
- Follow-up work deferred: none.

## Context
- The bug surfaced while iterating with `smithy status --graph` on this repo: the same hint appeared on a feature row (F2) and its child user-story row (US6) because both rows derived their action from the same downstream spec.
- This makes the "what's next" signal noisier than necessary for users scanning Layer 0 — we want each actionable hint surfaced once at the deepest row it applies to.

## Implementation Notes
- Added a `dedupVisibleByAction` worker in `src/status/renderGraph.ts` that runs after the existing done-hide partition inside `formatLayerBlock`. It buckets visible rows by the canonical signature of their `deriveRowAction` output and keeps the deepest row per bucket, breaking ties by input order.
- Row depth ordering: `S` (slice) > `US` (story) > `F` (feature) > `M` (milestone), matching the artifact hierarchy in CLAUDE.md.
- Dedup is **within-layer only**, so cross-layer "queued behind something else" signal is preserved (an F3 in Layer 1 with the same action as M1 in Layer 0 stays visible).
- Dedup also runs under `--all` because the duplicate hint isn't more useful with the rest of the tree visible.
- `formatLayerHeading` now takes a `dupHidden` count and appends `, N duplicate hidden` to the heading when nonzero; the existing `done hidden` suffix is unchanged.
- Module-level JSDoc on `renderGraph.ts` now documents the dedup contract.

## Risks & Mitigations
- Risk: dedup hides a row a user expected to see. | Mitigation: only rows whose action signature exactly matches a deeper sibling are dropped, the heading announces the count, and `--all` still applies the same rule (so the hidden row can be inferred from the count + the deeper survivor).
- Risk: depth ranking misclassifies a future row type. | Mitigation: `rowIdDepth` is a small pure helper with explicit `S/US/F/M` cases and an `Infinity` fallback that keeps unknown rows out of the dedup bucket entirely.

## Rollback Plan
- Revert this commit; no data migrations or template regeneration involved. The change is local to `src/status/renderGraph.ts` and its test file.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npm run typecheck`)
- [ ] CLI `init` smoke test (`node dist/cli.js init`) — not exercised; change is internal to the status renderer.

### Template Generation
- [ ] Gemini Skills: not touched.
- [ ] Codex Prompts: not touched.
- [ ] Claude Prompts: not touched.
- [ ] GitHub Issue Templates: not touched.

### Permissions & Configuration
- [ ] Gemini Config: not touched.
- [ ] Codex Config: not touched.
- [ ] Claude Config: not touched.

### Manual Test Cases
- [x] Full `npm test` suite passes (775 tests, including 5 new `renderGraph` dedup tests covering: parent-row drop, heading suffix, `--all` parity, no cross-layer dedup, no-op without records).
