### PR TITLE
fix(evals): point cut-from-spec prompt to spec file not directory

### DIFF
--- a/evals/cases/cut-from-spec.yaml
+++ b/evals/cases/cut-from-spec.yaml
@@ -11,7 +11,7 @@
 
 name: cut-from-spec
 skill: /smithy.cut
-prompt: evals/fixture/specs/cut-eval 1
+prompt: evals/fixture/specs/cut-eval/cut-eval.spec.md 1
 # Empirical calibration: local Codex run on 2026-05-16 completed the cut
 # command in 247.5s; 600s leaves headroom for slower sub-agent dispatches
 # while staying below the sibling long-running planning-command budget.


### PR DESCRIPTION
## Summary

- Fixes `evals/cases/cut-from-spec.yaml`: the `prompt` field was referencing `evals/fixture/specs/cut-eval` (a directory) instead of `evals/fixture/specs/cut-eval/cut-eval.spec.md 1` (the spec file + story number).
- Without this fix, the runner composes `/smithy.cut evals/fixture/specs/cut-eval 1`, and cut's Phase 1 file-read fails immediately — the scenario would report FAIL on every `npm run eval` invocation.

## Artifact

`specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/03-cut-eval-inherits-spec-debt.tasks.md` — Slice 2, task "Author the cut-from-spec YAML scenario"

Acceptance criterion satisfied: `prompt` is the exact repo-relative path to the Slice 1 spec plant followed by user-story number `1`.

## Verification

- `evals/fixture/specs/cut-eval/cut-eval.spec.md` confirmed present (Slice 1 plant)
- `npm run test:evals` — 187/187 tests pass
- Full end-to-end `npm run eval -- --case cut-from-spec` requires US2 Slice 1 (runner git-init) to be merged first (documented cross-story dependency in the tasks file); not gated on this PR.

## Verification gaps

End-to-end eval PASS is deferred until US2 Slice 1 (runner git-init) merges — this is the documented hard cross-story dependency in the tasks file (see Cross-Story Dependencies table). This PR unblocks that run; it cannot be verified standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)