### PR TITLE
Provision orders body templates during init

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Smithy CLI
 
-Smithy is a CLI tool that bootstraps AI-assisted development workflows across multiple agentic coding CLIs (Claude Code, Gemini CLI, Codex). It installs prompt templates, slash commands, permissions, and issue templates into a target repository so developers can invoke structured workflows like `/smithy.strike` directly from their AI assistant.
+Smithy is a CLI tool that bootstraps AI-assisted development workflows across multiple agentic coding CLIs (Claude Code, Gemini CLI, Codex). It installs prompt templates, slash commands, permissions, and orders body templates into a target repository so developers can invoke structured workflows like `/smithy.strike` directly from their AI assistant.
 
 ## What Smithy Does
 
@@ -24,7 +24,7 @@ Smithy is a CLI tool that bootstraps AI-assisted development workflows across mu
 - **Agent deployers**: `src/agents/{claude,gemini}.ts` — per-agent deploy/remove logic. (`codex.ts` exists but is not exposed in the CLI yet.)
 - **Templates**: `src/templates/agent-skills/{commands,prompts,agents}/*.prompt` — categorized by deployment target. Uses [Dotprompt](https://firebase.google.com/docs/genkit/dotprompt)'s native `.prompt` extension with YAML frontmatter (`name`, `description`). Dotprompt handles Handlebars rendering at deploy time — resolving partials (`{{>snippet-name}}`), conditionals (`{{#ifAgent}}...{{/ifAgent}}`), and other expressions. Frontmatter is stripped when deploying to Claude (kept for Gemini skills). Deployed files are translated to `.md`. See `src/templates/agent-skills/README.md` for full conventions.
 - **Snippets**: `src/templates/agent-skills/snippets/*.md` — shared Markdown fragments injected via `{{>partial-name}}` Handlebars partials. Resolved by Dotprompt at deploy time; not deployed as standalone files.
-- **Issue templates**: `src/templates/issues/` — GitHub issue templates, copied as-is.
+- **Orders body templates**: `src/orders-templates.ts` — exports the four canonical default body strings (`rfc` / `features` / `spec` / `tasks`) plus the `provisionOrdersTemplates` function that `smithy init` calls to write them under `<manifestDir>/templates/orders/<type>.md`. The same defaults double as the built-in fallback bodies in `smithy.orders` (parity asserted in `src/templates.test.ts`).
 - **Manifest**: `src/manifest.ts` — tracks deployed files in `.smithy/smithy-manifest.json` for reliable cleanup and upgrades.
 - **Build**: `tsup` bundles to `dist/cli.js` (ESM). Run `npm run build` to compile.
 

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/01-provision-orders-templates-during-init.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/01-provision-orders-templates-during-init.tasks.md
@@ -120,7 +120,7 @@
   - Assertions describe observable filesystem state, not internal prompt mechanics.
   - `npm test` passes on Linux; cross-platform behavior (Windows `USERPROFILE`) is documented in the test or marked as out of scope.
 
-- [ ] **Refresh `CLAUDE.md` to reflect the new template family**
+- [x] **Refresh `CLAUDE.md` to reflect the new template family**
 
   Update the project preamble in `CLAUDE.md` so the line referencing `src/templates/issues/` and the prose describing smithy as installing "issue templates" describe the new `<manifestDir>/templates/orders/` provisioning instead. This belongs in Slice 2 because the doc accurately describes the codebase only once both removal (Slice 1) and addition (Slice 2 prior tasks) have landed.
 

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/01-provision-orders-templates-during-init.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/01-provision-orders-templates-during-init.tasks.md
@@ -99,7 +99,7 @@
   - The prompt fires at most once per init invocation regardless of how many of the four files pre-exist.
   - Behavior matches AS 4 (decline → existing preserved, missing still written) and AS 5 (accept → only the four canonical files replaced).
 
-- [ ] **Wire orders-template provisioning into `initAction`**
+- [x] **Wire orders-template provisioning into `initAction`**
 
   After permission setup, language-toolchain selection, and the session-title decision (where the legacy `deployIssueTemplates` block previously sat), call into the new module to detect pre-existing files, prompt only when needed, and write defaults. Provisioning must run before the manifest-write step and must not alter the manifest file. Surface a brief console message reporting how many templates were written and how many were preserved, matching the existing init step's UX style (see SD-002 for the rationale).
 

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/01-provision-orders-templates-during-init.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/01-provision-orders-templates-during-init.tasks.md
@@ -78,7 +78,7 @@
 
 ### Tasks
 
-- [ ] **Add `src/orders-templates.ts` with default bodies and a provisioner**
+- [x] **Add `src/orders-templates.ts` with default bodies and a provisioner**
 
   Create one flat module under `src/` (matching the repo's existing `permissions.ts` / `language-detect.ts` / `manifest.ts` convention) that exports the four default body strings keyed by artifact type (`rfc`, `features`, `spec`, `tasks`) with content matching the spec's Default Template Content section verbatim, plus a `provisionOrdersTemplates` function that ensures `<manifestDir>/templates/orders/` exists and writes any missing defaults. Centralizing both in one module lets US4's built-in fallback import the same defaults later without a follow-up extraction. Resolve `<manifestDir>` through the existing manifest-directory helper in `src/manifest.ts` so deploy-location semantics match the rest of init.
 

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/01-provision-orders-templates-during-init.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/01-provision-orders-templates-during-init.tasks.md
@@ -110,7 +110,7 @@
   - With overwrite accepted, only the four canonical `<type>.md` files are replaced; non-canonical extras under `templates/orders/` and any peer `templates/<family>/` subtrees are untouched (AS 5).
   - A console line reports the written/preserved counts on each init run.
 
-- [ ] **Add CLI integration tests for unconditional provisioning**
+- [x] **Add CLI integration tests for unconditional provisioning**
 
   Extend `src/cli.test.ts` with cases that run `init` against a fresh temp directory and assert the four files exist with default content, that the manifest is byte-identical before and after re-running provisioning under "decline overwrite", and that overwrite preserves non-canonical neighbors. The `--location user` case must isolate the user's real `~/.smithy/` from the test — the isolation mechanism is left to implementation; see SD-001 for the open portability question.
 

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/01-provision-orders-templates-during-init.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/01-provision-orders-templates-during-init.tasks.md
@@ -89,7 +89,7 @@
   - The function never opens, reads, writes, truncates, or stats `<manifestDir>/smithy-manifest.json` or any non-`<type>.md` sibling under `<manifestDir>` (satisfies AS 3 and AS 5).
   - File presence (not content) is the override signal — empty existing files count as "exists" for overwrite gating, per the spec's Edge Cases section ("A template file exists but is empty" bullet).
 
-- [ ] **Add an overwrite prompt for existing orders templates**
+- [x] **Add an overwrite prompt for existing orders templates**
 
   Add a new prompt to `src/interactive.ts` that asks once whether to overwrite existing orders templates at `<manifestDir>/templates/orders/`, defaulting to `no`, with phrasing aligned to the Init Template Provisioning Contract's step 4 message. The prompt is invoked only when at least one of the four canonical files already exists; missing templates are always written without asking.
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { ORDERS_DEFAULT_TEMPLATES } from './orders-templates.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../package.json') as { version: string };
@@ -148,6 +149,22 @@ describe('CLI init --yes (non-interactive)', () => {
     });
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'prompts'))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(true);
+  });
+
+  it('init --yes provisions the four orders templates and emits a counts line', () => {
+    const output = execFileSync('node', [CLI, 'init', '-a', 'claude', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+
+    const ordersDir = path.join(tmpDir, '.smithy', 'templates', 'orders');
+    for (const type of ['rfc', 'features', 'spec', 'tasks'] as const) {
+      const dest = path.join(ordersDir, `${type}.md`);
+      expect(fs.existsSync(dest)).toBe(true);
+      expect(fs.readFileSync(dest, 'utf8')).toBe(ORDERS_DEFAULT_TEMPLATES[type]);
+    }
+
+    expect(output).toContain('Orders templates: 4 templates written, 0 preserved');
   });
 
 });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -613,6 +613,206 @@ describe('CLI init lifecycle and idempotency', () => {
   });
 });
 
+describe('CLI init orders-template provisioning', () => {
+  // Covers User Story 1 acceptance scenarios AS 1–5 from
+  // specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.spec.md.
+  //
+  // AS 1 (fresh --location repo writes the four canonical files) is already
+  // covered by the wiring test
+  //   'init --yes provisions the four orders templates and emits a counts line'
+  // in describe('CLI init --yes (non-interactive)') above. The cases below
+  // lock in AS 2 through AS 5 with durable filesystem-state assertions.
+  //
+  // AS 5 (overwrite accepted replaces only the four canonical files) is
+  // exercised here via a direct call to provisionOrdersTemplates({ overwrite: true })
+  // because the CLI's non-interactive (-y) path always declines the overwrite
+  // prompt (preserves user edits under automation, per FR-003). The function
+  // is the same code path init invokes when the user answers "yes" to the
+  // overwrite prompt, so the assertion is faithful to the contract. The
+  // function-level overwrite=true / overwrite=false paths are additionally
+  // covered by unit tests in src/orders-templates.test.ts.
+
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-orders-cli-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('AS 2: --location user writes templates under stubbed HOME and leaves the repo .smithy/ untouched', () => {
+    // Two isolated tmp dirs: one for the target repo (cwd) and one to stand
+    // in for the user's home directory.
+    //
+    // Overrides HOME (POSIX) and USERPROFILE (Windows) so os.homedir() — and
+    // therefore resolveManifestDir(_, 'user') in src/manifest.ts — resolves
+    // to tmpHome on both platforms. On Linux/macOS this is sufficient because
+    // Node honors HOME unconditionally; on Windows USERPROFILE is the primary
+    // source. Cross-platform CI on Windows is out of scope for this test
+    // suite, but the env override is set defensively so the test would still
+    // isolate correctly there.
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-orders-home-'));
+    try {
+      execFileSync('node', [CLI, 'init', '-a', 'claude', '-l', 'user', '-y'], {
+        encoding: 'utf-8',
+        cwd: tmpDir,
+        env: { ...process.env, HOME: tmpHome, USERPROFILE: tmpHome },
+      });
+
+      // All four canonical files exist under the stubbed home with default
+      // content, never under the target repo.
+      const homeOrdersDir = path.join(tmpHome, '.smithy', 'templates', 'orders');
+      for (const type of ['rfc', 'features', 'spec', 'tasks'] as const) {
+        const dest = path.join(homeOrdersDir, `${type}.md`);
+        expect(fs.existsSync(dest)).toBe(true);
+        expect(fs.readFileSync(dest, 'utf8')).toBe(ORDERS_DEFAULT_TEMPLATES[type]);
+      }
+
+      // Provisioning must not create the target repo's own .smithy/. With
+      // --location user, the manifest also lands under tmpHome/.smithy/, so
+      // the repo dir should have nothing under .smithy/.
+      expect(fs.existsSync(path.join(tmpDir, '.smithy'))).toBe(false);
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it('AS 3: provisioning does not modify the manifest across re-runs', () => {
+    // First init writes the manifest and the four templates.
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+    const manifestPath = path.join(tmpDir, '.smithy', 'smithy-manifest.json');
+    expect(fs.existsSync(manifestPath)).toBe(true);
+    const firstManifest = fs.readFileSync(manifestPath, 'utf8');
+
+    // Second init re-runs provisioning under decline-overwrite (-y always
+    // declines per FR-003). The manifest must be byte-identical: provisioning
+    // never touches it (the spec assertion), and re-running init with the
+    // same flags should regenerate an identical manifest since nothing else
+    // changed.
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+    const secondManifest = fs.readFileSync(manifestPath, 'utf8');
+    expect(secondManifest).toBe(firstManifest);
+  });
+
+  it('AS 4: re-init with overwrite declined preserves user edits and still writes missing templates', () => {
+    // First init creates the canonical four with default content.
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+    const ordersDir = path.join(tmpDir, '.smithy', 'templates', 'orders');
+    const specPath = path.join(ordersDir, 'spec.md');
+
+    // User edits one template by hand.
+    const customSpec = 'CUSTOM USER SPEC';
+    fs.writeFileSync(specPath, customSpec);
+
+    // Re-running init with -y declines the overwrite prompt: the edited
+    // spec.md is preserved verbatim, and the other three remain the
+    // unchanged defaults.
+    const rerunOutput = execFileSync('node', [CLI, 'init', '-a', 'claude', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+
+    expect(fs.readFileSync(specPath, 'utf8')).toBe(customSpec);
+    for (const type of ['rfc', 'features', 'tasks'] as const) {
+      const dest = path.join(ordersDir, `${type}.md`);
+      expect(fs.readFileSync(dest, 'utf8')).toBe(ORDERS_DEFAULT_TEMPLATES[type]);
+    }
+
+    // The user-visible counts line reflects the decline: nothing written,
+    // all four preserved.
+    expect(rerunOutput).toContain('Orders templates: 0 templates written, 4 preserved');
+  });
+
+  it('AS 4: missing canonical templates are written even when one pre-exists outside init', () => {
+    // Pre-create only spec.md without ever running init. The other three
+    // canonical files do not exist yet.
+    const ordersDir = path.join(tmpDir, '.smithy', 'templates', 'orders');
+    fs.mkdirSync(ordersDir, { recursive: true });
+    const specPath = path.join(ordersDir, 'spec.md');
+    const customSpec = 'PRE-EXISTING SPEC';
+    fs.writeFileSync(specPath, customSpec);
+
+    // Init under -y: overwrite is declined, but the three missing canonical
+    // files are still written with defaults (FR-003).
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+
+    expect(fs.readFileSync(specPath, 'utf8')).toBe(customSpec);
+    for (const type of ['rfc', 'features', 'tasks'] as const) {
+      const dest = path.join(ordersDir, `${type}.md`);
+      expect(fs.existsSync(dest)).toBe(true);
+      expect(fs.readFileSync(dest, 'utf8')).toBe(ORDERS_DEFAULT_TEMPLATES[type]);
+    }
+  });
+
+  it('AS 5: overwrite accepted replaces only canonical <type>.md files; manifest, peer families, and user extras are preserved', async () => {
+    // The CLI's non-interactive (-y) path always declines the prompt to
+    // preserve user content under automation (FR-003). To exercise the
+    // overwrite=true branch — which is what AS 5 specifies — we invoke
+    // provisionOrdersTemplates directly. See src/orders-templates.test.ts
+    // for the function-level unit coverage that mirrors this.
+    const { provisionOrdersTemplates } = await import('./orders-templates.js');
+
+    const manifestDir = path.join(tmpDir, '.smithy');
+    const ordersDir = path.join(manifestDir, 'templates', 'orders');
+    const artifactsDir = path.join(manifestDir, 'templates', 'artifacts');
+    fs.mkdirSync(ordersDir, { recursive: true });
+    fs.mkdirSync(artifactsDir, { recursive: true });
+
+    // Seed a manifest file, a user extra alongside the canonical files, a
+    // peer-family file under a sibling templates/<family>/ subtree, and a
+    // customized canonical spec.md. AS 5 requires that all of these be
+    // preserved EXCEPT the four canonical <type>.md files.
+    const manifestPath = path.join(manifestDir, 'smithy-manifest.json');
+    const manifestSentinel = '{"sentinel":true}';
+    fs.writeFileSync(manifestPath, manifestSentinel);
+
+    const readmePath = path.join(ordersDir, 'README.md');
+    const readmeBody = 'user README — not a canonical template';
+    fs.writeFileSync(readmePath, readmeBody);
+
+    const peerPath = path.join(artifactsDir, 'foo.md');
+    const peerBody = 'peer family file — orders provisioning must not touch this';
+    fs.writeFileSync(peerPath, peerBody);
+
+    const customSpec = 'CUSTOM SPEC — about to be overwritten';
+    fs.writeFileSync(path.join(ordersDir, 'spec.md'), customSpec);
+
+    const result = provisionOrdersTemplates({
+      targetDir: tmpDir,
+      location: 'repo',
+      overwrite: true,
+    });
+
+    // All four canonical files now hold the defaults.
+    for (const type of ['rfc', 'features', 'spec', 'tasks'] as const) {
+      const dest = path.join(ordersDir, `${type}.md`);
+      expect(fs.readFileSync(dest, 'utf8')).toBe(ORDERS_DEFAULT_TEMPLATES[type]);
+    }
+    expect(result.templatesWritten).toHaveLength(4);
+    expect(result.templatesPreserved).toHaveLength(0);
+
+    // The manifest, the user extra under templates/orders/, and the
+    // peer-family file are untouched.
+    expect(fs.readFileSync(manifestPath, 'utf8')).toBe(manifestSentinel);
+    expect(fs.readFileSync(readmePath, 'utf8')).toBe(readmeBody);
+    expect(fs.readFileSync(peerPath, 'utf8')).toBe(peerBody);
+  });
+});
+
 describe('CLI status', () => {
   let tmpDir: string;
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -12,7 +12,6 @@ import { detectLanguages } from '../language-detect.js';
 import { detectPlatforms } from '../platform-detect.js';
 import type { LanguageToolchain, PlatformPackageManager } from '../permissions.js';
 import {
-  copyDirSync,
   agentGitignoreEntries,
   addToGitignore,
 } from '../utils.js';

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,8 +1,10 @@
+import fs from 'fs';
 import path from 'path';
 import picocolors from 'picocolors';
 import {
   promptAgent,
   promptDeployLocation,
+  promptOverwriteOrdersTemplates,
   promptPermissions,
   promptToolchains,
 } from '../interactive.js';
@@ -14,7 +16,8 @@ import {
   agentGitignoreEntries,
   addToGitignore,
 } from '../utils.js';
-import { readManifest, removeStaleFiles, writeManifest } from '../manifest.js';
+import { readManifest, removeStaleFiles, resolveManifestDir, writeManifest } from '../manifest.js';
+import { provisionOrdersTemplates } from '../orders-templates.js';
 import * as gemini from '../agents/gemini.js';
 import * as claude from '../agents/claude.js';
 import * as codex from '../agents/codex.js';
@@ -106,6 +109,38 @@ export async function initAction(opts: InitOptions = {}): Promise<void> {
 
   // 5b. Session-title hook (Claude only). Default on; opt out via --no-session-titles.
   const deploySessionTitles = opts.sessionTitles ?? true;
+
+  // 5d. Orders templates — write canonical default bodies to
+  // <manifestDir>/templates/orders/. Provisioning runs BEFORE the manifest-write
+  // step and never reads or alters smithy-manifest.json. The four canonical
+  // <type>.md files are user content, not manifest-tracked artifacts (FR-009),
+  // so they are not added to deployedFiles.
+  const ordersManifestDir = resolveManifestDir(targetDir, deployLocation);
+  const ordersDir = path.join(ordersManifestDir, 'templates', 'orders');
+  const canonicalOrdersTypes = ['rfc', 'features', 'spec', 'tasks'] as const;
+  const existingOrdersTypes = canonicalOrdersTypes.filter(t =>
+    fs.existsSync(path.join(ordersDir, `${t}.md`)),
+  );
+  let overwriteOrders = false;
+  if (existingOrdersTypes.length > 0) {
+    if (opts.yes === true) {
+      overwriteOrders = false;
+    } else {
+      overwriteOrders = await promptOverwriteOrdersTemplates(ordersManifestDir);
+    }
+  }
+  const ordersResult = provisionOrdersTemplates({
+    targetDir,
+    location: deployLocation,
+    overwrite: overwriteOrders,
+  });
+  {
+    const w = ordersResult.templatesWritten.length;
+    const p = ordersResult.templatesPreserved.length;
+    const writtenPart = `${w} template${w === 1 ? '' : 's'} written`;
+    const preservedPart = `${p} preserved`;
+    console.log(picocolors.dim(`  Orders templates: ${writtenPart}, ${preservedPart}`));
+  }
 
   // --- Step 1: Check manifest (read old state for stale file cleanup) ---
   const oldManifest = readManifest(targetDir, deployLocation);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -16,7 +16,7 @@ import {
   addToGitignore,
 } from '../utils.js';
 import { readManifest, removeStaleFiles, resolveManifestDir, writeManifest } from '../manifest.js';
-import { provisionOrdersTemplates } from '../orders-templates.js';
+import { ORDERS_TEMPLATE_TYPES, provisionOrdersTemplates } from '../orders-templates.js';
 import * as gemini from '../agents/gemini.js';
 import * as claude from '../agents/claude.js';
 import * as codex from '../agents/codex.js';
@@ -116,8 +116,7 @@ export async function initAction(opts: InitOptions = {}): Promise<void> {
   // so they are not added to deployedFiles.
   const ordersManifestDir = resolveManifestDir(targetDir, deployLocation);
   const ordersDir = path.join(ordersManifestDir, 'templates', 'orders');
-  const canonicalOrdersTypes = ['rfc', 'features', 'spec', 'tasks'] as const;
-  const existingOrdersTypes = canonicalOrdersTypes.filter(t =>
+  const existingOrdersTypes = ORDERS_TEMPLATE_TYPES.filter(t =>
     fs.existsSync(path.join(ordersDir, `${t}.md`)),
   );
   let overwriteOrders = false;

--- a/src/interactive.test.ts
+++ b/src/interactive.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { confirmMock } = vi.hoisted(() => ({ confirmMock: vi.fn() }));
+
+vi.mock('@inquirer/prompts', () => ({
+  confirm: confirmMock,
+  select: vi.fn(),
+  checkbox: vi.fn(),
+}));
+
+import { promptOverwriteOrdersTemplates } from './interactive.js';
+
+describe('promptOverwriteOrdersTemplates', () => {
+  beforeEach(() => {
+    confirmMock.mockReset();
+  });
+
+  it('asks once with default false and a manifest-dir-aware message, returning the user answer', async () => {
+    confirmMock.mockResolvedValueOnce(true);
+
+    const result = await promptOverwriteOrdersTemplates('/tmp/.smithy');
+
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(confirmMock).toHaveBeenCalledWith({
+      message: 'Overwrite existing orders templates at /tmp/.smithy/templates/orders/?',
+      default: false,
+    });
+    expect(result).toBe(true);
+  });
+
+  it('returns whatever the underlying confirm yields (e.g. false when user declines)', async () => {
+    confirmMock.mockResolvedValueOnce(false);
+
+    const result = await promptOverwriteOrdersTemplates('/home/alice/.smithy');
+
+    expect(result).toBe(false);
+    expect(confirmMock).toHaveBeenCalledWith({
+      message: 'Overwrite existing orders templates at /home/alice/.smithy/templates/orders/?',
+      default: false,
+    });
+  });
+});

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -150,3 +150,10 @@ export async function promptConfirmResetPermissions(location: DeployLocation): P
     default: false,
   });
 }
+
+export async function promptOverwriteOrdersTemplates(manifestDir: string): Promise<boolean> {
+  return await confirm({
+    message: `Overwrite existing orders templates at ${manifestDir}/templates/orders/?`,
+    default: false,
+  });
+}

--- a/src/orders-templates.test.ts
+++ b/src/orders-templates.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  ORDERS_DEFAULT_TEMPLATES,
+  provisionOrdersTemplates,
+} from './orders-templates.js';
+
+const ORDERS_TYPES = ['rfc', 'features', 'spec', 'tasks'] as const;
+
+describe('provisionOrdersTemplates', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-orders-tpl-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('provisions all four files into a fresh repo with default content', () => {
+    const result = provisionOrdersTemplates({ targetDir: tmpDir, location: 'repo' });
+
+    const ordersDir = path.join(tmpDir, '.smithy', 'templates', 'orders');
+    for (const type of ORDERS_TYPES) {
+      const file = path.join(ordersDir, `${type}.md`);
+      expect(fs.existsSync(file)).toBe(true);
+      expect(fs.readFileSync(file, 'utf8')).toBe(ORDERS_DEFAULT_TEMPLATES[type]);
+      expect(result.templatesWritten).toContain(file);
+    }
+    expect(result.templatesWritten).toHaveLength(4);
+    expect(result.templatesPreserved).toEqual([]);
+  });
+
+  it('creates intermediate templates/ and orders/ directories when absent', () => {
+    expect(fs.existsSync(path.join(tmpDir, '.smithy'))).toBe(false);
+
+    provisionOrdersTemplates({ targetDir: tmpDir, location: 'repo' });
+
+    expect(fs.statSync(path.join(tmpDir, '.smithy')).isDirectory()).toBe(true);
+    expect(fs.statSync(path.join(tmpDir, '.smithy', 'templates')).isDirectory()).toBe(true);
+    expect(
+      fs.statSync(path.join(tmpDir, '.smithy', 'templates', 'orders')).isDirectory(),
+    ).toBe(true);
+  });
+
+  it('preserves existing files when overwrite is false (default)', () => {
+    const ordersDir = path.join(tmpDir, '.smithy', 'templates', 'orders');
+    fs.mkdirSync(ordersDir, { recursive: true });
+    const customSpec = 'custom user spec';
+    const specPath = path.join(ordersDir, 'spec.md');
+    fs.writeFileSync(specPath, customSpec);
+
+    const result = provisionOrdersTemplates({ targetDir: tmpDir, location: 'repo' });
+
+    expect(fs.readFileSync(specPath, 'utf8')).toBe(customSpec);
+    expect(result.templatesPreserved).toEqual([specPath]);
+
+    for (const type of ORDERS_TYPES) {
+      if (type === 'spec') continue;
+      const file = path.join(ordersDir, `${type}.md`);
+      expect(fs.existsSync(file)).toBe(true);
+      expect(fs.readFileSync(file, 'utf8')).toBe(ORDERS_DEFAULT_TEMPLATES[type]);
+      expect(result.templatesWritten).toContain(file);
+    }
+    expect(result.templatesWritten).toHaveLength(3);
+    expect(result.templatesWritten).not.toContain(specPath);
+  });
+
+  it('treats empty existing files as present and preserves them (presence is the signal)', () => {
+    const ordersDir = path.join(tmpDir, '.smithy', 'templates', 'orders');
+    fs.mkdirSync(ordersDir, { recursive: true });
+    const tasksPath = path.join(ordersDir, 'tasks.md');
+    fs.writeFileSync(tasksPath, '');
+
+    const result = provisionOrdersTemplates({
+      targetDir: tmpDir,
+      location: 'repo',
+      overwrite: false,
+    });
+
+    expect(fs.statSync(tasksPath).size).toBe(0);
+    expect(result.templatesPreserved).toEqual([tasksPath]);
+    expect(result.templatesWritten).not.toContain(tasksPath);
+  });
+
+  it('overwrite=true replaces only the four canonical files (extras untouched)', () => {
+    const ordersDir = path.join(tmpDir, '.smithy', 'templates', 'orders');
+    fs.mkdirSync(ordersDir, { recursive: true });
+    const specPath = path.join(ordersDir, 'spec.md');
+    const readmePath = path.join(ordersDir, 'README.md');
+    fs.writeFileSync(specPath, 'custom user spec');
+    fs.writeFileSync(readmePath, 'custom readme content');
+
+    const result = provisionOrdersTemplates({
+      targetDir: tmpDir,
+      location: 'repo',
+      overwrite: true,
+    });
+
+    expect(fs.readFileSync(specPath, 'utf8')).toBe(ORDERS_DEFAULT_TEMPLATES.spec);
+    expect(fs.readFileSync(readmePath, 'utf8')).toBe('custom readme content');
+
+    for (const type of ORDERS_TYPES) {
+      const file = path.join(ordersDir, `${type}.md`);
+      expect(result.templatesWritten).toContain(file);
+    }
+    expect(result.templatesWritten).toHaveLength(4);
+    expect(result.templatesWritten).not.toContain(readmePath);
+    expect(result.templatesPreserved).toEqual([]);
+  });
+
+  it('never touches the manifest file or non-orders siblings under <manifestDir>', () => {
+    const manifestDir = path.join(tmpDir, '.smithy');
+    fs.mkdirSync(manifestDir, { recursive: true });
+    const manifestPath = path.join(manifestDir, 'smithy-manifest.json');
+    const manifestContent = '{"sentinel":true}';
+    fs.writeFileSync(manifestPath, manifestContent);
+
+    // A peer template family that should also be left alone.
+    const peerDir = path.join(manifestDir, 'templates', 'artifacts');
+    fs.mkdirSync(peerDir, { recursive: true });
+    const peerFile = path.join(peerDir, 'note.md');
+    const peerContent = 'untouched peer template';
+    fs.writeFileSync(peerFile, peerContent);
+
+    const beforeManifestStat = fs.statSync(manifestPath);
+    const beforePeerStat = fs.statSync(peerFile);
+
+    provisionOrdersTemplates({ targetDir: tmpDir, location: 'repo' });
+
+    expect(fs.readFileSync(manifestPath, 'utf8')).toBe(manifestContent);
+    expect(fs.statSync(manifestPath).size).toBe(beforeManifestStat.size);
+
+    expect(fs.readFileSync(peerFile, 'utf8')).toBe(peerContent);
+    expect(fs.statSync(peerFile).size).toBe(beforePeerStat.size);
+
+    // Sanity: only the four canonical files exist under templates/orders/.
+    const ordersDir = path.join(manifestDir, 'templates', 'orders');
+    const entries = fs.readdirSync(ordersDir).sort();
+    expect(entries).toEqual(['features.md', 'rfc.md', 'spec.md', 'tasks.md']);
+  });
+
+  it('writes under a stubbed HOME when location is "user"', () => {
+    const stubbedHome = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-stub-home-'));
+    const repoTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-repo-'));
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    process.env.HOME = stubbedHome;
+    process.env.USERPROFILE = stubbedHome;
+
+    try {
+      const result = provisionOrdersTemplates({ targetDir: repoTmp, location: 'user' });
+
+      const userOrdersDir = path.join(stubbedHome, '.smithy', 'templates', 'orders');
+      for (const type of ORDERS_TYPES) {
+        const file = path.join(userOrdersDir, `${type}.md`);
+        expect(fs.existsSync(file)).toBe(true);
+        expect(fs.readFileSync(file, 'utf8')).toBe(ORDERS_DEFAULT_TEMPLATES[type]);
+        expect(result.templatesWritten).toContain(file);
+      }
+      // The repo's own .smithy/ must NOT be created by user-location provisioning.
+      expect(fs.existsSync(path.join(repoTmp, '.smithy'))).toBe(false);
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = originalUserProfile;
+      fs.rmSync(stubbedHome, { recursive: true, force: true });
+      fs.rmSync(repoTmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/orders-templates.ts
+++ b/src/orders-templates.ts
@@ -1,10 +1,12 @@
 /**
- * Canonical default body templates for `smithy.orders`.
+ * Canonical default body templates for `smithy.orders` and the init-time
+ * provisioner that writes them under `<manifestDir>/templates/orders/`.
  *
- * These four strings are the source of truth for the "Default Template
- * Content" promised by the smithy-orders-issue-templates spec. They are
- * NOT consumed by `smithy.orders` at runtime — the agent reads the
- * Phase 5 heredoc fallback bodies inline in
+ * The four `ORDERS_DEFAULT_TEMPLATES` strings below are the source of truth
+ * for the "Default Template Content" promised by the
+ * smithy-orders-issue-templates spec. They are NOT consumed by
+ * `smithy.orders` at runtime — the agent reads the Phase 5 heredoc fallback
+ * bodies inline in
  * `src/templates/agent-skills/commands/smithy.orders.prompt`. The
  * relationship is a build/test-time invariant, not a runtime import:
  *
@@ -14,17 +16,23 @@
  *     smithy.gh-issue scripts` test) verifies that every variable and
  *     hybrid section header appears in both surfaces, so the two cannot
  *     silently drift.
- *   - When US1 ships, `smithy init` will write these strings verbatim to
+ *   - `smithy init` writes these strings verbatim to
  *     `<manifestDir>/templates/orders/<type>.md` as the user's default
- *     templates. That provisioner (`provisionOrdersTemplates`) lives in
- *     US1 Slice 2 and is intentionally omitted from this module today —
- *     only the body string exports are needed to satisfy the parity
- *     assertion.
+ *     templates via `provisionOrdersTemplates` (defined below). The
+ *     provisioner only ever touches the four canonical `<type>.md` files
+ *     under `templates/orders/`; `smithy-manifest.json` and any other
+ *     sibling under `<manifestDir>` (including peer template families and
+ *     user extras like READMEs or backups) are left untouched.
  *
  * Placeholder syntax is `{{variable}}` per the spec. The authoritative
  * per-type variable namespace lives in the spec's
  * `smithy-orders-issue-templates.data-model.md` Template Variable table.
  */
+import fs from 'fs';
+import path from 'path';
+import type { DeployLocation } from './interactive.js';
+import { resolveManifestDir } from './manifest.js';
+
 export const ORDERS_DEFAULT_TEMPLATES: Readonly<
   Record<'rfc' | 'features' | 'spec' | 'tasks', string>
 > = {
@@ -103,3 +111,73 @@ Run \`{{next_step}}\` (equivalent to \`smithy.cut {{spec_folder}} {{user_story_n
 Run \`{{next_step}}\` to implement this slice as a PR.
 `,
 };
+
+/** Canonical template type identifiers, ordered for deterministic output. */
+const ORDERS_TEMPLATE_TYPES = ['rfc', 'features', 'spec', 'tasks'] as const;
+type OrdersTemplateType = (typeof ORDERS_TEMPLATE_TYPES)[number];
+
+export interface ProvisionOrdersTemplatesOptions {
+  /** Target directory whose `.smithy/` is used when `location === 'repo'`. */
+  targetDir: string;
+  /** Active deploy location — drives `<manifestDir>` resolution. */
+  location: DeployLocation;
+  /**
+   * When `true`, replace existing canonical `<type>.md` files with the
+   * default bodies. Defaults to `false`, which preserves any existing
+   * canonical file (presence — not content — is the override signal, so
+   * empty files count as "exists" too). Non-canonical siblings under
+   * `templates/orders/` are never written regardless of this flag.
+   */
+  overwrite?: boolean;
+}
+
+export interface ProvisionOrdersTemplatesResult {
+  /** Absolute paths of canonical template files written (created or overwritten). */
+  templatesWritten: string[];
+  /** Absolute paths of canonical template files that already existed and were preserved. */
+  templatesPreserved: string[];
+}
+
+/**
+ * Ensure `<manifestDir>/templates/orders/` exists and write default body
+ * templates for any of the four canonical types that are missing.
+ *
+ * Behavior:
+ *   - Resolves `<manifestDir>` via `resolveManifestDir(targetDir, location)`
+ *     so deploy-location semantics match the rest of init.
+ *   - Creates `<manifestDir>/templates/orders/` (and intermediate
+ *     `templates/`) when absent. The mkdir call never stats or modifies
+ *     `<manifestDir>/smithy-manifest.json` or any other sibling.
+ *   - For each canonical type (`rfc`, `features`, `spec`, `tasks`), writes
+ *     the default body if `<type>.md` does not exist; otherwise, when
+ *     `overwrite` is `true` writes the default, and when `overwrite` is
+ *     falsy (default) preserves the existing file untouched. Existing
+ *     files are never opened or read — only `existsSync` checks them.
+ *   - Returns the set of paths written and the set preserved, matching the
+ *     contract's `templates_written` / `templates_preserved` outputs.
+ */
+export function provisionOrdersTemplates(
+  opts: ProvisionOrdersTemplatesOptions,
+): ProvisionOrdersTemplatesResult {
+  const manifestDir = resolveManifestDir(opts.targetDir, opts.location);
+  const ordersDir = path.join(manifestDir, 'templates', 'orders');
+  if (!fs.existsSync(ordersDir)) {
+    fs.mkdirSync(ordersDir, { recursive: true });
+  }
+
+  const templatesWritten: string[] = [];
+  const templatesPreserved: string[] = [];
+
+  for (const type of ORDERS_TEMPLATE_TYPES) {
+    const dest = path.join(ordersDir, `${type}.md`);
+    const exists = fs.existsSync(dest);
+    if (!exists || opts.overwrite === true) {
+      fs.writeFileSync(dest, ORDERS_DEFAULT_TEMPLATES[type as OrdersTemplateType]);
+      templatesWritten.push(dest);
+    } else {
+      templatesPreserved.push(dest);
+    }
+  }
+
+  return { templatesWritten, templatesPreserved };
+}

--- a/src/orders-templates.ts
+++ b/src/orders-templates.ts
@@ -113,8 +113,8 @@ Run \`{{next_step}}\` to implement this slice as a PR.
 };
 
 /** Canonical template type identifiers, ordered for deterministic output. */
-const ORDERS_TEMPLATE_TYPES = ['rfc', 'features', 'spec', 'tasks'] as const;
-type OrdersTemplateType = (typeof ORDERS_TEMPLATE_TYPES)[number];
+export const ORDERS_TEMPLATE_TYPES = ['rfc', 'features', 'spec', 'tasks'] as const;
+export type OrdersTemplateType = (typeof ORDERS_TEMPLATE_TYPES)[number];
 
 export interface ProvisionOrdersTemplatesOptions {
   /** Target directory whose `.smithy/` is used when `location === 'repo'`. */


### PR DESCRIPTION
## Source

- Spec: [`smithy-orders-issue-templates.spec.md`](../tree/feature/smithy/forge/smithy-orders-us1-s2/specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.spec.md)
- Tasks file: [`01-provision-orders-templates-during-init.tasks.md`](../tree/feature/smithy/forge/smithy-orders-us1-s2/specs/2026-03-21-002-smithy-orders-issue-templates/01-provision-orders-templates-during-init.tasks.md)

## Slice

**Slice 2: Provision Orders Body Templates Unconditionally** (User Story 1)

After `smithy init`'s permission, session-title, and language-toolchain steps complete, write `<manifestDir>/templates/orders/{rfc,features,spec,tasks}.md` with the spec's default bodies, creating intermediate directories as needed and gating only existing files behind a single overwrite prompt. Provisioning never reads or alters `<manifestDir>/smithy-manifest.json` or any sibling outside `templates/orders/`.

## Addresses

- **FR-001** — `smithy init` provisions the four orders template files unconditionally after agent / deploy-location / permission setup.
- **FR-002** — Files written to `<manifestDir>/templates/orders/{rfc,features,spec,tasks}.md`; intermediate `templates/` and `templates/orders/` dirs created as needed.
- **FR-003** — Single overwrite prompt (default no) when one or more canonical files already exist; declining preserves existing files; missing files are still written.
- **FR-004** — Provisioning never reads, modifies, truncates, or deletes `<manifestDir>/smithy-manifest.json` or anything outside `templates/orders/<type>.md`.
- **US1 AS 1** — `--location repo` writes the four files alongside the manifest, manifest untouched by provisioning.
- **US1 AS 2** — `--location user` writes under `~/.smithy/`; the target repo's `.smithy/` is not created by provisioning.
- **US1 AS 3** — Pre-existing manifest is never read, modified, truncated, or rewritten by provisioning.
- **US1 AS 4** — Decline overwrite preserves existing canonical files; missing canonical files are still written.
- **US1 AS 5** — Accept overwrite replaces only the four canonical `<type>.md` files; manifest, peer `templates/<family>/` subtrees, and user extras under `templates/orders/` are preserved.

## Tasks completed

- [x] Add `provisionOrdersTemplates` to `src/orders-templates.ts` (with new `src/orders-templates.test.ts`, 7 cases)
- [x] Add `promptOverwriteOrdersTemplates` to `src/interactive.ts` (with new `src/interactive.test.ts`, mocked confirm)
- [x] Wire orders-template provisioning into `initAction` (after session-title decision, before manifest-write); emit dim `Orders templates: <N> templates written, <M> preserved` line; `-y` treats prompt as decline
- [x] Add CLI integration tests covering AS 1–5 in `src/cli.test.ts`
- [x] Refresh `CLAUDE.md`: opening paragraph and architecture bullet now describe the new `<manifestDir>/templates/orders/` flow instead of the deleted `src/templates/issues/`

## Review

`smithy-implementation-review` returned **0 Critical, 0 Important, 1 Minor**. Per the slice protocol, Minor findings are noted in the PR body rather than auto-fixed:

- **Minor / High confidence — unused `copyDirSync` import in `src/commands/init.ts`.** The Slice 1 retirement removed the legacy `copyDirSync(issueTemplatesSrcDir, …)` call but left the import. `tsconfig.json` has `noUnusedLocals` disabled so this does not break typecheck or build. Trivial one-line cleanup; left here for a future sweep.

No specification debt was introduced by this slice. The four open SD entries from the tasks file (SD-001 through SD-004) were addressed during implementation:

- **SD-001** (`--location user` HOME stubbing) — resolved by overriding `HOME` and `USERPROFILE` in `src/cli.test.ts`'s AS 2 case; Windows CI explicitly out of scope, documented in-test.
- **SD-002** (counts-message wording) — resolved as `Orders templates: <N> templates written, <M> preserved` in `picocolors.dim`, matching the housekeeping line style.
- **SD-003** (resolved in Slice 1) — unchanged.
- **SD-004** (overwrite prompt phrasing) — resolved as `Overwrite existing orders templates at ${manifestDir}/templates/orders/?` with `default: false`, matching the contract's Flow step 4 example string.

## Documentation

`smithy-maid` scan: clean. CLAUDE.md was updated as part of Task 5; no further doc drift detected. Maid noted a pre-existing cosmetic inconsistency (init.ts step-numbering comments run `5c` → `5b` → `5d`) that predates this slice — left untouched.

## Validation

Commands run after all code and doc commits landed (HEAD = `2913000`):

| Command | Result |
|---|---|
| `npm run build` | ✅ `dist/cli.js 133.76 KB` — clean |
| `npm run typecheck` | ✅ Clean (no diagnostics) |
| `npm test` | ✅ 803/803 tests across 26 files |
