### PR TITLE
Add mark-eval representative fixture plants

### DIFF
--- a/evals/fixture/README.md
+++ b/evals/fixture/README.md
@@ -29,12 +29,13 @@ Together with the **Intentional Gap** above, these plants are the fixture's twin
 
 ## Planted Parent Artifacts
 
-In addition to the scout-flawed plants documented in `## Planted Inconsistencies` above, the fixture hosts **representative parent artifacts** — scenario-isolated files that conform to a producing command's canonical template and are consumed as **input** by downstream eval scenarios (for example, a PRD that `/smithy.ignite` workshops into an RFC). Representative plants differ from scout-flawed plants in intent: representative plants are deliberately *well-formed* so a downstream command can produce realistic output from them, whereas scout-flawed plants are deliberately *malformed* so `smithy-scout` can detect their flaws. Both kinds are deliberate fixtures — **do not "clean up" either kind**; removing a representative plant silently breaks the owner scenario that feeds on it.
+In addition to the scout-flawed plants documented in `## Planted Inconsistencies` above, the fixture hosts **representative parent artifacts** — scenario-isolated files that conform to a producing command's canonical template and are consumed as **input** by downstream eval scenarios (for example, a PRD that `/smithy.ignite` workshops into an RFC). Representative plants differ from scout-flawed plants in intent: representative plants are deliberately *well-formed* so a downstream command can produce realistic output from them, whereas scout-flawed plants are deliberately *malformed* so `smithy-scout` can detect their flaws. Both kinds are deliberate fixtures — **do not "clean up" either kind**; removing, moving, or renaming a representative plant without coordinating with the owning scenario silently breaks the scenario that feeds on it.
 
 | Path | Owner Scenario | Realism | Purpose |
 |------|----------------|---------|---------|
 | `evals/fixture/specs/cut-eval/` | `cut-from-spec` | representative | Three-file spec / data-model / contracts plant consumed by `/smithy.cut` to assert the generated tasks file inherits the SD-001 debt row from the upstream spec. |
 | `evals/fixture/prds/ignite-eval/` | `ignite-from-prd` | representative | Canonical PRD fed to `/smithy.ignite` to produce an RFC. |
+| `evals/fixture/rfcs/mark-eval/` | `mark-from-features` | representative | Co-located RFC and features-map plant consumed by `/smithy.mark`; the features-map starts with its `Artifact` cell unset so the scenario can verify spec-artifact production. |
 | `evals/fixture/rfcs/render-eval/` | `render-from-rfc` | representative | Minimal Smithy RFC consumed by the render scenario; exercises render's Phase 1 milestone-extraction routing. |
 
 ## Usage

--- a/evals/fixture/rfcs/mark-eval/01-core.features.md
+++ b/evals/fixture/rfcs/mark-eval/01-core.features.md
@@ -1,0 +1,49 @@
+<!--
+  Planted feature-map fixture for the `mark-from-features` eval scenario.
+  Realism: representative (per data-model PlantedArtifact.realism enum).
+  Owner: mark-from-features (single consumer).
+  Purpose: gives /smithy.mark a structurally valid, self-contained feature map
+  to expand into a feature specification. Content is fictional and references
+  only the co-located RFC plant.
+-->
+
+# Feature Map: Subscription Reminder Core
+
+**Source RFC**: `mark-eval.rfc.md`
+**Milestone**: 1 — Subscription Reminder Core
+**Created**: 2026-05-15
+
+## Features
+
+### Feature 1: Upcoming Renewal Summary
+
+**Description**: Deliver a read-only summary that shows each customer which
+subscriptions renew in the next billing window, including renewal date,
+service name, and expected charge. The first implementation focuses on a
+single customer account at a time and returns deterministic sample data for
+the eval fixture.
+
+**User-Facing Value**: Customers can see upcoming charges before they happen
+and decide whether they need to update, cancel, or review a subscription.
+
+**Scope Boundaries**:
+- Includes: a renewal-summary contract, a small in-memory subscription model,
+  date-window filtering, and stable empty-state behavior.
+- Excludes: payment processing, cancellation workflows, notification delivery,
+  multi-account aggregation, and third-party provider synchronization.
+
+## Specification Debt
+
+None — all ambiguities resolved.
+
+## Dependency Order
+
+Recommended specification sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|-----------|----------|
+| F1 | Upcoming Renewal Summary | — | — |
+
+## Cross-Milestone Dependencies
+
+None — this milestone is self-contained.

--- a/evals/fixture/rfcs/mark-eval/mark-eval.rfc.md
+++ b/evals/fixture/rfcs/mark-eval/mark-eval.rfc.md
@@ -71,11 +71,11 @@ those cases lead to different support conversations.
 
 ## Open Questions
 
-None — all ambiguities resolved.
+- None — all ambiguities resolved.
 
 ## Specification Debt
 
-None — all ambiguities resolved.
+- None — all ambiguities resolved.
 
 ## Milestones
 

--- a/evals/fixture/rfcs/mark-eval/mark-eval.rfc.md
+++ b/evals/fixture/rfcs/mark-eval/mark-eval.rfc.md
@@ -1,0 +1,101 @@
+<!--
+  Planted RFC fixture for the `mark-from-features` eval scenario.
+  Realism: representative (per data-model PlantedArtifact.realism enum).
+  Owner: mark-from-features (single consumer).
+  Purpose: provides the co-located source RFC referenced by the feature-map
+  plant. Content is fictional and references no external files.
+-->
+
+# RFC: Subscription Reminder Service
+
+**Created**: 2026-05-15  |  **Status**: Draft
+
+## Summary
+
+Build a small service that helps customers understand which subscriptions are
+about to renew. The service exposes a read path for upcoming renewal summaries
+and gives support teams a predictable shape for explaining upcoming charges.
+
+## Motivation / Problem Statement
+
+Customers often discover subscription renewals only after a charge appears on
+their statement. Support teams can answer individual questions, but they do
+not have a simple, consistent summary view to share before the renewal date.
+The result is avoidable support volume and customer frustration around charges
+that were expected but not visible.
+
+## Goals
+
+- Show upcoming renewals for a customer in a predictable billing window.
+- Include enough detail for a customer to recognize the subscription and
+  expected charge.
+- Keep the first release read-only so it can be implemented without payment
+  or cancellation side effects.
+
+## Out of Scope
+
+- Cancelling subscriptions or changing payment methods.
+- Sending email, SMS, push, or in-app notifications.
+- Syncing with external subscription providers.
+
+## Personas
+
+- **Customer** - reviews upcoming subscription charges before renewal.
+- **Support Specialist** - uses the same summary shape to answer renewal
+  questions consistently.
+
+## Proposal
+
+Implement a read-only renewal summary backed by a compact subscription record.
+The summary filters active subscriptions by a configurable upcoming-renewal
+window and returns service name, renewal date, expected amount, and currency.
+The first milestone uses fixture-local sample data so the planning command can
+produce a realistic feature specification without depending on external
+systems.
+
+## Design Considerations
+
+The renewal window should be explicit and deterministic so tests and support
+screens do not drift by time zone. Empty states need to distinguish "no active
+subscriptions" from "active subscriptions exist but none renew soon" because
+those cases lead to different support conversations.
+
+## Decisions
+
+- The first release is read-only to avoid coupling the summary view to billing
+  mutations.
+- Renewal dates are treated as calendar dates rather than timestamps to keep
+  customer-facing wording stable across time zones.
+- Fixture data is intentionally small and deterministic so downstream planning
+  evals can assert against stable output.
+
+## Open Questions
+
+None — all ambiguities resolved.
+
+## Specification Debt
+
+None — all ambiguities resolved.
+
+## Milestones
+
+### Milestone 1: Subscription Reminder Core
+
+**Description**: Deliver the read-only upcoming renewal summary for a single
+customer account, including the domain model and response contract needed for a
+feature specification.
+
+**Success Criteria**:
+- The summary returns active subscriptions renewing inside the configured
+  upcoming-renewal window.
+- The response includes service name, renewal date, expected amount, and
+  currency for each matching subscription.
+- The empty response is deterministic and distinguishable from lookup failure.
+
+## Dependency Order
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|-----------|----------|
+| M1 | Subscription Reminder Core | — | — |


### PR DESCRIPTION
## Summary
- Adds representative RFC + features-map fixtures under `evals/fixture/rfcs/mark-eval/` for the `mark-from-features` eval scenario.
- Documents the new plant in the Planted Parent Artifacts table in `evals/fixture/README.md` and tightens the "do not clean up" guidance to also cover moves/renames.

Implements Slice 2 of `specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/02-mark-eval-produces-spec-artifact-set.tasks.md`.

## Test plan
- [ ] Confirm fixture files are present and self-contained (no external refs)
- [ ] Subsequent slices wire the `mark-from-features` scenario to consume these plants

🤖 Generated with [Claude Code](https://claude.com/claude-code)
