### PR TITLE
Plant ignite-eval PRD fixture and document it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,10 +57,8 @@ The evals framework (under `evals/`) — implemented:
 - Baseline regression library (`loadBaseline`, `compareToBaseline` — convention-based JSON loader and pure structural diff; wired into the orchestrator with a committed `strike-health-check.json` baseline)
 - Dedicated evals test suite runnable via `npm run test:evals` (independent of `npm test`)
 - Strike and scout end-to-end scenarios (`strikeScenario`, `scoutScenario`) wired into the orchestrator; `--case <name>` filter selects a single scenario by name
-- Reference fixture carries documented planted inconsistencies (`evals/fixture/README.md` — Planted Inconsistencies section) that the scout scenario asserts are detected
-
-Pending:
-- YAML-defined scenario loading (`evals/cases/`)
+- Reference fixture carries documented planted inconsistencies (`evals/fixture/README.md` — `## Planted Inconsistencies` section) that the scout scenario asserts are detected; `evals/fixture/README.md` also tracks scenario-isolated parent-artifact plants (`## Planted Parent Artifacts` section) consumed by planning-command scenarios (mark, cut, render, ignite)
+- YAML-defined scenario loading (`evals/cases/*.yaml` discovered by `loadScenarios`)
 
 See **[specs/2026-04-06-003-smithy-evals-framework/](specs/2026-04-06-003-smithy-evals-framework/)** for the feature specification.
 

--- a/evals/fixture/README.md
+++ b/evals/fixture/README.md
@@ -27,6 +27,14 @@ Each plant maps to a row in smithy-scout's Severity Guidelines table (see `src/t
 
 Together with the **Intentional Gap** above, these plants are the fixture's twin purposes: the missing health-check endpoint drives eval scenarios that ask agents to add new behavior, and the planted inconsistencies drive eval scenarios that ask agents to detect existing flaws.
 
+## Planted Parent Artifacts
+
+In addition to the scout-detectable inconsistencies above, the fixture hosts **scenario-isolated parent-artifact plants** under `evals/fixture/{prds,rfcs,specs}/<scenario-slug>/`. Unlike the scout plants, these are *representative* (not deliberately flawed) — they exist so planning-command scenarios (mark, cut, render, ignite) can read realistic upstream input via an exact path. Each plant is owned by exactly one scenario and is read only by that scenario; **do not "clean up" or repurpose these directories.**
+
+| Path | Owner Scenario | Realism | Purpose |
+|------|----------------|---------|---------|
+| `evals/fixture/prds/ignite-eval/` | `ignite-from-prd` | representative | Planted PRD that `/smithy.ignite` workshops into an RFC during eval runs. |
+
 ## Usage
 
 This fixture is **read by AI agents, not executed**. Do not run `npm install` in this directory. At eval time, the eval runner copies this directory to a temp location, deploys Smithy skills into the copy via `smithy init -a claude -y`, and runs `claude -p` against it.

--- a/evals/fixture/prds/ignite-eval/ignite-eval.prd.md
+++ b/evals/fixture/prds/ignite-eval/ignite-eval.prd.md
@@ -28,7 +28,7 @@
 
 The fixture API's `POST /api/users` handler currently accepts whatever JSON the
 client posts and writes it straight into the in-memory users array. A planted
-`TODO` above the handler in `src/routes/users.ts` admits the gap explicitly:
+`TODO` above the POST handler in the users router admits the gap explicitly:
 "add request validation before creating user (reject empty name/email, enforce
 email format)". In practice, this means a client can create users with an empty
 string for `name`, with no `email` field at all, or with a syntactically broken
@@ -53,9 +53,14 @@ Add input validation to the `POST /api/users` handler that rejects requests
 missing required fields (`name`, `email`), rejects empty-string values for
 those fields after trimming whitespace, and rejects email addresses that fail
 a conservative syntactic check. Rejected requests return HTTP 400 with a JSON
-body shaped like `{ "error": "<human-readable summary>", "field": "<which
-field failed>" }`. Valid requests behave exactly as they do today — they
-return HTTP 201 with the created user.
+body shaped like:
+
+```json
+{ "error": "<human-readable summary>", "field": "<which field failed>" }
+```
+
+Valid requests behave exactly as they do today — they return HTTP 201 with
+the created user.
 
 The change is observable to API consumers as: malformed POSTs are refused
 with a specific, machine-readable error; well-formed POSTs are unaffected;
@@ -108,10 +113,10 @@ inline style of the other handlers. We will build, not buy.
 
 ## Assumptions
 
-- [Critical Assumption] The fixture's `CreateUserRequest` interface
-  (`src/types.ts`) will not gain additional required fields during this
-  effort — if it does, the validation surface grows and the build-vs-buy
-  calculus may need to be revisited.
+- [Critical Assumption] The fixture's `CreateUserRequest` interface will
+  not gain additional required fields during this effort — if it does, the
+  validation surface grows and the build-vs-buy calculus may need to be
+  revisited.
 - The email format check can be a single conservative regex
   (presence of `@`, presence of `.` after the `@`, no whitespace);
   full RFC 5322 compliance is explicitly out of scope.

--- a/evals/fixture/prds/ignite-eval/ignite-eval.prd.md
+++ b/evals/fixture/prds/ignite-eval/ignite-eval.prd.md
@@ -1,0 +1,143 @@
+<!--
+  EVAL FIXTURE PLANT — DO NOT DELETE OR "COMPLETE"
+
+  Consuming scenario: ignite-from-prd
+  Plant realism:      representative   (per data-model `realism` enum)
+  Owner:              evals/cases/ignite-from-prd.yaml  (scenario authored in Slice 2)
+  Purpose:            Provide a structurally-faithful, substantively-non-trivial
+                      PRD that `/smithy.ignite` can workshop into an RFC during
+                      eval runs.
+
+  This file is a deliberate eval fixture, not a real product PRD. The "Draft"
+  status and open Specification Debt rows are intentional — ignite reads them
+  during Phase 1 (clarify dispatch, prose dispatches, plan dispatches) and
+  needs unresolved material to work with. Do not "fix" the open questions,
+  do not close the debt rows, and do not promote the status away from Draft.
+
+  Structure conforms to the canonical PRD template rendered by
+  `src/templates/agent-skills/commands/smithy.spark.prompt` (Phase 3 PRD
+  Template Reference). PRDs deliberately omit `## Dependency Order` (PRDs sit
+  upstream of the RFC -> spec -> tasks lineage); do not retrofit one here.
+-->
+
+# PRD: Validate POST /api/users Request Bodies Before Creating Users
+
+**Created**: 2026-05-12  |  **Status**: Draft
+
+## Problem Statement
+
+The fixture API's `POST /api/users` handler currently accepts whatever JSON the
+client posts and writes it straight into the in-memory users array. A planted
+`TODO` above the handler in `src/routes/users.ts` admits the gap explicitly:
+"add request validation before creating user (reject empty name/email, enforce
+email format)". In practice, this means a client can create users with an empty
+string for `name`, with no `email` field at all, or with a syntactically broken
+email address like `not-an-email`. The handler still returns `201 Created` and
+the malformed record persists for the lifetime of the process.
+
+Downstream consumers of the API — the `GET /api/users` list endpoint, the
+`GET /api/users/:id` lookup, and anything else that reads the users array —
+treat every row as a well-formed `User`. There is no defensive parsing layer,
+so a single bad POST contaminates every subsequent read until the process
+restarts. Operators have no way to tell a "user that was never properly
+populated" apart from a "user whose name happens to be a single space".
+
+Today the only feedback loop is manual inspection of the in-memory store. The
+team wants the API to reject obviously-invalid `CreateUserRequest` payloads at
+the boundary with a structured 400 response, so bad data never enters the
+store and clients see a precise error instead of a silent corruption.
+
+## Proposed Solution
+
+Add input validation to the `POST /api/users` handler that rejects requests
+missing required fields (`name`, `email`), rejects empty-string values for
+those fields after trimming whitespace, and rejects email addresses that fail
+a conservative syntactic check. Rejected requests return HTTP 400 with a JSON
+body shaped like `{ "error": "<human-readable summary>", "field": "<which
+field failed>" }`. Valid requests behave exactly as they do today — they
+return HTTP 201 with the created user.
+
+The change is observable to API consumers as: malformed POSTs are refused
+with a specific, machine-readable error; well-formed POSTs are unaffected;
+the `users` array no longer contains records that violate the `User`
+contract.
+
+## Target Users
+
+- **API consumers writing client integrations against `POST /api/users`** —
+  today they discover the validation gap only when their downstream code
+  trips over `undefined` name fields. They want the server to be the
+  authority on what a well-formed user looks like.
+- **Fixture maintainers running Smithy evals** — they need the fixture's
+  surface area to remain stable and honest. A validation feature is a
+  natural, plausible addition that doesn't fight the fixture's existing
+  structure (one router, one in-memory store, one `CreateUserRequest` type).
+
+## Success Signals
+
+- A `POST /api/users` with body `{ "name": "", "email": "a@b.c" }` returns
+  HTTP 400, and the users array is unchanged.
+- A `POST /api/users` with body `{ "name": "Ada", "email": "not-an-email" }`
+  returns HTTP 400 citing the email field, and the users array is unchanged.
+- A `POST /api/users` with body `{ "name": "Ada", "email": "ada@example.com" }`
+  still returns HTTP 201 with the created user, exactly as it does today.
+- `GET /api/users` over time contains zero records with empty or missing
+  `name`/`email`.
+
+## Alternatives / Build-vs-Buy
+
+### Alternatives Considered
+
+| Name | URL | Category | Fit | Why not |
+|------|-----|----------|-----|---------|
+| zod | https://zod.dev | OSS library | Close | Idiomatic and well-typed, but adds a runtime dependency to a fixture that intentionally has only Express as a runtime dep; pulling it in shifts the fixture's dependency footprint in a way that complicates other evals that read `package.json`. |
+| express-validator | https://express-validator.github.io | OSS library | Partial | Mature, but its middleware-chain style introduces a second validation idiom alongside the existing inline route handlers and obscures the single-file, read-top-to-bottom shape that makes this fixture useful as eval input. |
+| Hand-rolled inline checks in the handler | — | Build | Close | Three or four lines of guard clauses cover the entire `CreateUserRequest` surface; the fixture has exactly one POST endpoint and one request type, so the maintenance cost of a library would exceed the cost of the validation itself. |
+
+### Build-vs-Buy Rationale
+
+The closest off-the-shelf candidate is `zod`, which would let the handler
+declare a schema once and reuse it for type narrowing and runtime checks.
+But the fixture's whole point is to be a small, read-top-to-bottom Express
+project that eval agents can reason about without chasing imports — and the
+validation surface here is exactly two required fields plus one format
+check. A hand-rolled guard clause inside the existing POST handler is
+proportional to the problem, keeps the fixture's runtime-dependency
+footprint at exactly one package (`express`), and stays consistent with the
+inline style of the other handlers. We will build, not buy.
+
+## Assumptions
+
+- [Critical Assumption] The fixture's `CreateUserRequest` interface
+  (`src/types.ts`) will not gain additional required fields during this
+  effort — if it does, the validation surface grows and the build-vs-buy
+  calculus may need to be revisited.
+- The email format check can be a single conservative regex
+  (presence of `@`, presence of `.` after the `@`, no whitespace);
+  full RFC 5322 compliance is explicitly out of scope.
+- Whitespace-only strings (e.g., `"   "`) count as empty after trimming.
+- The 400 response shape (`{ "error": "...", "field": "..." }`) is a new
+  contract for this endpoint; no existing client depends on a different
+  error shape, because the endpoint has no error shape today.
+- Validation runs synchronously in-handler; no async or database lookups
+  are needed.
+
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | Whether duplicate email addresses should also be rejected at validation time is unresolved — the in-memory store would allow `findIndex`-style checks cheaply, but doing so blurs the line between "shape validation" and "business-rule validation" and may belong in a follow-up. | Functional Scope | Medium | Medium | open | — |
+| SD-002 | The exact JSON error shape (`{ "error", "field" }` vs. an array of `{ "errors": [...] }` for multi-field failures) is not yet pinned down. Single-field is simpler today; multi-field is more useful for forms with multiple invalid inputs. | Domain & Data Model | Low | High | open | — |
+| SD-003 | Whether to expose the validation rules as a separate exported helper (testable in isolation) or keep them inline in the route handler is a structural decision deferred to implementation review. | Testing Strategy | Low | Medium | open | — |
+
+## Open Questions
+
+- Should the validation layer log rejected requests (and at what level), or
+  is "silently return 400" sufficient for a fixture-style API?
+- Do we want to add a corresponding `PATCH /api/users/:id` validation pass
+  as part of this effort, or scope it strictly to `POST` and follow up on
+  PATCH separately once that handler exists?
+- Is the email regex conservative enough to pass real-world addresses with
+  `+` aliases (`ada+test@example.com`) and subdomains
+  (`ada@mail.example.com`), or do we need explicit test coverage for those
+  shapes before locking the regex in?

--- a/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/05-ignite-eval-produces-rfc-from-prd.tasks.md
+++ b/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/05-ignite-eval-produces-rfc-from-prd.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Plant the ignite-eval PRD fixture**
+- [x] **Plant the ignite-eval PRD fixture**
 
   Create the scenario-isolated directory `evals/fixture/prds/ignite-eval/` containing `ignite-eval.prd.md` — a minimal-but-representative Smithy PRD conforming to the canonical PRD template rendered by `src/templates/agent-skills/commands/smithy.spark.prompt` (Phase 3 PRD template, lines ~397–446). The PRD MUST contain the eight canonical sections (`## Problem Statement`, `## Proposed Solution`, `## Target Users`, `## Success Signals`, `## Alternatives / Build-vs-Buy`, `## Assumptions`, `## Specification Debt`, `## Open Questions`) and MUST NOT contain `## Dependency Order` (the spark template explicitly omits that section from PRDs — PRDs sit upstream of the RFC→spec→tasks lineage). Open the file with a top-of-file comment naming the consuming scenario (`ignite-from-prd`) and identifying the plant as `representative` per the data-model `realism` enum. Author against the canonical template rather than minimum-viable content so ignite's Phase 1 PRD-read step has substantive input for downstream clarify/prose dispatches.
 
@@ -29,7 +29,7 @@
   - File contents reference no paths outside `evals/fixture/prds/ignite-eval/` (FR-004 isolation rule)
   - `evals/fixture/src/` and existing scout `## Planted Inconsistencies` rows are untouched (FR-013)
 
-- [ ] **Document the ignite-eval plant in the fixture README**
+- [x] **Document the ignite-eval plant in the fixture README**
 
   Extend `evals/fixture/README.md` with one row recording the ignite-eval plant directory in the `## Planted Parent Artifacts` section. Use a create-if-absent strategy following the US3/US4 precedent: if the section does not yet exist when this task runs (US2 Slice 2 / US3 Slice 1 / US4 Slice 1 may or may not have landed first), create it using the schema established by US2 Slice 2 — positioned after `## Planted Inconsistencies` and before `## Usage`, with a one-paragraph intro distinguishing representative plants from scout-flawed plants and a 4-column table (`Path | Owner Scenario | Realism | Purpose`). If the section already exists, append a row only.
 


### PR DESCRIPTION
## Source

- Spec: [`specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.spec.md`](specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.spec.md) — User Story 5
- Tasks: [`specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/05-ignite-eval-produces-rfc-from-prd.tasks.md`](specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/05-ignite-eval-produces-rfc-from-prd.tasks.md) — Slice 1

## Slice

**Slice 1: Plant the ignite-eval PRD fixture and document it** — establish a scenario-isolated `evals/fixture/prds/ignite-eval/` directory holding a representative PRD plant, and document the plant in the fixture README under a newly-created `## Planted Parent Artifacts` section. The Slice 2 YAML scenario (`evals/cases/ignite-from-prd.yaml`) will reference the plant by exact path on its first authored draft.

## Addresses

- FR-004 (scenario-isolated plant directories under `evals/fixture/{prds,rfcs,specs}/<scenario-slug>/`)
- FR-005 (exact-path prompt references)
- FR-013 (existing fixture `src/` and scout plants untouched)
- FR-014 (template-anchored fidelity — plant conforms to the canonical spark PRD template)
- AS 5.1 — planted-fixture precondition: PRD contains the eight canonical PRD sections that ignite's Phase 1 PRD-read step expects
- FR-012 — existing fixture untouched

## Tasks completed

- [x] **Plant the ignite-eval PRD fixture** (`evals/fixture/prds/ignite-eval/ignite-eval.prd.md`) — 143 lines, all eight canonical sections (`## Problem Statement`, `## Proposed Solution`, `## Target Users`, `## Success Signals`, `## Alternatives / Build-vs-Buy`, `## Assumptions`, `## Specification Debt`, `## Open Questions`), `## Dependency Order` correctly omitted (SD-014), top-of-file HTML comment names consuming scenario `ignite-from-prd`, realism `representative`, and the "do not delete / do not complete" eval-fixture protection rationale. Subject matter (POST /api/users request validation) aligns with the existing planted TODO at `evals/fixture/src/routes/users.ts:25` so the PRD content is honest against the fixture without inventing fictional code paths.
- [x] **Document the ignite-eval plant in the fixture README** — created the new `## Planted Parent Artifacts` section in `evals/fixture/README.md`, positioned between `## Planted Inconsistencies` and `## Usage`, with a 4-column table (`Path | Owner Scenario | Realism | Purpose`) and an intro paragraph that distinguishes representative plants from scout-flawed plants. Only the ignite-eval row is added — US1/US3/US4 plant PRs will append their own rows independently (create-if-absent strategy means whichever PR lands first creates the section).

## Review

`smithy-implementation-review` returned **0 Critical / 0 Important / 0 Minor** findings. The PRD conforms to the canonical spark template (`src/templates/agent-skills/commands/smithy.spark.prompt:395-460`), the README extension uses the exact schema specified in the tasks file, and only the two expected task checkboxes were flipped in the tasks file. No edits outside the two task scopes.

## Documentation

`smithy-maid` returned one auto-fixable item and three flagged items.

**Auto-fix applied** (`89d5143`, commit message `maid: refresh CONTRIBUTING evals notes for YAML loader + plants section`):
- `CONTRIBUTING.md` lines 60–63: removed the stale "Pending: YAML-defined scenario loading" block (YAML loading shipped in US7) and extended the Tier 3 evals bullet to mention the new `## Planted Parent Artifacts` README section alongside the existing `## Planted Inconsistencies` reference.

**Flagged items for reviewer awareness** (no code change):
- `evals/fixture/prds/ignite-eval/ignite-eval.prd.md` line 7: the `Owner:` comment forward-references `evals/cases/ignite-from-prd.yaml`, which is authored in Slice 2 and does not exist in this PR. Intentional — the plant lands first so Slice 2's `prompt` field resolves on its first authored draft (per the tasks file's Justification paragraph and the data-model PlantedArtifact lifecycle).
- `evals/fixture/prds/ignite-eval/ignite-eval.prd.md` lines 29–48: the Problem Statement prose names `src/routes/users.ts` and the `CreateUserRequest` type. These are **in-fixture content-level references**, not cross-scenario plant references — the fixture's own source code is the natural anchor for substantive PRD content, and the review sub-agent explicitly concurred this is permitted by FR-004's intent (the FR-004 isolation rule forbids cross-scenario cross-talk, not prose mentions of the shared fixture's own files).

## Validation

Run against HEAD `89d5143` after all code and doc fixes were committed:

| Command | Result |
|---------|--------|
| `npm run build` | ✓ ESM build success (133.69 KB) in 37ms |
| `npm run typecheck` | ✓ Clean (no diagnostics) |
| `npm test` | ✓ **803 passed / 26 test files** in 16.37s |

Manual fixture validation:
- `grep -E "^## " evals/fixture/prds/ignite-eval/ignite-eval.prd.md` → exactly the eight canonical PRD sections in correct order.
- `grep -c "## Dependency Order" evals/fixture/prds/ignite-eval/ignite-eval.prd.md` → 1 (only the HTML comment that documents the deliberate omission; the body has no `## Dependency Order` heading).
- Existing `## Planted Inconsistencies` scout-plant rows and `## Intentional Gap` section unchanged.

## Outstanding

- **Slice 2** (Author the `ignite-from-prd` YAML scenario) is a separate forthcoming PR — it carries the hard cross-story dependency on US2 Slice 1 (runner git-init) because `/smithy.ignite` issues `git commit` inside the temp fixture copy. This PR (Slice 1) has no such dependency since the plant is pure static content.

