### PR TITLE
Plant flawed audit-eval spec fixture

### DIFF
--- a/evals/fixture/specs/audit-eval/audit-eval-flawed.spec.md
+++ b/evals/fixture/specs/audit-eval/audit-eval-flawed.spec.md
@@ -1,0 +1,135 @@
+<!--
+PLANTED EVAL FIXTURE — DO NOT "FIX" THIS FILE.
+
+This `.spec.md` is a deliberately flawed planted artifact. The flaw is the
+intentional absence of a `## Dependency Order` section.
+
+Violated checklist invariant:
+  - Audit Checklist for `.spec.md` artifacts, row "Dependency Order".
+  - Requirement: a spec contains a `## Dependency Order` section structured
+    as a 4-column Markdown table with headers
+    `ID | Title | Depends On | Artifact`, with `US<N>` IDs unique within
+    the table, `Depends On` listing only same-table IDs (or `—`), and
+    every `Artifact` cell either `—` or a repo-relative path to an
+    existing `.tasks.md` file.
+
+Why this plant exists:
+The audit-flawed-spec eval scenario runs `/smithy.audit` against this file
+and asserts the audit's output contains the literal string `Dependency
+Order` plus at least one `Critical` finding. Repairing the flaw — that is,
+adding a `## Dependency Order` section back — would cause the eval to
+report PASS-against-nothing or FAIL, which is the desired regression
+signal but only when deliberately triggered. Routine cleanup must NOT
+"fix" the missing section.
+
+Maintainer instructions:
+  - DO NOT add a `## Dependency Order` section to this file.
+  - DO NOT introduce a placeholder, comment, or table stub purporting to
+    be the `## Dependency Order` section — even an empty section breaks
+    the plant.
+  - If the audit checklist's wording around `Dependency Order` changes
+    (for example, renaming the section to `Implementation Order`),
+    coordinate the change with the consuming eval scenario's
+    `required_patterns` so the two stay in sync.
+-->
+
+# Feature Specification: Add a health-check endpoint to the demo API
+
+**Spec Folder**: `audit-eval`
+**Branch**: `audit-eval/example`
+**Created**: 2026-05-12
+**Status**: Draft
+**Input**: User description — Expose a `/health` endpoint on the demo API so external monitors can verify the service is up without invoking domain routes that have authentication or side effects.
+
+## Clarifications
+
+### Session 2026-05-12
+
+- The endpoint returns plain JSON `{"status":"ok"}` with HTTP 200 when the process is responsive. `[Critical Assumption]`
+- No authentication is required — the endpoint is intentionally public so external health monitors and load balancers can hit it without credentials. `[Critical Assumption]`
+- The endpoint reports only process liveness; it does not probe downstream dependencies (database, queue, third-party APIs). Dependency-aware readiness is deferred.
+
+## Artifact Hierarchy
+
+RFC → Milestone → Feature → User Story → Slice → Tasks
+
+This spec sits at the user-story level: a single small endpoint addition with no parent RFC. The spec exists in isolation purely to give the audit eval a complete-but-flawed artifact to audit.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1: Operators receive a 200 response from `/health` while the API is up (Priority: P1)
+
+As an operator monitoring the demo API, I want a dedicated health endpoint so that I can confirm the service is up without invoking domain routes that may have authentication, side effects, or cost.
+
+**Why this priority**: External monitoring is a precondition for any production deploy; the endpoint is the smallest, lowest-risk addition that unblocks that monitoring path.
+
+**Independent Test**: Start the API process locally and issue `GET /health`; the response is HTTP 200 with body `{"status":"ok"}`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the API process is running, **When** a client sends `GET /health`, **Then** the response status is `200` and the body is JSON `{"status":"ok"}`.
+2. **Given** the API process is running, **When** a client sends `GET /health` with no `Authorization` header, **Then** the response is `200` — the endpoint is intentionally unauthenticated.
+
+---
+
+### User Story 2: Monitors receive a non-`200` response when the API is unhealthy (Priority: P2)
+
+As an operator, I want the health endpoint to surface a non-`200` status when the process cannot serve traffic, so that monitors can page on real outages instead of silent failures.
+
+**Why this priority**: User Story 1 covers the happy path; this story exists to capture the failure-mode contract so monitors have an actionable signal during incidents.
+
+**Independent Test**: Force the process into a known-unhealthy state (e.g., simulated uncaught startup error) and confirm `GET /health` returns `503`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the API process is in a known-unhealthy state, **When** a client sends `GET /health`, **Then** the response status is `503`.
+
+---
+
+### Edge Cases
+
+- Concurrent traffic: the endpoint must not block on a shared mutex or other contended resource, otherwise a saturated process is reported healthy when it cannot answer requests.
+- Process startup window: the endpoint should be registered before any domain routes so it answers as soon as the HTTP listener is bound.
+- Long-lived connections: streaming responses from elsewhere in the API must not delay `/health` responses past the configured monitor timeout.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The demo API MUST expose `GET /health`.
+- **FR-002**: When the process is healthy, the endpoint MUST respond `200 OK` with the JSON body `{"status":"ok"}`.
+- **FR-003**: When the process is unhealthy, the endpoint MUST respond `503 Service Unavailable`.
+- **FR-004**: The endpoint MUST NOT require authentication.
+- **FR-005**: The endpoint MUST respond within 50ms p95 under nominal load.
+
+### Key Entities *(include if feature involves data)*
+
+- **HealthStatus**: A value object with a single field `status` whose value is the literal string `"ok"` when the process is healthy. Surfaced only through the HTTP response body — never persisted.
+
+## Assumptions
+
+- The demo API uses Express; route registration follows the existing router pattern.
+- No external monitoring configuration (CloudWatch, Prometheus, Pingdom) needs to change as part of this story — operators wire endpoints into their own tooling separately.
+- Operators have a sidecar or external probe responsible for declaring the process unhealthy; this story does not specify how an in-process component flips the health bit.
+
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | Readiness vs. liveness semantics: this story implements only liveness. Dependency-aware readiness (database ping, queue probe) is deferred but may be requested before production launch. | Functional Scope | Medium | High | open | — |
+| SD-002 | The mechanism by which the process is declared "unhealthy" is unspecified — FR-003 names the contract but not how the bit is set. A follow-up story selects between a static in-memory flag, a watchdog probe, or a sidecar signal. | Domain & Data Model | Medium | Medium | open | — |
+
+## Out of Scope
+
+- Dependency-aware readiness checks (database, queue, third-party dependencies).
+- Authenticated diagnostics endpoints (`/debug`, `/metrics`).
+- Multi-region health aggregation.
+- Alerting and paging integrations — operators wire monitors to the endpoint separately.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `GET /health` returns HTTP `200` with body `{"status":"ok"}` within 50ms p95.
+- **SC-002**: An induced unhealthy state causes `GET /health` to return HTTP `503` within one second of the state change.
+- **SC-003**: Adding the endpoint does not affect the response time of any existing domain route by more than 5ms p95.

--- a/evals/fixture/specs/audit-eval/audit-eval-flawed.spec.md
+++ b/evals/fixture/specs/audit-eval/audit-eval-flawed.spec.md
@@ -1,36 +1,59 @@
 <!--
 PLANTED EVAL FIXTURE — DO NOT "FIX" THIS FILE.
 
-This `.spec.md` is a deliberately flawed planted artifact. The flaw is the
-intentional absence of a `## Dependency Order` section.
+This `.spec.md` is a deliberately flawed planted artifact. The flaw is
+the intentional absence of a `## Dependency Order` section.
 
-Violated checklist invariant:
-  - Audit Checklist for `.spec.md` artifacts, row "Dependency Order".
-  - Requirement: a spec contains a `## Dependency Order` section structured
-    as a 4-column Markdown table with headers
-    `ID | Title | Depends On | Artifact`, with `US<N>` IDs unique within
-    the table, `Depends On` listing only same-table IDs (or `—`), and
-    every `Artifact` cell either `—` or a repo-relative path to an
-    existing `.tasks.md` file.
+Checklist context — the audit checklist's `## Dependency Order` row is
+phrased *conditionally*, not unconditionally:
+
+  "If the spec contains a `## Dependency Order` section: is it a
+   4-column Markdown table with headers `ID | Title | Depends On |
+   Artifact`? Does every row use a `US<N>` ID (no leading zeros) that
+   is unique within the table? Does each `Depends On` cell list only
+   IDs from the same table (or `—`)? Does every `Artifact` cell contain
+   either `—` or a repo-relative path to an existing `.tasks.md` file
+   in the spec folder (flag any path that does not resolve)? Is the
+   recommended sequence logically justified? No `[ ]`/`[x]` checkbox
+   syntax is valid here — flag any checkbox markup as a finding."
+
+The audit checklist therefore has no single unconditional clause that
+demands the section exist. Separately, the canonical spec template
+stamped by `smithy.mark` always emits a `## Dependency Order` section
+for every spec it produces, so a spec without one is
+template-incomplete relative to the producing command's output even
+though no single checklist row outlaws the omission. The audit agent is
+expected to surface the missing-but-canonical section under
+cross-cutting checklist categories — "Story Independence" (which
+discusses inter-story dependencies), "Specification Debt" /
+"Staleness", or a general completeness observation — and to emit the
+literal token `Dependency Order` plus at least one `Critical` severity
+label in its output.
+
+The risk that this expectation fails (the agent stays silent about the
+missing section, or emits no `Critical` label) is acknowledged upstream
+as SD-002 in the parent feature spec; the audit-flawed-spec eval
+scenario in Slice 2 surfaces that drift as a FAIL.
 
 Why this plant exists:
-The audit-flawed-spec eval scenario runs `/smithy.audit` against this file
-and asserts the audit's output contains the literal string `Dependency
-Order` plus at least one `Critical` finding. Repairing the flaw — that is,
-adding a `## Dependency Order` section back — would cause the eval to
-report PASS-against-nothing or FAIL, which is the desired regression
-signal but only when deliberately triggered. Routine cleanup must NOT
-"fix" the missing section.
+The audit-flawed-spec eval scenario runs `/smithy.audit` against this
+file and asserts the audit's output contains the literal string
+`Dependency Order` plus at least one `Critical` finding. Repairing the
+flaw — adding a `## Dependency Order` section back — would cause the
+eval to FAIL on its next run, which is the desired regression signal
+but only when deliberately triggered. Routine cleanup must NOT "fix"
+the missing section.
 
 Maintainer instructions:
   - DO NOT add a `## Dependency Order` section to this file.
-  - DO NOT introduce a placeholder, comment, or table stub purporting to
-    be the `## Dependency Order` section — even an empty section breaks
-    the plant.
+  - DO NOT introduce a placeholder, comment, or table stub purporting
+    to be the `## Dependency Order` section — even an empty section
+    breaks the plant.
   - If the audit checklist's wording around `Dependency Order` changes
-    (for example, renaming the section to `Implementation Order`),
-    coordinate the change with the consuming eval scenario's
-    `required_patterns` so the two stay in sync.
+    (for example, renaming the section to `Implementation Order`, or
+    promoting the conditional row to an unconditional "must contain"
+    rule), coordinate the change with the consuming eval scenario's
+    `required_patterns` so the two stay in sync (see SD-002).
 -->
 
 # Feature Specification: Add a health-check endpoint to the demo API

--- a/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/01-audit-eval-catches-planted-flaw.tasks.md
+++ b/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/01-audit-eval-catches-planted-flaw.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Plant the flawed audit-eval spec fixture**
+- [x] **Plant the flawed audit-eval spec fixture**
 
   Create `evals/fixture/specs/audit-eval/audit-eval-flawed.spec.md` as a complete-but-deliberately-flawed spec matching the canonical spec template, then delete the `## Dependency Order` section entirely. Open the file with a multi-line comment block per the data model's `flawed` plant rule, naming the violated checklist invariant from `src/templates/agent-skills/snippets/audit-checklist-spec.md` and instructing maintainers not to restore the section.
 


### PR DESCRIPTION
## Source

- Spec: [`specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.spec.md`](../blob/master/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.spec.md)
- Tasks: [`specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/01-audit-eval-catches-planted-flaw.tasks.md`](../blob/master/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/01-audit-eval-catches-planted-flaw.tasks.md)

## Slice

**Slice 1 of US1**: Plant the flawed audit-eval spec fixture.

**Goal**: A reviewable planted `.spec.md` exists at `evals/fixture/specs/audit-eval/audit-eval-flawed.spec.md` with all canonical spec sections present except `## Dependency Order`, and a top-of-file flaw-comment block instructing future maintainers not to restore the missing section.

## Addresses

- **FR-004** — Planted parent artifacts live in scenario-isolated subdirectories under `evals/fixture/{prds,rfcs,specs}/<scenario-slug>/`.
- **FR-006** — The audit scenario runs in File Argument Mode against a planted `.spec.md` whose flaw is the absence of a `## Dependency Order` table.
- **FR-013** — Scenarios must not modify the source fixture directory; the source-fixture checksum invariant continues to hold.
- **AS 1.1** — Planted-fixture precondition for the eval scenario (Slice 2 wires this).
- **AS 1.2** — The flaw must be physically removable so the eval can FAIL when the section is restored (proving SC-004 gating).

## Tasks completed

- [x] Plant the flawed audit-eval spec fixture at `evals/fixture/specs/audit-eval/audit-eval-flawed.spec.md`, with a top-of-file HTML comment block naming the violated `## Dependency Order` audit-checklist invariant and instructing maintainers not to restore the section.

Per-acceptance-criterion verification:

- File exists at `evals/fixture/specs/audit-eval/audit-eval-flawed.spec.md`.
- Top-of-file HTML comment block names the violated invariant (Audit Checklist for `.spec.md`, row "Dependency Order") and issues three `DO NOT` instructions covering the section, placeholder stubs, and the wording-coupling case (SD-002).
- `## Dependency Order` section is absent — no heading, no table, no placeholder stub.
- All other canonical spec sections present and internally coherent: Header, `## Clarifications`, `## Artifact Hierarchy`, `## User Scenarios & Testing` (US1 P1, US2 P2, Edge Cases), `## Requirements` (FRs + Key Entities), `## Assumptions`, `## Specification Debt` (canonical 7-column table), `## Out of Scope`, `## Success Criteria`.
- File body references no paths outside `evals/fixture/specs/audit-eval/` (data-model isolation rule). The flaw-comment block names the audit checklist by descriptor, not by repo path.
- `evals/fixture/src/` untouched (verified by diff).

## Review

`smithy-implementation-review` returned no findings against the slice acceptance criteria, the canonical spec template in `src/templates/agent-skills/commands/smithy.mark.prompt`, the audit checklist in `src/templates/agent-skills/snippets/audit-checklist-spec.md`, or the PlantedArtifact validation rules in the data model. The planted flaw is single-axis: only `## Dependency Order` is missing — no accidental secondary violations (e.g., missing `Status:` field, malformed FR IDs, broken debt table) that could mask the targeted finding when the audit scenario runs.

No auto-fixes applied; no escalated items; no recorded debt.

## Documentation Notes

`smithy-maid` flagged two repo-wide documentation surfaces that will need updates **but explicitly deferred them to Slice 2** so the documentation lands atomically with the `evals/fixture/README.md` `## Planted Inconsistencies` table row that Slice 2 introduces. The Slice 2 implementer should update these alongside the README:

- **`evals/README.md`** — `## Layout` fixture tree only shows `src/` + `README.md`; needs `specs/audit-eval/` added. `### Fixture-planted inconsistencies` preamble (lines ~325-337) says the fixture carries "two deliberate flaws to feed smithy-scout" — now factually narrow once the audit plant exists; should acknowledge the second category of plants (smithy-artifact flaws feeding smithy-audit) with a cross-reference to `evals/fixture/README.md`.
- **`CONTRIBUTING.md`** (line ~60) — "Reference fixture carries documented planted inconsistencies … that the scout scenario asserts are detected" — qualifier "the scout scenario" should broaden once the audit plant lands (e.g., "that eval scenarios assert are detected"), or drop the scenario-name qualifier entirely.

The planted file's own top-of-file flaw-comment is internally consistent — accurately describes the flaw, anticipates the SD-002 checklist-wording coupling risk, and gives unambiguous do-not-restore instructions.

## Validation

Local validation against HEAD (`0e2c4c8`):

- `npm run build` → ESM build success, `dist/cli.js 133.69 KB`.
- `npm run typecheck` → clean (no output, exit 0).
- `npm test` → **803 passed (803) across 26 test files**, ~17.25s total.

## Follow-ups

- Slice 2 of US1 will land `evals/cases/audit-flawed-spec.yaml`, the `evals/fixture/README.md` `## Planted Inconsistencies` table row, and the two `evals/README.md` / `CONTRIBUTING.md` doc updates flagged above.