### PR TITLE
Enable Smithy installs for Codex

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Smithy is a CLI tool that bootstraps AI-assisted development workflows across mu
 |-------|---------|-------------------|---------------------|-------------|
 | Claude | `.claude/prompts/` | `.claude/commands/` | `.claude/agents/` | `.claude/settings.json` |
 | Gemini | `.gemini/skills/<name>/SKILL.md` | `.gemini/skills/<name>/SKILL.md` | (not deployed) | `.gemini/settings.json` |
-| Codex | `tools/codex/prompts/` and `.agents/skills/<name>/SKILL.md` | `.agents/skills/<name>/SKILL.md` | (not deployed) | `.codex/config.toml` |
+| Codex | `tools/codex/prompts/` and `.agents/skills/<name>/SKILL.md` | `.agents/skills/<name>/SKILL.md` | (not deployed) | `.codex/rules/default.rules` |
 
 `smithy uninit` removes all deployed artifacts (but preserves config/permissions).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,7 @@ Smithy is a CLI tool that bootstraps AI-assisted development workflows across mu
 |-------|---------|-------------------|---------------------|-------------|
 | Claude | `.claude/prompts/` | `.claude/commands/` | `.claude/agents/` | `.claude/settings.json` |
 | Gemini | `.gemini/skills/<name>/SKILL.md` | `.gemini/skills/<name>/SKILL.md` | (not deployed) | `.gemini/settings.json` |
-
-> **Note:** Codex support exists in the codebase (`src/agents/codex.ts`) but is not currently exposed as a CLI option. It will be revisited once Codex's skill/prompt conventions are better understood.
+| Codex | `tools/codex/prompts/` and `.agents/skills/<name>/SKILL.md` | `.agents/skills/<name>/SKILL.md` | (not deployed) | `.codex/config.toml` |
 
 `smithy uninit` removes all deployed artifacts (but preserves config/permissions).
 
@@ -21,7 +20,7 @@ Smithy is a CLI tool that bootstraps AI-assisted development workflows across mu
 
 - **CLI entry**: `src/cli.ts` — Commander setup and arg parsing.
 - **Commands**: `src/commands/init.ts`, `src/commands/uninit.ts`, `src/commands/update.ts` — action handlers.
-- **Agent deployers**: `src/agents/{claude,gemini}.ts` — per-agent deploy/remove logic. (`codex.ts` exists but is not exposed in the CLI yet.)
+- **Agent deployers**: `src/agents/{claude,gemini,codex}.ts` — per-agent deploy/remove logic.
 - **Templates**: `src/templates/agent-skills/{commands,prompts,agents}/*.prompt` — categorized by deployment target. Uses [Dotprompt](https://firebase.google.com/docs/genkit/dotprompt)'s native `.prompt` extension with YAML frontmatter (`name`, `description`). Dotprompt handles Handlebars rendering at deploy time — resolving partials (`{{>snippet-name}}`), conditionals (`{{#ifAgent}}...{{/ifAgent}}`), and other expressions. Frontmatter is stripped when deploying to Claude (kept for Gemini skills). Deployed files are translated to `.md`. See `src/templates/agent-skills/README.md` for full conventions.
 - **Snippets**: `src/templates/agent-skills/snippets/*.md` — shared Markdown fragments injected via `{{>partial-name}}` Handlebars partials. Resolved by Dotprompt at deploy time; not deployed as standalone files.
 - **Orders body templates**: `src/orders-templates.ts` — exports the four canonical default body strings (`rfc` / `features` / `spec` / `tasks`) plus the `provisionOrdersTemplates` function that `smithy init` calls to write them under `<manifestDir>/templates/orders/<type>.md`. The same defaults double as the built-in fallback bodies in `smithy.orders` (parity asserted in `src/templates.test.ts`).
@@ -100,11 +99,11 @@ Templates are organized by their deployment target:
 - **`commands/`** — invocable as slash commands (e.g., `/smithy.strike "add verbose flag"`). Deployed to `.claude/commands/` for Claude, `.agents/skills/` for Codex, `.gemini/skills/` for Gemini.
 - **`prompts/`** — reference files the AI can read, but NOT invocable as `/command`. Deployed to `.claude/prompts/` for Claude, `tools/codex/prompts/` for Codex, `.gemini/skills/` for Gemini.
 - **`agents/`** — sub-agent definitions (deployed to `.claude/agents/` only, with frontmatter intact).
-- **`skills/`** — lazy-loaded operational skills. Each skill is a directory containing a `SKILL.prompt` (frontmatter retained at deploy) plus optional `scripts/`. Deployed to `.claude/skills/<name>/SKILL.md` (+ executable `scripts/`).
+- **`skills/`** — lazy-loaded operational skills. Each skill is a directory containing a `SKILL.prompt` (frontmatter retained at deploy) plus optional `scripts/`. Deployed to `.claude/skills/<name>/SKILL.md`, `.gemini/skills/<name>/SKILL.md`, and `.agents/skills/<name>/SKILL.md` for Codex (+ executable `scripts/` where present).
 - **`snippets/`** — shared Markdown fragments injected into other templates via `{{>partial-name}}` Handlebars partials (resolved by Dotprompt at deploy time).
 
 ### Cross-Agent Compatibility
-The same template source serves all three agents. Gemini keeps frontmatter (for skill metadata). Claude/Codex strip it. The prompt text uses `$ARGUMENTS` which Claude replaces but Gemini/Codex leave as literal — so prompts include a fallback: "If no feature description is clear, ask the user."
+The same template source serves all three agents. Gemini and Codex keep frontmatter for skill metadata; Claude strips it from commands/prompts while retaining it for sub-agents and skills. The prompt text uses `$ARGUMENTS` which Claude replaces but Gemini/Codex leave as literal — so prompts include a fallback: "If no feature description is clear, ask the user."
 
 ### Artifact Hierarchy and Relationships
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Smithy CLI
 
-An initialization tool for the **Smithy Agentic Development Workflow**. This package provides a CLI that easily sets up the `smithy` prompt templates for various AI assistant workflows, including Claude and Gemini CLI.
+An initialization tool for the **Smithy Agentic Development Workflow**. This package provides a CLI that easily sets up the `smithy` prompt templates for various AI assistant workflows, including Claude, Gemini CLI, and Codex.
 
 ## Installation
 
@@ -21,6 +21,7 @@ smithy init
 
 - **Claude:** Installs commands, prompts, and sub-agents into `.claude/` for use within your Claude Code workflows.
 - **Gemini CLI:** Installs workspace skills (`.gemini/skills/`) so you can type `/skills reload` and immediately use Smithy workflow commands.
+- **Codex:** Installs project skills into `.agents/skills/` and reference prompts into `tools/codex/prompts/`, with `smithy.forge` and `smithy.fix` ready for Codex-driven implementation and repair workflows.
 
 ## Workflow Industrial Pipeline
 

--- a/src/agents/codex.test.ts
+++ b/src/agents/codex.test.ts
@@ -48,19 +48,19 @@ describe('deploy', () => {
   it('writes permissions when initPermissions is true', async () => {
     await deploy(tmpDir, true);
 
-    const configPath = path.join(tmpDir, '.codex', 'config.toml');
-    expect(fs.existsSync(configPath)).toBe(true);
+    const rulesPath = path.join(tmpDir, '.codex', 'rules', 'default.rules');
+    expect(fs.existsSync(rulesPath)).toBe(true);
 
-    const content = fs.readFileSync(configPath, 'utf8');
-    expect(content).toContain('[approvals]');
-    expect(content).toContain('policy = "auto"');
+    const content = fs.readFileSync(rulesPath, 'utf8');
+    expect(content).toContain('# BEGIN SMITHY CODEX RULES');
+    expect(content).toContain('prefix_rule(pattern=["git","status"], decision="allow")');
   });
 
   it('does not write permissions when initPermissions is false', async () => {
     await deploy(tmpDir, false);
 
-    const configPath = path.join(tmpDir, '.codex', 'config.toml');
-    expect(fs.existsSync(configPath)).toBe(false);
+    const rulesPath = path.join(tmpDir, '.codex', 'rules', 'default.rules');
+    expect(fs.existsSync(rulesPath)).toBe(false);
   });
 
   it('returns deployed file paths', async () => {
@@ -202,102 +202,125 @@ describe('writePermissions (via deploy)', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('creates .codex directory if it does not exist', async () => {
+  it('creates .codex rules directory if it does not exist', async () => {
     await deploy(tmpDir, true);
 
-    const codexDir = path.join(tmpDir, '.codex');
-    expect(fs.existsSync(codexDir)).toBe(true);
+    const rulesDir = path.join(tmpDir, '.codex', 'rules');
+    expect(fs.existsSync(rulesDir)).toBe(true);
   });
 
-  it('generates valid TOML with approvals rules', async () => {
+  it('generates Codex prefix rules', async () => {
     await deploy(tmpDir, true);
 
-    const configPath = path.join(tmpDir, '.codex', 'config.toml');
-    const content = fs.readFileSync(configPath, 'utf8');
+    const rulesPath = path.join(tmpDir, '.codex', 'rules', 'default.rules');
+    const content = fs.readFileSync(rulesPath, 'utf8');
 
-    expect(content).toContain('[approvals]');
-    expect(content).toContain('policy = "auto"');
-    expect(content).toContain('[[approvals.rules]]');
-    expect(content).toContain('command = "git"');
+    expect(content).toContain('# BEGIN SMITHY CODEX RULES');
+    expect(content).toContain('# END SMITHY CODEX RULES');
+    expect(content).toContain('prefix_rule(pattern=["git","status"], decision="allow")');
   });
 
   it('includes filesystem commands in rules', async () => {
     await deploy(tmpDir, true);
 
-    const configPath = path.join(tmpDir, '.codex', 'config.toml');
-    const content = fs.readFileSync(configPath, 'utf8');
+    const rulesPath = path.join(tmpDir, '.codex', 'rules', 'default.rules');
+    const content = fs.readFileSync(rulesPath, 'utf8');
 
-    expect(content).toContain('command = "ls"');
-    expect(content).toContain('command = "cat"');
-    expect(content).toContain('command = "cp"');
-    expect(content).toContain('command = "mkdir"');
+    expect(content).toContain('prefix_rule(pattern=["ls"], decision="allow")');
+    expect(content).toContain('prefix_rule(pattern=["cat"], decision="allow")');
+    expect(content).toContain('prefix_rule(pattern=["cp"], decision="allow")');
+    expect(content).toContain('prefix_rule(pattern=["mkdir"], decision="allow")');
   });
 
-  it('uses args_startswith for wildcard entries', async () => {
+  it('trims wildcard entries into prefix patterns', async () => {
     await deploy(tmpDir, true);
 
-    const configPath = path.join(tmpDir, '.codex', 'config.toml');
-    const content = fs.readFileSync(configPath, 'utf8');
+    const rulesPath = path.join(tmpDir, '.codex', 'rules', 'default.rules');
+    const content = fs.readFileSync(rulesPath, 'utf8');
 
-    // Wildcard entries should produce args_startswith
-    expect(content).toContain('args_startswith');
+    expect(content).toContain('prefix_rule(pattern=["git","fetch"], decision="allow")');
+    expect(content).toContain('prefix_rule(pattern=["mkdir","-p"], decision="allow")');
   });
 
-  it('uses args for non-wildcard entries', async () => {
+  it('includes non-wildcard arguments in prefix patterns', async () => {
     await deploy(tmpDir, true);
 
-    const configPath = path.join(tmpDir, '.codex', 'config.toml');
-    const content = fs.readFileSync(configPath, 'utf8');
+    const rulesPath = path.join(tmpDir, '.codex', 'rules', 'default.rules');
+    const content = fs.readFileSync(rulesPath, 'utf8');
 
-    // Non-wildcard entries like "git status" (no args) should produce args = []
-    expect(content).toContain('args = []');
+    expect(content).toContain('prefix_rule(pattern=["git","status"], decision="allow")');
+    expect(content).toContain('prefix_rule(pattern=["git","push","--force-with-lease"], decision="allow")');
   });
 
-  it('uses empty args_startswith for commands with bare wildcard and flag variants', async () => {
+  it('does not emit duplicate prefix patterns for bare wildcard and flag variants', async () => {
     await deploy(tmpDir, true);
 
-    const configPath = path.join(tmpDir, '.codex', 'config.toml');
-    const content = fs.readFileSync(configPath, 'utf8');
+    const rulesPath = path.join(tmpDir, '.codex', 'rules', 'default.rules');
+    const content = fs.readFileSync(rulesPath, 'utf8');
 
-    // mkdir: ["*", "-p *"] should produce args_startswith = [], not ["-p "]
-    const mkdirRule = content.match(
-      /\[\[approvals\.rules\]\]\ncommand = "mkdir"\n(args\S* = [^\n]+)/
+    const bareMkdirRules = content.match(/prefix_rule\(pattern=\["mkdir"\], decision="allow"\)/g);
+    expect(bareMkdirRules).toHaveLength(1);
+    expect(content).toContain('prefix_rule(pattern=["mkdir","-p"], decision="allow")');
+  });
+
+  it('allows Smithy skill helper scripts used by Codex skills', async () => {
+    await deploy(tmpDir, true);
+
+    const rulesPath = path.join(tmpDir, '.codex', 'rules', 'default.rules');
+    const content = fs.readFileSync(rulesPath, 'utf8');
+
+    expect(content).toContain(
+      'prefix_rule(pattern=["./.agents/skills/smithy.pr-review/scripts/find-pr.sh"], decision="allow")'
     );
-    expect(mkdirRule).not.toBeNull();
-    expect(mkdirRule![1]).toBe('args_startswith = []');
+    expect(content).toContain(
+      'prefix_rule(pattern=["./.agents/skills/smithy.pr-review/scripts/get-comments.sh"], decision="allow")'
+    );
+    expect(content).toContain(
+      'prefix_rule(pattern=["./.agents/skills/smithy.pr-review/scripts/reply-comment.sh"], decision="allow")'
+    );
+    expect(content).toContain(
+      'prefix_rule(pattern=["./.agents/skills/smithy.gh-issue/scripts/check-env.sh"], decision="allow")'
+    );
   });
 
-  it('does not overwrite existing config with approvals section', async () => {
-    const codexDir = path.join(tmpDir, '.codex');
-    fs.mkdirSync(codexDir, { recursive: true });
-    const configPath = path.join(codexDir, 'config.toml');
+  it('preserves existing user rules and appends Smithy rules', async () => {
+    const rulesDir = path.join(tmpDir, '.codex', 'rules');
+    fs.mkdirSync(rulesDir, { recursive: true });
+    const rulesPath = path.join(rulesDir, 'default.rules');
 
-    const existing = '[approvals]\npolicy = "suggest"\n';
-    fs.writeFileSync(configPath, existing);
+    const existing = 'prefix_rule(pattern=["custom"], decision="allow")\n';
+    fs.writeFileSync(rulesPath, existing);
 
     await deploy(tmpDir, true);
 
-    const content = fs.readFileSync(configPath, 'utf8');
-    // Should not have appended a second [approvals] section
-    expect(content).toBe(existing);
+    const content = fs.readFileSync(rulesPath, 'utf8');
+    expect(content).toContain(existing.trim());
+    expect(content).toContain('# BEGIN SMITHY CODEX RULES');
+    expect(content).toContain('prefix_rule(pattern=["git","status"], decision="allow")');
   });
 
-  it('appends to existing config without approvals section', async () => {
-    const codexDir = path.join(tmpDir, '.codex');
-    fs.mkdirSync(codexDir, { recursive: true });
-    const configPath = path.join(codexDir, 'config.toml');
+  it('updates the managed Smithy rules block idempotently', async () => {
+    const rulesDir = path.join(tmpDir, '.codex', 'rules');
+    fs.mkdirSync(rulesDir, { recursive: true });
+    const rulesPath = path.join(rulesDir, 'default.rules');
 
-    const existing = '[model]\nname = "gpt-4"\n';
-    fs.writeFileSync(configPath, existing);
+    const existing = [
+      'prefix_rule(pattern=["custom"], decision="allow")',
+      '',
+      '# BEGIN SMITHY CODEX RULES',
+      'prefix_rule(pattern=["old"], decision="allow")',
+      '# END SMITHY CODEX RULES',
+      '',
+    ].join('\n');
+    fs.writeFileSync(rulesPath, existing);
 
     await deploy(tmpDir, true);
+    const firstContent = fs.readFileSync(rulesPath, 'utf8');
+    await deploy(tmpDir, true);
 
-    const content = fs.readFileSync(configPath, 'utf8');
-    // Should preserve existing content
-    expect(content).toContain('[model]');
-    expect(content).toContain('name = "gpt-4"');
-    // Should have appended approvals
-    expect(content).toContain('[approvals]');
-    expect(content).toContain('policy = "auto"');
+    const secondContent = fs.readFileSync(rulesPath, 'utf8');
+    expect(secondContent).toBe(firstContent);
+    expect(secondContent).not.toContain('prefix_rule(pattern=["old"], decision="allow")');
+    expect(secondContent.match(/# BEGIN SMITHY CODEX RULES/g)).toHaveLength(1);
   });
 });

--- a/src/agents/codex.test.ts
+++ b/src/agents/codex.test.ts
@@ -71,7 +71,7 @@ describe('deploy', () => {
     }
   });
 
-  it('deploys command-flagged templates as skills to .agents/skills/', async () => {
+  it('deploys commands, prompts, and operational skills to .agents/skills/', async () => {
     await deploy(tmpDir, false);
 
     const skillsDir = path.join(tmpDir, '.agents', 'skills');
@@ -80,11 +80,14 @@ describe('deploy', () => {
     const skillDirs = fs.readdirSync(skillsDir);
     expect(skillDirs.length).toBeGreaterThan(0);
 
-    // Verify only command-category templates with names become skills
-    const templates = await getComposedTemplates();
-    const expectedSkills = [...templates.commands.entries()]
+    const templates = await getComposedTemplates('codex');
+    const expectedSkills = [
+      ...templates.commands.entries(),
+      ...templates.prompts.entries(),
+    ]
       .map(([, content]) => parseFrontmatterName(content)!)
-      .filter(Boolean);
+      .filter(Boolean)
+      .concat([...templates.skills.keys()]);
 
     expect(skillDirs.sort()).toEqual(expectedSkills.sort());
 
@@ -95,6 +98,31 @@ describe('deploy', () => {
       const content = fs.readFileSync(skillFile, 'utf8');
       expect(content).toMatch(/^---\s*\n/);
     }
+  });
+
+  it('deploys operational skill scripts for Codex', async () => {
+    await deploy(tmpDir, false);
+
+    const prReviewDir = path.join(tmpDir, '.agents', 'skills', 'smithy.pr-review');
+    expect(fs.existsSync(path.join(prReviewDir, 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(prReviewDir, 'scripts', 'find-pr.sh'))).toBe(true);
+    expect(fs.existsSync(path.join(prReviewDir, 'scripts', 'get-comments.sh'))).toBe(true);
+    expect(fs.existsSync(path.join(prReviewDir, 'scripts', 'reply-comment.sh'))).toBe(true);
+
+    const skillMd = fs.readFileSync(path.join(prReviewDir, 'SKILL.md'), 'utf8');
+    expect(skillMd).toContain('./.agents/skills/smithy.pr-review/scripts/find-pr.sh');
+    expect(skillMd).not.toContain('${CLAUDE_SKILL_DIR}');
+    expect(skillMd).not.toContain('./.gemini/skills/smithy.pr-review');
+  });
+
+  it('renders forge for direct Codex execution instead of sub-agent orchestration', async () => {
+    await deploy(tmpDir, false);
+
+    const forgeSkill = path.join(tmpDir, '.agents', 'skills', 'smithy-forge', 'SKILL.md');
+    const content = fs.readFileSync(forgeSkill, 'utf8');
+    expect(content).toContain('Use test-driven development for each task');
+    expect(content).not.toContain('Dispatch a sub-agent for each task');
+    expect(content).not.toContain('smithy-implement sub-agent');
   });
 
   it('is idempotent — deploying twice does not duplicate content', async () => {
@@ -143,12 +171,16 @@ describe('removeLegacy', () => {
   it('removes smithy-prefixed skill directories', () => {
     const skillsDir = path.join(tmpDir, '.agents', 'skills');
     const staleSkillDir = path.join(skillsDir, 'smithy-patch');
+    const staleDottedSkillDir = path.join(skillsDir, 'smithy.pr-review');
     fs.mkdirSync(staleSkillDir, { recursive: true });
+    fs.mkdirSync(staleDottedSkillDir, { recursive: true });
     fs.writeFileSync(path.join(staleSkillDir, 'SKILL.md'), '# stale');
+    fs.writeFileSync(path.join(staleDottedSkillDir, 'SKILL.md'), '# stale');
 
     const removedCount = removeLegacy(tmpDir);
-    expect(removedCount).toBeGreaterThanOrEqual(1);
+    expect(removedCount).toBeGreaterThanOrEqual(2);
     expect(fs.existsSync(staleSkillDir)).toBe(false);
+    expect(fs.existsSync(staleDottedSkillDir)).toBe(false);
   });
 
   it('returns 0 when no files exist to remove', () => {

--- a/src/agents/codex.test.ts
+++ b/src/agents/codex.test.ts
@@ -209,6 +209,67 @@ describe('writePermissions (via deploy)', () => {
     expect(fs.existsSync(rulesDir)).toBe(true);
   });
 
+  it('writes Codex Auto-review defaults to config.toml', async () => {
+    await deploy(tmpDir, true);
+
+    const configPath = path.join(tmpDir, '.codex', 'config.toml');
+    const content = fs.readFileSync(configPath, 'utf8');
+
+    expect(content).toContain('# BEGIN SMITHY CODEX CONFIG');
+    expect(content).toContain('approval_policy = "on-request"');
+    expect(content).toContain('sandbox_mode = "workspace-write"');
+    expect(content).toContain('approvals_reviewer = "auto_review"');
+    expect(content).toContain('web_search = "cached"');
+    expect(content).toContain('# END SMITHY CODEX CONFIG');
+  });
+
+  it('places managed Codex config before TOML tables', async () => {
+    const codexDir = path.join(tmpDir, '.codex');
+    fs.mkdirSync(codexDir, { recursive: true });
+    const configPath = path.join(codexDir, 'config.toml');
+    fs.writeFileSync(
+      configPath,
+      ['notify = ["custom"]', '', '[plugins."github@openai-curated"]', 'enabled = true', ''].join('\n')
+    );
+
+    await deploy(tmpDir, true);
+
+    const content = fs.readFileSync(configPath, 'utf8');
+    expect(content.indexOf('approvals_reviewer = "auto_review"')).toBeLessThan(
+      content.indexOf('[plugins."github@openai-curated"]')
+    );
+    expect(content).toContain('notify = ["custom"]');
+    expect(content).toContain('[plugins."github@openai-curated"]');
+  });
+
+  it('updates managed Codex config idempotently', async () => {
+    const codexDir = path.join(tmpDir, '.codex');
+    fs.mkdirSync(codexDir, { recursive: true });
+    const configPath = path.join(codexDir, 'config.toml');
+    fs.writeFileSync(
+      configPath,
+      [
+        '# BEGIN SMITHY CODEX CONFIG',
+        'approval_policy = "never"',
+        '# END SMITHY CODEX CONFIG',
+        '',
+        '[profiles.custom]',
+        'sandbox_mode = "read-only"',
+        '',
+      ].join('\n')
+    );
+
+    await deploy(tmpDir, true);
+    const firstContent = fs.readFileSync(configPath, 'utf8');
+    await deploy(tmpDir, true);
+
+    const secondContent = fs.readFileSync(configPath, 'utf8');
+    expect(secondContent).toBe(firstContent);
+    expect(secondContent).toContain('approval_policy = "on-request"');
+    expect(secondContent).not.toContain('approval_policy = "never"');
+    expect(secondContent.match(/# BEGIN SMITHY CODEX CONFIG/g)).toHaveLength(1);
+  });
+
   it('generates Codex prefix rules', async () => {
     await deploy(tmpDir, true);
 

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -5,6 +5,19 @@ import { getComposedTemplates, getTemplateFilesByCategory, stripFrontmatter, par
 import { permissions } from '../permissions.js';
 import { removeIfExists } from '../utils.js';
 
+const SMITHY_CODEX_RULES_BEGIN = '# BEGIN SMITHY CODEX RULES';
+const SMITHY_CODEX_RULES_END = '# END SMITHY CODEX RULES';
+
+const SMITHY_SKILL_SCRIPT_RULES = [
+  './.agents/skills/smithy.pr-review/scripts/find-pr.sh',
+  './.agents/skills/smithy.pr-review/scripts/get-comments.sh',
+  './.agents/skills/smithy.pr-review/scripts/reply-comment.sh',
+  './.agents/skills/smithy.gh-issue/scripts/check-env.sh',
+  './.agents/skills/smithy.gh-issue/scripts/search-issues.sh',
+  './.agents/skills/smithy.gh-issue/scripts/create-issue.sh',
+  './.agents/skills/smithy.gh-issue/scripts/link-blocked-by.sh',
+];
+
 /**
  * Deploy Codex templates. Returns the list of deployed file paths (relative to targetDir).
  */
@@ -88,46 +101,79 @@ export function removeLegacy(targetDir: string): number {
 }
 
 function writePermissions(targetDir: string): void {
-  const codexBaseDir = path.join(targetDir, '.codex');
-  if (!fs.existsSync(codexBaseDir)) fs.mkdirSync(codexBaseDir, { recursive: true });
+  const rulesDir = path.join(targetDir, '.codex', 'rules');
+  if (!fs.existsSync(rulesDir)) fs.mkdirSync(rulesDir, { recursive: true });
 
-  const configPath = path.join(codexBaseDir, 'config.toml');
+  const rulesPath = path.join(rulesDir, 'default.rules');
+  const rulesBlock = [
+    SMITHY_CODEX_RULES_BEGIN,
+    ...buildCodexRules().map(formatPrefixRule),
+    SMITHY_CODEX_RULES_END,
+    '',
+  ].join('\n');
 
-  let tomlContent = `[approvals]\npolicy = "auto"\n\n`;
+  const existing = fs.existsSync(rulesPath) ? fs.readFileSync(rulesPath, 'utf8') : '';
+  const next = upsertManagedRulesBlock(existing, rulesBlock);
+
+  fs.writeFileSync(rulesPath, next);
+  console.log(picocolors.blue(`  Added default permissions to ${rulesPath}`));
+}
+
+function buildCodexRules(): string[][] {
+  const patterns = SMITHY_SKILL_SCRIPT_RULES.map(script => [script]);
 
   for (const [cmd, value] of Object.entries(permissions)) {
     if (Array.isArray(value)) {
-      if (value.length === 0) {
-        tomlContent += `[[approvals.rules]]\ncommand = "${cmd}"\nargs = []\n\n`;
-      } else if (value.includes('*')) {
-        tomlContent += `[[approvals.rules]]\ncommand = "${cmd}"\nargs_startswith = []\n\n`;
-      } else {
-        const hasWildcard = value.some(arg => arg.includes('*'));
-        if (hasWildcard) {
-          const cleanArgs = value.map(arg => arg.replace('*', '')).filter(arg => arg !== '');
-          tomlContent += `[[approvals.rules]]\ncommand = "${cmd}"\nargs_startswith = ${JSON.stringify(cleanArgs)}\n\n`;
-        } else {
-          tomlContent += `[[approvals.rules]]\ncommand = "${cmd}"\nargs = ${JSON.stringify(value)}\n\n`;
-        }
-      }
+      if (value.length === 0) patterns.push([cmd]);
+      for (const arg of value) patterns.push(buildPrefixPattern(cmd, arg));
     } else {
       for (const [sub, args] of Object.entries(value)) {
-        const subParts = sub.split(' ');
-        const fullArgs = [...subParts, ...args];
-        const hasWildcard = fullArgs.some(arg => arg.includes('*'));
-
-        if (hasWildcard) {
-          const cleanArgs = fullArgs.map(arg => arg.replace('*', '')).filter(arg => arg !== '');
-          tomlContent += `[[approvals.rules]]\ncommand = "${cmd}"\nargs_startswith = ${JSON.stringify(cleanArgs)}\n\n`;
-        } else {
-          tomlContent += `[[approvals.rules]]\ncommand = "${cmd}"\nargs = ${JSON.stringify(fullArgs)}\n\n`;
-        }
+        if (args.length === 0) patterns.push(buildPrefixPattern(cmd, sub));
+        for (const arg of args) patterns.push(buildPrefixPattern(cmd, sub, arg));
       }
     }
   }
 
-  if (!fs.existsSync(configPath) || !fs.readFileSync(configPath, 'utf8').includes('[approvals]')) {
-    fs.appendFileSync(configPath, (fs.existsSync(configPath) ? '\n' : '') + tomlContent);
-    console.log(picocolors.blue(`  Added default permissions to ${configPath}`));
+  const seen = new Set<string>();
+  return patterns.filter(pattern => {
+    const key = JSON.stringify(pattern);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function buildPrefixPattern(command: string, ...parts: string[]): string[] {
+  const tokens = [command];
+
+  for (const part of parts) {
+    for (const token of part.split(/\s+/)) {
+      const cleanToken = token.trim().replace(/\*+$/, '');
+      if (cleanToken && cleanToken !== '*') tokens.push(cleanToken);
+    }
   }
+
+  return tokens;
+}
+
+function formatPrefixRule(pattern: string[]): string {
+  return `prefix_rule(pattern=${JSON.stringify(pattern)}, decision="allow")`;
+}
+
+function upsertManagedRulesBlock(existing: string, rulesBlock: string): string {
+  const managedBlockPattern = new RegExp(
+    `${escapeRegExp(SMITHY_CODEX_RULES_BEGIN)}[\\s\\S]*?${escapeRegExp(SMITHY_CODEX_RULES_END)}\\n?`
+  );
+
+  if (managedBlockPattern.test(existing)) {
+    return existing.replace(managedBlockPattern, rulesBlock);
+  }
+
+  if (!existing.trim()) return rulesBlock;
+
+  return `${existing.replace(/\s*$/, '')}\n\n${rulesBlock}`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -9,7 +9,7 @@ import { removeIfExists } from '../utils.js';
  * Deploy Codex templates. Returns the list of deployed file paths (relative to targetDir).
  */
 export async function deploy(targetDir: string, initPermissions: boolean): Promise<string[]> {
-  const templates = await getComposedTemplates();
+  const templates = await getComposedTemplates('codex');
   const deployedFiles: string[] = [];
 
   // Deploy prompts -> tools/codex/prompts/
@@ -24,16 +24,33 @@ export async function deploy(targetDir: string, initPermissions: boolean): Promi
     deployedFiles.push(path.relative(targetDir, dest));
   }
 
-  // Deploy commands as Codex skills -> .agents/skills/<name>/SKILL.md
+  // Deploy commands, reference prompts, and operational skills as Codex skills.
   const skillsDir = path.join(targetDir, '.agents', 'skills');
-  for (const [, content] of templates.commands) {
-    const name = parseFrontmatterName(content);
-    if (name) {
-      const skillPath = path.join(skillsDir, name);
-      if (!fs.existsSync(skillPath)) fs.mkdirSync(skillPath, { recursive: true });
-      const dest = path.join(skillPath, 'SKILL.md');
-      fs.writeFileSync(dest, content);
-      deployedFiles.push(path.relative(targetDir, dest));
+  const deployAsSkill = (content: string, name?: string): string | undefined => {
+    const skillName = name ?? parseFrontmatterName(content);
+    if (!skillName) return undefined;
+    const skillPath = path.join(skillsDir, skillName);
+    if (!fs.existsSync(skillPath)) fs.mkdirSync(skillPath, { recursive: true });
+    const dest = path.join(skillPath, 'SKILL.md');
+    fs.writeFileSync(dest, content);
+    deployedFiles.push(path.relative(targetDir, dest));
+    return skillPath;
+  };
+
+  for (const [, content] of templates.commands) deployAsSkill(content);
+  for (const [, content] of templates.prompts) deployAsSkill(content);
+
+  for (const [skillName, skill] of templates.skills) {
+    const skillPath = deployAsSkill(skill.prompt, skillName);
+    if (skillPath && skill.scripts.size > 0) {
+      const scriptsDir = path.join(skillPath, 'scripts');
+      if (!fs.existsSync(scriptsDir)) fs.mkdirSync(scriptsDir, { recursive: true });
+      for (const [filename, content] of skill.scripts) {
+        const dest = path.join(scriptsDir, filename);
+        fs.writeFileSync(dest, content);
+        fs.chmodSync(dest, 0o755);
+        deployedFiles.push(path.relative(targetDir, dest));
+      }
     }
   }
 
@@ -58,7 +75,7 @@ export function removeLegacy(targetDir: string): number {
   const skillsDir = path.join(targetDir, '.agents', 'skills');
   if (fs.existsSync(skillsDir)) {
     for (const entry of fs.readdirSync(skillsDir)) {
-      if (entry.startsWith('smithy-')) {
+      if (entry.startsWith('smithy-') || entry.startsWith('smithy.')) {
         const entryPath = path.join(skillsDir, entry);
         if (fs.statSync(entryPath).isDirectory() && fs.existsSync(path.join(entryPath, 'SKILL.md'))) {
           if (removeIfExists(entryPath)) removedCount++;

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -7,6 +7,18 @@ import { removeIfExists } from '../utils.js';
 
 const SMITHY_CODEX_RULES_BEGIN = '# BEGIN SMITHY CODEX RULES';
 const SMITHY_CODEX_RULES_END = '# END SMITHY CODEX RULES';
+const SMITHY_CODEX_CONFIG_BEGIN = '# BEGIN SMITHY CODEX CONFIG';
+const SMITHY_CODEX_CONFIG_END = '# END SMITHY CODEX CONFIG';
+
+const CODEX_CONFIG_BLOCK = [
+  SMITHY_CODEX_CONFIG_BEGIN,
+  'approval_policy = "on-request"',
+  'sandbox_mode = "workspace-write"',
+  'approvals_reviewer = "auto_review"',
+  'web_search = "cached"',
+  SMITHY_CODEX_CONFIG_END,
+  '',
+].join('\n');
 
 const SMITHY_SKILL_SCRIPT_RULES = [
   './.agents/skills/smithy.pr-review/scripts/find-pr.sh',
@@ -101,7 +113,15 @@ export function removeLegacy(targetDir: string): number {
 }
 
 function writePermissions(targetDir: string): void {
-  const rulesDir = path.join(targetDir, '.codex', 'rules');
+  const codexDir = path.join(targetDir, '.codex');
+  if (!fs.existsSync(codexDir)) fs.mkdirSync(codexDir, { recursive: true });
+
+  const configPath = path.join(codexDir, 'config.toml');
+  const existingConfig = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf8') : '';
+  const nextConfig = upsertManagedTopLevelConfigBlock(existingConfig, CODEX_CONFIG_BLOCK);
+  fs.writeFileSync(configPath, nextConfig);
+
+  const rulesDir = path.join(codexDir, 'rules');
   if (!fs.existsSync(rulesDir)) fs.mkdirSync(rulesDir, { recursive: true });
 
   const rulesPath = path.join(rulesDir, 'default.rules');
@@ -116,6 +136,7 @@ function writePermissions(targetDir: string): void {
   const next = upsertManagedRulesBlock(existing, rulesBlock);
 
   fs.writeFileSync(rulesPath, next);
+  console.log(picocolors.blue(`  Added Codex Auto-review defaults to ${configPath}`));
   console.log(picocolors.blue(`  Added default permissions to ${rulesPath}`));
 }
 
@@ -172,6 +193,26 @@ function upsertManagedRulesBlock(existing: string, rulesBlock: string): string {
   if (!existing.trim()) return rulesBlock;
 
   return `${existing.replace(/\s*$/, '')}\n\n${rulesBlock}`;
+}
+
+function upsertManagedTopLevelConfigBlock(existing: string, configBlock: string): string {
+  const managedBlockPattern = new RegExp(
+    `${escapeRegExp(SMITHY_CODEX_CONFIG_BEGIN)}[\\s\\S]*?${escapeRegExp(SMITHY_CODEX_CONFIG_END)}\\n?`
+  );
+  const withoutManagedBlock = existing.replace(managedBlockPattern, '').replace(/^\s+/, '');
+  if (!withoutManagedBlock.trim()) return configBlock;
+
+  const firstTableIndex = withoutManagedBlock.search(/^\s*\[[^\]]+\]\s*$/m);
+  if (firstTableIndex === -1) {
+    return `${configBlock}\n${withoutManagedBlock.replace(/^\s+/, '')}`;
+  }
+
+  const beforeTables = withoutManagedBlock.slice(0, firstTableIndex).replace(/\s*$/, '');
+  const tables = withoutManagedBlock.slice(firstTableIndex).replace(/^\s+/, '');
+
+  if (!beforeTables) return `${configBlock}${tables}`;
+
+  return `${beforeTables}\n\n${configBlock}${tables}`;
 }
 
 function escapeRegExp(value: string): string {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -58,9 +58,11 @@ describe('CLI init --yes (non-interactive)', () => {
     expect(output).toContain('Welcome to Smithy CLI');
     expect(output).toContain('Initialization complete');
 
-    // Both agents deployed
+    // All repo-scoped agents deployed
     expect(fs.existsSync(path.join(tmpDir, '.gemini', 'skills'))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'prompts'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.agents', 'skills'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, 'tools', 'codex', 'prompts'))).toBe(true);
 
     // Manifest directory created at .smithy/ (repo default)
     expect(fs.existsSync(path.join(tmpDir, '.smithy'))).toBe(true);
@@ -95,6 +97,21 @@ describe('CLI init --yes (non-interactive)', () => {
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'prompts'))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, '.gemini', 'skills'))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, 'tools', 'codex', 'prompts'))).toBe(false);
+  });
+
+  it('deploys only codex when --agent codex is specified', () => {
+    const output = execFileSync('node', [CLI, 'init', '-a', 'codex', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+    expect(output).toContain('Initialization complete');
+
+    expect(fs.existsSync(path.join(tmpDir, '.agents', 'skills', 'smithy-forge', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.agents', 'skills', 'smithy-fix', 'SKILL.md'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.agents', 'skills', 'smithy.pr-review', 'scripts', 'find-pr.sh'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, 'tools', 'codex', 'prompts'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'prompts'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, '.gemini', 'skills'))).toBe(false);
   });
 
   it('does not advertise the retired --issue-templates / --no-issue-templates flags', () => {
@@ -159,6 +176,16 @@ describe('CLI init --yes (non-interactive)', () => {
     expect(output).toContain('not supported by gemini');
     // Should not deploy anything
     expect(fs.existsSync(path.join(tmpDir, '.gemini', 'skills'))).toBe(false);
+  });
+
+  it('rejects --location user for codex', () => {
+    const result = spawnSync('node', [CLI, 'init', '-a', 'codex', '--location', 'user', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+    const output = result.stdout + result.stderr;
+    expect(output).toContain('not supported by codex');
+    expect(fs.existsSync(path.join(tmpDir, '.agents', 'skills'))).toBe(false);
   });
 
   it('accepts --location flag', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ program
   .description('Initialize smithy prompts in the current repository')
   .addOption(
     new Option('-a, --agent <name>', 'AI assistant to configure')
-      .choices(['claude', 'gemini', 'all'])
+      .choices(['claude', 'gemini', 'codex', 'all'])
   )
   .addOption(
     new Option('-l, --location <location>', 'Deploy location')

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -146,7 +146,11 @@ export async function initAction(opts: InitOptions = {}): Promise<void> {
   // --- Step 2: Deploy ---
 
   // Deploy agents and collect deployed files per agent
-  const agentsToSetup = agent === 'all' ? ['gemini', 'claude'] as const : [agent] as const;
+  const agentsToSetup = agent === 'all'
+    ? (deployLocation === 'repo'
+        ? ['gemini', 'claude', 'codex'] as const
+        : ['claude'] as const)
+    : [agent] as const;
   const deployedFiles: Record<string, string[]> = {};
 
   for (const a of agentsToSetup) {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -43,7 +43,10 @@ export interface UpdateOptions {
 /** Map a manifest's agents array back to an AgentChoice for initAction. */
 function toAgentChoice(agents: string[]): AgentChoice {
   const sorted = [...agents].sort();
-  if (sorted.length === 2 && sorted[0] === 'claude' && sorted[1] === 'gemini') {
+  if (
+    (sorted.length === 2 && sorted[0] === 'claude' && sorted[1] === 'gemini') ||
+    (sorted.length === 3 && sorted[0] === 'claude' && sorted[1] === 'codex' && sorted[2] === 'gemini')
+  ) {
     return 'all';
   }
   return agents[0] as AgentChoice;

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -359,10 +359,12 @@ describe('getTemplateFilesByCategory', () => {
 describe('getComposedTemplates', () => {
   let composed: ComposedTemplates;
   let claudeComposed: ComposedTemplates;
+  let codexComposed: ComposedTemplates;
 
   beforeAll(async () => {
     composed = await getComposedTemplates();
     claudeComposed = await getComposedTemplates('claude');
+    codexComposed = await getComposedTemplates('codex');
   });
 
   it('returns commands, prompts, agents, and skills maps', () => {
@@ -418,6 +420,15 @@ describe('getComposedTemplates', () => {
     // The skill must explicitly direct the agent through the dual-path flow.
     expect(skill.prompt).toMatch(/MCP[^\n]+(first|prefer)/i);
     expect(skill.prompt).toMatch(/(fall back|fallback)/i);
+  });
+
+  it('smithy.pr-review renders Codex script fallback paths', () => {
+    const skill = codexComposed.skills.get('smithy.pr-review')!;
+    expect(skill.prompt).toContain('./.agents/skills/smithy.pr-review/scripts/find-pr.sh');
+    expect(skill.prompt).toContain('./.agents/skills/smithy.pr-review/scripts/get-comments.sh');
+    expect(skill.prompt).toContain('./.agents/skills/smithy.pr-review/scripts/reply-comment.sh');
+    expect(skill.prompt).not.toContain('${CLAUDE_SKILL_DIR}');
+    expect(skill.prompt).not.toContain('./.gemini/skills/smithy.pr-review');
   });
 
   it('smithy.pr-review scripts start with bash shebang', () => {
@@ -612,6 +623,25 @@ describe('getComposedTemplates', () => {
       /smithy\.cut \{\{spec_folder\}\} \{\{user_story_number\}\}/
     );
     expect(orders).toMatch(/smithy\.cut \{\{spec_folder\}\} \{\{user_story_number\}\}/);
+  });
+
+  it('smithy.orders renders Codex gh-issue script paths', () => {
+    const orders = codexComposed.commands.get('smithy.orders.md')!;
+    expect(orders).toContain('./.agents/skills/smithy.gh-issue/scripts/check-env.sh');
+    expect(orders).toContain('./.agents/skills/smithy.gh-issue/scripts/search-issues.sh');
+    expect(orders).toContain('./.agents/skills/smithy.gh-issue/scripts/create-issue.sh');
+    expect(orders).toContain('./.agents/skills/smithy.gh-issue/scripts/link-blocked-by.sh');
+    expect(orders).not.toContain('${CLAUDE_SKILL_DIR}');
+    expect(orders).not.toContain('./.gemini/skills/smithy.gh-issue');
+  });
+
+  it('smithy.forge renders direct implementation and review instructions for Codex', () => {
+    const forge = codexComposed.commands.get('smithy.forge.md')!;
+    expect(forge).toContain('Use test-driven development for each task');
+    expect(forge).toContain('Review your implementation by examining the diff');
+    expect(forge).not.toContain('Dispatch a sub-agent for each task');
+    expect(forge).not.toContain('smithy-implementation-review sub-agent');
+    expect(forge).not.toContain('smithy-maid sub-agent');
   });
 
   // US4 Slice 1 Task 1: the RFC parser in Phase 3 must enumerate

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -225,6 +225,7 @@ export function getTemplateFilesByCategory(): Record<TemplateCategory, string[]>
 export async function getComposedTemplates(variant?: string): Promise<ComposedTemplates> {
   const snippets = loadSnippets();
   const renderer = new Dotprompt({ partials: Object.fromEntries(buildPartialsMap(snippets)) });
+  const supportsSubAgents = variant === 'claude' || variant === 'gemini';
 
   // Register {{#ifAgent}} block helper. Dotprompt uses knownHelpersOnly so
   // standard {{#if variable}} doesn't work — custom block helpers are required.
@@ -234,7 +235,7 @@ export async function getComposedTemplates(variant?: string): Promise<ComposedTe
       const agentName = args[0] as string;
       return variant === agentName ? options.fn(this) : options.inverse(this);
     }
-    return variant ? options.fn(this) : options.inverse(this);
+    return supportsSubAgents ? options.fn(this) : options.inverse(this);
   });
 
   const resolve = async (dir: string): Promise<Map<string, string>> => {

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -8,7 +8,8 @@ repositories. Templates are written as [Dotprompt](https://firebase.google.com/d
 
 ```
 agent-skills/
-  commands/    Slash commands (invocable as /smithy.<name>)
+  commands/    Slash commands / project skills (invocable as /smithy.<name>
+               where supported, or as loaded skills)
   prompts/     Reference prompts (readable by the AI, not invocable)
   agents/      Sub-agent definitions (dispatched by parent commands)
   skills/      Lazy-loaded operational skills (frontmatter visible, body
@@ -26,8 +27,9 @@ See the README in each subdirectory for details on its contents and conventions.
 - **Body**: Markdown with Handlebars expressions. Dotprompt resolves partials
   (`{{>snippet-name}}`) and conditionals (`{{#ifAgent}}...{{/ifAgent}}`) at
   deploy time.
-- **Deploy transform**: Frontmatter is stripped when deploying to Claude
-  (kept for Gemini skills). Files are renamed from `.prompt` to `.md`.
+- **Deploy transform**: Frontmatter is stripped when deploying Claude
+  commands/prompts (kept for Gemini and Codex skills). Files are renamed from
+  `.prompt` to `.md`.
 
 ## Workflow Pipeline
 

--- a/src/templates/agent-skills/commands/README.md
+++ b/src/templates/agent-skills/commands/README.md
@@ -5,6 +5,7 @@ Slash commands invocable by users (e.g., `/smithy.strike "add verbose flag"`).
 Deployed to:
 - **Claude**: `.claude/commands/smithy.<name>.md` (frontmatter stripped)
 - **Gemini**: `.gemini/skills/smithy.<name>/SKILL.md` (frontmatter kept)
+- **Codex**: `.agents/skills/smithy-<name>/SKILL.md` (frontmatter kept)
 
 ## Current Commands
 
@@ -15,7 +16,7 @@ Deployed to:
 | `smithy.render` | Break an RFC milestone into a feature map | clarify, refine, **scout** |
 | `smithy.mark` | Transform a feature into a spec with user stories | clarify, refine, **scout** |
 | `smithy.cut` | Decompose a user story into PR-sized task slices | clarify, refine, **scout** |
-| `smithy.forge` | Implement a slice end-to-end (TDD + review + PR) | implement, review, **maid** |
+| `smithy.forge` | Implement a slice end-to-end (TDD + review + PR) | implement, review, **maid** in Claude/Gemini agent mode; direct TDD/review in Codex |
 | `smithy.fix` | Minimal-diff bug fix from a GitHub issue | (none) |
 | `smithy.audit` | Audit a Smithy artifact against its checklist | (none) |
 | `smithy.orders` | Show available Smithy commands and their usage | (none) |
@@ -30,4 +31,4 @@ It is still invocable explicitly via `/smithy.status …`.
 - Commands that should deploy as slash commands set `command: true` in frontmatter.
 - Use `$ARGUMENTS` for user input; include a fallback for agents that don't substitute it.
 - Use `{{>partial-name}}` to include shared snippets (resolved by Dotprompt at deploy time).
-- Use `{{#ifAgent}}...{{else}}...{{/ifAgent}}` for orchestrator vs standalone conditional blocks.
+- Use `{{#ifAgent}}...{{else}}...{{/ifAgent}}` for orchestrator vs standalone conditional blocks; named branches such as `{{#ifAgent 'codex'}}` handle agent-specific paths.

--- a/src/templates/agent-skills/commands/smithy.orders.prompt
+++ b/src/templates/agent-skills/commands/smithy.orders.prompt
@@ -32,11 +32,13 @@ If no file path is provided, ask the user which artifact file to create tickets 
 `CLAUDE_SKILL_DIR` is unset and the scripts cannot be located.{{/ifAgent}}
 {{#ifAgent 'gemini'}}Running the scripts requires the `smithy.gh-issue` skill
 to be deployed in the `.gemini/skills/` directory.{{/ifAgent}}
+{{#ifAgent 'codex'}}Running the scripts requires the `smithy.gh-issue` skill
+to be deployed in the `.agents/skills/` directory.{{/ifAgent}}
 
 Then run the environment check:
 
 ```bash
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/check-env.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/check-env.sh{{/ifAgent}}
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/check-env.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/check-env.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/check-env.sh{{/ifAgent}}
 ```
 
 If it fails, surface the message it printed and stop. On success, capture the
@@ -225,7 +227,7 @@ Parse the tasks file to extract:
 For each ticket you plan to create, search for existing matches by title:
 
 ```bash
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/search-issues.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/search-issues.sh{{/ifAgent}} all "<title keywords>" 5
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/search-issues.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/search-issues.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/search-issues.sh{{/ifAgent}} all "<title keywords>" 5
 ```
 
 If matches are found:
@@ -279,7 +281,7 @@ cat > /tmp/orders_body.md << 'BODY'
 **Next step for each milestone**: `smithy.render` to produce a feature map.
 BODY
 
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "[RFC] <rfc-title>" /tmp/orders_body.md
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "[RFC] <rfc-title>" /tmp/orders_body.md
 ```
 
 **Children**: one issue per milestone, linked to the parent. The body
@@ -310,7 +312,7 @@ cat > /tmp/orders_body.md << 'BODY'
 Run `\{{next_step}}` to produce a feature map for this milestone.
 BODY
 
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "[RFC][Milestone] <milestone-title>" /tmp/orders_body.md
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "[RFC][Milestone] <milestone-title>" /tmp/orders_body.md
 ```
 
 ### Ticket mapping: `.features.md`
@@ -320,7 +322,7 @@ BODY
 disambiguate across RFCs. Use both the RFC title and milestone title in the search:
 
 ```bash
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/search-issues.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/search-issues.sh{{/ifAgent}} open "[RFC][Milestone] <milestone-title> in:title" 10
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/search-issues.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/search-issues.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/search-issues.sh{{/ifAgent}} open "[RFC][Milestone] <milestone-title> in:title" 10
 ```
 
 Verify the match by checking that the issue body references the same source RFC
@@ -350,7 +352,7 @@ cat > /tmp/orders_body.md << 'BODY'
 Run `\{{next_step}}` on this feature to produce a spec with user stories.
 BODY
 
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "[Feature] <feature-title>" /tmp/orders_body.md
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "[Feature] <feature-title>" /tmp/orders_body.md
 ```
 
 ### Ticket mapping: `.spec.md`
@@ -421,7 +423,7 @@ For **each** user story extracted in Phase 3, perform the following steps:
    Write the rendered body to `/tmp/orders_body.md` and then call:
 
    ```bash
-   ${CLAUDE_SKILL_DIR}/scripts/create-issue.sh "[Story] <story-title>" /tmp/orders_body.md
+   {{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "[Story] <story-title>" /tmp/orders_body.md
    ```
 
    Skip the heredoc fallthrough below for this user story.
@@ -458,7 +460,7 @@ cat > /tmp/orders_body.md << 'BODY'
 Run `\{{next_step}}` (equivalent to `smithy.cut \{{spec_folder}} \{{user_story_number}}`) to decompose this story into implementable slices, then `smithy.forge` on each slice.
 BODY
 
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "[Story] <story-title>" /tmp/orders_body.md
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "[Story] <story-title>" /tmp/orders_body.md
 ```
 
 ### Ticket mapping: `.tasks.md`
@@ -470,7 +472,7 @@ matches this tasks file's story number (`<NN>` from the filename
 using the same `[Story]` title prefix:
 
 ```bash
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/search-issues.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/search-issues.sh{{/ifAgent}} open "[Story] <story-title>" 10
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/search-issues.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/search-issues.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/search-issues.sh{{/ifAgent}} open "[Story] <story-title>" 10
 ```
 
 Match by story title (the `<story-title>` from `### User Story N: <Title>` —
@@ -506,7 +508,7 @@ cat > /tmp/orders_body.md << 'BODY'
 Run `\{{next_step}}` to implement this slice as a PR.
 BODY
 
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "[Slice] <slice-title>" /tmp/orders_body.md
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "[Slice] <slice-title>" /tmp/orders_body.md
 ```
 
 ---
@@ -523,7 +525,7 @@ After creating all tickets, establish parent-child relationships:
    `blocked-by` link from each child to its parent:
 
 ```bash
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/link-blocked-by.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/link-blocked-by.sh{{/ifAgent}} <child-number> <parent-number>
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/link-blocked-by.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/link-blocked-by.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/link-blocked-by.sh{{/ifAgent}} <child-number> <parent-number>
 ```
 
 Treat `link-blocked-by` failures as best-effort: print a brief note and continue

--- a/src/templates/agent-skills/prompts/README.md
+++ b/src/templates/agent-skills/prompts/README.md
@@ -7,6 +7,7 @@ commands reference during their workflows.
 Deployed to:
 - **Claude**: `.claude/prompts/smithy.<name>.md` (frontmatter stripped)
 - **Gemini**: `.gemini/skills/smithy.<name>/SKILL.md` (frontmatter kept)
+- **Codex**: `tools/codex/prompts/smithy.<name>.md` (frontmatter stripped) and `.agents/skills/smithy-<name>/SKILL.md` (frontmatter kept)
 
 ## Current Prompts
 

--- a/src/templates/agent-skills/skills/smithy.gh-issue/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.gh-issue/SKILL.prompt
@@ -14,6 +14,11 @@ Provides GitHub issue operations via shell scripts bundled in this skill's `scri
 directory. You can run them using `run_shell_command` with the relative path:
 `./.gemini/skills/smithy.gh-issue/scripts/<script-name>`.
 {{/ifAgent}}
+{{#ifAgent 'codex'}}
+Provides GitHub issue operations via shell scripts bundled in this skill's `scripts/`
+directory. Run them with the relative path:
+`./.agents/skills/smithy.gh-issue/scripts/<script-name>`.
+{{/ifAgent}}
 
 Each operation is implemented as a small, stable script with a fixed set of
 `gh` calls (most use one; `link-blocked-by.sh` makes a few — repo lookup, two
@@ -30,7 +35,7 @@ Returns JSON with `owner`, `repo`, and `ownerRepo`. Exits non-zero with a
 friendly stderr message on failure.
 
 ```bash
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/check-env.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/check-env.sh{{/ifAgent}}
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/check-env.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/check-env.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/check-env.sh{{/ifAgent}}
 ```
 
 Run this **once** at the start of any flow that will create or query issues.
@@ -43,7 +48,7 @@ Searches issues in the current repo. Use this for duplicate detection and for
 locating parent tickets when stitching artifacts together.
 
 ```bash
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/search-issues.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/search-issues.sh{{/ifAgent}} <state> <search-query> [limit]
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/search-issues.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/search-issues.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/search-issues.sh{{/ifAgent}} <state> <search-query> [limit]
 ```
 
 - `state`: `open`, `closed`, or `all`.
@@ -74,7 +79,7 @@ BODY
 
 **Step 2 — create the issue:**
 ```bash
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "<title>" /tmp/smithy_issue_body.md
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "<title>" /tmp/smithy_issue_body.md
 ```
 
 Output: JSON `{"number": N, "url": "..."}`. Capture the `number` for parent/child
@@ -90,7 +95,7 @@ Marks one issue as blocked by another via the GitHub `addBlockedBy` GraphQL
 mutation. Use this after both the parent and child issues exist.
 
 ```bash
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/link-blocked-by.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/link-blocked-by.sh{{/ifAgent}} <child-number> <blocker-number>
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/link-blocked-by.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/link-blocked-by.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/link-blocked-by.sh{{/ifAgent}} <child-number> <blocker-number>
 ```
 
 The script handles node-ID lookup and the mutation itself. Output: JSON

--- a/src/templates/agent-skills/skills/smithy.pr-review/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.pr-review/SKILL.prompt
@@ -19,9 +19,9 @@ Provides GitHub PR review operations through two interchangeable paths:
 
 | Operation             | MCP-first path                                    | Script fallback                                                                  |
 |-----------------------|---------------------------------------------------|----------------------------------------------------------------------------------|
-| Find Open PR          | `mcp__github__list_pull_requests`                 | {{#ifAgent 'claude'}}`${CLAUDE_SKILL_DIR}`{{/ifAgent}}{{#ifAgent 'gemini'}}`./.gemini/skills/smithy.pr-review`{{/ifAgent}}`/scripts/find-pr.sh` |
-| List Inline Comments  | `mcp__github__pull_request_read` (`get_review_comments`) | {{#ifAgent 'claude'}}`${CLAUDE_SKILL_DIR}`{{/ifAgent}}{{#ifAgent 'gemini'}}`./.gemini/skills/smithy.pr-review`{{/ifAgent}}`/scripts/get-comments.sh <ownerRepo> <pr-number>` |
-| Reply to a Comment    | `mcp__github__add_reply_to_pull_request_comment`  | {{#ifAgent 'claude'}}`${CLAUDE_SKILL_DIR}`{{/ifAgent}}{{#ifAgent 'gemini'}}`./.gemini/skills/smithy.pr-review`{{/ifAgent}}`/scripts/reply-comment.sh <ownerRepo> <pr-number> <id> <body-file>` |
+| Find Open PR          | `mcp__github__list_pull_requests`                 | {{#ifAgent 'claude'}}`${CLAUDE_SKILL_DIR}`{{/ifAgent}}{{#ifAgent 'gemini'}}`./.gemini/skills/smithy.pr-review`{{/ifAgent}}{{#ifAgent 'codex'}}`./.agents/skills/smithy.pr-review`{{/ifAgent}}`/scripts/find-pr.sh` |
+| List Inline Comments  | `mcp__github__pull_request_read` (`get_review_comments`) | {{#ifAgent 'claude'}}`${CLAUDE_SKILL_DIR}`{{/ifAgent}}{{#ifAgent 'gemini'}}`./.gemini/skills/smithy.pr-review`{{/ifAgent}}{{#ifAgent 'codex'}}`./.agents/skills/smithy.pr-review`{{/ifAgent}}`/scripts/get-comments.sh <ownerRepo> <pr-number>` |
+| Reply to a Comment    | `mcp__github__add_reply_to_pull_request_comment`  | {{#ifAgent 'claude'}}`${CLAUDE_SKILL_DIR}`{{/ifAgent}}{{#ifAgent 'gemini'}}`./.gemini/skills/smithy.pr-review`{{/ifAgent}}{{#ifAgent 'codex'}}`./.agents/skills/smithy.pr-review`{{/ifAgent}}`/scripts/reply-comment.sh <ownerRepo> <pr-number> <id> <body-file>` |
 
 ## Path Selection
 
@@ -81,7 +81,7 @@ Otherwise capture `number` from the first entry.
 ### Script fallback
 
 ```bash
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/find-pr.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.pr-review/scripts/find-pr.sh{{/ifAgent}}
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/find-pr.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.pr-review/scripts/find-pr.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.pr-review/scripts/find-pr.sh{{/ifAgent}}
 ```
 
 Returns JSON with `owner`, `repo`, `pr`, and `ownerRepo` fields, or `{}`
@@ -120,7 +120,7 @@ to the caller — only unresolved threads need a reply.
 ### Script fallback
 
 ```bash
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/get-comments.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.pr-review/scripts/get-comments.sh{{/ifAgent}} <ownerRepo> <pr-number>
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/get-comments.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.pr-review/scripts/get-comments.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.pr-review/scripts/get-comments.sh{{/ifAgent}} <ownerRepo> <pr-number>
 ```
 
 Returns a JSON array of **threads** (one entry per review thread). Each
@@ -167,7 +167,7 @@ then POST it:
 cat > /tmp/smithy_reply_<databaseId>.json << 'EOF'
 {"body": "your reply text here"}
 EOF
-{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/reply-comment.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.pr-review/scripts/reply-comment.sh{{/ifAgent}} <ownerRepo> <pr-number> <databaseId> /tmp/smithy_reply_<databaseId>.json
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/reply-comment.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.pr-review/scripts/reply-comment.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.pr-review/scripts/reply-comment.sh{{/ifAgent}} <ownerRepo> <pr-number> <databaseId> /tmp/smithy_reply_<databaseId>.json
 ```
 
 ### Reply body conventions (both paths)


### PR DESCRIPTION
## Summary
- expose Codex as a supported smithy init agent and include it in repo-level all installs
- render Codex-specific skills, prompts, and operational scripts under .agents/skills and tools/codex/prompts
- keep smithy.forge on direct Codex TDD/review behavior and wire Codex script paths for fix/orders helpers

## Validation
- npm test -- --run src/agents/codex.test.ts src/cli.test.ts src/templates.test.ts
- npm test
- npm run typecheck
- smoke: node dist/cli.js init -a codex --no-permissions -y -d <tmp>