### PR TITLE
Teach Codex PR review to use GitHub app actions

### DIFF
--- a/src/agents/codex.test.ts
+++ b/src/agents/codex.test.ts
@@ -110,6 +110,7 @@ describe('deploy', () => {
     expect(fs.existsSync(path.join(prReviewDir, 'scripts', 'reply-comment.sh'))).toBe(true);
 
     const skillMd = fs.readFileSync(path.join(prReviewDir, 'SKILL.md'), 'utf8');
+    expect(skillMd).toContain('allowed-tools:');
     expect(skillMd).toContain('_list_pull_request_review_threads');
     expect(skillMd).toContain('_reply_to_review_comment');
     expect(skillMd).toContain('./.agents/skills/smithy.pr-review/scripts/find-pr.sh');

--- a/src/agents/codex.test.ts
+++ b/src/agents/codex.test.ts
@@ -110,6 +110,8 @@ describe('deploy', () => {
     expect(fs.existsSync(path.join(prReviewDir, 'scripts', 'reply-comment.sh'))).toBe(true);
 
     const skillMd = fs.readFileSync(path.join(prReviewDir, 'SKILL.md'), 'utf8');
+    expect(skillMd).toContain('_list_pull_request_review_threads');
+    expect(skillMd).toContain('_reply_to_review_comment');
     expect(skillMd).toContain('./.agents/skills/smithy.pr-review/scripts/find-pr.sh');
     expect(skillMd).not.toContain('${CLAUDE_SKILL_DIR}');
     expect(skillMd).not.toContain('./.gemini/skills/smithy.pr-review');

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -431,6 +431,22 @@ describe('getComposedTemplates', () => {
     expect(skill.prompt).not.toContain('./.gemini/skills/smithy.pr-review');
   });
 
+  it('smithy.pr-review renders Codex GitHub app actions as the preferred review-thread path', () => {
+    const skill = codexComposed.skills.get('smithy.pr-review')!;
+    expect(skill.prompt).toContain("Codex's GitHub app connector");
+    expect(skill.prompt).toContain('_list_pull_request_review_threads');
+    expect(skill.prompt).toContain('_reply_to_review_comment');
+    expect(skill.prompt).toContain('use tool discovery');
+    expect(skill.prompt).toContain('The discovered Codex GitHub app actions do not provide a direct "find open PR');
+  });
+
+  it('smithy.fix tells Codex to use pr-review app actions before script fallbacks', () => {
+    const fix = codexComposed.commands.get('smithy.fix.md')!;
+    expect(fix).toContain("skill's Codex GitHub app path");
+    expect(fix).toContain('root comment ID identified by the `smithy.pr-review` Codex path');
+    expect(fix).not.toContain('Post your reply to\n   `comments[0].databaseId`');
+  });
+
   it('smithy.pr-review scripts start with bash shebang', () => {
     const skill = claudeComposed.skills.get('smithy.pr-review')!;
     for (const [, content] of skill.scripts) {

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -434,8 +434,10 @@ describe('getComposedTemplates', () => {
   it('smithy.pr-review renders Codex GitHub app actions as the preferred review-thread path', () => {
     const skill = codexComposed.skills.get('smithy.pr-review')!;
     expect(skill.prompt).toContain("Codex's GitHub app connector");
+    expect(skill.prompt).toContain('allowed-tools:');
     expect(skill.prompt).toContain('_list_pull_request_review_threads');
     expect(skill.prompt).toContain('_reply_to_review_comment');
+    expect(skill.prompt).toContain('reply-comment.sh <ownerRepo> <pr-number> <comment-id> <body-file>');
     expect(skill.prompt).toContain('use tool discovery');
     expect(skill.prompt).toContain('The discovered Codex GitHub app actions do not provide a direct "find open PR');
   });

--- a/src/templates/agent-skills/commands/smithy.fix.prompt
+++ b/src/templates/agent-skills/commands/smithy.fix.prompt
@@ -23,6 +23,13 @@ Determine what to fix based on `$ARGUMENTS`.
 Use the `smithy.pr-review` skill to check for PR review comments. Invoke
 `Skill("smithy.pr-review")` to load the operations, then:
 
+{{#ifAgent 'codex'}}
+For Codex, follow the skill's Codex GitHub app path for listing review
+threads and posting replies when those app actions are available. Use the
+script fallback only when the app connector or required action is unavailable,
+or when you need to discover the open PR for the current branch.
+{{/ifAgent}}
+
 1. Run the **Find Open PR** operation. If the result is `{}` (no PR), skip to **Path B**.
 2. Run the **List Inline Comments** operation with the `ownerRepo` and `pr` from step 1.
    If the result is an empty array `[]`, skip to **Path B**.
@@ -33,7 +40,12 @@ Use the `smithy.pr-review` skill to check for PR review comments. Invoke
    For each thread: read its full `comments[]` chain before deciding how to act.
    The **last** comment has the most recent context (a reviewer follow-up or
    escalation takes precedence over the original). Post your reply to
+{{#ifAgent 'codex'}}
+   the root comment ID identified by the `smithy.pr-review` Codex path.
+   Continue to the **Fix Loop**.
+{{else}}
    `comments[0].databaseId` (the thread root). Continue to the **Fix Loop**.
+{{/ifAgent}}
 
 ### Path B — No arguments, no PR or no comments
 

--- a/src/templates/agent-skills/skills/smithy.pr-review/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.pr-review/SKILL.prompt
@@ -5,6 +5,28 @@ allowed-tools: Bash(git remote get-url *) Bash(git branch --show-current) Bash(g
 ---
 # smithy.pr-review
 
+{{#ifAgent 'codex'}}
+Provides GitHub PR review operations through Codex's GitHub app connector,
+with the bundled `gh`-CLI scripts kept as a fallback:
+
+1. **Codex GitHub app connector** (preferred when available) — use the
+   GitHub app actions directly for review-thread operations:
+   `_list_pull_request_review_threads` and `_reply_to_review_comment`.
+   If those actions are not already visible in your tool set, use tool
+   discovery for "GitHub pull request review threads reply" before falling
+   back to shell. This path avoids `gh` for listing/replying to review
+   threads and avoids shell permission prompts.
+2. **Bundled `gh`-CLI shell scripts** (fallback) — three scripts in this
+   skill's `scripts/` directory wrap `gh` invocations. Use these when
+   the GitHub app connector is unavailable, a needed action is missing, or
+   you need to discover the open PR for the current branch.
+
+| Operation             | Codex app path                         | Script fallback                                                                  |
+|-----------------------|----------------------------------------|----------------------------------------------------------------------------------|
+| Find Open PR          | Use known PR context if available; otherwise use fallback script | `./.agents/skills/smithy.pr-review/scripts/find-pr.sh` |
+| List Inline Comments  | `_list_pull_request_review_threads`    | `./.agents/skills/smithy.pr-review/scripts/get-comments.sh <ownerRepo> <pr-number>` |
+| Reply to a Comment    | `_reply_to_review_comment`             | `./.agents/skills/smithy.pr-review/scripts/reply-comment.sh <ownerRepo> <pr-number> <id> <body-file>` |
+{{else}}
 Provides GitHub PR review operations through two interchangeable paths:
 
 1. **GitHub MCP server** (preferred when available) — calls
@@ -22,11 +44,23 @@ Provides GitHub PR review operations through two interchangeable paths:
 | Find Open PR          | `mcp__github__list_pull_requests`                 | {{#ifAgent 'claude'}}`${CLAUDE_SKILL_DIR}`{{/ifAgent}}{{#ifAgent 'gemini'}}`./.gemini/skills/smithy.pr-review`{{/ifAgent}}{{#ifAgent 'codex'}}`./.agents/skills/smithy.pr-review`{{/ifAgent}}`/scripts/find-pr.sh` |
 | List Inline Comments  | `mcp__github__pull_request_read` (`get_review_comments`) | {{#ifAgent 'claude'}}`${CLAUDE_SKILL_DIR}`{{/ifAgent}}{{#ifAgent 'gemini'}}`./.gemini/skills/smithy.pr-review`{{/ifAgent}}{{#ifAgent 'codex'}}`./.agents/skills/smithy.pr-review`{{/ifAgent}}`/scripts/get-comments.sh <ownerRepo> <pr-number>` |
 | Reply to a Comment    | `mcp__github__add_reply_to_pull_request_comment`  | {{#ifAgent 'claude'}}`${CLAUDE_SKILL_DIR}`{{/ifAgent}}{{#ifAgent 'gemini'}}`./.gemini/skills/smithy.pr-review`{{/ifAgent}}{{#ifAgent 'codex'}}`./.agents/skills/smithy.pr-review`{{/ifAgent}}`/scripts/reply-comment.sh <ownerRepo> <pr-number> <id> <body-file>` |
+{{/ifAgent}}
 
 ## Path Selection
 
 For each operation:
 
+{{#ifAgent 'codex'}}
+1. **Try the Codex GitHub app first** for listing and replying to review
+   threads. If the app actions are not visible, use tool discovery before
+   falling back to shell.
+2. **Use known PR context when present.** If the user, current task, or
+   previous tool output already identifies `owner/repo` and PR number, do
+   not run the Find Open PR fallback just to rediscover it.
+3. **Fall back to the script** if the GitHub app connector is unavailable,
+   returns a tool-not-found / connection error, lacks the needed action, or
+   the operation is Find Open PR and no PR number is known.
+{{else}}
 1. **Try MCP first.** If `mcp__github__<tool>` is in your available
    tool set, use it. The MCP path is faster (no shell hop), avoids
    permission prompts, and works regardless of whether `gh` is
@@ -37,6 +71,7 @@ For each operation:
 
 Decide path-by-path, not session-globally — some hosts may expose only a
 subset of the MCP tools.
+{{/ifAgent}}
 
 ---
 
@@ -44,8 +79,14 @@ subset of the MCP tools.
 
 Detects the open PR for the current branch.
 
-### MCP path
+{{#ifAgent 'codex'}}### Codex app path{{else}}### MCP path{{/ifAgent}}
 
+{{#ifAgent 'codex'}}
+The discovered Codex GitHub app actions do not provide a direct "find open PR
+for this branch" operation. If `repo_full_name` and `pr_number` are already
+known from the conversation or prior tool output, use them and skip this
+operation. Otherwise use the script fallback below.
+{{else}}
 Resolve `owner` and `repo` from the git origin remote, then call
 `list_pull_requests`:
 
@@ -77,6 +118,7 @@ Then call `mcp__github__list_pull_requests` with:
 
 If the response array is empty, treat as "no open PR for this branch".
 Otherwise capture `number` from the first entry.
+{{/ifAgent}}
 
 ### Script fallback
 
@@ -93,8 +135,17 @@ if no open PR exists for the current branch.
 
 Fetches review threads on the PR with their full reply chains.
 
-### MCP path
+{{#ifAgent 'codex'}}### Codex app path{{else}}### MCP path{{/ifAgent}}
 
+{{#ifAgent 'codex'}}
+Call `_list_pull_request_review_threads` with:
+- `repo_full_name`: `"<owner>/<repo>"`
+- `pr_number`
+
+The response contains GraphQL review thread nodes with resolved state,
+comment bodies, and comment IDs. Filter out resolved threads before handing
+them to the caller — only unresolved threads need a reply.
+{{else}}
 Call `mcp__github__pull_request_read` with:
 - `method`: `"get_review_comments"`
 - `owner`, `repo`, `pullNumber`
@@ -116,6 +167,7 @@ The response is an object with:
 
 **Filter out threads where `is_resolved == true`** before handing them
 to the caller — only unresolved threads need a reply.
+{{/ifAgent}}
 
 ### Script fallback
 
@@ -140,8 +192,14 @@ Returns `[]` if there are no unresolved review threads.
   follow-up or escalation from the reviewer takes precedence over the
   original).
 - The reply target is the **root comment**:
+{{#ifAgent 'codex'}}
+  - Codex app path: the numeric ID of the thread's top-level inline
+    review comment
+  - Script path: `comments[0].databaseId`
+{{else}}
   - MCP path: `comments[0].id`
   - Script path: `comments[0].databaseId`
+{{/ifAgent}}
 
 ---
 
@@ -149,14 +207,23 @@ Returns `[]` if there are no unresolved review threads.
 
 Posts an inline reply to a specific review thread.
 
-### MCP path
+{{#ifAgent 'codex'}}### Codex app path{{else}}### MCP path{{/ifAgent}}
 
+{{#ifAgent 'codex'}}
+Call `_reply_to_review_comment` with:
+- `repo_full_name`: `"<owner>/<repo>"`
+- `pr_number`
+- `comment_id`: the numeric ID of the thread's top-level inline review
+  comment
+- `comment`: the reply text
+{{else}}
 Call `mcp__github__add_reply_to_pull_request_comment` with:
 - `owner`, `repo`, `pullNumber`
 - `commentId`: the **root** comment's `id` (`comments[0].id` from the
   thread)
 - `body`: the reply text (plain string — no temp-file or JSON wrapping
   is needed; this is one of the simplifications over the script path).
+{{/ifAgent}}
 
 ### Script fallback
 

--- a/src/templates/agent-skills/skills/smithy.pr-review/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.pr-review/SKILL.prompt
@@ -1,7 +1,7 @@
 ---
 name: smithy.pr-review
 description: "GitHub PR review operations: list inline comments, reply to comments. Use when handling review feedback on an open pull request."
-allowed-tools: Bash(git remote get-url *) Bash(git branch --show-current) Bash(git config --get remote.origin.url) Bash(*/smithy.pr-review/scripts/find-pr.sh) Bash(*/smithy.pr-review/scripts/get-comments.sh:*) Bash(*/smithy.pr-review/scripts/reply-comment.sh:*) mcp__github__list_pull_requests mcp__github__pull_request_read mcp__github__add_reply_to_pull_request_comment
+allowed-tools: Bash(git remote get-url *) Bash(git branch --show-current) Bash(git config --get remote.origin.url) Bash(*/smithy.pr-review/scripts/find-pr.sh) Bash(*/smithy.pr-review/scripts/get-comments.sh:*) Bash(*/smithy.pr-review/scripts/reply-comment.sh:*) mcp__github__list_pull_requests mcp__github__pull_request_read mcp__github__add_reply_to_pull_request_comment _list_pull_request_review_threads _reply_to_review_comment
 ---
 # smithy.pr-review
 
@@ -25,7 +25,7 @@ with the bundled `gh`-CLI scripts kept as a fallback:
 |-----------------------|----------------------------------------|----------------------------------------------------------------------------------|
 | Find Open PR          | Use known PR context if available; otherwise use fallback script | `./.agents/skills/smithy.pr-review/scripts/find-pr.sh` |
 | List Inline Comments  | `_list_pull_request_review_threads`    | `./.agents/skills/smithy.pr-review/scripts/get-comments.sh <ownerRepo> <pr-number>` |
-| Reply to a Comment    | `_reply_to_review_comment`             | `./.agents/skills/smithy.pr-review/scripts/reply-comment.sh <ownerRepo> <pr-number> <id> <body-file>` |
+| Reply to a Comment    | `_reply_to_review_comment`             | `./.agents/skills/smithy.pr-review/scripts/reply-comment.sh <ownerRepo> <pr-number> <comment-id> <body-file>` |
 {{else}}
 Provides GitHub PR review operations through two interchangeable paths:
 


### PR DESCRIPTION
## Summary
- add a Codex-specific smithy.pr-review path that prefers GitHub app actions for listing/replying to review threads
- point smithy.fix no-arg PR review handling at that Codex app-first path
- add template and Codex deploy regression coverage

## Tests
- npm test