### PR TITLE
feat(mark): spec F1.3a per-case token totals in EvalReport

### DIFF
--- a/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
+++ b/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
@@ -106,7 +106,7 @@ Recommended specification sequence:
 |----|-------|------------|----------|
 | F1.1 | Reference Baseline Evals Infrastructure | — | — |
 | F1.2 | Expand-Evals Planning-Command Coverage (cross-RFC) | — | — |
-| F1.3a | Per-Case Token Totals in EvalReport | F1.1 | — |
+| F1.3a | Per-Case Token Totals in EvalReport | F1.1 | specs/2026-05-18-007-per-case-token-totals-in-evalreport/ |
 | F1.3b | Per-Sub-Agent Token Attribution | F1.3a | — |
 | F1.4 | smithy.fix End-to-End Eval Scenario | F1.3a | — |
 | F1.5 | smithy.forge End-to-End Eval Scenario + Runner git-init (RFC SD-002) | F1.3a | — |

--- a/specs/2026-05-18-007-per-case-token-totals-in-evalreport/per-case-token-totals-in-evalreport.contracts.md
+++ b/specs/2026-05-18-007-per-case-token-totals-in-evalreport/per-case-token-totals-in-evalreport.contracts.md
@@ -1,0 +1,206 @@
+# Contracts: Per-Case Token Totals in EvalReport
+
+## Overview
+
+This feature extends existing eval-framework contracts in three places: stream usage extraction, report result aggregation/rendering, and baseline comparison. The contracts are additive and preserve compatibility with existing structural-only baselines and report status semantics.
+
+## Interfaces
+
+### 1) Stream Usage Extraction
+
+**Purpose**: Converts raw stream usage metadata into normalized token totals.
+**Consumers**: Scenario runner output assembly and report result assembly.
+**Providers**: Parsed stream events emitted by the configured agent CLI.
+
+#### Signature
+
+```ts
+extractTokenTotals(events: StreamEvent[]): TokenTotals
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `events` | StreamEvent[] | Yes | Parsed stream events from one scenario run. Events may or may not include usage metadata. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `input` | integer | Summed non-negative input token count. |
+| `output` | integer | Summed non-negative output token count. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| No usage metadata exists | Return zero totals. | Missing usage is not a scenario failure. |
+| Usage metadata is malformed | Ignore malformed fields and continue. | Unknown stream shapes remain tolerated. |
+| Events are empty | Return zero totals. | Empty or unparsable output can still produce a valid error result. |
+
+### 2) Scenario Result Assembly
+
+**Purpose**: Carries token totals from a scenario run into the per-case eval result.
+**Consumers**: Report aggregation, report formatting, and baseline comparison.
+**Providers**: Scenario runner output and validation checks.
+
+#### Signature
+
+```ts
+scenarioRunToResult(
+  scenario: EvalScenario,
+  output: RunOutput,
+  structuralChecks: CheckResult[],
+  subAgentChecks?: CheckResult[],
+  baselineChecks?: CheckResult[],
+): EvalResult
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `output.tokens` | TokenTotals | Yes | Token totals for the scenario run. |
+| `structuralChecks` | CheckResult[] | Yes | Existing structural validation results. |
+| `subAgentChecks` | CheckResult[] | No | Existing sub-agent evidence validation results. |
+| `baselineChecks` | CheckResult[] | No | Existing baseline validation results, including token checks when applicable. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tokens` | TokenTotals | Token totals copied into the per-case result. |
+| `status` | enum | Existing status behavior is preserved. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Scenario timed out | Preserve token totals and return timeout status. | Available usage remains useful for cost analysis. |
+| Scenario exited non-zero | Preserve token totals and return error status. | Cost reporting does not depend on pass status. |
+| Validation checks fail | Preserve token totals and return fail status. | Token totals are orthogonal to structural correctness. |
+
+### 3) Report Aggregation and Rendering
+
+**Purpose**: Aggregates per-case token totals and renders them in the eval summary.
+**Consumers**: CLI users running evals and downstream token-delta tooling.
+**Providers**: Per-case eval results.
+
+#### Signature
+
+```ts
+buildReport(results: EvalResult[], totalDurationMs: number): EvalReport
+formatReport(report: EvalReport): string
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `results[].tokens` | TokenTotals | Yes | Per-case token totals to sum and render. |
+| `totalDurationMs` | integer | Yes | Existing aggregate run duration. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `report.tokens` | TokenTotals | Aggregate input and output token totals. |
+| formatted case line | string | Includes status, scenario name, duration, token totals, and baseline marker when applicable. |
+
+#### Rendering Contract
+
+Each per-case line includes token totals in this semantic shape:
+
+```text
+input: <non-negative integer>, output: <non-negative integer>
+```
+
+The exact placement may follow the existing duration and baseline marker conventions, but the status token, scenario name, duration, baseline marker, total elapsed line, and final result line remain present.
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Empty result set | Aggregate token totals are zero. | Existing empty-report behavior remains well formed. |
+| Some cases lack baselines | Render token totals for every case and baseline markers according to existing baseline rules. | No-baseline scenarios stay readable. |
+
+### 4) Token-Aware Baseline Loading
+
+**Purpose**: Loads committed baselines with an optional token envelope while preserving structural-only compatibility.
+**Consumers**: Baseline comparison and report result assembly.
+**Providers**: JSON files under the baseline directory.
+
+#### Signature
+
+```ts
+loadBaseline(scenarioName: string, baselinesDir?: string): Baseline | null
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scenarioName` | string | Yes | Scenario name used to locate the baseline file. |
+| `token_envelope` | TokenEnvelope | No | Optional token bounds in the loaded JSON object. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Baseline` | object | Existing structural baseline fields plus optional token envelope. |
+| `null` | null | Returned when no baseline file exists. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Baseline has no token envelope | Load successfully. | Token comparison is optional. |
+| Token envelope has invalid bounds | Throw a descriptive baseline validation error. | Invalid cost bounds would make drift checks misleading. |
+| Baseline has unknown extra fields | Ignore unknown fields. | Forward compatibility is preserved. |
+
+### 5) Token Baseline Comparison
+
+**Purpose**: Emits token drift checks when a baseline defines a token envelope.
+**Consumers**: Scenario result assembly and formatted baseline marker.
+**Providers**: Live token totals and loaded baseline.
+
+#### Signature
+
+```ts
+compareToBaseline(output: string, baseline: Baseline, tokens?: TokenTotals): CheckResult[]
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `output` | string | Yes | Existing live extracted text used for structural comparison. |
+| `baseline` | Baseline | Yes | Loaded baseline with structural expectations and optional token envelope. |
+| `tokens` | TokenTotals | Conditional | Required for token comparison when the baseline includes a token envelope. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `CheckResult[]` | array | Existing structural checks plus one token envelope check when applicable. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Baseline has no token envelope | Emit only structural checks. | Backward compatibility path. |
+| Baseline has token envelope but no live tokens are supplied | Emit a failing token check. | A token-aware baseline requires live measured totals. |
+| Live tokens exceed envelope | Emit a failing token check with expected bounds and actual totals. | The formatted report's baseline marker becomes failing through existing rules. |
+| Live tokens are inside envelope | Emit a passing token check. | Structural checks still determine their own pass/fail independently. |
+
+## Events / Hooks
+
+No new events or hooks are introduced. Token totals are derived from the existing stream-event flow and are carried through the existing eval report pipeline.
+
+## Integration Boundaries
+
+- **Agent stream output**: usage metadata is consumed from the existing stream-json boundary. Unknown event fields remain tolerated.
+- **Filesystem baseline files**: baseline JSON remains the committed storage mechanism; token envelopes are optional additions to the existing shape.
+- **Eval report stdout**: report formatting adds token totals to per-case lines while preserving existing status and summary semantics.
+- **Downstream token-delta work**: later M2/M3 features consume the token totals and token-aware baselines produced here, but no downstream protocol is implemented by F1.3a.

--- a/specs/2026-05-18-007-per-case-token-totals-in-evalreport/per-case-token-totals-in-evalreport.contracts.md
+++ b/specs/2026-05-18-007-per-case-token-totals-in-evalreport/per-case-token-totals-in-evalreport.contracts.md
@@ -39,6 +39,15 @@ extractTokenTotals(events: StreamEvent[]): TokenTotals
 | Usage metadata is malformed | Ignore malformed fields and continue. | Unknown stream shapes remain tolerated. |
 | Events are empty | Return zero totals. | Empty or unparsable output can still produce a valid error result. |
 
+#### Deduplication Rule
+
+When usage metadata appears on more than one stream event for the same logical run (for example a terminal `result` event reporting cumulative totals alongside earlier `message_delta` or `assistant` events reporting per-step totals), the extractor MUST avoid double-counting by applying this precedence:
+
+1. **Terminal-event precedence.** If at least one event whose type is `result` (the run-terminating summary event) carries usage metadata, the extractor MUST take the per-field maximum of the input and output token counts reported by those terminal events and MUST ignore usage on non-terminal events for the same run.
+2. **Delta fallback.** If no terminal event carries usage metadata, the extractor MUST sum the per-event usage values from non-terminal events (`message_delta`, `assistant`, and any other event types that surface usage).
+
+This precedence is deterministic for both cumulative-totals shapes and delta-totals shapes regardless of the agent CLI version. SD-001 in the specification tracks empirically verifying the event shapes emitted by the configured CLI; the precedence rule above is the contract regardless of where usage ultimately lands.
+
 ### 2) Scenario Result Assembly
 
 **Purpose**: Carries token totals from a scenario run into the per-case eval result.

--- a/specs/2026-05-18-007-per-case-token-totals-in-evalreport/per-case-token-totals-in-evalreport.data-model.md
+++ b/specs/2026-05-18-007-per-case-token-totals-in-evalreport/per-case-token-totals-in-evalreport.data-model.md
@@ -1,0 +1,151 @@
+# Data Model: Per-Case Token Totals in EvalReport
+
+## Overview
+
+This feature extends the existing eval report data model with additive token usage fields. It introduces a reusable token-count value object, carries those totals through per-scenario and aggregate report entities, and adds an optional token envelope to committed baselines. No persistent database or external storage is introduced.
+
+## Entities
+
+### 1) TokenTotals (`token_totals`)
+
+Purpose: Represents measured token usage for a single scenario run or aggregate report.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `input` | integer | Yes | Non-negative input token count. Defaults to `0` when no usable usage metadata is observed. |
+| `output` | integer | Yes | Non-negative output token count. Defaults to `0` when no usable usage metadata is observed. |
+
+Validation rules:
+
+- Values must be finite non-negative integers.
+- Missing, null, non-numeric, negative, or non-finite source usage values are ignored during extraction.
+- Aggregate totals are computed by summing per-case totals.
+
+### 2) TokenEnvelope (`token_envelope`)
+
+Purpose: Defines the accepted token range for a committed baseline.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `input` | object | No | Optional accepted range for input tokens. |
+| `input.min` | integer | Conditional | Non-negative lower bound when `input` is present. |
+| `input.max` | integer | Conditional | Non-negative upper bound when `input` is present. Must be greater than or equal to `input.min`. |
+| `output` | object | No | Optional accepted range for output tokens. |
+| `output.min` | integer | Conditional | Non-negative lower bound when `output` is present. |
+| `output.max` | integer | Conditional | Non-negative upper bound when `output` is present. Must be greater than or equal to `output.min`. |
+
+Validation rules:
+
+- A token envelope may define input, output, or both ranges.
+- When a range is present, both `min` and `max` are required.
+- Bounds must be finite non-negative integers.
+- Structural-only baselines remain valid when the token envelope is absent.
+
+### 3) StreamEvent (`stream_event`)
+
+Purpose: Existing loose-typed representation of a single agent stream event. This feature permits optional usage metadata on stream events without making the stream parser depend on a fixed event union.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `usage` | object | No | Optional raw usage payload from the agent stream. Unknown extra fields remain allowed. |
+| `usage.input_tokens` | number | No | Source input token count when present and valid. |
+| `usage.output_tokens` | number | No | Source output token count when present and valid. |
+
+Validation rules:
+
+- Stream parsing preserves unknown event fields.
+- Usage extraction reads only supported numeric usage fields.
+- Invalid usage values do not invalidate the stream event.
+
+### 4) RunOutput (`run_output`)
+
+Purpose: Existing per-scenario runner output extended with measured token totals derived from stream events.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `tokens` | TokenTotals | Yes | Summed token totals for the scenario run. |
+
+Validation rules:
+
+- `tokens` is present for successful, failing, timeout, and error runs.
+- The value is derived from parseable stream events; when events cannot be parsed, it defaults to zero totals.
+
+### 5) EvalResult (`eval_result`)
+
+Purpose: Existing per-case report result extended with token totals.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `tokens` | TokenTotals | Yes | Token totals copied from the scenario run output. |
+
+Validation rules:
+
+- Token totals do not determine scenario status.
+- Token totals are preserved whether structural, sub-agent, or baseline checks pass or fail.
+
+### 6) EvalReport (`eval_report`)
+
+Purpose: Existing aggregate report extended with total token counts across all case results.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `tokens` | TokenTotals | Yes | Sum of every included result's token totals. |
+
+Validation rules:
+
+- Empty reports have zero input and output totals.
+- Aggregate token totals are deterministic for a given ordered result set.
+
+### 7) Baseline (`baseline`)
+
+Purpose: Existing committed scenario baseline extended with an optional token envelope.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `token_envelope` | TokenEnvelope | No | Optional accepted token range for the scenario. Absence means token comparison is skipped. |
+
+Validation rules:
+
+- Existing baseline fields remain required.
+- Unknown extra fields remain ignored unless they are part of the token envelope contract.
+- A malformed token envelope makes the baseline invalid because it would produce misleading drift checks.
+
+## Relationships
+
+- `StreamEvent` N:1 `RunOutput` via token extraction and summation.
+- `RunOutput` 1:1 `EvalResult` via result assembly.
+- `EvalResult` N:1 `EvalReport` via report aggregation.
+- `Baseline` 0..1:1 `TokenEnvelope` via optional baseline token bounds.
+- `TokenEnvelope` 1:1 `Baseline Check Result` when token comparison runs.
+
+## State Transitions
+
+### Token measurement lifecycle
+
+1. `unobserved` -> `extracted`
+   - Trigger: stream events are parsed after a scenario run.
+   - Effects: valid usage values are summed into `TokenTotals`.
+
+2. `extracted` -> `reported`
+   - Trigger: the scenario run is converted to an eval result and then an aggregate report.
+   - Effects: per-case and aggregate token totals are available to report formatting.
+
+3. `reported` -> `compared`
+   - Trigger: a matching baseline with a token envelope is loaded.
+   - Effects: token envelope pass/fail is emitted as a baseline check result.
+
+### Baseline schema lifecycle
+
+1. `structural_only` -> `token_aware`
+   - Trigger: a baseline is refreshed after F1.3a lands.
+   - Effects: the baseline keeps its structural expectations and adds a token envelope.
+
+2. `token_aware` -> `recalibrated`
+   - Trigger: repeated clean runs show the initial envelope is too narrow or too broad.
+   - Effects: token envelope bounds are adjusted in a follow-up baseline update.
+
+## Identity & Uniqueness
+
+- A scenario's live token totals are identified by the scenario name within a single eval run.
+- A baseline token envelope is identified by the baseline's scenario name.
+- Aggregate report token totals are identified by the report timestamp and result set.

--- a/specs/2026-05-18-007-per-case-token-totals-in-evalreport/per-case-token-totals-in-evalreport.spec.md
+++ b/specs/2026-05-18-007-per-case-token-totals-in-evalreport/per-case-token-totals-in-evalreport.spec.md
@@ -16,7 +16,7 @@
 - Token totals are recorded as input and output token counts; missing or unparseable usage data is represented as zero totals rather than failing an otherwise valid scenario run.
 - Token baseline checks compare committed per-case token envelopes with live per-case totals and emit a baseline check result without replacing existing structural baseline checks.
 - Per-sub-agent token attribution is excluded from this specification and remains owned by F1.3b.
-- The RFC touched-files matrix is amended by this specification to include the stream parsing, runner output, and shared type surfaces needed for token totals; the matrix amendment is tracked as specification debt so implementation PRs carry the governance update explicitly.
+- The RFC touched-files matrix does not yet name the stream parsing, runner output, and shared type surfaces needed for token totals; the matrix amendment is deferred to the implementation PR and tracked as SD-003 so the governance update lands alongside the code rather than as a separate planning revision.
 
 ## Artifact Hierarchy
 
@@ -112,7 +112,7 @@ Recommended implementation sequence:
 - **FR-001**: The system MUST represent token totals as separate non-negative integer input and output counts.
 - **FR-002**: Each scenario run result MUST include token totals, even when no usage metadata is present.
 - **FR-003**: Token extraction MUST read usage metadata from supported stream events without failing on unknown event shapes.
-- **FR-004**: Token extraction MUST ignore absent, null, non-numeric, negative, or non-finite usage values.
+- **FR-004**: Token extraction MUST ignore absent, null, non-numeric, non-integer (fractional, e.g., `12.3`), negative, or non-finite usage values so the non-negative integer invariant in FR-001 is preserved by construction. Numbers whose value is integral but whose JSON encoding is a float (e.g., `12.0`) are accepted as the equivalent integer.
 - **FR-005**: Scenario results MUST carry token totals through report aggregation without mutating existing structural, sub-agent, or baseline check arrays.
 - **FR-006**: The aggregate eval report MUST expose total input and output token counts across all included scenario results.
 - **FR-007**: The formatted eval report MUST render input and output token totals on every per-case line.
@@ -145,7 +145,7 @@ Recommended implementation sequence:
 
 | ID | Description | Source Category | Impact | Confidence | Status | Resolution |
 |----|-------------|-----------------|--------|------------|--------|------------|
-| SD-001 | The exact stream-json event placement for usage metadata may vary by Claude CLI version. Implementers must verify whether usage appears on final result events, assistant events, or both, and must avoid double-counting if both are present for the same logical run. | Integration | High | Medium | open | — |
+| SD-001 | The exact stream-json event placement for usage metadata may vary by Claude CLI version. Implementers must verify whether usage appears on final `result` events, assistant events, or both, and apply the Stream Usage Extraction deduplication rule in the contracts document (terminal `result` event precedence, with delta-event sum as the fallback) when both are present for the same logical run. | Integration | High | Medium | open | — |
 | SD-002 | The token envelope tolerance is not calibrated until the first token-aware strike baseline is captured. Implementers should choose a conservative initial envelope and document the captured live totals in the implementation PR. | Non-Functional Quality | Medium | Medium | open | — |
 | SD-003 | The RFC touched-files matrix currently omits some token-threading surfaces needed by F1.3a. The implementation PR must amend the matrix to name all owned parsing, runner-output, report, and type surfaces touched by this feature. | Integration | Medium | High | open | — |
 

--- a/specs/2026-05-18-007-per-case-token-totals-in-evalreport/per-case-token-totals-in-evalreport.spec.md
+++ b/specs/2026-05-18-007-per-case-token-totals-in-evalreport/per-case-token-totals-in-evalreport.spec.md
@@ -1,0 +1,170 @@
+# Feature Specification: Per-Case Token Totals in EvalReport
+
+**Spec Folder**: `2026-05-18-007-per-case-token-totals-in-evalreport`
+**Branch**: `2026-05-18-007-per-case-token-totals-in-evalreport`
+**Created**: 2026-05-18
+**Status**: Draft
+**Input**: `docs/rfcs/2026-001-token-savings/token-savings.rfc.md` — Milestone 1 measurement foundation feature for per-case eval token reporting, baseline token envelopes, and token-aware report rendering.
+**Source Feature Map**: `docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md` — Feature 1.3a: Per-Case Token Totals in EvalReport
+
+## Clarifications
+
+### Session 2026-05-18
+
+- F1.1 and F1.2 are reference-only feature-map rows with no child spec; this specification targets the first implementable unspecced feature, F1.3a. `[Critical Assumption]`
+- Per-case token reporting is additive: existing structural pass/fail behavior, scenario loading, sub-agent evidence checks, and no-baseline scenario behavior remain compatible.
+- Token totals are recorded as input and output token counts; missing or unparseable usage data is represented as zero totals rather than failing an otherwise valid scenario run.
+- Token baseline checks compare committed per-case token envelopes with live per-case totals and emit a baseline check result without replacing existing structural baseline checks.
+- Per-sub-agent token attribution is excluded from this specification and remains owned by F1.3b.
+- The RFC touched-files matrix is amended by this specification to include the stream parsing, runner output, and shared type surfaces needed for token totals; the matrix amendment is tracked as specification debt so implementation PRs carry the governance update explicitly.
+
+## Artifact Hierarchy
+
+RFC -> Milestone -> Feature -> User Story -> Slice -> Tasks
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1: Capture Per-Case Token Totals (Priority: P1)
+
+As a Smithy maintainer, I want each eval scenario result to include input and output token totals so that every eval run has a measured cost signal alongside structural pass/fail.
+
+**Why this priority**: This is the foundation for the entire token-savings program. Baselines, rendered deltas, and downstream M2/M3 savings claims cannot be credible until each scenario produces token totals.
+
+**Independent Test**: Run a fixture scenario with stream events containing usage fields and verify the resulting scenario output carries the summed input and output totals.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scenario run emits one or more stream events with usage metadata, **When** the run is converted into a scenario result, **Then** the result includes the summed input token count and summed output token count for that case.
+2. **Given** a scenario run emits no usage metadata, **When** the run is converted into a scenario result, **Then** the result includes input and output token totals of zero and no token-specific error is raised.
+3. **Given** a scenario run times out or exits with an error after emitting parseable stream events, **When** the run is converted into a scenario result, **Then** any available usage metadata is still reflected in the result's token totals.
+
+---
+
+### User Story 2: Render Token Totals in Eval Reports (Priority: P1)
+
+As a Smithy contributor, I want the eval report to show input and output tokens for each case so that I can see the cost impact of a change without inspecting raw stream captures.
+
+**Why this priority**: The user-facing value of F1.3a is a report surface. Hidden totals in internal data structures do not help contributors make cost-aware template changes.
+
+**Independent Test**: Build a report with multiple scenario results and verify each case line renders `input: <N>, output: <N>` without changing the aggregate pass/fail summary.
+
+**Acceptance Scenarios**:
+
+1. **Given** an eval report contains one passing scenario with non-zero token totals, **When** the report is formatted, **Then** the scenario line displays its input and output token counts.
+2. **Given** an eval report contains passing, failing, timeout, and error scenarios, **When** the report is formatted, **Then** every scenario line displays token totals and the status tokens remain unchanged.
+3. **Given** an eval report includes scenarios with and without committed baselines, **When** the report is formatted, **Then** token totals and the existing baseline marker are both visible on the relevant case lines.
+
+---
+
+### User Story 3: Extend Baselines with Token Envelopes (Priority: P1)
+
+As a Smithy maintainer, I want committed baseline files to carry token envelopes so that eval runs can flag material token drift against known-good scenario outputs.
+
+**Why this priority**: The token-savings program needs committed baselines before downstream M2/M3 PRs can compute token deltas without rerunning historical comparisons.
+
+**Independent Test**: Load a baseline containing a token envelope, compare it with a live scenario result, and verify the baseline checks include a token-delta result in addition to structural checks.
+
+**Acceptance Scenarios**:
+
+1. **Given** a baseline file includes a token envelope and a live scenario result stays within that envelope, **When** baseline comparison runs, **Then** the token baseline check passes.
+2. **Given** a baseline file includes a token envelope and a live scenario result exceeds the envelope, **When** baseline comparison runs, **Then** the token baseline check fails with the expected and actual token totals visible.
+3. **Given** a baseline file uses the previous structural-only shape, **When** baseline loading runs, **Then** the baseline remains valid and token comparison is skipped for that file.
+
+---
+
+### User Story 4: Refresh the Strike Baseline in the Token-Aware Schema (Priority: P2)
+
+As a Smithy maintainer, I want the existing strike scenario baseline committed in the token-aware schema so that the first measured case establishes the envelope format for later M1 scenarios.
+
+**Why this priority**: The strike scenario is the committed baseline already present in the eval suite. Refreshing it proves the new schema is usable before fix and forge baselines arrive in later M1 features.
+
+**Independent Test**: Run the strike scenario, refresh its baseline in the token-aware schema, and verify a subsequent eval run reports both structural and token baseline checks.
+
+**Acceptance Scenarios**:
+
+1. **Given** the existing strike scenario has a refreshed token-aware baseline, **When** the strike scenario runs successfully, **Then** its report line includes token totals and a passing baseline marker.
+2. **Given** the refreshed strike baseline is loaded, **When** the baseline comparator runs, **Then** it still validates the structural headings and tables recorded in the baseline.
+3. **Given** the token-aware strike baseline contains its token envelope, **When** the live token totals exceed that envelope, **Then** the report shows a failing baseline marker for the scenario.
+
+### Edge Cases
+
+- Stream events may carry usage metadata on final result events, assistant events, or both; totals must avoid double-counting the same logical usage record.
+- Usage fields may be absent, null, or non-numeric; those fields are ignored rather than converted to invalid totals.
+- A scenario can fail structurally while still producing useful token totals; token collection must not depend on pass status.
+- Existing structural-only baselines remain loadable so partially migrated baseline sets do not block incremental M1 work.
+- The report line must remain readable when duration, baseline marker, and token totals are all present.
+
+## Dependency Order
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| US1 | Capture Per-Case Token Totals | — | — |
+| US2 | Render Token Totals in Eval Reports | US1 | — |
+| US3 | Extend Baselines with Token Envelopes | US1 | — |
+| US4 | Refresh the Strike Baseline in the Token-Aware Schema | US2, US3 | — |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST represent token totals as separate non-negative integer input and output counts.
+- **FR-002**: Each scenario run result MUST include token totals, even when no usage metadata is present.
+- **FR-003**: Token extraction MUST read usage metadata from supported stream events without failing on unknown event shapes.
+- **FR-004**: Token extraction MUST ignore absent, null, non-numeric, negative, or non-finite usage values.
+- **FR-005**: Scenario results MUST carry token totals through report aggregation without mutating existing structural, sub-agent, or baseline check arrays.
+- **FR-006**: The aggregate eval report MUST expose total input and output token counts across all included scenario results.
+- **FR-007**: The formatted eval report MUST render input and output token totals on every per-case line.
+- **FR-008**: Existing pass/fail/timeout/error status tokens and aggregate result rendering MUST remain stable.
+- **FR-009**: Existing baseline markers MUST remain visible when token totals are rendered.
+- **FR-010**: Baseline files MUST support an optional token envelope while preserving compatibility with structural-only baselines.
+- **FR-011**: Baseline comparison MUST emit a token check result when a baseline contains a token envelope.
+- **FR-012**: Baseline comparison MUST skip token checks when a baseline has no token envelope.
+- **FR-013**: The existing strike scenario baseline MUST be refreshed into the token-aware schema.
+- **FR-014**: The token-aware strike baseline MUST preserve its existing structural baseline expectations.
+- **FR-015**: Unit tests MUST cover token extraction, report rendering, baseline loading, baseline comparison, and structural-only baseline compatibility.
+
+### Key Entities
+
+- **TokenTotals**: The per-case and aggregate pair of input and output token counts.
+- **TokenEnvelope**: The committed baseline bounds used to decide whether a live scenario's token totals remain within an accepted range.
+- **Scenario Result**: The per-case eval result extended with token totals.
+- **Eval Report**: The aggregate eval report extended with total token counts and per-case token rendering.
+- **Baseline**: The committed known-good scenario snapshot extended with an optional token envelope.
+- **Baseline Check Result**: The existing check-result shape reused for token envelope pass/fail output.
+
+## Assumptions
+
+- Claude stream-json usage metadata remains available as input and output token fields on events produced during headless eval runs.
+- A zero-token total means "no usable usage metadata was observed," not "the scenario had no cost."
+- Token baseline envelopes are intentionally broad enough to tolerate expected provider-side variance while still catching material drift.
+- Structural-only baseline compatibility is required during M1 because later features will add additional baselines after F1.3a lands.
+
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | The exact stream-json event placement for usage metadata may vary by Claude CLI version. Implementers must verify whether usage appears on final result events, assistant events, or both, and must avoid double-counting if both are present for the same logical run. | Integration | High | Medium | open | — |
+| SD-002 | The token envelope tolerance is not calibrated until the first token-aware strike baseline is captured. Implementers should choose a conservative initial envelope and document the captured live totals in the implementation PR. | Non-Functional Quality | Medium | Medium | open | — |
+| SD-003 | The RFC touched-files matrix currently omits some token-threading surfaces needed by F1.3a. The implementation PR must amend the matrix to name all owned parsing, runner-output, report, and type surfaces touched by this feature. | Integration | Medium | High | open | — |
+
+## Out of Scope
+
+- Per-sub-agent token attribution, per-agent rendering, and per-agent token baselines.
+- New eval scenarios for smithy.fix, smithy.forge, or JVM forge coverage.
+- Planning-command baseline creation owned by the expand-evals dependency.
+- Token-delta PR-description protocol for template PRs.
+- Any cost-reduction prompt or sub-agent model changes.
+- Any public CLI surface changes outside the eval report output.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every eval scenario result produced by the report pipeline includes input and output token totals.
+- **SC-002**: The formatted eval report displays `input: <N>, output: <N>` for every case line.
+- **SC-003**: The aggregate eval report exposes total input and output token counts across all cases.
+- **SC-004**: The existing strike baseline is committed in a token-aware schema and still validates its structural expectations.
+- **SC-005**: Structural-only baselines continue to load and compare successfully.
+- **SC-006**: Unit tests cover token totals for successful, failing, timeout, missing-usage, and baseline-comparison paths.


### PR DESCRIPTION
## Summary

Runs `smithy.mark` against `docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md` to produce the spec artifacts for feature **F1.3a — Per-Case Token Totals in EvalReport**.

Changes:
- **Feature map update**: `Artifact` column for F1.3a changed from `—` → `specs/2026-05-18-007-per-case-token-totals-in-evalreport/`
- **New spec** (`per-case-token-totals-in-evalreport.spec.md`): 4 user stories (US1–US4), FR-001–FR-015, 3 spec debt items (SD-001–SD-003), success criteria SC-001–SC-006
- **New data model** (`per-case-token-totals-in-evalreport.data-model.md`): 7 entities (TokenTotals, TokenEnvelope, StreamEvent, RunOutput, EvalResult, EvalReport, Baseline), relationships and state transitions
- **New contracts** (`per-case-token-totals-in-evalreport.contracts.md`): 5 interface contracts covering stream usage extraction, scenario result assembly, report aggregation/rendering, token-aware baseline loading, and token baseline comparison

## Verification

- All 825 existing tests pass (`npm test`)
- No source code changed — this is a documentation-only spec step

## Known gaps / spec debt carried forward

- **SD-001**: Exact stream-json event placement for usage metadata needs verification at implementation time to avoid double-counting.
- **SD-002**: Token envelope tolerance is not calibrated until first token-aware strike baseline is captured.
- **SD-003**: RFC touched-files matrix omits some token-threading surfaces; implementation PR must amend.

Closes #N/A — this is a planning artifact step, not implementation.