### PR TITLE
Cross-location isolation tests for smithy init orders provisioning

### DIFF
--- a/specs/2026-03-21-002-smithy-orders-issue-templates/03-deployment-location-honored-end-to-end.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/03-deployment-location-honored-end-to-end.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Add cross-location isolation tests for repo and user init**
+- [x] **Add cross-location isolation tests for repo and user init**
 
   Extend `src/cli.test.ts` with HOME-isolated test cases that exercise both `--location repo` and `--location user` provisioning, asserting the chosen `<manifestDir>` is populated AND the other manifest dir remains absent. Reuse whatever HOME-override mechanism US1 Slice 2 Task 4 establishes (see SD-001) — these tests are US3's primary regression guard for cross-location isolation, so they must execute on every supported CI platform. Do not gate them behind a skip path: if the inherited mechanism does not produce a reliable isolated home on a target platform, treat that as a US1-side gap to fix in the shared mechanism, not a US3 reason to weaken the contract. Satisfies AS 3.1 and AS 3.2.
 

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/03-deployment-location-honored-end-to-end.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/03-deployment-location-honored-end-to-end.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [x] **Add cross-location isolation tests for repo and user init**
+- [ ] **Add cross-location isolation tests for repo and user init**
 
   Extend `src/cli.test.ts` with HOME-isolated test cases that exercise both `--location repo` and `--location user` provisioning, asserting the chosen `<manifestDir>` is populated AND the other manifest dir remains absent. Reuse whatever HOME-override mechanism US1 Slice 2 Task 4 establishes (see SD-001) — these tests are US3's primary regression guard for cross-location isolation, so they must execute on every supported CI platform. Do not gate them behind a skip path: if the inherited mechanism does not produce a reliable isolated home on a target platform, treat that as a US1-side gap to fix in the shared mechanism, not a US3 reason to weaken the contract. Satisfies AS 3.1 and AS 3.2.
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -169,6 +169,68 @@ describe('CLI init --yes (non-interactive)', () => {
 
 });
 
+describe('CLI init cross-location isolation (orders templates)', () => {
+  let tmpDir: string;
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-test-target-'));
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-test-home-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  // The four orders-template files US1 Slice 2 provisions under
+  // <manifestDir>/templates/orders/. Asserted by name (not by directory
+  // listing) so the isolation contract is observable and stable even if
+  // sibling artifacts land alongside them later.
+  const ORDERS_FILES = ['rfc.md', 'features.md', 'spec.md', 'tasks.md'];
+
+  it('--location repo populates <targetDir>/.smithy/templates/orders/ and leaves <HOME>/.smithy/ alone (AS 3.1)', () => {
+    // HOME / USERPROFILE are overridden via the spawn env (not via mutating
+    // process.env) so the developer's real ~/.smithy/ is never read or
+    // written, and other tests in this file are unaffected. os.homedir()
+    // — which resolveManifestDir() calls for 'user' location — honors HOME
+    // on POSIX and USERPROFILE on Windows, so setting both gives
+    // cross-platform parity on every supported CI runner.
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '--location', 'repo', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+      env: { ...process.env, HOME: tmpHome, USERPROFILE: tmpHome },
+    });
+
+    for (const f of ORDERS_FILES) {
+      expect(fs.existsSync(path.join(tmpDir, '.smithy', 'templates', 'orders', f))).toBe(true);
+    }
+    // The isolated user home must not have been touched for orders templates
+    // when provisioning was directed at the repo location.
+    expect(fs.existsSync(path.join(tmpHome, '.smithy', 'templates', 'orders'))).toBe(false);
+  });
+
+  it('--location user populates <HOME>/.smithy/templates/orders/ and leaves <targetDir>/.smithy/ alone (AS 3.2)', () => {
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '--location', 'user', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+      env: { ...process.env, HOME: tmpHome, USERPROFILE: tmpHome },
+    });
+
+    for (const f of ORDERS_FILES) {
+      expect(fs.existsSync(path.join(tmpHome, '.smithy', 'templates', 'orders', f))).toBe(true);
+    }
+    // The target repo's .smithy/ must not contain an orders/ subtree when
+    // provisioning was directed at the user-level home. We assert on the
+    // templates/orders/ subtree specifically (not the entire .smithy/
+    // tree) because under --location user the target .smithy/ may
+    // legitimately hold sibling artifacts (e.g. a smithy-manifest.json
+    // from other init flows). The isolation contract this slice owns is
+    // the orders subtree.
+    expect(fs.existsSync(path.join(tmpDir, '.smithy', 'templates', 'orders'))).toBe(false);
+  });
+});
+
 describe('CLI uninit --yes (non-interactive)', () => {
   let tmpDir: string;
 


### PR DESCRIPTION
## Source

- Spec: [`smithy-orders-issue-templates.spec.md`](../blob/master/specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.spec.md) — User Story 3
- Tasks: [`03-deployment-location-honored-end-to-end.tasks.md`](../blob/master/specs/2026-03-21-002-smithy-orders-issue-templates/03-deployment-location-honored-end-to-end.tasks.md) — Slice 1

## Slice

**Slice 1 — Cross-Location Isolation Tests for `smithy init` Provisioning.** Goal: prove that `smithy init --location repo` and `smithy init --location user` each confine orders-template provisioning to their respective `<manifestDir>` and never pollute the other location. Adds the inverse-direction non-pollution checks that US1 Slice 2's positive provisioning tests do not commit to. Test-only; no production code touched.

## Addresses

- **FR-002** — `smithy init` writes templates to `<manifestDir>/templates/orders/...` where `<manifestDir>` is resolved by `resolveManifestDir(deployLocation)`.
- **AS 3.1** — `--location repo` writes under `<repo>/.smithy/` and nothing under `~/.smithy/`.
- **AS 3.2** — `--location user` writes under `~/.smithy/` and nothing under `<repo>/.smithy/` from template provisioning.

## Tasks completed

- [x] Add cross-location isolation tests for repo and user init (`src/cli.test.ts`)

Two new tests added in a new `describe('CLI init cross-location isolation (orders templates)', ...)` block (`src/cli.test.ts:160-220`). Each test creates two isolated temp dirs (`tmpDir` for the "target repo", `tmpHome` for an isolated user home) and overrides `HOME`/`USERPROFILE` through the `execFileSync` `env` option — never via `process.env` mutation — so the developer's real `~/.smithy/` is untouched and other tests are unaffected. `os.homedir()` (which `resolveManifestDir` calls for `--location user`) honors `HOME` on POSIX and `USERPROFILE` on Windows, giving cross-platform parity. Both temp dirs are cleaned in `afterEach`.

The `--location user` test asserts absence only of the `templates/orders/` subtree of `<targetDir>/.smithy/`, not the entire `.smithy/` tree — faithful to AS 3.2's "by template provisioning" qualifier, since the manifest-write phase may legitimately write a sibling artifact there in some flows.

## Review

`smithy-implementation-review` returned **zero findings**. Review confirmed: HOME isolation is correct (env-via-spawn, not process.env mutation), AS 3.2's narrowed-to-`templates/orders/` assertion is faithful to the "by template provisioning" qualifier, no skip path was added, no shared state between tests, all temp dirs cleaned up. No auto-fixes applied, no escalations, no minor notes.

## Documentation

`smithy-maid` returned **clean** (no auto-fixes, no flagged items). Existing references in `CONTRIBUTING.md` and `CLAUDE.md` to `src/cli.test.ts` remain accurate; legacy `--issue-templates` comments adjacent to the new block are still describing live code (FR-011 retirement has not landed yet); the tasks file's `Specification Debt` entries (SD-001 still `open`, SD-006 still `open`) correctly reflect the inline HOME-override choice this slice made — neither pre-empts the upstream decisions they track.

## Validation

| Step | Result |
| --- | --- |
| `npm run build` | ✅ `dist/cli.js` built, 131.95 KB |
| `npm run typecheck` | ✅ Clean (`tsc --noEmit`) |
| `npm test` | ⚠️ **786 pass / 2 fail** — the only failures are the two new tests in this PR (see "Cross-story dependency" below). No regressions in any other suite. |

## Cross-story dependency — CI red until US1 Slice 2 merges

The tasks file explicitly anticipates this state:

> Slice 1 cannot pass CI until US1 (specifically US1 Slice 2) has merged — the provisioning behavior the isolation tests assert about must exist.

US1 (which adds `<manifestDir>/templates/orders/{rfc,features,spec,tasks}.md` provisioning to `smithy init`) has not been opened or merged. The two new tests therefore fail at the `expect(fs.existsSync(...rfc.md)).toBe(true)` lines with `AssertionError: expected false to be true`. This is the **expected, documented committable state** — the slice's acceptance criteria explicitly forbid skip paths (`it.skip`, `.todo`, conditional gates) because these tests are US3's primary regression guard for cross-location isolation and must execute on every supported CI platform.

Suggested ordering: hold this PR (or land it accepting the temporary red) until US1 Slice 2 lands. Once US1 Slice 2's provisioning ships, both tests should flip green with no further changes here. If US1's eventual test code chooses a different HOME-override mechanism (per SD-001, still `open`), converge on it then — for now this PR inlines the natural Node.js `env`-override approach (SD-006 deferred a shared helper until a second consumer materializes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)