### PR TITLE
[codex] auto-upgrade Codex Smithy install

### DIFF
--- a/.github/workflows/smithy-upgrade.yml
+++ b/.github/workflows/smithy-upgrade.yml
@@ -86,8 +86,8 @@ jobs:
               on the triggering commit
             - Ran `smithy update -y` against the repo manifest
 
-            Review the diff in `.claude/` and `.smithy/smithy-manifest.json`
-            before merging.
+            Review the diff in `.claude/`, `.agents/`, `tools/codex/`,
+            `.codex/`, and `.smithy/smithy-manifest.json` before merging.
 
             > Note: this workflow requires *Settings → Actions → General →
             > Workflow permissions → "Allow GitHub Actions to create and

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@ dist
 .gemini/
 .claude/local/
 .claude/settings.local.json
-.codex/
-tools/codex/

--- a/.smithy/smithy-manifest.json
+++ b/.smithy/smithy-manifest.json
@@ -3,7 +3,8 @@
   "smithyVersion": "0.4.6",
   "deployLocation": "repo",
   "agents": [
-    "claude"
+    "claude",
+    "codex"
   ],
   "permissions": false,
   "issueTemplates": false,
@@ -47,6 +48,7 @@
       ".claude/skills/smithy.pr-review/scripts/reply-comment.sh",
       ".claude/skills/smithy.status/SKILL.md",
       ".claude/hooks/smithy-session-title.mjs"
-    ]
+    ],
+    "codex": []
   }
 }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -399,6 +399,32 @@ describe('CLI update (non-interactive)', () => {
     expect(fs.existsSync(path.join(tmpDir, 'tools', 'codex', 'prompts'))).toBe(false);
   });
 
+  it('replays a claude plus codex manifest without adding gemini', () => {
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+
+    const manifestPath = path.join(tmpDir, '.smithy', 'smithy-manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    manifest.agents = ['claude', 'codex'];
+    manifest.files.codex = [];
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+    execFileSync('node', [CLI, 'update', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+
+    const updated = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    expect(updated.agents).toEqual(['claude', 'codex']);
+    expect(updated.files.codex.length).toBeGreaterThan(0);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'prompts'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, 'tools', 'codex', 'prompts'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.agents', 'skills'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.gemini', 'skills'))).toBe(false);
+  });
+
   it('manifest version is updated after update', () => {
     execFileSync('node', [CLI, 'init', '-y'], {
       encoding: 'utf-8',

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -425,6 +425,59 @@ describe('CLI update (non-interactive)', () => {
     expect(fs.existsSync(path.join(tmpDir, '.gemini', 'skills'))).toBe(false);
   });
 
+  it('refuses to update a manifest with an unsupported agent', () => {
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+
+    const manifestPath = path.join(tmpDir, '.smithy', 'smithy-manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    manifest.agents = ['claude', 'future-agent'];
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+    const result = spawnSync('node', [CLI, 'update', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+    const output = result.stdout + result.stderr;
+    expect(result.status).toBe(1);
+    expect(output).toContain('unsupported agent');
+    expect(output).toContain('future-agent');
+    expect(output).toContain('refusing to update');
+    expect(output).not.toContain('Upgrade complete');
+
+    const after = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    expect(after.agents).toEqual(['claude', 'future-agent']);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'prompts'))).toBe(true);
+  });
+
+  it('refuses to update a manifest with no agents', () => {
+    execFileSync('node', [CLI, 'init', '-a', 'claude', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+
+    const manifestPath = path.join(tmpDir, '.smithy', 'smithy-manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    manifest.agents = [];
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+    const result = spawnSync('node', [CLI, 'update', '-y'], {
+      encoding: 'utf-8',
+      cwd: tmpDir,
+    });
+    const output = result.stdout + result.stderr;
+    expect(result.status).toBe(1);
+    expect(output).toContain('manifest contains no agents');
+    expect(output).toContain('refusing to update');
+    expect(output).not.toContain('Upgrade complete');
+
+    const after = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    expect(after.agents).toEqual([]);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'prompts'))).toBe(true);
+  });
+
   it('manifest version is updated after update', () => {
     execFileSync('node', [CLI, 'init', '-y'], {
       encoding: 'utf-8',

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -21,10 +21,12 @@ import * as gemini from '../agents/gemini.js';
 import * as claude from '../agents/claude.js';
 import * as codex from '../agents/codex.js';
 import { agentDeployLocations } from '../interactive.js';
-import type { AgentChoice, DeployLocation } from '../interactive.js';
+import type { AgentChoice, AgentName, DeployLocation } from '../interactive.js';
 
 export interface InitOptions {
   agent?: AgentChoice;
+  /** Exact agent subset to deploy. Used by manifest replay during update. */
+  agents?: AgentName[];
   location?: DeployLocation;
   permissions?: boolean;
   /**
@@ -52,13 +54,17 @@ export async function initAction(opts: InitOptions = {}): Promise<void> {
   }
 
   // 1. Agent selection
-  const agent = opts.agent ?? (opts.yes ? 'all' : await promptAgent());
+  const agent = opts.agent ?? (opts.yes || opts.agents ? 'all' : await promptAgent());
 
   // 2. Deploy location (limited by agent capabilities)
   const deployLocation = opts.location ?? (opts.yes ? 'repo' : await promptDeployLocation(agent));
 
   // Validate that the deploy location is supported by the selected agent
-  const supportedLocations = agentDeployLocations[agent];
+  const supportedLocations = opts.agents
+    ? (['repo', 'user'] as DeployLocation[]).filter(location =>
+        opts.agents!.every(a => agentDeployLocations[a].includes(location)),
+      )
+    : agentDeployLocations[agent];
   if (!supportedLocations.includes(deployLocation)) {
     console.error(picocolors.red(
       `Error: Deploy location '${deployLocation}' is not supported by ${agent}. ` +
@@ -146,11 +152,11 @@ export async function initAction(opts: InitOptions = {}): Promise<void> {
   // --- Step 2: Deploy ---
 
   // Deploy agents and collect deployed files per agent
-  const agentsToSetup = agent === 'all'
+  const agentsToSetup = opts.agents ?? (agent === 'all'
     ? (deployLocation === 'repo'
         ? ['gemini', 'claude', 'codex'] as const
         : ['claude'] as const)
-    : [agent] as const;
+    : [agent] as const);
   const deployedFiles: Record<string, string[]> = {};
 
   for (const a of agentsToSetup) {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -43,8 +43,26 @@ export interface UpdateOptions {
 const knownAgents = new Set<AgentName>(['claude', 'gemini', 'codex']);
 
 /** Validate a manifest's agent list before replaying it through initAction. */
-function toAgentNames(agents: string[]): AgentName[] {
-  return agents.filter((agent): agent is AgentName => knownAgents.has(agent as AgentName));
+function validateManifestAgents(
+  manifest: SmithyManifest,
+  location: DeployLocation,
+): AgentName[] | null {
+  if (manifest.agents.length === 0) {
+    console.error(picocolors.red(`  ${location} manifest contains no agents; refusing to update.`));
+    process.exitCode = 1;
+    return null;
+  }
+
+  const unknown = manifest.agents.filter(agent => !knownAgents.has(agent as AgentName));
+  if (unknown.length > 0) {
+    console.error(picocolors.red(
+      `  ${location} manifest contains unsupported agent${unknown.length === 1 ? '' : 's'}: ${unknown.join(', ')}; refusing to update.`,
+    ));
+    process.exitCode = 1;
+    return null;
+  }
+
+  return manifest.agents as AgentName[];
 }
 
 /**
@@ -93,9 +111,10 @@ async function confirmVersionChange(
 async function redeployFromManifest(
   manifest: SmithyManifest,
   targetDir: string,
+  agents: AgentName[],
 ): Promise<void> {
   await initAction({
-    agents: toAgentNames(manifest.agents),
+    agents,
     location: manifest.deployLocation,
     permissions: manifest.permissions,
     sessionTitles: manifest.sessionTitles ?? true,
@@ -172,6 +191,9 @@ export async function updateAction(opts: UpdateOptions = {}): Promise<void> {
       continue;
     }
 
+    const agents = validateManifestAgents(manifest, location);
+    if (!agents) return;
+
     const proceed = await confirmVersionChange(manifest, nonInteractive, location);
     if (!proceed) {
       console.log(picocolors.dim(`Skipping ${manifest.deployLocation} manifest update.`));
@@ -193,7 +215,7 @@ export async function updateAction(opts: UpdateOptions = {}): Promise<void> {
     // because the file already matches the baseline.
     const drift = reset ? null : collectClaudeDrift(targetDir, location, manifest);
 
-    await redeployFromManifest(manifest, targetDir);
+    await redeployFromManifest(manifest, targetDir, agents);
 
     if (drift) {
       const settingsPath = resolveSettingsPath(targetDir, location);

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -10,7 +10,7 @@ import {
   promptConfirmResetPermissions,
 } from '../interactive.js';
 import type { SmithyManifest } from '../manifest.js';
-import type { AgentChoice, DeployLocation } from '../interactive.js';
+import type { AgentName, DeployLocation } from '../interactive.js';
 import { toolchains, type LanguageToolchain } from '../permissions.js';
 import { detectPlatforms } from '../platform-detect.js';
 import {
@@ -40,16 +40,11 @@ export interface UpdateOptions {
   resetPermissions?: boolean;
 }
 
-/** Map a manifest's agents array back to an AgentChoice for initAction. */
-function toAgentChoice(agents: string[]): AgentChoice {
-  const sorted = [...agents].sort();
-  if (
-    (sorted.length === 2 && sorted[0] === 'claude' && sorted[1] === 'gemini') ||
-    (sorted.length === 3 && sorted[0] === 'claude' && sorted[1] === 'codex' && sorted[2] === 'gemini')
-  ) {
-    return 'all';
-  }
-  return agents[0] as AgentChoice;
+const knownAgents = new Set<AgentName>(['claude', 'gemini', 'codex']);
+
+/** Validate a manifest's agent list before replaying it through initAction. */
+function toAgentNames(agents: string[]): AgentName[] {
+  return agents.filter((agent): agent is AgentName => knownAgents.has(agent as AgentName));
 }
 
 /**
@@ -100,7 +95,7 @@ async function redeployFromManifest(
   targetDir: string,
 ): Promise<void> {
   await initAction({
-    agent: toAgentChoice(manifest.agents),
+    agents: toAgentNames(manifest.agents),
     location: manifest.deployLocation,
     permissions: manifest.permissions,
     sessionTitles: manifest.sessionTitles ?? true,

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -2,7 +2,8 @@ import { select, confirm, checkbox } from '@inquirer/prompts';
 import picocolors from 'picocolors';
 import { toolchains, type LanguageToolchain } from './permissions.js';
 
-export type AgentChoice = 'gemini' | 'claude' | 'codex' | 'all';
+export type AgentName = 'gemini' | 'claude' | 'codex';
+export type AgentChoice = AgentName | 'all';
 export type DeployLocation = 'repo' | 'user';
 export type PermissionLevel = 'repo' | 'user' | 'none';
 export type DeployablePermissionLevel = Exclude<PermissionLevel, 'none'>;


### PR DESCRIPTION
## Summary

- Extend Smithy's self-upgrade manifest to include Codex alongside Claude while leaving Gemini out.
- Teach `smithy update` to replay the exact manifest agent subset instead of collapsing multi-agent manifests to `all`.
- Stop ignoring Codex-managed paths so workflow-created PRs can include `.codex/` and `tools/codex/` updates.
- Update the self-upgrade workflow PR instructions to mention the Codex artifacts reviewers should inspect.

## Validation

- `npm test`