### PR TITLE
Plant cut-eval spec fixture and document it

### DIFF
--- a/evals/fixture/README.md
+++ b/evals/fixture/README.md
@@ -33,6 +33,7 @@ In addition to the scout-flawed plants documented in `## Planted Inconsistencies
 
 | Path | Owner Scenario | Realism | Purpose |
 |------|----------------|---------|---------|
+| `evals/fixture/specs/cut-eval/` | `cut-from-spec` | representative | Three-file spec / data-model / contracts plant consumed by `/smithy.cut` to assert the generated tasks file inherits the SD-001 debt row from the upstream spec. |
 | `evals/fixture/prds/ignite-eval/` | `ignite-from-prd` | representative | Canonical PRD fed to `/smithy.ignite` to produce an RFC. |
 
 ## Usage

--- a/evals/fixture/specs/cut-eval/cut-eval.contracts.md
+++ b/evals/fixture/specs/cut-eval/cut-eval.contracts.md
@@ -1,0 +1,73 @@
+<!--
+SCENARIO: cut-from-spec (evals/cases/cut-from-spec.yaml)
+TYPE: representative (non-flawed) parent-artifact plant
+PURPOSE: Companion contracts file for cut-eval.spec.md. Cut's Phase 1 reads
+  this file as part of its spec input set; this plant exists so that read
+  succeeds.
+DO NOT "fix" or "clean up": this file is a deliberate eval fixture committed
+  for the cut-from-spec scenario.
+-->
+
+# Contracts: Add a Health Check Endpoint to the Fixture Express Application
+
+## Overview
+
+This feature introduces one new HTTP interface (the health check endpoint) and no new programmatic interfaces internal to the application. External orchestrators consume the HTTP interface; no internal modules depend on it.
+
+## Interfaces
+
+### 1) Health Check HTTP Endpoint
+
+**Purpose**: A single unauthenticated HTTP endpoint that returns 200 when the application is alive and listening.
+
+**Consumers**:
+- External orchestrators (load balancers, container platforms, uptime monitors) that probe the endpoint to decide whether to route traffic to this instance.
+
+**Providers**:
+- The Express application this fixture represents, which mounts the route during application bootstrap.
+
+#### Signature
+
+```
+GET <health-path>
+  → 200 OK
+    Content-Type: application/json
+    Body: { "status": "ok" }
+```
+
+The exact value of `<health-path>` is intentionally not pinned by this contract; see the spec's `SD-001`. Downstream task slices must select a concrete path.
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| (HTTP method) | string | Yes | MUST be `GET`. Other methods MAY return 405 Method Not Allowed; non-GET behavior is not pinned by this contract. |
+| (request body) | n/a | No | No request body is read. |
+| (auth credentials) | n/a | No | No credentials are read. The endpoint is unauthenticated per FR-002. |
+
+#### Outputs
+
+| Field | Description |
+|-------|-------------|
+| HTTP status | `200` when the application is alive and listening. |
+| `Content-Type` header | `application/json`. |
+| Response body | A JSON object conforming to the `HealthResponse` entity in the data model (a single `status` field set to `"ok"`). |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Application not yet bootstrapped | Connection refused or non-200 status | The endpoint MUST NOT return 200 from a partially initialized application (AS 1.2). |
+| Health path collides with an existing API route | Implementer rejects the path choice during task implementation | Mitigation lives in task decomposition, not in this contract. |
+| Orchestrator probes at high rate | 200 responses, no rate-limit rejections | The endpoint is exempt from rate-limit middleware (FR-003). |
+
+## Events / Hooks
+
+This feature publishes no events. It consumes no events. The endpoint is a pure read-only synchronous HTTP handler.
+
+## Integration Boundaries
+
+- **External HTTP** (new boundary surface): orchestrators reach the endpoint over HTTP. No outbound calls are made from the handler; the endpoint synthesizes its response from in-process state only.
+- **Express middleware stack** (existing): the health route is mounted such that auth and rate-limit middleware do not apply (FR-002, FR-003). Mount ordering is the implementation strategy.
+
+No new external system integrations are introduced.

--- a/evals/fixture/specs/cut-eval/cut-eval.data-model.md
+++ b/evals/fixture/specs/cut-eval/cut-eval.data-model.md
@@ -1,0 +1,42 @@
+<!--
+SCENARIO: cut-from-spec (evals/cases/cut-from-spec.yaml)
+TYPE: representative (non-flawed) parent-artifact plant
+PURPOSE: Companion data-model file for cut-eval.spec.md. Cut's Phase 1 reads
+  this file as part of its spec input set; this plant exists so that read
+  succeeds.
+DO NOT "fix" or "clean up": this file is a deliberate eval fixture committed
+  for the cut-from-spec scenario.
+-->
+
+# Data Model: Add a Health Check Endpoint to the Fixture Express Application
+
+## Overview
+
+This feature adds one small response entity (`HealthResponse`) consumed by external orchestrators probing the application's liveness. No persistent storage is introduced; the health endpoint is read-only and synthesizes its response from in-process state.
+
+## Entities
+
+### 1) HealthResponse (new)
+
+Purpose: The JSON body returned by the health check endpoint. Indicates the application is alive and listening.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `status` | string | Yes | A short liveness indicator. Convention: `"ok"` when the application is alive. No additional values are emitted by the first cut. |
+
+Validation:
+
+- The response body MUST be a valid JSON object with exactly the `status` field; additional fields are forbidden by FR-004 (no secrets, no build hashes, no environment details).
+- The `status` value MUST be a non-empty string. The first cut emits only `"ok"`; future cuts may add `"degraded"` once readiness probing lands (out of scope).
+
+## Relationships
+
+`HealthResponse` is a standalone response entity with no relationships to other domain entities. It is synthesized in the request handler and not persisted.
+
+## State Transitions
+
+`HealthResponse` is a transient value created per request; it has no lifecycle. The Express application itself has implicit liveness states (booting / alive / shutting down) but those are tracked by the runtime, not by a domain entity introduced here.
+
+## Identity & Uniqueness
+
+`HealthResponse` instances have no identity — they are ephemeral values returned per request. There is no uniqueness constraint to enforce.

--- a/evals/fixture/specs/cut-eval/cut-eval.spec.md
+++ b/evals/fixture/specs/cut-eval/cut-eval.spec.md
@@ -1,0 +1,108 @@
+<!--
+SCENARIO: cut-from-spec (evals/cases/cut-from-spec.yaml)
+TYPE: representative (non-flawed) parent-artifact plant
+PURPOSE: Provides input to the cut-from-spec eval scenario, which exercises
+  /smithy.cut against this spec and asserts the resulting tasks file
+  inherits SD-001 with the `inherited from spec:` literal.
+DO NOT "fix" or "clean up": this file is a deliberate eval fixture. Removing
+  US1 or flipping SD-001 to `resolved` will silently break the
+  cut-from-spec scenario.
+-->
+
+# Feature Specification: Add a Health Check Endpoint to the Fixture Express Application
+
+**Spec Folder**: `cut-eval`
+**Branch**: `cut-eval/health-check-endpoint`
+**Created**: 2026-05-12
+**Status**: Draft
+**Input**: User description — add an HTTP health check endpoint to the Express application this fixture represents so external orchestrators can verify the service is alive and responding before routing traffic to it.
+
+## Clarifications
+
+### Session 2026-05-12
+
+- The health check endpoint returns HTTP 200 with a small JSON body indicating liveness; no upstream dependency probing is required for the first cut. `[Critical Assumption]`
+- The endpoint is unauthenticated (orchestrators may not have credentials when probing) and is exempt from any rate limiting that would otherwise apply to API routes. `[Critical Assumption]`
+- The exact path of the endpoint (`/health`, `/healthz`, `/status`, or other) is intentionally left ambiguous in this spec and resolved during task decomposition; see SD-001.
+- The endpoint is mounted on the same Express application instance as the rest of the API (no separate process or port). `[Critical Assumption]`
+
+## Artifact Hierarchy
+
+RFC → Milestone → Feature → User Story → Slice → Tasks
+
+This feature lives at the user-story level. There is no parent RFC for this fixture spec; the originating description is the user input above.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1: Add a health check endpoint exposing service liveness (Priority: P1)
+
+As an external orchestrator (load balancer, container platform, or uptime monitor), I want a stable HTTP endpoint that returns a 200 response when the Express application this fixture represents is alive and serving requests, so that I can route traffic to healthy instances and pull unhealthy instances out of rotation without false positives.
+
+**Why this priority**: The Express application this fixture represents currently exposes no health check surface at all (the fixture README explicitly notes this as an Intentional Gap). Until a liveness endpoint exists, orchestrators must fall back on TCP-level probes or full API requests, both of which produce false-positive healthy signals when the application is partially degraded.
+
+**Independent Test**: With the endpoint implemented and the application running, a single HTTP GET to the chosen health path returns 200 with a JSON body. The check is independent of any other API route — no auth, no database, no upstream calls.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Express application is running and listening, **When** an unauthenticated HTTP GET is issued to the chosen health path, **Then** the response is HTTP 200 with a JSON body indicating liveness.
+2. **Given** the application has not finished booting, **When** the same GET is issued, **Then** the response is either a connection error or a non-200 status — never a 200 from a partially-initialized application.
+3. **Given** the health endpoint exists, **When** an existing API route is exercised, **Then** the existing route's behavior is unchanged (the new endpoint does not regress existing routes).
+
+---
+
+### Edge Cases
+
+- The health path collides with an existing API route. Mitigation: pick a path under a reserved prefix and verify no collision exists during task implementation.
+- An orchestrator probes the endpoint at a rate that would otherwise trigger rate limiting. Mitigation: exempt the health path from rate-limit middleware.
+- The endpoint accidentally exposes internal state (build hashes, environment variables). Mitigation: keep the response body minimal (a single liveness flag).
+
+## Dependency Order
+
+Recommended implementation sequence (priority, then independence):
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| US1 | Add a health check endpoint exposing service liveness | — | — |
+
+US1 is the only story in this spec — cut's "user story 1" routing must resolve deterministically against this single row.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Express application MUST expose a single health check endpoint that returns HTTP 200 when the application is alive and listening.
+- **FR-002**: The health endpoint MUST be unauthenticated and reachable without API keys, session cookies, or any other credential.
+- **FR-003**: The health endpoint MUST be exempt from any rate-limiting middleware applied to the rest of the API.
+- **FR-004**: The health endpoint's response body MUST be a small JSON document indicating liveness; it MUST NOT expose secrets, build hashes, or environment variables.
+- **FR-005**: Existing API routes MUST continue to behave identically after the health endpoint is added; the new endpoint is strictly additive.
+
+### Key Entities
+
+- **HealthResponse** *(new)*: The JSON body returned by the health endpoint. A minimal object with a single liveness indicator (e.g., `{ "status": "ok" }`). No timestamps, build identifiers, or environment details.
+
+## Assumptions
+
+- The Express application this fixture represents has a single mount point; the health endpoint is added at that same mount point and not on a separate process or port.
+- Orchestrators that probe the endpoint expect a 200 within a few hundred milliseconds; the endpoint MUST NOT perform any I/O that could block beyond that window.
+- The Express middleware stack ordering supports inserting the health route before any auth or rate-limit middleware so the exemption requirements are satisfied by mount ordering, not by per-middleware allowlists.
+
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | Health check endpoint contract is not pinned to a specific path (`/health`, `/healthz`, `/status`) — downstream task slices must choose and the choice is currently ambiguous. The chosen path becomes part of the public contract orchestrators integrate against, so the choice is non-trivial to revisit once external consumers have hard-coded it. | Functional Scope | Medium | Medium | open | — |
+
+## Out of Scope
+
+- **Readiness checks** (distinguishing "alive" from "ready to serve traffic"). The first cut covers liveness only; readiness — which would probe upstream dependencies — is deferred.
+- **Health metrics export** (Prometheus, OpenTelemetry, etc.). The endpoint returns a binary alive/not-alive signal; metrics integrations are a follow-up.
+- **Authenticated diagnostic endpoints** (returning detailed status to authenticated callers). Out of scope; the public health endpoint stays unauthenticated and minimal.
+- **Multi-region health aggregation**. Out of scope; the endpoint reports the local instance's health only.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A single HTTP GET against the chosen health path returns HTTP 200 with a JSON body in fewer than 500ms under no load.
+- **SC-002**: All existing API route tests continue to pass after the health endpoint is added; no regressions.
+- **SC-003**: An orchestrator probing the endpoint at 1 request per second for 60 seconds receives 60 successful 200 responses with no rate-limit rejections.

--- a/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/03-cut-eval-inherits-spec-debt.tasks.md
+++ b/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/03-cut-eval-inherits-spec-debt.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Plant the cut-eval spec, data-model, and contracts fixture**
+- [x] **Plant the cut-eval spec, data-model, and contracts fixture**
 
   Create the scenario-isolated directory `evals/fixture/specs/cut-eval/` containing three files conforming to the canonical Smithy spec / data-model / contracts shape: `cut-eval.spec.md`, `cut-eval.data-model.md`, `cut-eval.contracts.md`. The spec must contain at least one user story whose `## Dependency Order` row carries the ID `US1`, AND a `## Specification Debt` table with at least one row whose `ID` is `SD-001` and `Status` is `open` (satisfies AS 3.1 and AS 3.2 preconditions). The data-model and contracts files are minimal but structurally valid instances of their canonical templates so cut's Phase 1 reads succeed. All three files open with a top-of-file comment naming the consuming scenario (`cut-from-spec`) and that the plants are representative (non-flawed).
 

--- a/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/03-cut-eval-inherits-spec-debt.tasks.md
+++ b/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/03-cut-eval-inherits-spec-debt.tasks.md
@@ -29,7 +29,7 @@
   - File contents reference no paths outside `evals/fixture/specs/cut-eval/` (FR-004 data-model isolation rule)
   - `evals/fixture/src/` and existing scout `## Planted Inconsistencies` rows are untouched (FR-013)
 
-- [ ] **Document the cut-eval plant in the fixture README**
+- [x] **Document the cut-eval plant in the fixture README**
 
   Extend `evals/fixture/README.md` with one row recording the cut-eval plant directory in the `## Planted Parent Artifacts` section. If that section does not yet exist when this task runs (US2 Slice 2 may or may not have landed first), create it using the schema established by US2 Slice 2: positioned after `## Planted Inconsistencies` and before `## Usage`, with a one-paragraph intro distinguishing representative plants from scout-flawed plants, and a 4-column table (`Path | Owner Scenario | Realism | Purpose`). If the section already exists from US2, append a row only.
 


### PR DESCRIPTION
## Source

- Spec: [specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.spec.md](specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.spec.md)
- Tasks: [specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/03-cut-eval-inherits-spec-debt.tasks.md](specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/03-cut-eval-inherits-spec-debt.tasks.md)

## Slice

**Slice 1: Plant the cut-eval spec fixture and document it**

Goal: A scenario-isolated directory `evals/fixture/specs/cut-eval/` exists containing three representative parent-artifact files (`cut-eval.spec.md` with one user story whose row in `## Dependency Order` carries `US1`, plus a `## Specification Debt` table with one `SD-001` row whose `Status` is `open`; `cut-eval.data-model.md`; `cut-eval.contracts.md`), and `evals/fixture/README.md` carries a `## Planted Parent Artifacts` row referencing the new plant directory — creating the section if it does not yet exist.

## Addresses

- **FRs**: FR-004 (plant isolation), FR-005 (exact-path prompts), FR-013 (existing scout plants untouched), FR-014 (authoring conventions).
- **Acceptance Scenarios**: AS 3.1 precondition (`SD-001` row with `Status: open`), AS 3.2 precondition (`US1` row in `## Dependency Order`), AS 3.3 source-fixture checksum invariant (plant is committed static content).

## Tasks completed

- [x] Plant the cut-eval spec, data-model, and contracts fixture (`evals/fixture/specs/cut-eval/{cut-eval.spec.md,cut-eval.data-model.md,cut-eval.contracts.md}`).
- [x] Document the cut-eval plant in the fixture README (creates the `## Planted Parent Artifacts` section since US2 Slice 2 has not yet landed).

## Review

`smithy-implementation-review` returned **zero findings**. AS 3.1 / AS 3.2 preconditions are satisfied verbatim; plant isolation (FR-004) is upheld — no references to other scenario plants, `evals/fixture/src/`, or real specs directories; all mandatory canonical sections (spec / data-model / contracts) are present.

## Documentation Notes

`smithy-maid` returned three flagged (judgment-call) findings, none auto-fixed in this slice:

1. **Parent contracts §4 may want updating** — `expand-evals-coverage-planning-and-audit.contracts.md` lines 155–158 list `top-of-file comment (flawed plants only)` as a planted-artifact input, but the tasks file required (and the implementation added) scenario comments on the *representative* plants too. The convention has drifted ahead of the contract. Updating the contracts table to document that representative plants also carry scenario comments would close the gap; deferred here because it touches the parent feature's contracts file (out of this slice's scope).
2. **`tests/Agent.tests.md` A9 is now superseded by the upcoming Slice 2 YAML scenario** — the parent spec's User Story 3 motivation explicitly names A9 as the manual procedure being replaced. Removing or annotating A9 is explicitly deferred by the parent spec's `## Out of Scope` (deprecation of `Agent.tests.md` is a follow-up feature).
3. **`evals/README.md` `## Layout` block does not enumerate `evals/fixture/specs/`** — judgment call whether the evals README documents fixture subdirectories or defers to `evals/fixture/README.md` as the canonical index. Left untouched here.

## Validation

| Command | Result |
|---------|--------|
| `npm run build` | PASS (tsup, `dist/cli.js` 133.69 KB) |
| `npm run typecheck` | PASS |
| `npm test` | PASS (26 files, 803 tests) |

No test code changed in this slice — the new fixture content is consumed by the upcoming Slice 2 YAML scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)