### PR TITLE
Plant ignite-eval PRD fixture and document it in fixture README

### DIFF
--- a/evals/fixture/README.md
+++ b/evals/fixture/README.md
@@ -27,6 +27,14 @@ Each plant maps to a row in smithy-scout's Severity Guidelines table (see `src/t
 
 Together with the **Intentional Gap** above, these plants are the fixture's twin purposes: the missing health-check endpoint drives eval scenarios that ask agents to add new behavior, and the planted inconsistencies drive eval scenarios that ask agents to detect existing flaws.
 
+## Planted Parent Artifacts
+
+In addition to the scout-flawed plants documented in `## Planted Inconsistencies` above, the fixture hosts **representative parent artifacts** — scenario-isolated files that conform to a producing command's canonical template and are consumed as **input** by downstream eval scenarios (for example, a PRD that `/smithy.ignite` workshops into an RFC). Representative plants differ from scout-flawed plants in intent: representative plants are deliberately *well-formed* so a downstream command can produce realistic output from them, whereas scout-flawed plants are deliberately *malformed* so `smithy-scout` can detect their flaws. Both kinds are deliberate fixtures — **do not "clean up" either kind**; removing a representative plant silently breaks the owner scenario that feeds on it.
+
+| Path | Owner Scenario | Realism | Purpose |
+|------|----------------|---------|---------|
+| `evals/fixture/prds/ignite-eval/` | `ignite-from-prd` | representative | Canonical PRD fed to `/smithy.ignite` to produce an RFC. |
+
 ## Usage
 
 This fixture is **read by AI agents, not executed**. Do not run `npm install` in this directory. At eval time, the eval runner copies this directory to a temp location, deploys Smithy skills into the copy via `smithy init -a claude -y`, and runs `claude -p` against it.

--- a/evals/fixture/prds/ignite-eval/ignite-eval.prd.md
+++ b/evals/fixture/prds/ignite-eval/ignite-eval.prd.md
@@ -1,0 +1,138 @@
+<!--
+Eval fixture plant for the `ignite-from-prd` scenario.
+
+scenario: ignite-from-prd
+realism: representative
+
+This PRD is a deliberate fixture used by the evals framework to exercise
+`/smithy.ignite`'s Phase 1 PRD-read step and downstream clarify/prose
+dispatches. It conforms to the canonical PRD template rendered by
+`smithy.spark` (eight sections; the dependency-order section is
+deliberately omitted because PRDs sit upstream of the
+RFC-feature-spec-tasks lineage and have nothing to order). Do not delete
+or "clean up" this file; removing it silently breaks the
+`ignite-from-prd` eval.
+-->
+
+# PRD: dotfile-sync — One-shot dotfile bootstrap CLI
+
+**Created**: 2026-05-12  |  **Status**: Draft
+
+## Problem Statement
+
+Developers who work across more than one machine — a personal laptop, a work
+laptop, a temporary cloud dev box, and the occasional container — spend a
+non-trivial amount of time at the start of each new environment hand-copying
+dotfiles. The usual workflow is to clone a `dotfiles` repo, then manually
+`ln -s` each file into place, then remember which machine had which extra
+overrides, then re-create those overrides from memory. It is repetitive,
+error-prone, and the divergence between machines quietly grows over time.
+
+The pain is sharpest for engineers who provision short-lived environments
+several times per week — students cycling through lab machines, contractors
+moving between client laptops, infra engineers SSH'd into freshly-imaged
+VMs. The cost is not catastrophic on any one provisioning, but it
+compounds, and the recovery path when a machine drifts (an editor that
+won't open because a colour-scheme symlink is dangling, a shell that hangs
+on a missing prompt module) is disproportionately frustrating.
+
+Existing options ask the user to either commit to a heavyweight
+configuration-management framework or to roll their own shell script and
+maintain it forever. Neither matches the "I just want my dotfiles on this
+new box" use case that motivates the work.
+
+## Proposed Solution
+
+`dotfile-sync` is a single-binary CLI that, given a git URL pointing at a
+user's dotfiles repository, bootstraps a new machine in one command:
+clones the repo into `~/.dotfiles`, reads a declarative manifest at the
+repo root, and creates the symlinks the manifest describes. A subsequent
+invocation of the same command on the same machine is a no-op when nothing
+has drifted, and reports clearly when something has.
+
+Users observe one command (`dotfile-sync apply <repo-url>`), one place to
+edit (`dotfiles.toml` at the root of their dotfiles repo), and one place
+their dotfiles live on disk (`~/.dotfiles` plus the symlinks it creates).
+No daemons, no background syncs, no opinions about which dotfiles to
+include — the manifest is whatever the user writes.
+
+## Target Users
+
+- Polyglot developers who already keep a `dotfiles` git repo and re-clone
+  it by hand on each new machine — they encounter the problem every time
+  they touch a new environment.
+- Engineers who provision short-lived cloud dev boxes (Codespaces,
+  Gitpod, ad-hoc EC2) several times per week — they hit the problem at
+  the highest frequency.
+- Engineers onboarding new teammates onto a shared opinionated dev
+  environment — they need a "run this one command" story to hand to a
+  new hire on day one.
+
+## Success Signals
+
+- A first-time user can clone a sample dotfiles repo and run
+  `dotfile-sync apply` on a fresh Linux or macOS machine and have their
+  shell, editor, and git config in place inside 60 seconds, with no
+  follow-up manual symlink steps.
+- Re-running `dotfile-sync apply` on the same machine reports
+  "everything in sync" and exits non-zero only when the user's actual
+  on-disk state has drifted from the manifest.
+- The README of an early-adopter dotfiles repo can replace its
+  hand-written setup script with a single `dotfile-sync apply` line and
+  not lose any functionality.
+
+## Alternatives / Build-vs-Buy
+
+### Alternatives Considered
+
+| Name | URL | Category | Fit | Why not |
+|------|-----|----------|-----|---------|
+| GNU Stow | <https://www.gnu.org/software/stow/> | OSS CLI tool | Close | Requires a strict directory-layout convention in the dotfiles repo; gives no first-run "clone this URL then apply" UX. |
+| chezmoi | <https://www.chezmoi.io/> | OSS CLI tool | Partial | Powerful but template-heavy; the templating language is a learning curve the target persona does not want to pay. |
+| yadm | <https://yadm.io/> | OSS CLI tool | Partial | Wraps git directly with a bare repo; powerful for advanced users but the conceptual model (working tree IS your home directory) confuses first-time users. |
+| Custom shell scripts | — | DIY | Poor | The exact thing the project is trying to retire — each user maintains their own variant forever. |
+
+### Build-vs-Buy Rationale
+
+The closest off-the-shelf candidate is `chezmoi`, which solves a superset
+of the problem but charges the user a meaningful templating-language tax
+on day one. The target persona — a developer who wants their dotfiles on
+a new box and nothing more — drops off before reaching the value. GNU
+Stow is conceptually simpler but assumes the user has already cloned the
+repo and laid it out correctly. The opportunity is to ship the smallest
+possible interface (`apply <url>`) that handles the "I'm on a new machine
+right now" path well and leaves heavier configuration management to the
+tools that already do it. Building (rather than buying or adopting) is
+warranted because the differentiator is UX-shape, not capability.
+
+## Assumptions
+
+- [Critical Assumption] The target persona is willing to keep their
+  dotfiles in a git repo. Users who store dotfiles in cloud drives or
+  encrypted vaults are out of scope.
+- The single-binary CLI is acceptable to install via the platform's
+  native package manager (Homebrew on macOS, the user's package manager
+  of choice on Linux) — no need for a custom installer.
+- Symlinks (not file copies) are the correct on-disk representation —
+  users want edits made on one machine, committed, and pulled to flow
+  through transparently.
+
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | Windows support is unclear — symlink semantics differ enough that a first cut should likely target macOS + Linux only and explicitly defer Windows. | Functional Scope | High | High | open | — |
+| SD-002 | The manifest schema (`dotfiles.toml`) is sketched but not specified — exact key names, conflict-resolution semantics, and whether per-host overrides are first-class fields all need definition. | Domain & Data Model | High | Medium | open | — |
+| SD-003 | Behavior when a target symlink already exists and points elsewhere is undefined — overwrite-with-backup vs. refuse-and-warn vs. interactive-prompt all have advocates. | Edge Cases | Medium | Medium | open | — |
+
+## Open Questions
+
+- Should `dotfile-sync` ship a `bootstrap` mode that also installs the
+  user's declared package list (Homebrew bundles, `apt` packages) or
+  stay strictly in the symlink-only lane?
+- How should the tool behave when the dotfiles repo itself is private
+  and requires SSH auth that the new machine has not yet configured —
+  is there a useful first-run experience or is that user out of scope?
+- Is a "dry-run" mode that prints the planned symlink operations and
+  exits without touching the filesystem worth shipping in the first
+  release, or can it wait?

--- a/evals/fixture/prds/ignite-eval/ignite-eval.prd.md
+++ b/evals/fixture/prds/ignite-eval/ignite-eval.prd.md
@@ -45,16 +45,16 @@ new box" use case that motivates the work.
 
 `dotfile-sync` is a single-binary CLI that, given a git URL pointing at a
 user's dotfiles repository, bootstraps a new machine in one command:
-clones the repo into `~/.dotfiles`, reads a declarative manifest at the
-repo root, and creates the symlinks the manifest describes. A subsequent
-invocation of the same command on the same machine is a no-op when nothing
-has drifted, and reports clearly when something has.
+clones the repo into a local directory, reads a declarative manifest at
+the repo root, and creates the symlinks the manifest describes. A
+subsequent invocation of the same command on the same machine is a no-op
+when nothing has drifted, and reports clearly when something has.
 
-Users observe one command (`dotfile-sync apply <repo-url>`), one place to
-edit (`dotfiles.toml` at the root of their dotfiles repo), and one place
-their dotfiles live on disk (`~/.dotfiles` plus the symlinks it creates).
-No daemons, no background syncs, no opinions about which dotfiles to
-include — the manifest is whatever the user writes.
+Users observe one command (`dotfile-sync apply <repo-url>`), one place
+to edit (the manifest file at the root of their dotfiles repo), and one
+place their dotfiles live on disk (the local clone plus the symlinks it
+creates). No daemons, no background syncs, no opinions about which
+dotfiles to include — the manifest is whatever the user writes.
 
 ## Target Users
 

--- a/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/05-ignite-eval-produces-rfc-from-prd.tasks.md
+++ b/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/05-ignite-eval-produces-rfc-from-prd.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Plant the ignite-eval PRD fixture**
+- [x] **Plant the ignite-eval PRD fixture**
 
   Create the scenario-isolated directory `evals/fixture/prds/ignite-eval/` containing `ignite-eval.prd.md` — a minimal-but-representative Smithy PRD conforming to the canonical PRD template rendered by `src/templates/agent-skills/commands/smithy.spark.prompt` (Phase 3 PRD template, lines ~397–446). The PRD MUST contain the eight canonical sections (`## Problem Statement`, `## Proposed Solution`, `## Target Users`, `## Success Signals`, `## Alternatives / Build-vs-Buy`, `## Assumptions`, `## Specification Debt`, `## Open Questions`) and MUST NOT contain `## Dependency Order` (the spark template explicitly omits that section from PRDs — PRDs sit upstream of the RFC→spec→tasks lineage). Open the file with a top-of-file comment naming the consuming scenario (`ignite-from-prd`) and identifying the plant as `representative` per the data-model `realism` enum. Author against the canonical template rather than minimum-viable content so ignite's Phase 1 PRD-read step has substantive input for downstream clarify/prose dispatches.
 
@@ -29,7 +29,7 @@
   - File contents reference no paths outside `evals/fixture/prds/ignite-eval/` (FR-004 isolation rule)
   - `evals/fixture/src/` and existing scout `## Planted Inconsistencies` rows are untouched (FR-013)
 
-- [ ] **Document the ignite-eval plant in the fixture README**
+- [x] **Document the ignite-eval plant in the fixture README**
 
   Extend `evals/fixture/README.md` with one row recording the ignite-eval plant directory in the `## Planted Parent Artifacts` section. Use a create-if-absent strategy following the US3/US4 precedent: if the section does not yet exist when this task runs (US2 Slice 2 / US3 Slice 1 / US4 Slice 1 may or may not have landed first), create it using the schema established by US2 Slice 2 — positioned after `## Planted Inconsistencies` and before `## Usage`, with a one-paragraph intro distinguishing representative plants from scout-flawed plants and a 4-column table (`Path | Owner Scenario | Realism | Purpose`). If the section already exists, append a row only.
 


### PR DESCRIPTION
## Source

- Spec: [`specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.spec.md`](specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.spec.md) — User Story 5
- Tasks: [`specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/05-ignite-eval-produces-rfc-from-prd.tasks.md`](specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/05-ignite-eval-produces-rfc-from-prd.tasks.md)

## Slice

**Slice 1**: Plant the ignite-eval PRD fixture and document it.

**Goal**: A scenario-isolated directory `evals/fixture/prds/ignite-eval/` exists containing a representative PRD plant (`ignite-eval.prd.md`) conforming to the canonical spark PRD template (eight sections, **no** `## Dependency Order`), and `evals/fixture/README.md` carries a `## Planted Parent Artifacts` row referencing the new plant directory — creating the section if it does not yet exist.

## Addresses

- FR-004 (scenario-isolated plant directories), FR-005 (representative plants exercise realistic content), FR-013 (existing fixture untouched), FR-014 (template-stable anchors)
- AS 5.1 — planted-fixture precondition: PRD contains the eight standard PRD sections that ignite's Phase 1 PRD-read step expects
- FR-012 — existing fixture left untouched (no edits to `evals/fixture/src/`; no edits to `## Planted Inconsistencies`)

## Tasks completed

- [x] **Plant the ignite-eval PRD fixture** — `evals/fixture/prds/ignite-eval/ignite-eval.prd.md` created with the eight canonical PRD sections (`## Problem Statement`, `## Proposed Solution`, `## Target Users`, `## Success Signals`, `## Alternatives / Build-vs-Buy`, `## Assumptions`, `## Specification Debt`, `## Open Questions`), top-of-file HTML comment naming the consuming scenario (`ignite-from-prd`) and `realism: representative`, and **no** `## Dependency Order` heading (per SD-014). Subject matter: `dotfile-sync` — a single-binary CLI that bootstraps a developer's dotfiles on a new machine from a git URL plus a declarative TOML manifest. Stand-alone idea — no references to paths outside the plant directory (FR-004).
- [x] **Document the ignite-eval plant in the fixture README** — `evals/fixture/README.md` extended with a new `## Planted Parent Artifacts` section, positioned after `## Planted Inconsistencies` and before `## Usage`. The intro paragraph distinguishes representative plants (well-formed input to a downstream command) from scout-flawed plants (deliberately malformed for `smithy-scout` to detect). The 4-column table (`Path | Owner Scenario | Realism | Purpose`) holds one row for `evals/fixture/prds/ignite-eval/`; sibling US3/US4/US6 plants can be appended without restructuring.

## Review

`smithy-implementation-review` returned **zero findings** (no Critical / Important / Minor). Spot-checked:

- All eight canonical PRD sections present in template order; `**Created**: YYYY-MM-DD  |  **Status**: Draft` header line matches the template exactly.
- `ripgrep` confirms zero occurrences of `Dependency Order` anywhere in the PRD file (HTML comment refers to it in lowercase prose form only — not a heading).
- PRD body references no paths outside `evals/fixture/prds/ignite-eval/` (FR-004).
- README's new section sits between `## Planted Inconsistencies` (line 28) and `## Usage` (line 38); existing rows untouched (FR-013); convention extends cleanly.

No auto-fixes applied — review was clean.

## Documentation

`smithy-maid` flagged three documentation items for follow-up. **None applied in this PR** because they touch files outside this slice's stated scope (the slice is narrow: plant + plant-section-in-fixture-README); applying them would widen the diff beyond the slice's PR-outcome contract. Logging here for a follow-up doc-sweep PR:

- **`CONTRIBUTING.md` line 63**: Tier-3 "Pending" block still lists `YAML-defined scenario loading (`evals/cases/`)` even though YAML loading shipped (CLAUDE.md's Testing section already records this as complete). Suggest deleting the two-line "Pending" block.
- **`evals/README.md` `## Layout` section (lines 138–171)**: ASCII tree under `fixture/` does not mention the new `prds/` subdirectory (or the upcoming `rfcs/` / `specs/` siblings from US1–US4). Suggest extending the tree to anticipate the planted-artifact subdirectories.
- **`evals/README.md` `### Fixture-planted inconsistencies` (lines 325–337)**: cross-reference sentence "See `evals/fixture/README.md` for the full table" now lands on a README with two distinct plant categories. Suggest updating to "for the full table of intentional flaws and representative parent artifacts".

These three findings should land together in a doc-sweep PR once US1–US4 are also in flight so the `evals/README.md` Layout tree can be updated against the full set of plant subdirectories.

## Validation

All run after every code and doc commit was in place. Working tree clean.

| Command | Result |
|---------|--------|
| `npm run build` | PASS — `ESM dist/cli.js 133.69 KB`, build success in 37ms |
| `npm run typecheck` | PASS — clean (no diagnostics) |
| `npm test` | PASS — 26 test files, 803 / 803 tests passed in 14.27s |

## Outstanding

- Slice 2 (`Author the ignite-from-prd YAML scenario`) is left for a separate PR — it has a hard cross-story dependency on US2 Slice 1 (runner git-init) per the tasks file's `## Cross-Story Dependencies` table.
- The three maid findings above are logged for a follow-up doc-sweep PR — not applied here to keep this slice's diff narrowly scoped to its stated goal.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
