### PR TITLE
Orders renders .spec.md issues from manifest-aware templates

### DIFF
--- a/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md
@@ -40,7 +40,7 @@
   - Unknown `{{variable}}` names survive as literal text per the data-model validation rule.
   - When `<manifestDir>/templates/orders/spec.md` is absent the existing heredoc body is used.
 
-- [ ] **Assert manifest-load and spec template lookup are present in composed orders prompt**
+- [x] **Assert manifest-load and spec template lookup are present in composed orders prompt**
 
   Extend the existing `smithy.orders command delegates GitHub ops to smithy.gh-issue scripts` block in `src/templates.test.ts` with behavioral assertions that the composed `smithy.orders.md` references `resolveManifestDir`, names the `<manifestDir>/templates/orders/` path pattern, and references the `spec.md` template specifically. Match by content, not line number, so the assertion survives prompt reflows.
 

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Add manifest discovery and manifest-dir resolution phase to orders prompt**
+- [x] **Add manifest discovery and manifest-dir resolution phase to orders prompt**
 
   Insert a new phase in `src/templates/agent-skills/commands/smithy.orders.prompt` that performs manifest discovery without circular reasoning: probe both candidate manifest paths — the repo-local `<targetDir>/.smithy/smithy-manifest.json` and the user-global `~/.smithy/smithy-manifest.json` — using the same two `resolveManifestDir(targetDir, location)` calls (one per `location` value) that `updateAction` and `uninitAction` use in `src/commands/update.ts` and `src/commands/uninit.ts`. Select the active manifest by precedence: **(a) neither exists** → halt with the "run `smithy init` first" error mandated by FR-005; **(b) only repo exists** → use repo; **(c) only user exists** → use user; **(d) both exist** → prefer the repo manifest (it is scoped to this repository and matches the deploy semantics a user got when they ran `smithy init --location repo` here). After selection, validate the self-consistency check used by `update.ts` — the selected manifest's stored `deployLocation` field must equal the `location` it was read from; if they diverge, halt with the same "fix the manifest or rerun `smithy init`" message that `update.ts` emits. The selected `(targetDir, location)` pair drives the final `<manifestDir>` value used by Phase 5 template lookups. Position the phase early enough that Phase 4 duplicate detection never runs against a missing-manifest state.
 

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md
@@ -30,7 +30,7 @@
   - Phase prose forbids reading or modifying `smithy-manifest.json` as a template at either candidate path.
   - The composed `smithy.orders.md` template still satisfies the existing `smithy.orders command delegates GitHub ops to smithy.gh-issue scripts` structural assertion in `src/templates.test.ts`.
 
-- [ ] **Replace `.spec.md` Phase 5 heredoc with template-driven rendering**
+- [x] **Replace `.spec.md` Phase 5 heredoc with template-driven rendering**
 
   In Phase 5 of `smithy.orders.prompt`, replace the `.spec.md` mapping's hardcoded heredoc body with prose that reads `<manifestDir>/templates/orders/spec.md` (when present) and globally substitutes every placeholder named in the data-model's spec row. When the template file is absent, fall through to the existing heredoc body so `orders` keeps producing an issue. Substitution must visit every occurrence of every known placeholder across the rendered body so the default template's `{{next_step}}` parenthetical does not leak literal `{{spec_folder}}` / `{{user_story_number}}` text after `{{next_step}}` itself is replaced.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -509,6 +509,17 @@ describe('getComposedTemplates', () => {
     expect(orders).not.toContain('gh issue create --title');
     expect(orders).not.toContain('gh issue list --search');
 
+    // Manifest-load phase (US2 S1 Task 1): the prompt must name the
+    // resolveManifestDir helper that drives <manifestDir> selection, and
+    // it must name the runtime templates path pattern that Phase 5 reads
+    // from.
+    expect(orders).toContain('resolveManifestDir');
+    expect(orders).toContain('<manifestDir>/templates/orders/');
+    // Spec template lookup (US2 S1 Task 2): the .spec.md mapping must
+    // specifically reference the spec.md template file under the
+    // manifest's orders templates directory.
+    expect(orders).toContain('<manifestDir>/templates/orders/spec.md');
+
     // US4 Slice 1 Task 2: parity between the prompt's Phase 5 fallback
     // bodies and the canonical default exports in `src/orders-templates.ts`.
     // For each of the four orders-eligible artifact types, both surfaces

--- a/src/templates/agent-skills/commands/smithy.orders.prompt
+++ b/src/templates/agent-skills/commands/smithy.orders.prompt
@@ -109,11 +109,17 @@ from Step 2). If they diverge, halt with the same wording style
 `update.ts` emits (see `src/commands/update.ts:168-176`):
 
   > `<location>` manifest declares `deployLocation="<other>"`; refusing to
-  > proceed — fix the manifest or rerun `smithy init`.
+  > run orders — fix the manifest or rerun `smithy init`.
 
 (Substitute the actual values: e.g. ``repo manifest declares
-deployLocation="user"; refusing to proceed — fix the manifest or rerun
+deployLocation="user"; refusing to run orders — fix the manifest or rerun
 `smithy init`.``)
+
+The verb ("refusing to run orders") deliberately mirrors `update.ts`'s
+`refusing to update` wording shape — the surrounding sentence structure
+and the trailing ``— fix the manifest or rerun `smithy init` `` half
+are kept identical so the two halts read as siblings; only the verb
+varies because `orders` is not "updating" anything.
 
 **Step 4 — Compute `<manifestDir>`.** Once selection passes Step 3, set the
 named variable `<manifestDir>` for downstream phases:

--- a/src/templates/agent-skills/commands/smithy.orders.prompt
+++ b/src/templates/agent-skills/commands/smithy.orders.prompt
@@ -352,6 +352,81 @@ The body below is the built-in fallback used when
 `<manifestDir>/templates/orders/spec.md` is absent (US4); when present,
 US2's template-resolution path wins and this heredoc is bypassed.
 
+**Template-driven rendering (preferred path).** Before falling back to the
+heredoc below, attempt to render the body from the user-overridable spec
+template provisioned by `smithy init` under
+`<manifestDir>/templates/orders/spec.md`. `<manifestDir>` is the value
+captured at the end of Phase 1's "Manifest Discovery and `<manifestDir>`
+Resolution" sub-section — do not re-probe the filesystem; reuse the
+already-resolved value.
+
+For **each** user story extracted in Phase 3, perform the following steps:
+
+1. **Build the spec-type interpolation context.** Compute a value for every
+   variable named in the data-model's spec row. Sources:
+
+   - `{{title}}` ← the user story's title (the same `<story-title>` used in
+     the `[Story] <story-title>` issue title).
+   - `{{parent_issue}}` ← empty string. The `.spec.md` mapping creates no
+     parent ticket upstream, so there is no `#<n>` reference to inject.
+   - `{{user_story}}` ← the user story body parsed in Phase 3
+     (`As a <persona>, I want <goal> so that <benefit>.`).
+   - `{{user_story_number}}` ← the integer `N` from the `### User Story N:`
+     heading (no leading zeros — e.g., `3`).
+   - `{{acceptance_scenarios}}` ← the Given/When/Then scenarios block for
+     this story from Phase 3.
+   - `{{priority}}` ← the story's priority (`P1` / `P2` / `P3`).
+   - `{{spec_path}}` ← the artifact path argument that `smithy.orders` was
+     invoked with (the `.spec.md` file).
+   - `{{spec_folder}}` ← the parent folder of `{{spec_path}}` (e.g.,
+     `specs/2026-03-14-001-webhook-support`).
+   - `{{data_model_path}}` ← the sibling `<spec_folder>/<basename>.data-model.md`
+     path. If no such file exists on disk, use empty string.
+   - `{{contracts_path}}` ← the sibling `<spec_folder>/<basename>.contracts.md`
+     path. If no such file exists on disk, use empty string.
+   - `{{next_step}}` ← the literal string `smithy.cut <spec_folder> <user_story_number>`
+     per the data-model next-step mapping, **with `<spec_folder>` and
+     `<user_story_number>` already substituted using the values captured
+     above** (e.g., `smithy.cut specs/2026-03-14-001-webhook-support 3`).
+     Compose `{{next_step}}`'s value first, before running the global
+     substitution pass on the template body, so the rendered body's
+     `{{next_step}}` becomes the fully-resolved command rather than a
+     command still containing `{{spec_folder}}` / `{{user_story_number}}`.
+
+2. **Read the template file.** Using the `Read` tool, attempt to read
+   `<manifestDir>/templates/orders/spec.md`.
+
+3. **If the read succeeds** (the template file exists): perform a
+   **global** substitution of every variable in the context built in
+   step 1 across the entire template body. Every occurrence of every
+   known placeholder must be replaced — not just the first. This single
+   pass is what handles the parenthetical-leak case: if the default
+   template body contains an aside such as ``Run `{{next_step}}`
+   (equivalent to `smithy.cut {{spec_folder}} {{user_story_number}}`) to
+   …``, the parenthetical's `{{spec_folder}}` and `{{user_story_number}}`
+   are replaced inline in the same pass that replaces `{{next_step}}`
+   itself — so the rendered output contains no leftover `{{…}}` tokens
+   for known variables. Unknown `{{variable}}` names (any token not in
+   the spec-row context above) are **left as literal text** per the
+   data-model validation rule — do not error and do not delete them.
+
+   Write the rendered body to `/tmp/orders_body.md` and then call:
+
+   ```bash
+   ${CLAUDE_SKILL_DIR}/scripts/create-issue.sh "[Story] <story-title>" /tmp/orders_body.md
+   ```
+
+   Skip the heredoc fallthrough below for this user story.
+
+4. **If the read fails** because the file does not exist (i.e.,
+   `<manifestDir>/templates/orders/spec.md` is absent on disk): fall
+   through to the heredoc body below so `orders` still produces an
+   issue. Do **not** treat any other read failure (permission denied,
+   I/O error) as "absent" — surface those errors and stop.
+
+**Fallthrough heredoc body.** Used only when the template file at
+`<manifestDir>/templates/orders/spec.md` is absent:
+
 ```bash
 cat > /tmp/orders_body.md << 'BODY'
 # \{{title}}

--- a/src/templates/agent-skills/commands/smithy.orders.prompt
+++ b/src/templates/agent-skills/commands/smithy.orders.prompt
@@ -40,6 +40,102 @@ ${CLAUDE_SKILL_DIR}/scripts/check-env.sh
 If it fails, surface the message it printed and stop. On success, capture the
 returned `ownerRepo` for use in the summary.
 
+### Manifest Discovery and `<manifestDir>` Resolution
+
+After `check-env.sh` succeeds, locate the active smithy manifest **before**
+Phase 4 ever runs. Phase 5's `.spec.md` mapping (and the rfc/features/tasks
+mappings added in later slices) reads body templates from
+`<manifestDir>/templates/orders/<type>.md`, so the prompt must resolve a
+trustworthy `<manifestDir>` here. The resolver matches the two-arg
+`resolveManifestDir(targetDir, location)` helper at `src/manifest.ts:38-43`
+that `updateAction` and `uninitAction` already use
+(`src/commands/update.ts`, `src/commands/uninit.ts`):
+
+```
+resolveManifestDir(targetDir, location):
+  if location === 'user' → path.join(os.homedir(), '.smithy')
+  else                   → path.join(targetDir,     '.smithy')
+```
+
+Where the two arguments come from at runtime:
+
+- `targetDir` — the current working directory (the repo you are running
+  `smithy.orders` from). It is **not** read from any manifest; the prompt has
+  not loaded one yet.
+- `location` — the **hardcoded `DeployLocation` enum value** for the candidate
+  you are probing this iteration: literal `'repo'` for the repo-local
+  candidate, literal `'user'` for the user-global candidate. Do **not** read
+  `location` from any manifest field — that would be circular reasoning
+  (using a field from a manifest you have not yet decided to use).
+
+**Step 1 — Probe both candidate manifest paths.** Using the `Read` tool, check
+for the manifest at each candidate:
+
+1. Repo candidate: `Read` the file at `<targetDir>/.smithy/smithy-manifest.json`
+   (equivalently `<resolveManifestDir(targetDir, 'repo')>/smithy-manifest.json`).
+2. User candidate: `Read` the file at `~/.smithy/smithy-manifest.json`
+   (equivalently `<resolveManifestDir(targetDir, 'user')>/smithy-manifest.json`).
+
+Record for each candidate whether the file exists and, when it does, the
+parsed JSON object (in particular its `deployLocation` field, which is one of
+`'repo'` or `'user'`).
+
+**Step 2 — Select the active manifest by precedence.** Apply the rules below
+in order. All four cases are handled explicitly:
+
+- **(a) Neither candidate exists.** Halt before Phase 4. Surface this exact
+  error to the user and stop:
+
+  > `smithy.orders` requires `smithy init` to have run first — no manifest
+  > was found at `<targetDir>/.smithy/smithy-manifest.json` or
+  > `~/.smithy/smithy-manifest.json`. Run `smithy init` to provision the
+  > orders templates and manifest, then re-run `smithy.orders`.
+
+- **(b) Only the repo candidate exists.** Select it: the active
+  `(targetDir, location)` pair is `(<cwd>, 'repo')`.
+
+- **(c) Only the user candidate exists.** Select it: the active
+  `(targetDir, location)` pair is `(<cwd>, 'user')`.
+
+- **(d) Both candidates exist.** **Prefer the repo manifest.** It is scoped
+  to this repository and matches the deploy semantics a user got when they
+  ran `smithy init --location repo` here. The active `(targetDir, location)`
+  pair is `(<cwd>, 'repo')`.
+
+**Step 3 — Validate selected manifest self-consistency.** Read the selected
+manifest's stored `deployLocation` field and confirm it equals the
+`location` value you used to read it (the hardcoded `'repo'` or `'user'`
+from Step 2). If they diverge, halt with the same wording style
+`update.ts` emits (see `src/commands/update.ts:168-176`):
+
+  > `<location>` manifest declares `deployLocation="<other>"`; refusing to
+  > proceed — fix the manifest or rerun `smithy init`.
+
+(Substitute the actual values: e.g. ``repo manifest declares
+deployLocation="user"; refusing to proceed — fix the manifest or rerun
+`smithy init`.``)
+
+**Step 4 — Compute `<manifestDir>`.** Once selection passes Step 3, set the
+named variable `<manifestDir>` for downstream phases:
+
+```
+<manifestDir> = resolveManifestDir(targetDir, location)
+              = (location === 'user') ? ~/.smithy : <targetDir>/.smithy
+```
+
+Subsequent phases — most importantly Phase 5's `.spec.md` mapping — reference
+`<manifestDir>` to look up body templates under
+`<manifestDir>/templates/orders/<type>.md`. Capture `<manifestDir>` (and the
+`(targetDir, location)` pair it was derived from) so later phases can reuse
+the value without re-probing the filesystem.
+
+**Forbidden operations.** Never read `<manifestDir>/smithy-manifest.json` as
+a body template, and never modify, truncate, rewrite, or delete it. The
+manifest is CLI-owned state (`src/manifest.ts`); the only template files in
+scope live under `<manifestDir>/templates/orders/<type>.md`. This rule
+applies at **both** candidate paths — the user-global path included — and
+holds regardless of which candidate Step 2 selected.
+
 ---
 
 ## Phase 2: Identify Artifact Type


### PR DESCRIPTION
## Source

- Spec: [`specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.spec.md`](specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.spec.md)
- Tasks: [`specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md`](specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md)
- Data Model: [`specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.data-model.md`](specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.data-model.md)
- Contracts: [`specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.contracts.md`](specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.contracts.md)

## Slice

**Slice 1**: Manifest-Aware Template Resolution and Spec-Type Rendering.

**Goal**: Add a manifest-load + `<manifestDir>` resolution phase to `smithy.orders.prompt`, then convert the `.spec.md` Phase 5 mapping from heredoc to template-driven rendering. The rfc/features/tasks mappings keep their existing heredocs and continue working unchanged.

## Addresses

- **FRs**: FR-005, FR-007, FR-008
- **Acceptance scenarios**: AS 2.1, AS 2.5, AS 2.6 (spec branch)

## Tasks completed

- [x] Add manifest discovery and `<manifestDir>` resolution phase to the orders prompt (Phase 1 sub-section, non-circular two-arg `resolveManifestDir(targetDir, location)` probe across both candidates, repo-precedence on tie, `update.ts`-style halt on mismatched `deployLocation`, "run `smithy init` first" halt on missing manifest, manifest never read/written as a template).
- [x] Replace `.spec.md` Phase 5 heredoc with template-driven rendering (reads `<manifestDir>/templates/orders/spec.md` when present, globally substitutes every data-model spec-row placeholder, pre-renders `{{next_step}}` so nested `{{spec_folder}}` / `{{user_story_number}}` are replaced in the same pass — preventing the parenthetical-leak risk SD-004 calls out, falls through to the existing heredoc when the template file is absent).
- [x] Assert manifest-load and spec template lookup are present in composed orders prompt (three substring assertions added to the existing `smithy.orders command delegates GitHub ops to smithy.gh-issue scripts` block in `src/templates.test.ts`; content-based, no line numbers or pasted snippets).

## Specification Debt context (no new debt opened by this slice)

The slice's implementation choices for the two open SD entries it touches:

- **SD-001** (Phase 1 placement vs new phase between Phase 2 and Phase 3) — chose Phase 1, alongside `check-env.sh`, so the manifest-discovery halt is the natural fail-fast site and Phase 4 duplicate detection cannot run against a missing-manifest state.
- **SD-004** (parenthetical-variable-leak handling — in-place vs remove) — chose in-place preservation, because the spec's "Default Template Content" example for `spec.md` includes the `(equivalent to `smithy.cut {{spec_folder}} {{user_story_number}}`)` aside, and global substitution of every known placeholder makes the parenthetical work without rewriting it.

SD-002, SD-003, and SD-005 remain open — they are owned by Slices 2 and 3 (parser extension and test-coverage debt) and are out of scope here.

## Review

The implementation-review agent returned **no Critical or Important findings**. Two Minor / Low-confidence observations for reviewer awareness only (per the standard severity × confidence triage, Minor findings are noted in the PR body and not auto-applied):

- **Wording-style variation**: the new Phase 1 halt for mismatched `deployLocation` uses the verb _"refusing to proceed"_ where `src/commands/update.ts` uses _"refusing to update"_. The acceptance criterion required "matching the wording style", and the verb swap is intentional — `orders` is not "updating" anything — but a side-by-side reader of the two strings will notice.
- **Contracts-doc circular phrasing**: the Template Resolution Contract in `smithy-orders-issue-templates.contracts.md` step 1 describes a logically-circular flow ("load the manifest and read its `deployLocation` field, then call `resolveManifestDir(deployLocation)`") that the slice intentionally works around with the probe-then-validate algorithm Task 1 ships. The implementation is correct; the contracts document is the thing that drifts. Worth tightening in a future spec-maintenance pass but not blocking this slice.

## Documentation

Smithy-maid scanned the diff. Two notes for the reviewer (none auto-applied because they are pre-existing drift outside this slice's scope):

- **`CLAUDE.md` `smithy.orders` description is stale**: the project CLAUDE.md still says `smithy.orders — Show available Smithy commands and their usage`. That predates this slice (and is wrong even before this PR), but this PR makes it further from reality. Worth a follow-up chore commit to read something like "Create GitHub tickets from any smithy artifact file; reads body templates from `<manifestDir>/templates/orders/` when available." Out of scope for this PR.
- **`src/manifest.ts:32-37` citations in spec/contracts/data-model files** point at the JSDoc comment range; the function body is at `38-43`. Both are defensible; the prompt added in Task 1 cites `38-43`. The inconsistency is pre-existing in the spec artifacts and not introduced by this slice — better resolved in a spec-maintenance pass alongside the SD-002 / SD-005 cleanup than mixed into this implementation PR.

Maid also incorrectly flagged a "syntax error" at lines 510 / 516 of `src/templates.test.ts` (claimed `/` rather than `//`); verified — comments are correct `//` on both lines, tests pass.

## Validation

| Command | Result |
|---|---|
| `npm run build` | PASS — ESM bundle `dist/cli.js` 131.95 KB |
| `npm run typecheck` | PASS — clean |
| `npm test` | PASS — 786 / 786 tests across 24 files |

Run against the post-review HEAD (no review or maid auto-fixes were applied).
