### PR TITLE
feat(orders): template-driven rendering for features issues with features_path resolution

### DIFF
--- a/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md
@@ -110,7 +110,7 @@
 
 ### Tasks
 
-- [ ] **Extend Phase 3 features parser to resolve `{{features_path}}` from the source RFC**
+- [x] **Extend Phase 3 features parser to resolve `{{features_path}}` from the source RFC**
 
   In Phase 3 of `smithy.orders.prompt`, extend the `.features.md` parse instructions so the agent locates the source RFC referenced in the features file's header, then reads that RFC's `## Dependency Order` table, finds the milestone row whose ID matches this features file's milestone, and captures the `Artifact` column value as `{{features_path}}`. When the source RFC cannot be located, the milestone row is missing, or the `Artifact` cell is `—`, populate `{{features_path}}` with empty string per the data-model validation rule.
 
@@ -120,7 +120,7 @@
   - Empty `Artifact` cell (`—` or absent) yields empty-string substitution rather than the literal `{{features_path}}`.
   - The captured value is stored for Phase 5 interpolation context.
 
-- [ ] **Replace `.features.md` per-feature heredoc with template-driven body**
+- [x] **Replace `.features.md` per-feature heredoc with template-driven body**
 
   In Phase 5 of `smithy.orders.prompt`, replace the per-feature body's heredoc with prose that reads `<manifestDir>/templates/orders/features.md` (when present) and globally substitutes every placeholder named in the data-model's features row, using the `{{features_path}}` value captured by the Phase 3 parser extension. The parent milestone-linkage search logic earlier in the Phase 5 features section is preserved. When the template file is absent, fall through to the existing per-feature heredoc.
 
@@ -132,7 +132,7 @@
   - Global substitution — every occurrence of every known placeholder is replaced.
   - When `<manifestDir>/templates/orders/features.md` is absent the existing per-feature heredoc is used.
 
-- [ ] **Assert features template lookup and `{{features_path}}` parser are present**
+- [x] **Assert features template lookup and `{{features_path}}` parser are present**
 
   Extend the existing `smithy.orders` block in `src/templates.test.ts` with behavioral assertions that the composed prompt references `<manifestDir>/templates/orders/features.md`, names `{{features_path}}` as a populated placeholder, and references the source RFC's `## Dependency Order` table as the lookup site for the features path.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -582,6 +582,14 @@ describe('getComposedTemplates', () => {
     expect(orders).toContain('## RFC Tracking Issue');
     expect(orders).toContain('[RFC] <rfc-title>');
 
+    // US2 S3: features issues render from the features template when
+    // present, and the features parser populates {{features_path}} from
+    // the source RFC's Dependency Order table rather than guessing a path.
+    expect(orders).toContain('<manifestDir>/templates/orders/features.md');
+    expect(orders).toContain('{{features_path}}');
+    expect(orders).toMatch(/Source RFC[\s\S]+## Dependency Order[\s\S]+Artifact/);
+    expect(orders).toMatch(/milestone number[\s\S]+M<N>/);
+
     // US4 Slice 1 Task 2: parity between the prompt's Phase 5 fallback
     // bodies and the canonical default exports in `src/orders-templates.ts`.
     // For each of the four orders-eligible artifact types, both surfaces

--- a/src/templates/agent-skills/commands/smithy.orders.prompt
+++ b/src/templates/agent-skills/commands/smithy.orders.prompt
@@ -207,10 +207,18 @@ Parse the feature map to extract:
   Features/Feature List section) becomes a ticket.
 - **Feature map metadata** — read the feature map's header metadata rather
   than guessing paths:
-  - **Source RFC** — from the `**Source RFC**` field. If the field is absent
-    or the referenced RFC cannot be located, keep parsing features but set the
-    downstream `\{{features_path}}` value to empty string per the data-model
-    validation rule.
+  - **Source RFC** — from the `**Source RFC**` field. Resolve the path as
+    follows:
+    1. If the value is an absolute path or starts with the repo root, try it
+       as-is.
+    2. Otherwise treat it as a path **relative to the `.features.md` file's
+       own directory** (not the current working directory). For example, if the
+       feature map is at `evals/fixture/rfcs/mark-eval/01-core.features.md`
+       and the field value is `mark-eval.rfc.md`, resolve to
+       `evals/fixture/rfcs/mark-eval/mark-eval.rfc.md`.
+    If the field is absent or the resolved RFC path cannot be located on disk,
+    keep parsing features but set the downstream `\{{features_path}}` value to
+    empty string per the data-model validation rule.
   - **Milestone number** — from the `**Milestone**: <N> — <Title>` field. Use
     the number `<N>` as the stable lookup key; do not match by milestone title
     because names can collide across RFCs.

--- a/src/templates/agent-skills/commands/smithy.orders.prompt
+++ b/src/templates/agent-skills/commands/smithy.orders.prompt
@@ -205,6 +205,23 @@ Parse the RFC to extract:
 Parse the feature map to extract:
 - **Features** — each feature entry (typically H3 or list items under a
   Features/Feature List section) becomes a ticket.
+- **Feature map metadata** — read the feature map's header metadata rather
+  than guessing paths:
+  - **Source RFC** — from the `**Source RFC**` field. If the field is absent
+    or the referenced RFC cannot be located, keep parsing features but set the
+    downstream `\{{features_path}}` value to empty string per the data-model
+    validation rule.
+  - **Milestone number** — from the `**Milestone**: <N> — <Title>` field. Use
+    the number `<N>` as the stable lookup key; do not match by milestone title
+    because names can collide across RFCs.
+- **Feature map path for interpolation** — when the Source RFC can be read and
+  the milestone number is known, read the source RFC's `## Dependency Order`
+  table, find the row whose ID is `M<N>` for the feature map's milestone
+  number, and capture that row's `Artifact` column value as
+  `\{{features_path}}` for Phase 5. If the `## Dependency Order` table is
+  missing, the matching milestone row is absent, the `Artifact` cell is absent,
+  or the cell is `—`, capture empty string instead of leaving a literal
+  `\{{features_path}}` token in the rendered body.
 
 ### For `.spec.md`
 
@@ -408,11 +425,71 @@ path. If multiple milestones share the same name across RFCs, use the body's
 child ticket body.
 
 **Children**: one issue per feature. Template-driven rendering for
-the features type is implemented in Slice 3 — until then, the heredoc
-body below is always used, regardless of whether
-`<manifestDir>/templates/orders/features.md` exists on disk. Any
-`features.md` file in `<manifestDir>/templates/orders/` is ignored by
-the current `.features.md` mapping.
+the features type uses `<manifestDir>/templates/orders/features.md` when the
+file exists; otherwise it falls through to the heredoc below so `orders` still
+produces an issue.
+
+**Template-driven rendering (preferred path).** Before falling back to the
+heredoc below, attempt to render the body from the user-overridable features
+template provisioned by `smithy init` under
+`<manifestDir>/templates/orders/features.md`. `<manifestDir>` is the value
+captured at the end of Phase 1's "Manifest Discovery and `<manifestDir>`
+Resolution" sub-section — do not re-probe the filesystem; reuse the
+already-resolved value. Preserve the parent milestone-linkage search logic
+above; the resulting `#<n>` reference is part of the interpolation context.
+
+For **each** feature extracted in Phase 3, perform the following steps:
+
+1. **Build the features-type interpolation context.** Compute a value for every
+   variable named in the data-model's features row. Sources:
+
+   - `{{title}}` ← the feature's title (the same `<feature-title>` used in the
+     `[Feature] <feature-title>` issue title).
+   - `{{feature_description}}` ← the feature description body parsed in
+     Phase 3.
+   - `{{milestone_number}}` ← the milestone number parsed from the feature
+     map's `**Milestone**` metadata in Phase 3.
+   - `{{parent_issue}}` ← the `#<n>` reference for the matched
+     `[RFC][Milestone] <milestone-title>` issue. If no parent issue was found,
+     use empty string.
+   - `{{features_path}}` ← the value captured in Phase 3 from the source RFC's
+     `## Dependency Order` table `Artifact` column for this milestone. When
+     Phase 3 could not locate the source RFC, could not find the matching
+     milestone row by number, or found an empty/`—` artifact cell, use empty
+     string.
+   - `{{next_step}}` ← the literal instruction `smithy.mark` on this feature,
+     per the data-model next-step mapping. Include enough context for the
+     operator to run mark on the specific feature, e.g.
+     `smithy.mark <features_path> <feature_number>` when that source path and
+     feature number are known; otherwise use `smithy.mark` on this feature.
+
+2. **Read the template file.** Using the `Read` tool, attempt to read
+   `<manifestDir>/templates/orders/features.md`.
+
+3. **If the read succeeds** (the template file exists): perform a
+   **global** substitution of every variable in the context built in
+   step 1 across the entire template body. Every occurrence of every
+   known placeholder must be replaced — not just the first. Unknown
+   `{{variable}}` names (any token not in the features-row context above)
+   are **left as literal text** per the data-model validation rule — do
+   not error and do not delete them.
+
+   Write the rendered body to `/tmp/orders_body.md` and then call:
+
+   ```bash
+   {{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "[Feature] <feature-title>" /tmp/orders_body.md
+   ```
+
+   Skip the heredoc fallthrough below for this feature.
+
+4. **If the read fails** because the file does not exist (i.e.,
+   `<manifestDir>/templates/orders/features.md` is absent on disk): fall
+   through to the heredoc body below so `orders` still produces an
+   issue. Do **not** treat any other read failure (permission denied,
+   I/O error) as "absent" — surface those errors and stop.
+
+**Fallthrough heredoc body.** Used only when the template file at
+`<manifestDir>/templates/orders/features.md` is absent:
 
 ```bash
 cat > /tmp/orders_body.md << 'BODY'


### PR DESCRIPTION
## Summary
- Primary outcome: `smithy.orders` now reads `<manifestDir>/templates/orders/features.md` when present and renders per-feature issue bodies by substituting all known placeholders, including `{{features_path}}` resolved from the source RFC's `## Dependency Order` table.
- Notable behaviour changes: Phase 3 now reads the feature map's `**Source RFC**` and `**Milestone**` metadata fields; Phase 5 attempts template-driven rendering before falling back to the existing heredoc.
- Follow-up work deferred (if any): None — all three US2 S3 tasks are now complete.

## Context
- This completes US2 Slice 3 of the orders-uses-templates spec (`specs/2026-03-21-002-smithy-orders-issue-templates/02-orders-uses-templates-when-creating-issues.tasks.md`).
- Enables operators to customise features-type issue bodies via a provisioned template file, consistent with how rfc/spec/tasks types already work.

## Implementation Notes
- Phase 3 extended: reads `**Source RFC**` field → resolves RFC path → reads RFC's `## Dependency Order` table → finds `M<N>` row by milestone number → captures `Artifact` column as `{{features_path}}`.
- Phase 5 extended: attempts `Read <manifestDir>/templates/orders/features.md`; on success performs global placeholder substitution across all six context variables; on absence falls through to heredoc; other read errors surface and stop.
- Unknown `{{variable}}` tokens in the template are left as literal text per the data-model rule.
- Impacted modules: `src/templates/agent-skills/commands/smithy.orders.prompt`, `src/templates.test.ts`, tasks file.

## Risks & Mitigations
- Risk: RFC path resolution fails silently. | Mitigation: When source RFC is absent/unresolvable, `{{features_path}}` is set to empty string and processing continues — the issue is still created.
- Risk: Template read errors swallowed. | Mitigation: Only "file not found" is treated as absent; all other errors surface and stop.

## Rollback Plan
- Revert this commit; the heredoc path remains the only path and behaviour is identical to the prior release.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] All 823 tests pass (`npm test`)

### Template Generation
- [x] New test assertions in `src/templates.test.ts` cover template lookup, `{{features_path}}` interpolation, and RFC Dependency Order table resolution.

### Manual Test Cases
- [ ] End-to-end `smithy.orders` against a real `.features.md` with a provisioned `features.md` template (Tier 3 eval — not wired to CI).