### PR TITLE
[codex] Handle non-thread PR comments

### DIFF
--- a/.agents/skills/smithy-fix/SKILL.md
+++ b/.agents/skills/smithy-fix/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: smithy-fix
-description: "Fix errors from CI failures, local test failures, or bugs. When run with no arguments on a branch with an open PR, automatically addresses inline review comments."
+description: "Fix errors from CI failures, local test failures, or bugs. When run with no arguments on a branch with an open PR, automatically addresses PR review comments."
 ---
 # smithy-fix
 
 You are the **smithy-fix agent**. You diagnose and fix problems — whether from CI failures,
-local test failures, bugs, or inline PR review comments. You work on the current branch
+local test failures, bugs, or PR review comments. You work on the current branch
 and produce the smallest correct fix.
 
 ## Input
@@ -29,17 +29,19 @@ script fallback only when the app connector or required action is unavailable,
 or when you need to discover the open PR for the current branch.
 
 1. Run the **Find Open PR** operation. If the result is `{}` (no PR), skip to **Path B**.
-2. Run the **List Inline Comments** operation with the `ownerRepo` and `pr` from step 1.
+2. Run the **List PR Comments** operation with the `ownerRepo` and `pr` from step 1.
    If the result is an empty array `[]`, skip to **Path B**.
-3. Build a **problem list** — **one item per thread**, not per comment. Cap at the
-   first **10 threads**; if more remain, tell the user to re-run `/smithy.fix` for
+3. Build a **problem list** — **one item per returned comment item**. Cap at the
+   first **10 items**; if more remain, tell the user to re-run `/smithy.fix` for
    the next batch.
 
-   For each thread: read its full `comments[]` chain before deciding how to act.
+   For each inline thread: read its full `comments[]` chain before deciding how to act.
    The **last** comment has the most recent context (a reviewer follow-up or
-   escalation takes precedence over the original). Post your reply to
+   escalation takes precedence over the original). For a top-level PR conversation
+   comment, `comments[]` contains the single comment to evaluate. Post inline replies to
    the root comment ID identified by the `smithy.pr-review` Codex path.
-   Continue to the **Fix Loop**.
+   For `kind: "conversation_comment"` items, reply with the **Reply to Conversation
+   Comment** operation instead. Continue to the **Fix Loop**.
 
 ### Path B — No arguments, no PR or no comments
 
@@ -128,13 +130,17 @@ one logical fix per commit.
 ### For PR review comments (Path A)
 
 After all items have been fixed or declined, use the `smithy.pr-review` skill's
-**Reply to a Comment** operation for each thread's root comment. Pick the
+**Reply to Inline Comment** operation for each inline thread's root comment. Pick the
 identifier that matches the path the skill chose for your environment: `id`
 (MCP path) or `databaseId` (script-fallback path) — both come from the first
 comment in the thread's `comments[]` array:
 
 - For fixed items: `"Fixed in <commit-sha>: <one-line explanation>"`
 - For declined items: `"Not addressed: <explanation>"`
+
+For `kind: "conversation_comment"` items, use **Reply to Conversation Comment**
+with the same fixed/declined wording, because those comments cannot receive an
+inline threaded reply.
 
 Then push the branch:
 ```

--- a/.agents/skills/smithy.pr-review/SKILL.md
+++ b/.agents/skills/smithy.pr-review/SKILL.md
@@ -68,9 +68,9 @@ if no open PR exists for the current branch.
 
 ## Operation: List PR Comments
 
-Fetches unresolved inline review threads and top-level PR conversation
-comments. Conversation comments are not review threads, so handle them as
-separate actionable items.
+Fetches unresolved inline review threads and unhandled top-level PR
+conversation comments. Conversation comments are not review threads, so handle
+them as separate actionable items.
 
 ### Codex app path
 
@@ -84,7 +84,9 @@ them to the caller — only unresolved threads need a reply.
 
 Also call `_fetch_pr_comments` with the same arguments and include top-level
 PR conversation comments that are not already represented inside an inline
-review thread. Return one item per inline thread or conversation comment.
+review thread, not authored by the current actor, and not already followed by
+one of this workflow's marker comments. Return one item per inline thread or
+conversation comment.
 
 ### Script fallback
 
@@ -106,6 +108,12 @@ Each conversation comment has:
 - `kind`: `"conversation_comment"`
 - `replyMode`: `"conversation"`
 - `comments[]`: a single top-level PR conversation comment.
+
+Conversation comments authored by the authenticated viewer are excluded. A
+conversation comment is also excluded when a later viewer-authored comment
+contains the marker `smithy-pr-review-response-to:<databaseId>`. The script
+fetches the most recent 100 conversation comments so newer feedback is not
+starved by older PR activity.
 
 Returns `[]` if there are no unresolved review items.
 
@@ -160,7 +168,8 @@ replies to issue-style PR conversation comments.
 Call `_add_comment_to_issue` with:
 - `repo_full_name`: `"<owner>/<repo>"`
 - `pr_number`
-- `comment`: the reply text
+- `comment`: the reply text plus an HTML marker:
+  `<!-- smithy-pr-review-response-to:<databaseId> -->`
 
 ### Script fallback
 
@@ -169,7 +178,7 @@ then POST it:
 
 ```bash
 cat > /tmp/smithy_pr_comment_<pr-number>.json << 'EOF'
-{"body": "your reply text here"}
+{"body": "your reply text here\n\n<!-- smithy-pr-review-response-to:<databaseId> -->"}
 EOF
 ./.agents/skills/smithy.pr-review/scripts/add-comment.sh <ownerRepo> <pr-number> /tmp/smithy_pr_comment_<pr-number>.json
 ```
@@ -178,6 +187,9 @@ EOF
 
 - For a **fix** reply: `"Fixed in <commit-sha>: <one-line explanation of what changed and why>"`
 - For a **decline** reply: `"Not addressed: <explanation — why the comment doesn't apply, or what was misunderstood>"`
+- For a **conversation comment** reply, append
+  `<!-- smithy-pr-review-response-to:<databaseId> -->` so future list
+  operations can suppress the handled comment.
 
 ---
 

--- a/.agents/skills/smithy.pr-review/SKILL.md
+++ b/.agents/skills/smithy.pr-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: smithy.pr-review
-description: "GitHub PR review operations: list inline comments, reply to comments. Use when handling review feedback on an open pull request."
-allowed-tools: Bash(git remote get-url *) Bash(git branch --show-current) Bash(git config --get remote.origin.url) Bash(*/smithy.pr-review/scripts/find-pr.sh) Bash(*/smithy.pr-review/scripts/get-comments.sh:*) Bash(*/smithy.pr-review/scripts/reply-comment.sh:*) mcp__github__list_pull_requests mcp__github__pull_request_read mcp__github__add_reply_to_pull_request_comment _list_pull_request_review_threads _reply_to_review_comment
+description: "GitHub PR review operations: list and reply to inline and conversation comments. Use when handling review feedback on an open pull request."
+allowed-tools: Bash(git remote get-url *) Bash(git branch --show-current) Bash(git config --get remote.origin.url) Bash(*/smithy.pr-review/scripts/find-pr.sh) Bash(*/smithy.pr-review/scripts/get-comments.sh:*) Bash(*/smithy.pr-review/scripts/reply-comment.sh:*) Bash(*/smithy.pr-review/scripts/add-comment.sh:*) mcp__github__list_pull_requests mcp__github__pull_request_read mcp__github__add_reply_to_pull_request_comment mcp__github__issue_write _list_pull_request_review_threads _reply_to_review_comment _fetch_pr_comments _add_comment_to_issue
 ---
 # smithy.pr-review
 
@@ -9,13 +9,14 @@ Provides GitHub PR review operations through Codex's GitHub app connector,
 with the bundled `gh`-CLI scripts kept as a fallback:
 
 1. **Codex GitHub app connector** (preferred when available) — use the
-   GitHub app actions directly for review-thread operations:
-   `_list_pull_request_review_threads` and `_reply_to_review_comment`.
+   GitHub app actions directly for PR comment operations:
+   `_list_pull_request_review_threads`, `_fetch_pr_comments`,
+   `_reply_to_review_comment`, and `_add_comment_to_issue`.
    If those actions are not already visible in your tool set, use tool
-   discovery for "GitHub pull request review threads reply" before falling
-   back to shell. This path avoids `gh` for listing/replying to review
-   threads and avoids shell permission prompts.
-2. **Bundled `gh`-CLI shell scripts** (fallback) — three scripts in this
+   discovery for "GitHub pull request review threads comments reply" before
+   falling back to shell. This path avoids `gh` for listing/replying to PR
+   comments and avoids shell permission prompts.
+2. **Bundled `gh`-CLI shell scripts** (fallback) — four scripts in this
    skill's `scripts/` directory wrap `gh` invocations. Use these when
    the GitHub app connector is unavailable, a needed action is missing, or
    you need to discover the open PR for the current branch.
@@ -23,15 +24,16 @@ with the bundled `gh`-CLI scripts kept as a fallback:
 | Operation             | Codex app path                         | Script fallback                                                                  |
 |-----------------------|----------------------------------------|----------------------------------------------------------------------------------|
 | Find Open PR          | Use known PR context if available; otherwise use fallback script | `./.agents/skills/smithy.pr-review/scripts/find-pr.sh` |
-| List Inline Comments  | `_list_pull_request_review_threads`    | `./.agents/skills/smithy.pr-review/scripts/get-comments.sh <ownerRepo> <pr-number>` |
-| Reply to a Comment    | `_reply_to_review_comment`             | `./.agents/skills/smithy.pr-review/scripts/reply-comment.sh <ownerRepo> <pr-number> <comment-id> <body-file>` |
+| List PR Comments      | `_list_pull_request_review_threads` plus `_fetch_pr_comments` | `./.agents/skills/smithy.pr-review/scripts/get-comments.sh <ownerRepo> <pr-number>` |
+| Reply to Inline Comment | `_reply_to_review_comment`           | `./.agents/skills/smithy.pr-review/scripts/reply-comment.sh <ownerRepo> <pr-number> <comment-id> <body-file>` |
+| Reply to Conversation Comment | `_add_comment_to_issue`        | `./.agents/skills/smithy.pr-review/scripts/add-comment.sh <ownerRepo> <pr-number> <body-file>` |
 
 ## Path Selection
 
 For each operation:
 
-1. **Try the Codex GitHub app first** for listing and replying to review
-   threads. If the app actions are not visible, use tool discovery before
+1. **Try the Codex GitHub app first** for listing and replying to PR
+   comments. If the app actions are not visible, use tool discovery before
    falling back to shell.
 2. **Use known PR context when present.** If the user, current task, or
    previous tool output already identifies `owner/repo` and PR number, do
@@ -64,9 +66,11 @@ if no open PR exists for the current branch.
 
 ---
 
-## Operation: List Inline Comments
+## Operation: List PR Comments
 
-Fetches review threads on the PR with their full reply chains.
+Fetches unresolved inline review threads and top-level PR conversation
+comments. Conversation comments are not review threads, so handle them as
+separate actionable items.
 
 ### Codex app path
 
@@ -78,36 +82,49 @@ The response contains GraphQL review thread nodes with resolved state,
 comment bodies, and comment IDs. Filter out resolved threads before handing
 them to the caller — only unresolved threads need a reply.
 
+Also call `_fetch_pr_comments` with the same arguments and include top-level
+PR conversation comments that are not already represented inside an inline
+review thread. Return one item per inline thread or conversation comment.
+
 ### Script fallback
 
 ```bash
 ./.agents/skills/smithy.pr-review/scripts/get-comments.sh <ownerRepo> <pr-number>
 ```
 
-Returns a JSON array of **threads** (one entry per review thread). Each
-thread has:
+Returns a JSON array of **comment items** (one entry per unresolved review
+thread or top-level PR conversation comment). Each inline thread has:
+- `kind`: `"inline_thread"`
+- `replyMode`: `"inline"`
 - `isResolved`: always `false` — resolved threads are filtered out by
   the script's `gh api graphql` query.
 - `comments[]`: the full reply chain, **oldest first**. Each comment
   carries `databaseId`, `body`, `path`, `diffHunk`, `author.login`, and
   `createdAt`.
 
-Returns `[]` if there are no unresolved review threads.
+Each conversation comment has:
+- `kind`: `"conversation_comment"`
+- `replyMode`: `"conversation"`
+- `comments[]`: a single top-level PR conversation comment.
 
-### Working a thread (both paths)
+Returns `[]` if there are no unresolved review items.
 
-- Read the **full** `comments[]` chain — the **last** comment is the
+### Working a comment item (both paths)
+
+- For inline threads, read the **full** `comments[]` chain — the **last** comment is the
   most recent reply and typically has the highest-priority context (a
   follow-up or escalation from the reviewer takes precedence over the
   original).
-- The reply target is the **root comment**:
+- For conversation comments, `comments[]` contains the single top-level PR
+  conversation comment. Treat it as its own problem item.
+- Inline reply target is the **root comment**:
   - Codex app path: the numeric ID of the thread's top-level inline
     review comment
   - Script path: `comments[0].databaseId`
 
 ---
 
-## Operation: Reply to a Comment
+## Operation: Reply to Inline Comment
 
 Posts an inline reply to a specific review thread.
 
@@ -130,6 +147,31 @@ cat > /tmp/smithy_reply_<databaseId>.json << 'EOF'
 {"body": "your reply text here"}
 EOF
 ./.agents/skills/smithy.pr-review/scripts/reply-comment.sh <ownerRepo> <pr-number> <databaseId> /tmp/smithy_reply_<databaseId>.json
+```
+
+## Operation: Reply to Conversation Comment
+
+Posts a new top-level PR conversation comment. Use this for
+`kind: "conversation_comment"` items because GitHub does not support threaded
+replies to issue-style PR conversation comments.
+
+### Codex app path
+
+Call `_add_comment_to_issue` with:
+- `repo_full_name`: `"<owner>/<repo>"`
+- `pr_number`
+- `comment`: the reply text
+
+### Script fallback
+
+Write the reply body to a temp JSON file first to avoid quoting issues,
+then POST it:
+
+```bash
+cat > /tmp/smithy_pr_comment_<pr-number>.json << 'EOF'
+{"body": "your reply text here"}
+EOF
+./.agents/skills/smithy.pr-review/scripts/add-comment.sh <ownerRepo> <pr-number> /tmp/smithy_pr_comment_<pr-number>.json
 ```
 
 ### Reply body conventions (both paths)

--- a/.agents/skills/smithy.pr-review/scripts/add-comment.sh
+++ b/.agents/skills/smithy.pr-review/scripts/add-comment.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# add-comment.sh — Post a top-level PR conversation comment
+#
+# Usage: ./.agents/skills/smithy.pr-review/scripts/add-comment.sh <owner/repo> <pr-number> <body-file>
+#
+# The body file must contain JSON in the shape: {"body": "comment text"}
+
+set -euo pipefail
+
+REPO="$1"
+PR="$2"
+BODY_FILE="$3"
+
+gh api "repos/$REPO/issues/$PR/comments" \
+  --method POST \
+  --input "$BODY_FILE"

--- a/.agents/skills/smithy.pr-review/scripts/get-comments.sh
+++ b/.agents/skills/smithy.pr-review/scripts/get-comments.sh
@@ -14,6 +14,9 @@
 #   - replyMode: "conversation"
 #   - comments[]: a single comment object with databaseId, body, author.login,
 #                 createdAt, and null path/diffHunk fields
+# Conversation comments authored by the authenticated viewer, or already
+# followed by a viewer comment containing the smithy-pr-review response marker,
+# are filtered out.
 #
 # Returns an empty array ([]) if there are no unresolved review items.
 
@@ -31,6 +34,7 @@ gh api graphql \
   -F pr="$PR" \
   -f query='
 query($owner: String!, $name: String!, $pr: Int!) {
+  viewer { login }
   repository(owner: $owner, name: $name) {
     pullRequest(number: $pr) {
       reviewThreads(first: 100) {
@@ -48,7 +52,7 @@ query($owner: String!, $name: String!, $pr: Int!) {
           }
         }
       }
-      comments(first: 100) {
+      comments(last: 100) {
         nodes {
           databaseId
           body
@@ -58,23 +62,35 @@ query($owner: String!, $name: String!, $pr: Int!) {
       }
     }
   }
-}' --jq '[
+}' --jq '
+.data as $data
+| ($data.viewer.login // "") as $viewer
+| ($data.repository.pullRequest.comments.nodes | sort_by(.createdAt)) as $conversationComments
+| [
   (.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | . + {
     kind: "inline_thread",
     replyMode: "inline",
     comments: (.comments.nodes | sort_by(.createdAt))
   }),
-  (.data.repository.pullRequest.comments.nodes[] | {
+  ($conversationComments[] as $comment
+  | select(($comment.author.login // "") != $viewer)
+  | select([
+      $conversationComments[]
+      | select((.author.login // "") == $viewer)
+      | select(.createdAt > $comment.createdAt)
+      | select((.body // "") | contains("smithy-pr-review-response-to:" + ($comment.databaseId | tostring)))
+    ] | length == 0)
+  | {
     kind: "conversation_comment",
     replyMode: "conversation",
     isResolved: false,
     comments: [{
-      databaseId,
-      body,
+      databaseId: $comment.databaseId,
+      body: $comment.body,
       path: null,
       diffHunk: null,
-      author,
-      createdAt
+      author: $comment.author,
+      createdAt: $comment.createdAt
     }]
   })
 ] | sort_by(.comments[0].createdAt)'

--- a/.agents/skills/smithy.pr-review/scripts/get-comments.sh
+++ b/.agents/skills/smithy.pr-review/scripts/get-comments.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
-# get-comments.sh — Fetch unresolved PR review threads with full reply chains
+# get-comments.sh — Fetch unresolved PR review threads and PR conversation comments
 #
 # Usage: ${CLAUDE_SKILL_DIR}/scripts/get-comments.sh <owner/repo> <pr-number>
 #
-# Output: JSON array of unresolved review threads. Each thread has:
+# Output: JSON array of unresolved review items. Inline review threads have:
+#   - kind: "inline_thread"
+#   - replyMode: "inline"
 #   - isResolved (always false in output — resolved threads are filtered)
 #   - comments[]: array of comment objects with databaseId, body, path, diffHunk,
 #                 author.login, createdAt (ordered oldest → newest)
+# Top-level PR conversation comments have:
+#   - kind: "conversation_comment"
+#   - replyMode: "conversation"
+#   - comments[]: a single comment object with databaseId, body, author.login,
+#                 createdAt, and null path/diffHunk fields
 #
-# Returns an empty array ([]) if there are no unresolved review threads.
+# Returns an empty array ([]) if there are no unresolved review items.
 
 set -euo pipefail
 
@@ -41,6 +48,33 @@ query($owner: String!, $name: String!, $pr: Int!) {
           }
         }
       }
+      comments(first: 100) {
+        nodes {
+          databaseId
+          body
+          author { login }
+          createdAt
+        }
+      }
     }
   }
-}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | . + { comments: (.comments.nodes | sort_by(.createdAt)) }]'
+}' --jq '[
+  (.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | . + {
+    kind: "inline_thread",
+    replyMode: "inline",
+    comments: (.comments.nodes | sort_by(.createdAt))
+  }),
+  (.data.repository.pullRequest.comments.nodes[] | {
+    kind: "conversation_comment",
+    replyMode: "conversation",
+    isResolved: false,
+    comments: [{
+      databaseId,
+      body,
+      path: null,
+      diffHunk: null,
+      author,
+      createdAt
+    }]
+  })
+] | sort_by(.comments[0].createdAt)'

--- a/src/agents/claude.test.ts
+++ b/src/agents/claude.test.ts
@@ -167,6 +167,7 @@ describe('deploy', () => {
     expect(content).toContain('Bash(*/smithy.pr-review/scripts/find-pr.sh)');
     expect(content).toContain('Bash(*/smithy.pr-review/scripts/get-comments.sh:*)');
     expect(content).toContain('Bash(*/smithy.pr-review/scripts/reply-comment.sh:*)');
+    expect(content).toContain('Bash(*/smithy.pr-review/scripts/add-comment.sh:*)');
   });
 
   it('deploys skill scripts as executable files in scripts/ subdirectory', async () => {
@@ -202,7 +203,7 @@ describe('deploy', () => {
     }
   });
 
-  it('deploys smithy.pr-review skill with all three scripts', async () => {
+  it('deploys smithy.pr-review skill with all scripts', async () => {
     // Issue #261 made the GitHub MCP tools the preferred path, but kept the
     // three `gh`-CLI shell scripts as a fallback for hosts without the
     // GitHub MCP server. The deploy step must still ship them.
@@ -215,6 +216,7 @@ describe('deploy', () => {
     expect(scripts).toContain('find-pr.sh');
     expect(scripts).toContain('get-comments.sh');
     expect(scripts).toContain('reply-comment.sh');
+    expect(scripts).toContain('add-comment.sh');
   });
 
   it('strips frontmatter from deployed prompt files', async () => {
@@ -416,10 +418,12 @@ describe('buildClaudeAllowList', () => {
     expect(list).toContain('Bash(.claude/skills/smithy.pr-review/scripts/find-pr.sh)');
     expect(list).toContain('Bash(.claude/skills/smithy.pr-review/scripts/get-comments.sh:*)');
     expect(list).toContain('Bash(.claude/skills/smithy.pr-review/scripts/reply-comment.sh:*)');
+    expect(list).toContain('Bash(.claude/skills/smithy.pr-review/scripts/add-comment.sh:*)');
     // Wildcard fallback for user-level / absolute deploys
     expect(list).toContain('Bash(*/smithy.pr-review/scripts/find-pr.sh)');
     expect(list).toContain('Bash(*/smithy.pr-review/scripts/get-comments.sh:*)');
     expect(list).toContain('Bash(*/smithy.pr-review/scripts/reply-comment.sh:*)');
+    expect(list).toContain('Bash(*/smithy.pr-review/scripts/add-comment.sh:*)');
   });
 
   it('includes multi-language build tool commands', () => {
@@ -683,10 +687,12 @@ describe('writePermissions', () => {
     expect(config.permissions.allow).toContain('Bash(.claude/skills/smithy.pr-review/scripts/find-pr.sh)');
     expect(config.permissions.allow).toContain('Bash(.claude/skills/smithy.pr-review/scripts/get-comments.sh:*)');
     expect(config.permissions.allow).toContain('Bash(.claude/skills/smithy.pr-review/scripts/reply-comment.sh:*)');
+    expect(config.permissions.allow).toContain('Bash(.claude/skills/smithy.pr-review/scripts/add-comment.sh:*)');
     // Wildcard fallback for other deploy locations
     expect(config.permissions.allow).toContain('Bash(*/smithy.pr-review/scripts/find-pr.sh)');
     expect(config.permissions.allow).toContain('Bash(*/smithy.pr-review/scripts/get-comments.sh:*)');
     expect(config.permissions.allow).toContain('Bash(*/smithy.pr-review/scripts/reply-comment.sh:*)');
+    expect(config.permissions.allow).toContain('Bash(*/smithy.pr-review/scripts/add-comment.sh:*)');
   });
 
   it('entries are Bash()-wrapped or Claude tool names', () => {

--- a/src/agents/codex.test.ts
+++ b/src/agents/codex.test.ts
@@ -108,11 +108,14 @@ describe('deploy', () => {
     expect(fs.existsSync(path.join(prReviewDir, 'scripts', 'find-pr.sh'))).toBe(true);
     expect(fs.existsSync(path.join(prReviewDir, 'scripts', 'get-comments.sh'))).toBe(true);
     expect(fs.existsSync(path.join(prReviewDir, 'scripts', 'reply-comment.sh'))).toBe(true);
+    expect(fs.existsSync(path.join(prReviewDir, 'scripts', 'add-comment.sh'))).toBe(true);
 
     const skillMd = fs.readFileSync(path.join(prReviewDir, 'SKILL.md'), 'utf8');
     expect(skillMd).toContain('allowed-tools:');
     expect(skillMd).toContain('_list_pull_request_review_threads');
     expect(skillMd).toContain('_reply_to_review_comment');
+    expect(skillMd).toContain('_fetch_pr_comments');
+    expect(skillMd).toContain('_add_comment_to_issue');
     expect(skillMd).toContain('./.agents/skills/smithy.pr-review/scripts/find-pr.sh');
     expect(skillMd).not.toContain('${CLAUDE_SKILL_DIR}');
     expect(skillMd).not.toContain('./.gemini/skills/smithy.pr-review');
@@ -341,6 +344,9 @@ describe('writePermissions (via deploy)', () => {
     );
     expect(content).toContain(
       'prefix_rule(pattern=["./.agents/skills/smithy.pr-review/scripts/reply-comment.sh"], decision="allow")'
+    );
+    expect(content).toContain(
+      'prefix_rule(pattern=["./.agents/skills/smithy.pr-review/scripts/add-comment.sh"], decision="allow")'
     );
     expect(content).toContain(
       'prefix_rule(pattern=["./.agents/skills/smithy.gh-issue/scripts/check-env.sh"], decision="allow")'

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -24,6 +24,7 @@ const SMITHY_SKILL_SCRIPT_RULES = [
   './.agents/skills/smithy.pr-review/scripts/find-pr.sh',
   './.agents/skills/smithy.pr-review/scripts/get-comments.sh',
   './.agents/skills/smithy.pr-review/scripts/reply-comment.sh',
+  './.agents/skills/smithy.pr-review/scripts/add-comment.sh',
   './.agents/skills/smithy.gh-issue/scripts/check-env.sh',
   './.agents/skills/smithy.gh-issue/scripts/search-issues.sh',
   './.agents/skills/smithy.gh-issue/scripts/create-issue.sh',

--- a/src/agents/gemini.test.ts
+++ b/src/agents/gemini.test.ts
@@ -130,6 +130,7 @@ describe('buildGeminiAllowList', () => {
     expect(joined).not.toContain('smithy.pr-review/scripts/find-pr.sh');
     expect(joined).not.toContain('smithy.pr-review/scripts/get-comments.sh');
     expect(joined).not.toContain('smithy.pr-review/scripts/reply-comment.sh');
+    expect(joined).not.toContain('smithy.pr-review/scripts/add-comment.sh');
     expect(joined).not.toContain('.claude/skills/');
     expect(list.some(e => e.includes(':*'))).toBe(false);
   });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -109,6 +109,7 @@ describe('CLI init --yes (non-interactive)', () => {
     expect(fs.existsSync(path.join(tmpDir, '.agents', 'skills', 'smithy-forge', 'SKILL.md'))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, '.agents', 'skills', 'smithy-fix', 'SKILL.md'))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, '.agents', 'skills', 'smithy.pr-review', 'scripts', 'find-pr.sh'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.agents', 'skills', 'smithy.pr-review', 'scripts', 'add-comment.sh'))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, 'tools', 'codex', 'prompts'))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'prompts'))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, '.gemini', 'skills'))).toBe(false);

--- a/src/permissions.test.ts
+++ b/src/permissions.test.ts
@@ -186,9 +186,11 @@ describe('flattenPermissions', () => {
     expect(extraPermissions).toContain('.claude/skills/smithy.pr-review/scripts/find-pr.sh');
     expect(extraPermissions).toContain('.claude/skills/smithy.pr-review/scripts/get-comments.sh:*');
     expect(extraPermissions).toContain('.claude/skills/smithy.pr-review/scripts/reply-comment.sh:*');
+    expect(extraPermissions).toContain('.claude/skills/smithy.pr-review/scripts/add-comment.sh:*');
     expect(extraPermissions).toContain('*/smithy.pr-review/scripts/find-pr.sh');
     expect(extraPermissions).toContain('*/smithy.pr-review/scripts/get-comments.sh:*');
     expect(extraPermissions).toContain('*/smithy.pr-review/scripts/reply-comment.sh:*');
+    expect(extraPermissions).toContain('*/smithy.pr-review/scripts/add-comment.sh:*');
   });
 
   it('filters to only node toolchain when languages=["node"]', () => {

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -434,9 +434,11 @@ export const extraPermissions: string[] = [
   ".claude/skills/smithy.pr-review/scripts/find-pr.sh",
   ".claude/skills/smithy.pr-review/scripts/get-comments.sh:*",
   ".claude/skills/smithy.pr-review/scripts/reply-comment.sh:*",
+  ".claude/skills/smithy.pr-review/scripts/add-comment.sh:*",
   "*/smithy.pr-review/scripts/find-pr.sh",
   "*/smithy.pr-review/scripts/get-comments.sh:*",
   "*/smithy.pr-review/scripts/reply-comment.sh:*",
+  "*/smithy.pr-review/scripts/add-comment.sh:*",
 ];
 
 /**
@@ -509,10 +511,11 @@ export const denyPermissions: string[] = [
  * creation step in forge / strike / cut / mark / ignite / render),
  * `list_pull_requests` (cut/mark "is there an existing PR for this branch"
  * check + the smithy.pr-review skill's Find Open PR operation),
- * `pull_request_read` (smithy.pr-review's List Inline Comments operation),
- * `add_reply_to_pull_request_comment` (smithy.pr-review's Reply to a
- * Comment operation), and `issue_write` (the example tool the
- * `guidance-shell` snippet calls out for issue creation).
+ * `pull_request_read` (smithy.pr-review's List PR Comments operation),
+ * `add_reply_to_pull_request_comment` (smithy.pr-review's Reply to an
+ * Inline Comment operation), and `issue_write` (the example tool the
+ * `guidance-shell` snippet calls out for issue creation, also used by
+ * smithy.pr-review's Reply to Conversation Comment operation).
  *
  * Anything broader — destructive operations like `merge_pull_request` /
  * `delete_file` / `fork_repository` / `create_repository` /

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -468,8 +468,10 @@ describe('getComposedTemplates', () => {
     const script = skill.scripts.get('get-comments.sh')!;
     expect(script).toContain('gh api graphql');
     expect(script).toContain('reviewThreads');
-    expect(script).toContain('comments(first: 100)');
+    expect(script).toContain('viewer { login }');
+    expect(script).toContain('comments(last: 100)');
     expect(script).toContain('conversation_comment');
+    expect(script).toContain('smithy-pr-review-response-to:');
     expect(script).toContain('isResolved');
     expect(script).toContain('databaseId');
   });

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -376,16 +376,17 @@ describe('getComposedTemplates', () => {
 
   it('skills map includes smithy.pr-review with prompt and scripts', () => {
     // Issue #261 added the GitHub MCP tools as the preferred path but kept
-    // the three `gh`-CLI shell scripts as the fallback for hosts without
+    // the `gh`-CLI shell scripts as the fallback for hosts without
     // the GitHub MCP server.
     const skill = claudeComposed.skills.get('smithy.pr-review');
     expect(skill).toBeDefined();
     expect(skill!.prompt).toBeTruthy();
     expect(skill!.scripts).toBeInstanceOf(Map);
-    expect(skill!.scripts.size).toBe(3);
+    expect(skill!.scripts.size).toBe(4);
     expect(skill!.scripts.has('find-pr.sh')).toBe(true);
     expect(skill!.scripts.has('get-comments.sh')).toBe(true);
     expect(skill!.scripts.has('reply-comment.sh')).toBe(true);
+    expect(skill!.scripts.has('add-comment.sh')).toBe(true);
   });
 
   it('smithy.pr-review prompt retains frontmatter including allowed-tools', () => {
@@ -401,20 +402,23 @@ describe('getComposedTemplates', () => {
     expect(skill.prompt).toContain('mcp__github__list_pull_requests');
     expect(skill.prompt).toContain('mcp__github__pull_request_read');
     expect(skill.prompt).toContain('mcp__github__add_reply_to_pull_request_comment');
+    expect(skill.prompt).toContain('mcp__github__issue_write');
     // gh-CLI script fallback (canonical `:*` argument-suffix form)
     expect(skill.prompt).toContain('Bash(*/smithy.pr-review/scripts/find-pr.sh)');
     expect(skill.prompt).toContain('Bash(*/smithy.pr-review/scripts/get-comments.sh:*)');
     expect(skill.prompt).toContain('Bash(*/smithy.pr-review/scripts/reply-comment.sh:*)');
+    expect(skill.prompt).toContain('Bash(*/smithy.pr-review/scripts/add-comment.sh:*)');
   });
 
-  it('smithy.pr-review documents the three operations and the MCP-first / script-fallback choice', () => {
-    // Spot-check that the prompt body teaches the three operations and the
+  it('smithy.pr-review documents PR comment operations and the MCP-first / script-fallback choice', () => {
+    // Spot-check that the prompt body teaches the comment operations and the
     // dual-path decision rule (try MCP first, fall back to scripts when the
     // GitHub MCP server is unavailable).
     const skill = claudeComposed.skills.get('smithy.pr-review')!;
     expect(skill.prompt).toContain('Find Open PR');
-    expect(skill.prompt).toContain('List Inline Comments');
-    expect(skill.prompt).toContain('Reply to a Comment');
+    expect(skill.prompt).toContain('List PR Comments');
+    expect(skill.prompt).toContain('Reply to Inline Comment');
+    expect(skill.prompt).toContain('Reply to Conversation Comment');
     // MCP method that exposes review threads
     expect(skill.prompt).toContain('get_review_comments');
     // The skill must explicitly direct the agent through the dual-path flow.
@@ -427,6 +431,7 @@ describe('getComposedTemplates', () => {
     expect(skill.prompt).toContain('./.agents/skills/smithy.pr-review/scripts/find-pr.sh');
     expect(skill.prompt).toContain('./.agents/skills/smithy.pr-review/scripts/get-comments.sh');
     expect(skill.prompt).toContain('./.agents/skills/smithy.pr-review/scripts/reply-comment.sh');
+    expect(skill.prompt).toContain('./.agents/skills/smithy.pr-review/scripts/add-comment.sh');
     expect(skill.prompt).not.toContain('${CLAUDE_SKILL_DIR}');
     expect(skill.prompt).not.toContain('./.gemini/skills/smithy.pr-review');
   });
@@ -436,7 +441,9 @@ describe('getComposedTemplates', () => {
     expect(skill.prompt).toContain("Codex's GitHub app connector");
     expect(skill.prompt).toContain('allowed-tools:');
     expect(skill.prompt).toContain('_list_pull_request_review_threads');
+    expect(skill.prompt).toContain('_fetch_pr_comments');
     expect(skill.prompt).toContain('_reply_to_review_comment');
+    expect(skill.prompt).toContain('_add_comment_to_issue');
     expect(skill.prompt).toContain('reply-comment.sh <ownerRepo> <pr-number> <comment-id> <body-file>');
     expect(skill.prompt).toContain('use tool discovery');
     expect(skill.prompt).toContain('The discovered Codex GitHub app actions do not provide a direct "find open PR');
@@ -461,8 +468,18 @@ describe('getComposedTemplates', () => {
     const script = skill.scripts.get('get-comments.sh')!;
     expect(script).toContain('gh api graphql');
     expect(script).toContain('reviewThreads');
+    expect(script).toContain('comments(first: 100)');
+    expect(script).toContain('conversation_comment');
     expect(script).toContain('isResolved');
     expect(script).toContain('databaseId');
+  });
+
+  it('add-comment.sh uses correct REST API path for PR conversation comments', () => {
+    const skill = claudeComposed.skills.get('smithy.pr-review')!;
+    const script = skill.scripts.get('add-comment.sh')!;
+    expect(script).toContain('repos/$REPO/issues/$PR/comments');
+    expect(script).toContain('--method POST');
+    expect(script).toContain('--input "$BODY_FILE"');
   });
 
   it('reply-comment.sh uses correct REST API path with pr number', () => {

--- a/src/templates/agent-skills/commands/smithy.fix.prompt
+++ b/src/templates/agent-skills/commands/smithy.fix.prompt
@@ -1,11 +1,11 @@
 ---
 name: smithy-fix
-description: "Fix errors from CI failures, local test failures, or bugs. When run with no arguments on a branch with an open PR, automatically addresses inline review comments."
+description: "Fix errors from CI failures, local test failures, or bugs. When run with no arguments on a branch with an open PR, automatically addresses PR review comments."
 ---
 # smithy-fix
 
 You are the **smithy-fix agent**. You diagnose and fix problems — whether from CI failures,
-local test failures, bugs, or inline PR review comments. You work on the current branch
+local test failures, bugs, or PR review comments. You work on the current branch
 and produce the smallest correct fix.
 
 ## Input
@@ -31,21 +31,23 @@ or when you need to discover the open PR for the current branch.
 {{/ifAgent}}
 
 1. Run the **Find Open PR** operation. If the result is `{}` (no PR), skip to **Path B**.
-2. Run the **List Inline Comments** operation with the `ownerRepo` and `pr` from step 1.
+2. Run the **List PR Comments** operation with the `ownerRepo` and `pr` from step 1.
    If the result is an empty array `[]`, skip to **Path B**.
-3. Build a **problem list** — **one item per thread**, not per comment. Cap at the
-   first **10 threads**; if more remain, tell the user to re-run `/smithy.fix` for
+3. Build a **problem list** — **one item per returned comment item**. Cap at the
+   first **10 items**; if more remain, tell the user to re-run `/smithy.fix` for
    the next batch.
 
-   For each thread: read its full `comments[]` chain before deciding how to act.
+   For each inline thread: read its full `comments[]` chain before deciding how to act.
    The **last** comment has the most recent context (a reviewer follow-up or
-   escalation takes precedence over the original). Post your reply to
+   escalation takes precedence over the original). For a top-level PR conversation
+   comment, `comments[]` contains the single comment to evaluate. Post inline replies to
 {{#ifAgent 'codex'}}
    the root comment ID identified by the `smithy.pr-review` Codex path.
-   Continue to the **Fix Loop**.
 {{else}}
-   `comments[0].databaseId` (the thread root). Continue to the **Fix Loop**.
+   `comments[0].databaseId` (the thread root).
 {{/ifAgent}}
+   For `kind: "conversation_comment"` items, reply with the **Reply to Conversation
+   Comment** operation instead. Continue to the **Fix Loop**.
 
 ### Path B — No arguments, no PR or no comments
 
@@ -134,13 +136,17 @@ one logical fix per commit.
 ### For PR review comments (Path A)
 
 After all items have been fixed or declined, use the `smithy.pr-review` skill's
-**Reply to a Comment** operation for each thread's root comment. Pick the
+**Reply to Inline Comment** operation for each inline thread's root comment. Pick the
 identifier that matches the path the skill chose for your environment: `id`
 (MCP path) or `databaseId` (script-fallback path) — both come from the first
 comment in the thread's `comments[]` array:
 
 - For fixed items: `"Fixed in <commit-sha>: <one-line explanation>"`
 - For declined items: `"Not addressed: <explanation>"`
+
+For `kind: "conversation_comment"` items, use **Reply to Conversation Comment**
+with the same fixed/declined wording, because those comments cannot receive an
+inline threaded reply.
 
 Then push the branch:
 ```

--- a/src/templates/agent-skills/skills/smithy.pr-review/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.pr-review/SKILL.prompt
@@ -1,7 +1,7 @@
 ---
 name: smithy.pr-review
-description: "GitHub PR review operations: list inline comments, reply to comments. Use when handling review feedback on an open pull request."
-allowed-tools: Bash(git remote get-url *) Bash(git branch --show-current) Bash(git config --get remote.origin.url) Bash(*/smithy.pr-review/scripts/find-pr.sh) Bash(*/smithy.pr-review/scripts/get-comments.sh:*) Bash(*/smithy.pr-review/scripts/reply-comment.sh:*) mcp__github__list_pull_requests mcp__github__pull_request_read mcp__github__add_reply_to_pull_request_comment _list_pull_request_review_threads _reply_to_review_comment
+description: "GitHub PR review operations: list and reply to inline and conversation comments. Use when handling review feedback on an open pull request."
+allowed-tools: Bash(git remote get-url *) Bash(git branch --show-current) Bash(git config --get remote.origin.url) Bash(*/smithy.pr-review/scripts/find-pr.sh) Bash(*/smithy.pr-review/scripts/get-comments.sh:*) Bash(*/smithy.pr-review/scripts/reply-comment.sh:*) Bash(*/smithy.pr-review/scripts/add-comment.sh:*) mcp__github__list_pull_requests mcp__github__pull_request_read mcp__github__add_reply_to_pull_request_comment mcp__github__issue_write _list_pull_request_review_threads _reply_to_review_comment _fetch_pr_comments _add_comment_to_issue
 ---
 # smithy.pr-review
 
@@ -10,13 +10,14 @@ Provides GitHub PR review operations through Codex's GitHub app connector,
 with the bundled `gh`-CLI scripts kept as a fallback:
 
 1. **Codex GitHub app connector** (preferred when available) — use the
-   GitHub app actions directly for review-thread operations:
-   `_list_pull_request_review_threads` and `_reply_to_review_comment`.
+   GitHub app actions directly for PR comment operations:
+   `_list_pull_request_review_threads`, `_fetch_pr_comments`,
+   `_reply_to_review_comment`, and `_add_comment_to_issue`.
    If those actions are not already visible in your tool set, use tool
-   discovery for "GitHub pull request review threads reply" before falling
-   back to shell. This path avoids `gh` for listing/replying to review
-   threads and avoids shell permission prompts.
-2. **Bundled `gh`-CLI shell scripts** (fallback) — three scripts in this
+   discovery for "GitHub pull request review threads comments reply" before
+   falling back to shell. This path avoids `gh` for listing/replying to PR
+   comments and avoids shell permission prompts.
+2. **Bundled `gh`-CLI shell scripts** (fallback) — four scripts in this
    skill's `scripts/` directory wrap `gh` invocations. Use these when
    the GitHub app connector is unavailable, a needed action is missing, or
    you need to discover the open PR for the current branch.
@@ -24,16 +25,18 @@ with the bundled `gh`-CLI scripts kept as a fallback:
 | Operation             | Codex app path                         | Script fallback                                                                  |
 |-----------------------|----------------------------------------|----------------------------------------------------------------------------------|
 | Find Open PR          | Use known PR context if available; otherwise use fallback script | `./.agents/skills/smithy.pr-review/scripts/find-pr.sh` |
-| List Inline Comments  | `_list_pull_request_review_threads`    | `./.agents/skills/smithy.pr-review/scripts/get-comments.sh <ownerRepo> <pr-number>` |
-| Reply to a Comment    | `_reply_to_review_comment`             | `./.agents/skills/smithy.pr-review/scripts/reply-comment.sh <ownerRepo> <pr-number> <comment-id> <body-file>` |
+| List PR Comments      | `_list_pull_request_review_threads` plus `_fetch_pr_comments` | `./.agents/skills/smithy.pr-review/scripts/get-comments.sh <ownerRepo> <pr-number>` |
+| Reply to Inline Comment | `_reply_to_review_comment`           | `./.agents/skills/smithy.pr-review/scripts/reply-comment.sh <ownerRepo> <pr-number> <comment-id> <body-file>` |
+| Reply to Conversation Comment | `_add_comment_to_issue`        | `./.agents/skills/smithy.pr-review/scripts/add-comment.sh <ownerRepo> <pr-number> <body-file>` |
 {{else}}
 Provides GitHub PR review operations through two interchangeable paths:
 
 1. **GitHub MCP server** (preferred when available) — calls
    `mcp__github__list_pull_requests`, `mcp__github__pull_request_read`,
-   and `mcp__github__add_reply_to_pull_request_comment` directly. No
+   `mcp__github__add_reply_to_pull_request_comment`, and
+   `mcp__github__issue_write` directly. No
    shell, no `gh` CLI dependency, no per-command approval prompts.
-2. **Bundled `gh`-CLI shell scripts** (fallback) — three scripts in this
+2. **Bundled `gh`-CLI shell scripts** (fallback) — four scripts in this
    skill's `scripts/` directory wrap `gh` invocations. Use these when
    the GitHub MCP server is not configured (e.g. claude.ai web without
    the MCP, local Claude Code installs that have not added the GitHub
@@ -42,8 +45,9 @@ Provides GitHub PR review operations through two interchangeable paths:
 | Operation             | MCP-first path                                    | Script fallback                                                                  |
 |-----------------------|---------------------------------------------------|----------------------------------------------------------------------------------|
 | Find Open PR          | `mcp__github__list_pull_requests`                 | {{#ifAgent 'claude'}}`${CLAUDE_SKILL_DIR}`{{/ifAgent}}{{#ifAgent 'gemini'}}`./.gemini/skills/smithy.pr-review`{{/ifAgent}}{{#ifAgent 'codex'}}`./.agents/skills/smithy.pr-review`{{/ifAgent}}`/scripts/find-pr.sh` |
-| List Inline Comments  | `mcp__github__pull_request_read` (`get_review_comments`) | {{#ifAgent 'claude'}}`${CLAUDE_SKILL_DIR}`{{/ifAgent}}{{#ifAgent 'gemini'}}`./.gemini/skills/smithy.pr-review`{{/ifAgent}}{{#ifAgent 'codex'}}`./.agents/skills/smithy.pr-review`{{/ifAgent}}`/scripts/get-comments.sh <ownerRepo> <pr-number>` |
-| Reply to a Comment    | `mcp__github__add_reply_to_pull_request_comment`  | {{#ifAgent 'claude'}}`${CLAUDE_SKILL_DIR}`{{/ifAgent}}{{#ifAgent 'gemini'}}`./.gemini/skills/smithy.pr-review`{{/ifAgent}}{{#ifAgent 'codex'}}`./.agents/skills/smithy.pr-review`{{/ifAgent}}`/scripts/reply-comment.sh <ownerRepo> <pr-number> <id> <body-file>` |
+| List PR Comments      | `mcp__github__pull_request_read` (`get_review_comments`) plus issue comments when available | {{#ifAgent 'claude'}}`${CLAUDE_SKILL_DIR}`{{/ifAgent}}{{#ifAgent 'gemini'}}`./.gemini/skills/smithy.pr-review`{{/ifAgent}}{{#ifAgent 'codex'}}`./.agents/skills/smithy.pr-review`{{/ifAgent}}`/scripts/get-comments.sh <ownerRepo> <pr-number>` |
+| Reply to Inline Comment | `mcp__github__add_reply_to_pull_request_comment` | {{#ifAgent 'claude'}}`${CLAUDE_SKILL_DIR}`{{/ifAgent}}{{#ifAgent 'gemini'}}`./.gemini/skills/smithy.pr-review`{{/ifAgent}}{{#ifAgent 'codex'}}`./.agents/skills/smithy.pr-review`{{/ifAgent}}`/scripts/reply-comment.sh <ownerRepo> <pr-number> <id> <body-file>` |
+| Reply to Conversation Comment | `mcp__github__issue_write` or host equivalent | {{#ifAgent 'claude'}}`${CLAUDE_SKILL_DIR}`{{/ifAgent}}{{#ifAgent 'gemini'}}`./.gemini/skills/smithy.pr-review`{{/ifAgent}}{{#ifAgent 'codex'}}`./.agents/skills/smithy.pr-review`{{/ifAgent}}`/scripts/add-comment.sh <ownerRepo> <pr-number> <body-file>` |
 {{/ifAgent}}
 
 ## Path Selection
@@ -51,8 +55,8 @@ Provides GitHub PR review operations through two interchangeable paths:
 For each operation:
 
 {{#ifAgent 'codex'}}
-1. **Try the Codex GitHub app first** for listing and replying to review
-   threads. If the app actions are not visible, use tool discovery before
+1. **Try the Codex GitHub app first** for listing and replying to PR
+   comments. If the app actions are not visible, use tool discovery before
    falling back to shell.
 2. **Use known PR context when present.** If the user, current task, or
    previous tool output already identifies `owner/repo` and PR number, do
@@ -131,9 +135,11 @@ if no open PR exists for the current branch.
 
 ---
 
-## Operation: List Inline Comments
+## Operation: List PR Comments
 
-Fetches review threads on the PR with their full reply chains.
+Fetches unresolved inline review threads and top-level PR conversation
+comments. Conversation comments are not review threads, so handle them as
+separate actionable items.
 
 {{#ifAgent 'codex'}}### Codex app path{{else}}### MCP path{{/ifAgent}}
 
@@ -145,6 +151,10 @@ Call `_list_pull_request_review_threads` with:
 The response contains GraphQL review thread nodes with resolved state,
 comment bodies, and comment IDs. Filter out resolved threads before handing
 them to the caller — only unresolved threads need a reply.
+
+Also call `_fetch_pr_comments` with the same arguments and include top-level
+PR conversation comments that are not already represented inside an inline
+review thread. Return one item per inline thread or conversation comment.
 {{else}}
 Call `mcp__github__pull_request_read` with:
 - `method`: `"get_review_comments"`
@@ -175,23 +185,32 @@ to the caller — only unresolved threads need a reply.
 {{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/get-comments.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.pr-review/scripts/get-comments.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.pr-review/scripts/get-comments.sh{{/ifAgent}} <ownerRepo> <pr-number>
 ```
 
-Returns a JSON array of **threads** (one entry per review thread). Each
-thread has:
+Returns a JSON array of **comment items** (one entry per unresolved review
+thread or top-level PR conversation comment). Each inline thread has:
+- `kind`: `"inline_thread"`
+- `replyMode`: `"inline"`
 - `isResolved`: always `false` — resolved threads are filtered out by
   the script's `gh api graphql` query.
 - `comments[]`: the full reply chain, **oldest first**. Each comment
   carries `databaseId`, `body`, `path`, `diffHunk`, `author.login`, and
   `createdAt`.
 
-Returns `[]` if there are no unresolved review threads.
+Each conversation comment has:
+- `kind`: `"conversation_comment"`
+- `replyMode`: `"conversation"`
+- `comments[]`: a single top-level PR conversation comment.
 
-### Working a thread (both paths)
+Returns `[]` if there are no unresolved review items.
 
-- Read the **full** `comments[]` chain — the **last** comment is the
+### Working a comment item (both paths)
+
+- For inline threads, read the **full** `comments[]` chain — the **last** comment is the
   most recent reply and typically has the highest-priority context (a
   follow-up or escalation from the reviewer takes precedence over the
   original).
-- The reply target is the **root comment**:
+- For conversation comments, `comments[]` contains the single top-level PR
+  conversation comment. Treat it as its own problem item.
+- Inline reply target is the **root comment**:
 {{#ifAgent 'codex'}}
   - Codex app path: the numeric ID of the thread's top-level inline
     review comment
@@ -203,7 +222,7 @@ Returns `[]` if there are no unresolved review threads.
 
 ---
 
-## Operation: Reply to a Comment
+## Operation: Reply to Inline Comment
 
 Posts an inline reply to a specific review thread.
 
@@ -235,6 +254,37 @@ cat > /tmp/smithy_reply_<databaseId>.json << 'EOF'
 {"body": "your reply text here"}
 EOF
 {{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/reply-comment.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.pr-review/scripts/reply-comment.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.pr-review/scripts/reply-comment.sh{{/ifAgent}} <ownerRepo> <pr-number> <databaseId> /tmp/smithy_reply_<databaseId>.json
+```
+
+## Operation: Reply to Conversation Comment
+
+Posts a new top-level PR conversation comment. Use this for
+`kind: "conversation_comment"` items because GitHub does not support threaded
+replies to issue-style PR conversation comments.
+
+{{#ifAgent 'codex'}}### Codex app path{{else}}### MCP path{{/ifAgent}}
+
+{{#ifAgent 'codex'}}
+Call `_add_comment_to_issue` with:
+- `repo_full_name`: `"<owner>/<repo>"`
+- `pr_number`
+- `comment`: the reply text
+{{else}}
+Call the host's issue-comment write tool with:
+- `owner`, `repo`, `issue_number` / `pr_number`
+- `body` / `comment`: the reply text
+{{/ifAgent}}
+
+### Script fallback
+
+Write the reply body to a temp JSON file first to avoid quoting issues,
+then POST it:
+
+```bash
+cat > /tmp/smithy_pr_comment_<pr-number>.json << 'EOF'
+{"body": "your reply text here"}
+EOF
+{{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/add-comment.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.pr-review/scripts/add-comment.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.pr-review/scripts/add-comment.sh{{/ifAgent}} <ownerRepo> <pr-number> /tmp/smithy_pr_comment_<pr-number>.json
 ```
 
 ### Reply body conventions (both paths)

--- a/src/templates/agent-skills/skills/smithy.pr-review/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.pr-review/SKILL.prompt
@@ -137,9 +137,9 @@ if no open PR exists for the current branch.
 
 ## Operation: List PR Comments
 
-Fetches unresolved inline review threads and top-level PR conversation
-comments. Conversation comments are not review threads, so handle them as
-separate actionable items.
+Fetches unresolved inline review threads and unhandled top-level PR
+conversation comments. Conversation comments are not review threads, so handle
+them as separate actionable items.
 
 {{#ifAgent 'codex'}}### Codex app path{{else}}### MCP path{{/ifAgent}}
 
@@ -154,7 +154,9 @@ them to the caller — only unresolved threads need a reply.
 
 Also call `_fetch_pr_comments` with the same arguments and include top-level
 PR conversation comments that are not already represented inside an inline
-review thread. Return one item per inline thread or conversation comment.
+review thread, not authored by the current actor, and not already followed by
+one of this workflow's marker comments. Return one item per inline thread or
+conversation comment.
 {{else}}
 Call `mcp__github__pull_request_read` with:
 - `method`: `"get_review_comments"`
@@ -199,6 +201,12 @@ Each conversation comment has:
 - `kind`: `"conversation_comment"`
 - `replyMode`: `"conversation"`
 - `comments[]`: a single top-level PR conversation comment.
+
+Conversation comments authored by the authenticated viewer are excluded. A
+conversation comment is also excluded when a later viewer-authored comment
+contains the marker `smithy-pr-review-response-to:<databaseId>`. The script
+fetches the most recent 100 conversation comments so newer feedback is not
+starved by older PR activity.
 
 Returns `[]` if there are no unresolved review items.
 
@@ -268,11 +276,13 @@ replies to issue-style PR conversation comments.
 Call `_add_comment_to_issue` with:
 - `repo_full_name`: `"<owner>/<repo>"`
 - `pr_number`
-- `comment`: the reply text
+- `comment`: the reply text plus an HTML marker:
+  `<!-- smithy-pr-review-response-to:<databaseId> -->`
 {{else}}
 Call the host's issue-comment write tool with:
 - `owner`, `repo`, `issue_number` / `pr_number`
-- `body` / `comment`: the reply text
+- `body` / `comment`: the reply text plus an HTML marker:
+  `<!-- smithy-pr-review-response-to:<databaseId> -->`
 {{/ifAgent}}
 
 ### Script fallback
@@ -282,7 +292,7 @@ then POST it:
 
 ```bash
 cat > /tmp/smithy_pr_comment_<pr-number>.json << 'EOF'
-{"body": "your reply text here"}
+{"body": "your reply text here\n\n<!-- smithy-pr-review-response-to:<databaseId> -->"}
 EOF
 {{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/add-comment.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.pr-review/scripts/add-comment.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.pr-review/scripts/add-comment.sh{{/ifAgent}} <ownerRepo> <pr-number> /tmp/smithy_pr_comment_<pr-number>.json
 ```
@@ -291,6 +301,9 @@ EOF
 
 - For a **fix** reply: `"Fixed in <commit-sha>: <one-line explanation of what changed and why>"`
 - For a **decline** reply: `"Not addressed: <explanation — why the comment doesn't apply, or what was misunderstood>"`
+- For a **conversation comment** reply, append
+  `<!-- smithy-pr-review-response-to:<databaseId> -->` so future list
+  operations can suppress the handled comment.
 
 ---
 

--- a/src/templates/agent-skills/skills/smithy.pr-review/scripts/add-comment.sh
+++ b/src/templates/agent-skills/skills/smithy.pr-review/scripts/add-comment.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# add-comment.sh — Post a top-level PR conversation comment
+#
+# Usage: ${CLAUDE_SKILL_DIR}/scripts/add-comment.sh <owner/repo> <pr-number> <body-file>
+#
+# The body file must contain JSON in the shape: {"body": "comment text"}
+
+set -euo pipefail
+
+REPO="$1"
+PR="$2"
+BODY_FILE="$3"
+
+gh api "repos/$REPO/issues/$PR/comments" \
+  --method POST \
+  --input "$BODY_FILE"

--- a/src/templates/agent-skills/skills/smithy.pr-review/scripts/get-comments.sh
+++ b/src/templates/agent-skills/skills/smithy.pr-review/scripts/get-comments.sh
@@ -14,6 +14,9 @@
 #   - replyMode: "conversation"
 #   - comments[]: a single comment object with databaseId, body, author.login,
 #                 createdAt, and null path/diffHunk fields
+# Conversation comments authored by the authenticated viewer, or already
+# followed by a viewer comment containing the smithy-pr-review response marker,
+# are filtered out.
 #
 # Returns an empty array ([]) if there are no unresolved review items.
 
@@ -31,6 +34,7 @@ gh api graphql \
   -F pr="$PR" \
   -f query='
 query($owner: String!, $name: String!, $pr: Int!) {
+  viewer { login }
   repository(owner: $owner, name: $name) {
     pullRequest(number: $pr) {
       reviewThreads(first: 100) {
@@ -48,7 +52,7 @@ query($owner: String!, $name: String!, $pr: Int!) {
           }
         }
       }
-      comments(first: 100) {
+      comments(last: 100) {
         nodes {
           databaseId
           body
@@ -58,23 +62,35 @@ query($owner: String!, $name: String!, $pr: Int!) {
       }
     }
   }
-}' --jq '[
+}' --jq '
+.data as $data
+| ($data.viewer.login // "") as $viewer
+| ($data.repository.pullRequest.comments.nodes | sort_by(.createdAt)) as $conversationComments
+| [
   (.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | . + {
     kind: "inline_thread",
     replyMode: "inline",
     comments: (.comments.nodes | sort_by(.createdAt))
   }),
-  (.data.repository.pullRequest.comments.nodes[] | {
+  ($conversationComments[] as $comment
+  | select(($comment.author.login // "") != $viewer)
+  | select([
+      $conversationComments[]
+      | select((.author.login // "") == $viewer)
+      | select(.createdAt > $comment.createdAt)
+      | select((.body // "") | contains("smithy-pr-review-response-to:" + ($comment.databaseId | tostring)))
+    ] | length == 0)
+  | {
     kind: "conversation_comment",
     replyMode: "conversation",
     isResolved: false,
     comments: [{
-      databaseId,
-      body,
+      databaseId: $comment.databaseId,
+      body: $comment.body,
       path: null,
       diffHunk: null,
-      author,
-      createdAt
+      author: $comment.author,
+      createdAt: $comment.createdAt
     }]
   })
 ] | sort_by(.comments[0].createdAt)'

--- a/src/templates/agent-skills/skills/smithy.pr-review/scripts/get-comments.sh
+++ b/src/templates/agent-skills/skills/smithy.pr-review/scripts/get-comments.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
-# get-comments.sh — Fetch unresolved PR review threads with full reply chains
+# get-comments.sh — Fetch unresolved PR review threads and PR conversation comments
 #
 # Usage: ${CLAUDE_SKILL_DIR}/scripts/get-comments.sh <owner/repo> <pr-number>
 #
-# Output: JSON array of unresolved review threads. Each thread has:
+# Output: JSON array of unresolved review items. Inline review threads have:
+#   - kind: "inline_thread"
+#   - replyMode: "inline"
 #   - isResolved (always false in output — resolved threads are filtered)
 #   - comments[]: array of comment objects with databaseId, body, path, diffHunk,
 #                 author.login, createdAt (ordered oldest → newest)
+# Top-level PR conversation comments have:
+#   - kind: "conversation_comment"
+#   - replyMode: "conversation"
+#   - comments[]: a single comment object with databaseId, body, author.login,
+#                 createdAt, and null path/diffHunk fields
 #
-# Returns an empty array ([]) if there are no unresolved review threads.
+# Returns an empty array ([]) if there are no unresolved review items.
 
 set -euo pipefail
 
@@ -41,6 +48,33 @@ query($owner: String!, $name: String!, $pr: Int!) {
           }
         }
       }
+      comments(first: 100) {
+        nodes {
+          databaseId
+          body
+          author { login }
+          createdAt
+        }
+      }
     }
   }
-}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | . + { comments: (.comments.nodes | sort_by(.createdAt)) }]'
+}' --jq '[
+  (.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | . + {
+    kind: "inline_thread",
+    replyMode: "inline",
+    comments: (.comments.nodes | sort_by(.createdAt))
+  }),
+  (.data.repository.pullRequest.comments.nodes[] | {
+    kind: "conversation_comment",
+    replyMode: "conversation",
+    isResolved: false,
+    comments: [{
+      databaseId,
+      body,
+      path: null,
+      diffHunk: null,
+      author,
+      createdAt
+    }]
+  })
+] | sort_by(.comments[0].createdAt)'


### PR DESCRIPTION
## Summary

Fixes #314 by teaching the Smithy PR review workflow to handle top-level PR conversation comments in addition to inline review threads.

## What changed

- `smithy.pr-review` now returns explicit comment item kinds for inline threads and conversation comments.
- Added a `Reply to Conversation Comment` path backed by a new `add-comment.sh` helper for `gh` fallback usage.
- Updated `smithy.fix` guidance so no-argument review handling processes each returned comment item and chooses the correct reply path.
- Updated Codex/Claude permissions, deployment coverage, and template tests for the new helper and operations.

## Root cause

The existing workflow assumed all actionable PR feedback came from inline review threads. Top-level PR conversation comments are issue-style comments and cannot be replied to with the inline review-thread API, so they were omitted or mishandled.

## Validation

- `npm test`
- `npm run typecheck`
- `npm test -- --run src/templates.test.ts src/agents/codex.test.ts src/agents/claude.test.ts src/permissions.test.ts src/cli.test.ts`
- `bash -n` on the updated `smithy.pr-review` helper scripts