### PR TITLE
fix(permissions): migrate own settings.json to post-#302/#304 canonical

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,6 +61,8 @@
       "Bash(git push origin chore/*)",
       "Bash(git push origin strike/*)",
       "Bash(git push origin claude/*)",
+      "Bash(git push --force-with-lease)",
+      "Bash(git push --force-with-lease origin *)",
       "Bash(ls *)",
       "Bash(ls -l *)",
       "Bash(ls -la *)",
@@ -228,10 +230,7 @@
       "Write(/tmp/**)",
       "Skill(smithy.*:*)"
     ],
-    "ask": [
-      "Bash(git push --force-with-lease)",
-      "Bash(git push --force-with-lease *)"
-    ],
+    "ask": [],
     "deny": [
       "Bash(git branch -d *)",
       "Bash(git branch -D *)",
@@ -252,6 +251,14 @@
       "Bash(git push --force *)",
       "Bash(git push -f)",
       "Bash(git push -f *)",
+      "Bash(git push --force-with-lease --force)",
+      "Bash(git push --force-with-lease --force *)",
+      "Bash(git push --force-with-lease -f)",
+      "Bash(git push --force-with-lease -f *)",
+      "Bash(git push --force-with-lease origin --force)",
+      "Bash(git push --force-with-lease origin --force *)",
+      "Bash(git push --force-with-lease origin -f)",
+      "Bash(git push --force-with-lease origin -f *)",
       "Bash(npm publish)",
       "Bash(npm publish *)"
     ]


### PR DESCRIPTION
## Summary

SmithyCli's own `.claude/settings.json` was the pre-#302 legacy state: `--force-with-lease` was still in the `ask` list rather than `allow`, and the defense-in-depth combinator denies added in #304 were missing. Drift went unnoticed because the manifest sets `"permissions": false` (the repo has narrow per-prefix git push patterns smithy doesn't model), so `smithy update --reset-permissions` is a no-op here.

Eats the dog food: brings SmithyCli's own settings to the canonical state defined in [`src/permissions.ts`](./src/permissions.ts).

## What changes

**Move `--force-with-lease` from `ask` to `allow`** (per #302 — the lease check is the safety boundary; user confirmation isn't):

```diff
- "ask": [
-   "Bash(git push --force-with-lease)",
-   "Bash(git push --force-with-lease *)"
- ],
+ "ask": [],
```

**Drop `Bash(git push --force-with-lease *)`** entirely. The trailing-`*` form would also match `--force-with-lease --force origin <branch>`, which defeats the lease. See the regression guard in `src/permissions.test.ts:146-149` and the rationale comment in `src/permissions.ts:83-92`.

**Add the one safe wildcarded target form to `allow`**:

```diff
+ "Bash(git push --force-with-lease)",
+ "Bash(git push --force-with-lease origin *)",
```

**Add the eight combinator denies to `deny`** (per #304 — defense-in-depth against `--force-with-lease` being weaponized via a `--force` follow-up):

```diff
+ "Bash(git push --force-with-lease --force)",
+ "Bash(git push --force-with-lease --force *)",
+ "Bash(git push --force-with-lease -f)",
+ "Bash(git push --force-with-lease -f *)",
+ "Bash(git push --force-with-lease origin --force)",
+ "Bash(git push --force-with-lease origin --force *)",
+ "Bash(git push --force-with-lease origin -f)",
+ "Bash(git push --force-with-lease origin -f *)",
```

## What's not touched

- The narrow per-prefix git push allows (`feature/*`, `fix/*`, `chore/*`, `strike/*`, `claude/*`) — these are the repo-specific customization that justified `"permissions": false` in the manifest.
- The manifest itself (`"permissions": false` stays). Flipping to `true` would let `smithy update --reset-permissions` manage SmithyCli's settings, but it would also drop those narrow per-prefix patterns. That's a separate call.

## Companion PRs (same upstream root cause)

- March: https://github.com/Balexda/March/pull/107 — manual edit (manifest is `"permissions": false`).
- GateCLI: https://github.com/Balexda/GateCLI/pull/44 — generated by `smithy update --reset-permissions --yes` (manifest is `"permissions": true`).

## Test plan

- [x] `npm test src/permissions.test.ts src/drift.test.ts` — 58/58 pass.
- [x] `jq . .claude/settings.json` parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)