### PR TITLE
test(evals): add cut-from-spec YAML eval scenario

### DIFF
--- a/evals/cases/cut-from-spec.yaml
+++ b/evals/cases/cut-from-spec.yaml
@@ -1,0 +1,62 @@
+# Cut end-to-end eval scenario - exercises `/smithy.cut` against the
+# representative spec artifact plant under `evals/fixture/specs/cut-eval/`.
+#
+# Spec:       specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.spec.md
+# Data model: specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.data-model.md
+# Contracts:  specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/expand-evals-coverage-planning-and-audit.contracts.md
+# Tasks:      specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/03-cut-eval-inherits-spec-debt.tasks.md
+#
+# Mirrors the EvalScenario shape in `evals/lib/types.ts` and the
+# single-quoted regex convention in `evals/cases/strike-health-check.yaml`.
+
+name: cut-from-spec
+skill: /smithy.cut
+prompt: evals/fixture/specs/cut-eval 1
+# Empirical calibration: local Codex run on 2026-05-16 completed the cut
+# command in 247.5s; 600s leaves headroom for slower sub-agent dispatches
+# while staying below the sibling long-running planning-command budget.
+timeout: 600
+structural_expectations:
+  required_headings:
+    # One-shot planning-command terminal contract from
+    # `src/templates/agent-skills/snippets/one-shot-output.md`, included by
+    # `src/templates/agent-skills/commands/smithy.cut.prompt` Phase 0.
+    - '## Summary'
+    - '## Assumptions'
+    - '## Specification Debt'
+    - '## PR'
+  required_patterns:
+    # AS 3.1 / AS 3.2 proxy: cut Phase 1 step 3 reads upstream
+    # `## Specification Debt` and prefixes inherited rows with this literal.
+    # Cross-ref: src/templates/agent-skills/commands/smithy.cut.prompt
+    # Phase 1 step 3, "Inherit upstream debt".
+    - 'inherited from spec:'
+    # One-shot summary marker from `one-shot-output.md`.
+    - '\*\*Spec folder\*\*'
+    # Accept either successful PR creation or the documented auth/network
+    # failure branch from `one-shot-output.md`.
+    - 'https://github\.com/\S+/pull/[0-9]+|PR creation failed[^\n]*artifacts are on disk at'
+  forbidden_patterns:
+    # FR-011 - strike-convention set: generic refusals / non-skill responses.
+    - "I'd be happy to help"
+    - "Sure, here's"
+    # Leading YAML frontmatter; `\r?\n` tolerates CRLF.
+    - '^---\r?\n'
+# Sub-Agent Evidence - cut's template dispatches smithy-scout (Phase 2.5),
+# smithy-clarify (Phase 3), and smithy-plan-review (Plan-Review Pass).
+sub_agent_evidence:
+  # smithy-scout: resultText leading-heading marker from
+  # `src/templates/agent-skills/agents/smithy.scout.prompt` Output.
+  - agent: smithy-scout
+    pattern: '^## Scout Report\n\n\*\*Depth\*\*'
+  # smithy-clarify: dispatch-description marker established by the strike
+  # scenario; clarify dispatches naturally open with "Clarify..." or
+  # "clarify...".
+  - agent: smithy-clarify
+    pattern: '^[Cc]larif'
+  # smithy-plan-review: dispatch-description marker. The cut template
+  # instructs the parent to dispatch plan-review to review the tasks artifact;
+  # descriptions for that call naturally open with "Review..." or
+  # "Plan-review...".
+  - agent: smithy-plan-review
+    pattern: '^[Rr]eview|^[Pp]lan-review'


### PR DESCRIPTION
## Summary
- Primary outcome: Adds `evals/cases/cut-from-spec.yaml` — the end-to-end eval scenario for `/smithy.cut` against the representative spec fixture.
- Notable behaviour changes: None — data-only addition; no source code changed.
- Follow-up work deferred (if any): Wiring the scenario into CI / baseline capture.

## Context
- The evals framework already covers strike, scout, and spark. This fills the gap for the `cut` command so it has a runnable scenario alongside its spec fixture plant.
- Unlocks US3 (cut command eval validation) from the expand-evals-coverage planning spec.

## Implementation Notes
- Mirrors the `EvalScenario` YAML shape established by `evals/cases/strike-health-check.yaml`.
- `structural_expectations` cover the one-shot terminal contract headings, inherited-debt pattern, PR URL, and generic-refusal guard from FR-011.
- `sub_agent_evidence` entries cover smithy-scout (Phase 2.5), smithy-clarify (Phase 3), and smithy-plan-review (Plan-Review Pass).
- Timeout set to 600 s based on empirical local run of 247.5 s with headroom for sub-agent dispatch variance.

## Risks & Mitigations
- Risk: regex patterns are brittle if cut template output phrasing changes. | Mitigation: patterns are anchored to structural markers (headings, literal keywords) rather than prose.

## Rollback Plan
- Delete `evals/cases/cut-from-spec.yaml`; no other artifacts affected.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npm run typecheck`)
- [x] Evals unit tests pass (`npm run test:evals`) — 187/187

### Template Generation
- N/A (no template changes)

### Permissions & Configuration
- N/A

### Manual Test Cases
- N/A (evals-only change)