### PR TITLE
test(orders): assert deploy-location routing and missing-manifest error

### DIFF
--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -546,6 +546,23 @@ describe('getComposedTemplates', () => {
     // from.
     expect(orders).toContain('resolveManifestDir');
     expect(orders).toContain('<manifestDir>/templates/orders/');
+    const manifestResolutionHeading = '### Manifest Discovery and `<manifestDir>` Resolution';
+    const manifestResolutionStart = orders.indexOf(manifestResolutionHeading);
+    expect(manifestResolutionStart).toBeGreaterThan(-1);
+    const manifestResolutionEnd = orders.indexOf('**Forbidden operations.**', manifestResolutionStart);
+    expect(manifestResolutionEnd).toBeGreaterThan(manifestResolutionStart);
+    const manifestResolution = orders.slice(manifestResolutionStart, manifestResolutionEnd);
+
+    // US3 Slice 2: deploy-location awareness must be routed through the
+    // manifest-load phase, not hardcoded to one location. The prompt may use a
+    // deploy-location-agnostic <manifestDir> placeholder downstream, so assert
+    // that both location values are inputs to resolveManifestDir here.
+    expect(manifestResolution).toMatch(
+      /stored `deployLocation` field[\s\S]+<manifestDir> = resolveManifestDir\(targetDir, location\)/
+    );
+    expect(manifestResolution).toContain("resolveManifestDir(targetDir, 'repo')");
+    expect(manifestResolution).toContain("resolveManifestDir(targetDir, 'user')");
+    expect(manifestResolution).toMatch(/Run `smithy init`[\s\S]+re-run `smithy\.orders`/);
     // Spec template lookup (US2 S1 Task 2): the .spec.md mapping must
     // specifically reference the spec.md template file under the
     // manifest's orders templates directory.


### PR DESCRIPTION
## Summary
- Implements US3 Slice 2 from `specs/2026-03-21-002-smithy-orders-issue-templates/03-deployment-location-honored-end-to-end.tasks.md`.
- Adds structural assertions on the composed `smithy.orders.md` prompt in `src/templates.test.ts`: both `'repo'` and `'user'` flow into `resolveManifestDir`, the manifest's persisted `deployLocation` field is named as the resolution source, and the missing-manifest error path references `smithy init`.
- Test-only change. No production code touched.

## Test plan
- [x] `npm test -- src/templates.test.ts` (136 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
