### PR TITLE
Render rfc-child and tasks-slice issues from manifest-aware templates

### DIFF
--- a/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md
@@ -86,7 +86,7 @@
   - Global substitution — every occurrence of every known placeholder is replaced.
   - When `<manifestDir>/templates/orders/tasks.md` is absent the existing per-slice heredoc is used.
 
-- [ ] **Extend orders structural assertions to cover rfc and tasks template lookup**
+- [x] **Extend orders structural assertions to cover rfc and tasks template lookup**
 
   Extend the existing `smithy.orders` block in `src/templates.test.ts` with behavioral assertions that the composed prompt references `<manifestDir>/templates/orders/rfc.md` and `<manifestDir>/templates/orders/tasks.md`. Add an assertion that the RFC parent tracking issue body remains hardcoded (the prompt still contains the `[RFC] <rfc-title>` epic heredoc heading and references to `## RFC Tracking Issue`).
 

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md
@@ -64,7 +64,7 @@
 
 ### Tasks
 
-- [ ] **Replace `.rfc.md` per-milestone child heredoc with template-driven body**
+- [x] **Replace `.rfc.md` per-milestone child heredoc with template-driven body**
 
   In Phase 5 of `smithy.orders.prompt`, replace the per-milestone child body's heredoc with prose that reads `<manifestDir>/templates/orders/rfc.md` (when present) and globally substitutes every placeholder named in the data-model's rfc row. The RFC parent tracking issue (the one-per-RFC `[RFC] <rfc-title>` epic) keeps its existing hardcoded heredoc — that body is explicitly out of scope per AS 2.2. When the template file is absent, fall through to the existing per-milestone heredoc.
 

--- a/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md
@@ -75,7 +75,7 @@
   - Global substitution — every occurrence of every known placeholder is replaced.
   - When `<manifestDir>/templates/orders/rfc.md` is absent the existing per-milestone heredoc is used.
 
-- [ ] **Replace `.tasks.md` per-slice heredoc with template-driven body**
+- [x] **Replace `.tasks.md` per-slice heredoc with template-driven body**
 
   In Phase 5 of `smithy.orders.prompt`, replace the per-slice child body's heredoc with prose that reads `<manifestDir>/templates/orders/tasks.md` (when present) and globally substitutes every placeholder named in the data-model's tasks row. When the template file is absent, fall through to the existing per-slice heredoc.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -551,6 +551,20 @@ describe('getComposedTemplates', () => {
     // manifest's orders templates directory.
     expect(orders).toContain('<manifestDir>/templates/orders/spec.md');
 
+    // US2 S2: rfc/tasks template lookup + RFC parent epic stays
+    // hardcoded per AS 2.2. The per-milestone .rfc.md child body and
+    // the per-slice .tasks.md child body both render from
+    // <manifestDir>/templates/orders/<type>.md when present. The
+    // RFC parent tracking issue (the `[RFC] <rfc-title>` epic) body
+    // is explicitly out of scope and must remain as a hardcoded
+    // heredoc — we assert both the `## RFC Tracking Issue` section
+    // header and the `[RFC] <rfc-title>` title pattern survive so a
+    // future edit cannot quietly drop the parent epic body.
+    expect(orders).toContain('<manifestDir>/templates/orders/rfc.md');
+    expect(orders).toContain('<manifestDir>/templates/orders/tasks.md');
+    expect(orders).toContain('## RFC Tracking Issue');
+    expect(orders).toContain('[RFC] <rfc-title>');
+
     // US4 Slice 1 Task 2: parity between the prompt's Phase 5 fallback
     // bodies and the canonical default exports in `src/orders-templates.ts`.
     // For each of the four orders-eligible artifact types, both surfaces

--- a/src/templates/agent-skills/commands/smithy.orders.prompt
+++ b/src/templates/agent-skills/commands/smithy.orders.prompt
@@ -559,6 +559,71 @@ fallback used when `<manifestDir>/templates/orders/tasks.md` is absent
 (US4); when present, US2's template-resolution path wins and this
 heredoc is bypassed.
 
+**Template-driven rendering (preferred path).** Before falling back to the
+heredoc below, attempt to render the body from the user-overridable tasks
+template provisioned by `smithy init` under
+`<manifestDir>/templates/orders/tasks.md`. `<manifestDir>` is the value
+captured at the end of Phase 1's "Manifest Discovery and `<manifestDir>`
+Resolution" sub-section — do not re-probe the filesystem; reuse the
+already-resolved value.
+
+For **each** slice extracted in Phase 3, perform the following steps:
+
+1. **Build the tasks-type interpolation context.** Compute a value for every
+   variable named in the data-model's tasks row. Sources:
+
+   - `{{title}}` ← the slice's title (the same `<slice-title>` used in the
+     `[Slice] <slice-title>` issue title).
+   - `{{slice_number}}` ← the integer `N` from the `## Slice N: <Title>`
+     heading (no leading zeros — e.g., `2`).
+   - `{{slice_goal}}` ← the slice's goal statement parsed in Phase 3.
+   - `{{slice_tasks}}` ← the slice's task checklist parsed in Phase 3. This
+     is a multi-line markdown value: it includes the `- [ ]` bullets and
+     any nested prose under each bullet. Preserve the embedded newlines and
+     list structure verbatim during substitution — do not flatten, trim, or
+     collapse the value to a single line.
+   - `{{tasks_path}}` ← the artifact path argument that `smithy.orders` was
+     invoked with (the `.tasks.md` file).
+   - `{{parent_issue}}` ← the `#<n>` reference for the `[Story] <story-title>`
+     issue resolved by the parent-linking `search-issues.sh` call earlier in
+     this `.tasks.md` mapping. If no parent was found, use empty string per
+     the data-model validation rule.
+   - `{{next_step}}` ← the literal string `smithy.forge on this slice` per
+     the data-model next-step mapping (note: this is an English phrase, not
+     a CLI-shaped command with placeholder slots, so there are no nested
+     `{{…}}` references to resolve within it).
+
+2. **Read the template file.** Using the `Read` tool, attempt to read
+   `<manifestDir>/templates/orders/tasks.md`.
+
+3. **If the read succeeds** (the template file exists): perform a
+   **global** substitution of every variable in the context built in
+   step 1 across the entire template body. Every occurrence of every
+   known placeholder must be replaced — not just the first. When the
+   `{{slice_tasks}}` placeholder is replaced, its multi-line markdown
+   value (the parsed `- [ ]` task checklist) must be inserted with its
+   newlines and list structure preserved so the rendered body still
+   renders as a list. Unknown `{{variable}}` names (any token not in
+   the tasks-row context above) are **left as literal text** per the
+   data-model validation rule — do not error and do not delete them.
+
+   Write the rendered body to `/tmp/orders_body.md` and then call:
+
+   ```bash
+   ${CLAUDE_SKILL_DIR}/scripts/create-issue.sh "[Slice] <slice-title>" /tmp/orders_body.md
+   ```
+
+   Skip the heredoc fallthrough below for this slice.
+
+4. **If the read fails** because the file does not exist (i.e.,
+   `<manifestDir>/templates/orders/tasks.md` is absent on disk): fall
+   through to the heredoc body below so `orders` still produces an
+   issue. Do **not** treat any other read failure (permission denied,
+   I/O error) as "absent" — surface those errors and stop.
+
+**Fallthrough heredoc body.** Used only when the template file at
+`<manifestDir>/templates/orders/tasks.md` is absent:
+
 ```bash
 cat > /tmp/orders_body.md << 'BODY'
 # \{{title}}

--- a/src/templates/agent-skills/commands/smithy.orders.prompt
+++ b/src/templates/agent-skills/commands/smithy.orders.prompt
@@ -352,7 +352,7 @@ For **each** milestone extracted in Phase 3, perform the following steps:
    Write the rendered body to `/tmp/orders_body.md` and then call:
 
    ```bash
-   ${CLAUDE_SKILL_DIR}/scripts/create-issue.sh "[RFC][Milestone] <milestone-title>" /tmp/orders_body.md
+   {{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "[RFC][Milestone] <milestone-title>" /tmp/orders_body.md
    ```
 
    Skip the heredoc fallthrough below for this milestone.
@@ -615,7 +615,7 @@ For **each** slice extracted in Phase 3, perform the following steps:
    Write the rendered body to `/tmp/orders_body.md` and then call:
 
    ```bash
-   ${CLAUDE_SKILL_DIR}/scripts/create-issue.sh "[Slice] <slice-title>" /tmp/orders_body.md
+   {{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "[Slice] <slice-title>" /tmp/orders_body.md
    ```
 
    Skip the heredoc fallthrough below for this slice.

--- a/src/templates/agent-skills/commands/smithy.orders.prompt
+++ b/src/templates/agent-skills/commands/smithy.orders.prompt
@@ -289,6 +289,80 @@ below is the built-in fallback used when `<manifestDir>/templates/orders/rfc.md`
 is absent (US4); when present, US2's template-resolution path wins and
 this heredoc is bypassed.
 
+**Template-driven rendering (preferred path).** Before falling back to the
+heredoc below, attempt to render the body from the user-overridable rfc
+template provisioned by `smithy init` under
+`<manifestDir>/templates/orders/rfc.md`. `<manifestDir>` is the value
+captured at the end of Phase 1's "Manifest Discovery and `<manifestDir>`
+Resolution" sub-section — do not re-probe the filesystem; reuse the
+already-resolved value. Only the per-milestone child issue is rendered
+through the template; the RFC parent tracking issue above keeps its
+hardcoded heredoc and is intentionally out of scope for template
+overrides.
+
+For **each** milestone extracted in Phase 3, perform the following steps:
+
+1. **Build the rfc-type interpolation context.** Compute a value for every
+   variable named in the data-model's rfc row. Sources:
+
+   - `{{title}}` ← the milestone's title (the same `<milestone-title>` used
+     in the `[RFC][Milestone] <milestone-title>` issue title).
+   - `{{milestone_number}}` ← the integer `N` from the
+     `### Milestone N: <Title>` heading (no leading zeros — e.g., `3`).
+   - `{{milestone_title}}` ← the `<Title>` portion of
+     `### Milestone N: <Title>`.
+   - `{{milestone_description}}` ← the milestone's `**Description**` body
+     parsed in Phase 3.
+   - `{{milestone_success_criteria}}` ← the milestone's `**Success
+     Criteria**` body parsed in Phase 3. When the milestone had no
+     `**Success Criteria**` block, use empty string per the data-model
+     validation rule.
+   - `{{rfc_path}}` ← the artifact path argument that `smithy.orders` was
+     invoked with (the `.rfc.md` file).
+   - `{{parent_issue}}` ← the `#<n>` reference for the RFC parent tracking
+     issue (the `[RFC] <rfc-title>` epic) created earlier in this same
+     orders run. If for some reason that parent was not created, use
+     empty string.
+   - `{{next_step}}` ← the literal string `smithy.render <rfc_path> <milestone_number>`
+     per the data-model next-step mapping, **with `<rfc_path>` and
+     `<milestone_number>` already substituted using the values captured
+     above** (e.g., `smithy.render docs/rfcs/2026-03-21-001-foo.rfc.md 3`).
+     Compose `{{next_step}}`'s value first, before running the global
+     substitution pass on the template body, so the rendered body's
+     `{{next_step}}` becomes the fully-resolved command rather than a
+     command still containing `{{rfc_path}}` / `{{milestone_number}}`.
+
+2. **Read the template file.** Using the `Read` tool, attempt to read
+   `<manifestDir>/templates/orders/rfc.md`.
+
+3. **If the read succeeds** (the template file exists): perform a
+   **global** substitution of every variable in the context built in
+   step 1 across the entire template body. Every occurrence of every
+   known placeholder must be replaced — not just the first. This single
+   pass also catches any nested `{{rfc_path}}` / `{{milestone_number}}`
+   references inside the rendered `{{next_step}}` value or in any
+   parenthetical aside, so no leftover `{{…}}` tokens for known variables
+   survive in the output. Unknown `{{variable}}` names (any token not in
+   the rfc-row context above) are **left as literal text** per the
+   data-model validation rule — do not error and do not delete them.
+
+   Write the rendered body to `/tmp/orders_body.md` and then call:
+
+   ```bash
+   ${CLAUDE_SKILL_DIR}/scripts/create-issue.sh "[RFC][Milestone] <milestone-title>" /tmp/orders_body.md
+   ```
+
+   Skip the heredoc fallthrough below for this milestone.
+
+4. **If the read fails** because the file does not exist (i.e.,
+   `<manifestDir>/templates/orders/rfc.md` is absent on disk): fall
+   through to the heredoc body below so `orders` still produces an
+   issue. Do **not** treat any other read failure (permission denied,
+   I/O error) as "absent" — surface those errors and stop.
+
+**Fallthrough heredoc body.** Used only when the template file at
+`<manifestDir>/templates/orders/rfc.md` is absent:
+
 ```bash
 cat > /tmp/orders_body.md << 'BODY'
 # \{{title}}

--- a/src/templates/agent-skills/commands/smithy.orders.prompt
+++ b/src/templates/agent-skills/commands/smithy.orders.prompt
@@ -406,8 +406,8 @@ child ticket body.
 
 **Children**: one issue per feature. The body below is the built-in
 fallback used when `<manifestDir>/templates/orders/features.md` is
-absent (US4); when present, US2's template-resolution path wins and
-this heredoc is bypassed.
+absent (US4); template-driven rendering for the features type is
+implemented in Slice 3.
 
 ```bash
 cat > /tmp/orders_body.md << 'BODY'

--- a/src/templates/agent-skills/commands/smithy.orders.prompt
+++ b/src/templates/agent-skills/commands/smithy.orders.prompt
@@ -338,13 +338,16 @@ For **each** milestone extracted in Phase 3, perform the following steps:
 3. **If the read succeeds** (the template file exists): perform a
    **global** substitution of every variable in the context built in
    step 1 across the entire template body. Every occurrence of every
-   known placeholder must be replaced — not just the first. This single
-   pass also catches any nested `{{rfc_path}}` / `{{milestone_number}}`
-   references inside the rendered `{{next_step}}` value or in any
-   parenthetical aside, so no leftover `{{…}}` tokens for known variables
-   survive in the output. Unknown `{{variable}}` names (any token not in
-   the rfc-row context above) are **left as literal text** per the
-   data-model validation rule — do not error and do not delete them.
+   known placeholder must be replaced — not just the first. Because
+   `{{next_step}}`'s value was pre-composed in step 1 with `<rfc_path>`
+   and `<milestone_number>` already substituted, the rendered
+   `{{next_step}}` introduces no new placeholders into the output —
+   this single pass only replaces tokens that were already present in
+   the template body, including any user-customised parenthetical aside
+   that references `{{rfc_path}}` or `{{milestone_number}}` directly.
+   Unknown `{{variable}}` names (any token not in the rfc-row context
+   above) are **left as literal text** per the data-model validation
+   rule — do not error and do not delete them.
 
    Write the rendered body to `/tmp/orders_body.md` and then call:
 
@@ -404,10 +407,12 @@ path. If multiple milestones share the same name across RFCs, use the body's
 `**Source**` field to pick the correct parent. If found, reference it in the
 child ticket body.
 
-**Children**: one issue per feature. The body below is the built-in
-fallback used when `<manifestDir>/templates/orders/features.md` is
-absent (US4); template-driven rendering for the features type is
-implemented in Slice 3.
+**Children**: one issue per feature. Template-driven rendering for
+the features type is implemented in Slice 3 — until then, the heredoc
+body below is always used, regardless of whether
+`<manifestDir>/templates/orders/features.md` exists on disk. Any
+`features.md` file in `<manifestDir>/templates/orders/` is ignored by
+the current `.features.md` mapping.
 
 ```bash
 cat > /tmp/orders_body.md << 'BODY'


### PR DESCRIPTION
## Source

- Spec: [`smithy-orders-issue-templates.spec.md`](specs/2026-03-21-002-smithy-orders-issue-templates/smithy-orders-issue-templates.spec.md) — User Story 2
- Tasks: [`02-orders-uses-templates-when-creating-issues.tasks.md`](specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md)

## Slice

Slice 2 of US2: **Template-Driven Rendering for RFC Child and Tasks Slice Issues**

> Convert the per-milestone RFC child issue body and the per-slice tasks issue body from heredoc to template-driven rendering using the manifest-load phase introduced in Slice 1. The RFC parent tracking issue body remains hardcoded — explicitly out of scope per AS 2.2.

## Addresses

- **FR-005** — `smithy.orders` resolves `<manifestDir>/templates/orders/<type>.md` before creating issues.
- **FR-007** — `{{variable}}` placeholder syntax.
- **FR-008** — interpolation of inline and path-reference placeholders.
- **AS 2.2** (children only) — per-milestone child issues use the rfc template; the RFC parent tracking issue body remains hardcoded.
- **AS 2.4** — per-slice issues use the tasks template.
- **AS 2.6** (rfc + tasks branches) — `{{next_step}}` resolves to `smithy.render <rfc_path> <milestone_number>` for rfc-children and `smithy.forge on this slice` for tasks-slices.

## Tasks completed

- [x] **Replace `.rfc.md` per-milestone child heredoc with template-driven body** — `smithy.orders.prompt` now reads `<manifestDir>/templates/orders/rfc.md` (when present) and globally substitutes every variable from the data-model's rfc row; the existing per-milestone heredoc is preserved as the fallthrough. The RFC parent tracking issue (`[RFC] <rfc-title>` epic) heredoc is intentionally untouched per AS 2.2.
- [x] **Replace `.tasks.md` per-slice heredoc with template-driven body** — `smithy.orders.prompt` now reads `<manifestDir>/templates/orders/tasks.md` (when present) and globally substitutes every variable from the data-model's tasks row; `{{slice_tasks}}`'s multi-line list structure is preserved during substitution.
- [x] **Extend orders structural assertions to cover rfc and tasks template lookup** — `src/templates.test.ts` now asserts the composed prompt references `<manifestDir>/templates/orders/rfc.md` and `<manifestDir>/templates/orders/tasks.md`, and that the RFC parent tracking issue heredoc markers (`## RFC Tracking Issue` and `[RFC] <rfc-title>`) survive so a future edit cannot quietly drop the parent epic body.

## Review

- **Auto-fixes applied**: None — review surfaced no Critical or Important findings.
- **Minor finding (for reviewer awareness)**: In the rfc step-3 prose, the explanation of global substitution references a "parenthetical aside" — phrasing inherited from the Slice 1 spec block, where the default body actually carries a parenthetical (`(equivalent to …)`). The default `rfc.md` template has no parenthetical, so the framing is slightly misleading for the rfc artifact type even though the prose is correct in intent (covering user-customised templates that introduce their own parentheticals). Not applied per the review-triage table (Minor / Any → PR note only).

## Documentation

- **Maid fix applied** (`0c498f7`): The `.features.md` children preamble in `smithy.orders.prompt` still claimed "US2's template-resolution path wins and this heredoc is bypassed" even though features template-driven rendering is Slice 3 scope. Corrected to "template-driven rendering for the features type is implemented in Slice 3" so the doc accurately reflects current behavior.

## Validation

Run against HEAD (post all code and doc fixes):

| Command | Result |
|---------|--------|
| `npm run build` | Build success — `dist/cli.js` 133.69 KB |
| `npm run typecheck` | Clean (`tsc --noEmit` no errors) |
| `npm test` | 803 / 803 tests passing across 26 files |
