### PR TITLE
feat(status): make --all partition the JSON graph payload

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1580,9 +1580,14 @@ describe('CLI status', () => {
     // Tree connectors reappear once the descendants surface.
     expect(allOut).toMatch(/[├└]/);
 
-    // JSON mode: `--all` is a no-op; the `tree` field always reflects
-    // the uncollapsed `buildTree(records)` output verbatim so machine
-    // consumers get the complete structural projection.
+    // JSON mode: `--all` is a no-op for the `tree`, `records`, and
+    // `summary` fields — `tree` always reflects the uncollapsed
+    // `buildTree(records)` output verbatim so machine consumers get
+    // the complete structural projection. `--all` *does* affect the
+    // `graph` field: default mode hides done nodes and surfaces a
+    // `complete_count` per layer; `--all` mode emits the full graph
+    // with partition indexes. We compare the non-graph fields for
+    // structural equality and verify the graph field flips modes.
     const jsonDefault = execFileSync(
       'node',
       [CLI, 'status', '--format', 'json', '--root', tmpDir],
@@ -1593,7 +1598,23 @@ describe('CLI status', () => {
       [CLI, 'status', '--format', 'json', '--root', tmpDir, '--all'],
       { encoding: 'utf-8' },
     );
-    expect(jsonDefault).toBe(jsonAll);
+    const jsonDefaultPayload = JSON.parse(jsonDefault) as {
+      summary: unknown;
+      records: unknown;
+      tree: unknown;
+      graph: { mode: string };
+    };
+    const jsonAllPayload = JSON.parse(jsonAll) as {
+      summary: unknown;
+      records: unknown;
+      tree: unknown;
+      graph: { mode: string };
+    };
+    expect(jsonDefaultPayload.summary).toEqual(jsonAllPayload.summary);
+    expect(jsonDefaultPayload.records).toEqual(jsonAllPayload.records);
+    expect(jsonDefaultPayload.tree).toEqual(jsonAllPayload.tree);
+    expect(jsonDefaultPayload.graph.mode).toBe('pending-only');
+    expect(jsonAllPayload.graph.mode).toBe('all');
     // Sanity: the JSON tree exposes every uncollapsed descendant.
     const collapsePayload = JSON.parse(jsonDefault) as {
       tree: {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1035,7 +1035,7 @@ describe('CLI status', () => {
     expect(output).toContain('--no-color');
   });
 
-  it('emits contract-shaped JSON with records, summary, tree, graph, and full per-type counts (AS 7.2)', () => {
+  it('emits contract-shaped JSON with records, summary, graph, and full per-type counts (AS 7.2)', () => {
     // Fixture stitches one record of every artifact type — rfc,
     // features, spec, tasks — through the canonical lineage so every
     // `counts[type][status]` slot in `payload.summary.counts` is
@@ -1086,15 +1086,17 @@ describe('CLI status', () => {
           suppressed_by_ancestor?: boolean;
         } | null;
       }>;
-      tree: { roots: unknown[] };
+      tree?: unknown;
       graph: { nodes: unknown; layers: unknown[]; cycles: unknown[]; dangling_refs: unknown[] };
     };
 
-    // Top-level shape matches the contracts.
+    // Top-level shape matches the contracts. `tree` was dropped from
+    // the JSON payload — consumers reconstruct it locally from
+    // `records.parent_path`.
     expect(payload).toHaveProperty('summary');
     expect(payload).toHaveProperty('records');
-    expect(payload).toHaveProperty('tree');
     expect(payload).toHaveProperty('graph');
+    expect(payload).not.toHaveProperty('tree');
 
     // Records embed the parsed dependency_order sub-object.
     const specRecord = payload.records.find((r) => r.type === 'spec');
@@ -1308,13 +1310,15 @@ describe('CLI status', () => {
     const payload = JSON.parse(output) as {
       summary: { parse_error_count: number };
       records: unknown[];
-      tree: { roots: unknown[] };
       graph: { nodes: unknown; layers: unknown[] };
+      tree?: unknown;
     };
     expect(payload.records).toEqual([]);
     expect(payload.summary.parse_error_count).toBe(0);
-    expect(payload.tree.roots).toEqual([]);
     expect(payload.graph.layers).toEqual([]);
+    // `tree` was removed from the JSON payload — consumers reconstruct
+    // it locally from `records.parent_path`.
+    expect(payload.tree).toBeUndefined();
   });
 
   it('exits 2 with a stderr message on an invalid --status value', () => {
@@ -1337,6 +1341,143 @@ describe('CLI status', () => {
     expect(result.status).toBe(2);
     expect(result.stderr).toContain('invalid --type');
     expect(result.stderr).toContain('rfc');
+  });
+
+  it('accepts a comma-separated --status set and filters as the union of statuses', () => {
+    write(
+      'docs/rfcs/demo.rfc.md',
+      `# Demo\n\n## Dependency Order\n\n${TABLE_HEADER}\n| M1 | First Milestone | — | docs/rfcs/demo.features.md |\n`,
+    );
+    write(
+      'docs/rfcs/demo.features.md',
+      `# Demo Features\n\n## Dependency Order\n\n${TABLE_HEADER}\n| F1 | A | — | specs/a-spec/ |\n`,
+    );
+    write(
+      'specs/done-spec/done-spec.spec.md',
+      `# Feature Specification: Done\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Done Story | — | specs/done-spec/01-done.tasks.md |\n`,
+    );
+    write(
+      'specs/done-spec/01-done.tasks.md',
+      `# Done\n\n## Slice 1\n\n- [x] Done\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Slice One | — | — |\n`,
+    );
+    write(
+      'specs/a-spec/a-spec.spec.md',
+      `# Feature Specification: A\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Pending Story | — | — |\n`,
+    );
+
+    const result = spawnSync(
+      'node',
+      [
+        CLI,
+        'status',
+        '--root',
+        tmpDir,
+        '--format',
+        'json',
+        '--status',
+        'in-progress,not-started',
+      ],
+      { encoding: 'utf-8' },
+    );
+    expect(result.status).toBe(0);
+    const payload = JSON.parse(result.stdout) as {
+      records: Array<{ path: string; status: string }>;
+    };
+    const statuses = payload.records.map((r) => r.status);
+    // No done records survive as direct matches; done parents may
+    // appear only as ancestors of pending descendants.
+    expect(statuses).not.toContain('done');
+    // Multi-value matched: both in-progress and not-started reach
+    // the wire.
+    const pendingPaths = payload.records
+      .filter((r) => r.status !== 'done')
+      .map((r) => r.path);
+    expect(pendingPaths.length).toBeGreaterThan(0);
+  });
+
+  it('rejects --status with a mix of valid and invalid tokens (exits 2 on the invalid one)', () => {
+    const result = spawnSync(
+      'node',
+      [
+        CLI,
+        'status',
+        '--root',
+        tmpDir,
+        '--status',
+        'in-progress,bogus',
+      ],
+      { encoding: 'utf-8' },
+    );
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('invalid --status');
+    expect(result.stderr).toContain('bogus');
+  });
+
+  it('rejects --status with empty tokens (e.g., ",,in-progress")', () => {
+    const result = spawnSync(
+      'node',
+      [CLI, 'status', '--root', tmpDir, '--status', ',,in-progress'],
+      { encoding: 'utf-8' },
+    );
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('invalid --status');
+  });
+
+  it('--pending is exactly equivalent to --status in-progress,not-started', () => {
+    write(
+      'specs/wip-spec/wip-spec.spec.md',
+      `# Feature Specification: WIP\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | WIP | — | — |\n`,
+    );
+    write(
+      'specs/done-spec/done-spec.spec.md',
+      `# Feature Specification: Done\n\n## Dependency Order\n\n${TABLE_HEADER}\n| US1 | Done | — | specs/done-spec/01.tasks.md |\n`,
+    );
+    write(
+      'specs/done-spec/01.tasks.md',
+      `# Done\n\n## Slice 1\n\n- [x] Done\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | First | — | — |\n`,
+    );
+
+    const pending = spawnSync(
+      'node',
+      [CLI, 'status', '--root', tmpDir, '--format', 'json', '--pending'],
+      { encoding: 'utf-8' },
+    );
+    const statusMulti = spawnSync(
+      'node',
+      [
+        CLI,
+        'status',
+        '--root',
+        tmpDir,
+        '--format',
+        'json',
+        '--status',
+        'in-progress,not-started',
+      ],
+      { encoding: 'utf-8' },
+    );
+    expect(pending.status).toBe(0);
+    expect(statusMulti.status).toBe(0);
+    // Byte-for-byte identical payloads — `--pending` is pure sugar.
+    expect(pending.stdout).toBe(statusMulti.stdout);
+  });
+
+  it('rejects combining --pending with --status (the user has specified two intents)', () => {
+    const result = spawnSync(
+      'node',
+      [
+        CLI,
+        'status',
+        '--root',
+        tmpDir,
+        '--pending',
+        '--status',
+        'in-progress',
+      ],
+      { encoding: 'utf-8' },
+    );
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('--pending cannot be combined with --status');
   });
 
   it('surfaces individual parse failures as records with status unknown and exits 0', () => {
@@ -1363,11 +1504,16 @@ describe('CLI status', () => {
     expect(payload.summary.parse_error_count).toBeGreaterThan(0);
   });
 
-  it('populates tree.roots via buildTree against a full-chain + orphan + broken-link fixture', async () => {
-    // US2 Slice 1: verify the JSON payload's `tree` field is populated
-    // by `buildTree(records)` and matches byte-for-byte a tree built
-    // from the same records in-process. Fixture intentionally mixes
-    // three shapes: one full RFC→features→spec→tasks chain, one
+  it('emits records covering a full-chain + orphan + broken-link fixture, and tree-able via buildTree from records alone', async () => {
+    // US2 Slice 1 (post-tree-drop): the JSON payload no longer carries
+    // a `tree` field, but `records` still includes every artifact with
+    // its `parent_path`, so a consumer can reconstruct the same tree
+    // locally by calling `buildTree(payload.records)`. This test
+    // asserts both: (a) the records cover the full-chain + orphan +
+    // broken-link shape, and (b) re-running `buildTree` against the
+    // emitted records produces a tree whose roots include the
+    // sentinel groups and the chain's RFC. Fixture intentionally
+    // mixes three shapes: one full RFC→features→spec→tasks chain, one
     // orphaned spec, and one broken-link tasks file whose declared
     // `**Source**:` header points at a missing spec.
     const FEATURE_TABLE = `${TABLE_HEADER}\n| F1 | Chain Feature | — | specs/chain-feature/ |\n`;
@@ -1420,35 +1566,36 @@ describe('CLI status', () => {
           suppressed_by_ancestor?: boolean;
         } | null;
       }>;
-      tree: { roots: Array<{ record: { path: string; title: string }; children: unknown[] }> };
+      tree?: unknown;
     };
 
-    // Import `buildTree` from the status module so we can compute an
-    // expected tree from the records the CLI produced, and assert
-    // byte-for-byte equality against the tree the CLI emitted.
-    const { buildTree } = await import('./status/tree.js');
-    // Import the types via the records payload; we cast here because
-    // JSON.parse loses the ArtifactRecord type branding.
-    const expectedTree = buildTree(payload.records as Parameters<typeof buildTree>[0]);
+    // The payload no longer carries a `tree` field — sanity-check
+    // that explicitly so a future reintroduction is loud.
+    expect(payload.tree).toBeUndefined();
 
-    // Byte-for-byte match: serialize both sides and compare strings.
-    expect(JSON.stringify(payload.tree)).toBe(JSON.stringify(expectedTree));
+    // Reconstruct the tree locally from `records` and assert the
+    // expected structural shape. `buildTree` is the same projector
+    // the CLI used to inline; running it on `payload.records` proves
+    // the records are sufficient to recover the hierarchical view
+    // without paying for it on the wire.
+    const { buildTree } = await import('./status/tree.js');
+    const tree = buildTree(payload.records as Parameters<typeof buildTree>[0]);
 
     // Structural sanity: the tree should contain the Orphaned Specs
     // group, the Broken Links group, and a real chain root.
-    const rootPaths = payload.tree.roots.map((r) => r.record.path);
+    const rootPaths = tree.roots.map((r) => r.record.path);
     expect(rootPaths).toContain('__orphaned_specs__');
     expect(rootPaths).toContain('__broken_links__');
 
     // The Orphaned Specs group has exactly one child (our orphan spec).
-    const orphanGroup = payload.tree.roots.find(
+    const orphanGroup = tree.roots.find(
       (r) => r.record.path === '__orphaned_specs__',
     );
     expect(orphanGroup).toBeDefined();
     expect(orphanGroup?.children).toHaveLength(1);
 
     // The Broken Links group has exactly one child (our dangling tasks).
-    const brokenGroup = payload.tree.roots.find(
+    const brokenGroup = tree.roots.find(
       (r) => r.record.path === '__broken_links__',
     );
     expect(brokenGroup).toBeDefined();
@@ -1456,7 +1603,7 @@ describe('CLI status', () => {
 
     // A full-chain root (the RFC) also lives in roots, somewhere
     // below the group sentinels.
-    const realRoots = payload.tree.roots.filter(
+    const realRoots = tree.roots.filter(
       (r) => !r.record.path.startsWith('__'),
     );
     expect(realRoots.length).toBeGreaterThanOrEqual(1);
@@ -1464,16 +1611,15 @@ describe('CLI status', () => {
     // is reachable at the deepest position (AS 2.1).
     const rfcRoot = realRoots.find((r) => r.record.path.endsWith('.rfc.md'));
     expect(rfcRoot).toBeDefined();
-    const features = rfcRoot?.children as
-      | Array<{ record: { path: string }; children: Array<{ record: { path: string }; children: Array<{ record: { path: string } }> }> }>
-      | undefined;
-    expect(features?.[0]?.record.path).toBe('docs/rfcs/0001-demo.features.md');
-    expect(features?.[0]?.children[0]?.record.path).toBe(
+    expect(rfcRoot?.children[0]?.record.path).toBe(
+      'docs/rfcs/0001-demo.features.md',
+    );
+    expect(rfcRoot?.children[0]?.children[0]?.record.path).toBe(
       'specs/chain-feature/chain-feature.spec.md',
     );
-    expect(features?.[0]?.children[0]?.children[0]?.record.path).toBe(
-      'specs/chain-feature/01-chain-story.tasks.md',
-    );
+    expect(
+      rfcRoot?.children[0]?.children[0]?.children[0]?.record.path,
+    ).toBe('specs/chain-feature/01-chain-story.tasks.md');
 
     // US4 Slice 1 Task 2: at least one non-done record in this fixture
     // carries a populated `next_action` with a valid smithy command.
@@ -1580,14 +1726,15 @@ describe('CLI status', () => {
     // Tree connectors reappear once the descendants surface.
     expect(allOut).toMatch(/[├└]/);
 
-    // JSON mode: `--all` is a no-op for the `tree`, `records`, and
-    // `summary` fields — `tree` always reflects the uncollapsed
-    // `buildTree(records)` output verbatim so machine consumers get
-    // the complete structural projection. `--all` *does* affect the
-    // `graph` field: default mode hides done nodes and surfaces a
-    // `complete_count` per layer; `--all` mode emits the full graph
-    // with partition indexes. We compare the non-graph fields for
-    // structural equality and verify the graph field flips modes.
+    // JSON mode: `--all` is a no-op for the `records` and `summary`
+    // fields. `tree` is no longer emitted in JSON at all (consumers
+    // reconstruct it from `records.parent_path` locally), so the
+    // collapsing behavior is purely a text-mode concern. `--all`
+    // *does* affect the `graph` field: default mode hides done nodes
+    // and surfaces a `complete_count` per layer; `--all` mode emits
+    // the full graph with partition indexes. We compare the non-graph
+    // fields for structural equality and verify the graph field
+    // flips modes.
     const jsonDefault = execFileSync(
       'node',
       [CLI, 'status', '--format', 'json', '--root', tmpDir],
@@ -1601,48 +1748,21 @@ describe('CLI status', () => {
     const jsonDefaultPayload = JSON.parse(jsonDefault) as {
       summary: unknown;
       records: unknown;
-      tree: unknown;
+      tree?: unknown;
       graph: { mode: string };
     };
     const jsonAllPayload = JSON.parse(jsonAll) as {
       summary: unknown;
       records: unknown;
-      tree: unknown;
+      tree?: unknown;
       graph: { mode: string };
     };
     expect(jsonDefaultPayload.summary).toEqual(jsonAllPayload.summary);
     expect(jsonDefaultPayload.records).toEqual(jsonAllPayload.records);
-    expect(jsonDefaultPayload.tree).toEqual(jsonAllPayload.tree);
+    expect(jsonDefaultPayload.tree).toBeUndefined();
+    expect(jsonAllPayload.tree).toBeUndefined();
     expect(jsonDefaultPayload.graph.mode).toBe('pending-only');
     expect(jsonAllPayload.graph.mode).toBe('all');
-    // Sanity: the JSON tree exposes every uncollapsed descendant.
-    const collapsePayload = JSON.parse(jsonDefault) as {
-      tree: {
-        roots: Array<{
-          record: { path: string };
-          children: Array<{
-            record: { path: string };
-            children: Array<{
-              record: { path: string };
-              children: Array<{ record: { path: string } }>;
-            }>;
-          }>;
-        }>;
-      };
-    };
-    const collapseRfcRoot = collapsePayload.tree.roots.find((r) =>
-      r.record.path.endsWith('.rfc.md'),
-    );
-    expect(collapseRfcRoot).toBeDefined();
-    expect(collapseRfcRoot?.children[0]?.record.path).toBe(
-      'docs/rfcs/01-milestone-one.features.md',
-    );
-    expect(collapseRfcRoot?.children[0]?.children[0]?.record.path).toBe(
-      'specs/feature-a/feature-a.spec.md',
-    );
-    expect(
-      collapseRfcRoot?.children[0]?.children[0]?.children[0]?.record.path,
-    ).toBe('specs/feature-a/01-first.tasks.md');
   });
 
   it('text mode renders next-action hints beneath actionable records only (US4 Slice 2, AS 4.1–4.5)', () => {
@@ -1819,7 +1939,6 @@ describe('CLI status', () => {
           virtual?: boolean;
           parent_path?: string | null;
         }>;
-        tree: { roots: Array<{ record: { path: string } }> };
       };
       raw: string;
     } {
@@ -1936,25 +2055,18 @@ describe('CLI status', () => {
       );
     });
 
-    it('--format json emits the filtered records and tree', () => {
+    it('--format json emits only filtered records (no hierarchical tree on the wire)', () => {
       writeFilterFixture();
       const { payload } = runStatusJson(['--status', 'in-progress']);
-      // `records` and `tree.roots` are both computed from the
-      // filtered set — Feature B's tree must not leak into `tree`.
-      const treePaths: string[] = [];
-      const walk = (nodes: typeof payload.tree.roots): void => {
-        for (const n of nodes) {
-          treePaths.push(n.record.path);
-          walk(
-            (n as unknown as {
-              children: typeof payload.tree.roots;
-            }).children,
-          );
-        }
-      };
-      walk(payload.tree.roots);
-      expect(treePaths).not.toContain('specs/feature-b/feature-b.spec.md');
-      expect(treePaths).toContain('specs/feature-a/01-story-a.tasks.md');
+      // The JSON payload no longer carries `tree` — consumers
+      // reconstruct it locally from `records.parent_path`. The
+      // filter's correctness is therefore expressed entirely against
+      // `records`: Feature B's records must be dropped and Feature
+      // A's tasks records must survive.
+      expect(payload).not.toHaveProperty('tree');
+      const paths = payload.records.map((r) => r.path);
+      expect(paths).not.toContain('specs/feature-b/feature-b.spec.md');
+      expect(paths).toContain('specs/feature-a/01-story-a.tasks.md');
     });
 
     it('summary counts are byte-identical with and without filter flags against the same fixture (SD-010)', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,7 +86,8 @@ program
   // exits with code 1, while the contracts mandate exit code 2 for
   // invalid values on these two flags. `statusAction` validates them
   // manually and sets `process.exitCode = 2`.
-  .option('--status <state>', 'Filter by status: done|in-progress|not-started|unknown')
+  .option('--status <states>', 'Filter by status (comma-separated for multi-value): done|in-progress|not-started|unknown')
+  .option('--pending', 'Shorthand for --status in-progress,not-started (the work left to dispatch)')
   .option('--type <artifact-type>', 'Filter by artifact type: rfc|features|spec|tasks')
   .option('--all', 'Disable collapsing of done subtrees so every artifact surfaces')
   .option('--graph', 'Render the cross-artifact dependency graph as topological layers (text mode)')

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1071,11 +1071,66 @@ describe('serializeGraphForJson', () => {
     }
   });
 
-  it('default mode filters the top-level nodes map to match visible IDs', () => {
+  it('default mode keeps every non-done node in graph.nodes (not just IDs in layers)', () => {
     const graph = makeGraph([
       { id: 'US1', status: 'done' },
       { id: 'US2', status: 'in-progress' },
     ]);
+    const serialized = serializeGraphForJson(graph, { all: false });
+    expect(Object.keys(serialized.nodes)).toEqual([id('US2')]);
+    expect(serialized.nodes[id('US1')]).toBeUndefined();
+  });
+
+  it('default mode preserves pending cycle participants that Kahn omitted from layers', () => {
+    // Simulates a repo with a 2-node cycle: US1 ↔ US2. Kahn's algorithm
+    // cannot place either in `layers`, so they only appear in `cycles`.
+    // The pending-only `nodes` map must still carry their metadata so
+    // the skill's "missing from graph.nodes ⇒ done" rule stays valid.
+    const graph: DependencyGraph = {
+      nodes: {
+        [id('US1')]: {
+          record_path: SPEC,
+          row: { id: 'US1', title: 'US1', depends_on: ['US2'], artifact_path: null },
+          status: 'in-progress',
+        },
+        [id('US2')]: {
+          record_path: SPEC,
+          row: { id: 'US2', title: 'US2', depends_on: ['US1'], artifact_path: null },
+          status: 'not-started',
+        },
+      },
+      layers: [],
+      cycles: [[id('US1'), id('US2')]],
+      dangling_refs: [],
+    };
+    const serialized = serializeGraphForJson(graph, { all: false });
+    expect(serialized.layers).toEqual([]);
+    expect(Object.keys(serialized.nodes).sort()).toEqual([id('US1'), id('US2')]);
+    expect(serialized.cycles).toEqual([[id('US1'), id('US2')]]);
+  });
+
+  it('default mode still drops done nodes even when they appear in graph.cycles', () => {
+    // A done node referenced by `cycles` should not be revived into the
+    // pending-only `nodes` map — pending-only's only purpose is dropping
+    // done. Skill rule: missing ⇒ done. Done nodes in cycles are still
+    // missing from `nodes`, and that is correct.
+    const graph: DependencyGraph = {
+      nodes: {
+        [id('US1')]: {
+          record_path: SPEC,
+          row: { id: 'US1', title: 'US1', depends_on: ['US2'], artifact_path: null },
+          status: 'done',
+        },
+        [id('US2')]: {
+          record_path: SPEC,
+          row: { id: 'US2', title: 'US2', depends_on: ['US1'], artifact_path: null },
+          status: 'in-progress',
+        },
+      },
+      layers: [],
+      cycles: [[id('US1'), id('US2')]],
+      dangling_refs: [],
+    };
     const serialized = serializeGraphForJson(graph, { all: false });
     expect(Object.keys(serialized.nodes)).toEqual([id('US2')]);
     expect(serialized.nodes[id('US1')]).toBeUndefined();

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -27,8 +27,10 @@ import type {
   DependencyGraph,
   NextAction,
   ScanSummary,
+  SerializedGraph,
   StatusTree,
 } from '../status/index.js';
+import { serializeGraphForJson } from '../status/index.js';
 import { createTheme, type Theme } from '../status/theme.js';
 
 const theme: Theme = createTheme({ color: false, encoding: 'utf8' });
@@ -395,18 +397,18 @@ describe('pickTopNextAction', () => {
 });
 
 /**
- * US10 Slice 1: lock in the type wiring between the JSON payload's
- * `graph` field and the canonical {@link DependencyGraph} type. The
- * compile-time assertions below would have failed against the
- * previous inline structural type (`Record<string, never>` / `[]`
- * literal tuples) because a populated `DependencyGraph` is not
- * assignable to that shape. The runtime guard re-checks the
- * zero-value stub still slots into the new type.
+ * Lock in the type wiring between the JSON payload's `graph` field and
+ * the canonical {@link SerializedGraph} type. `StatusJsonPayload.graph`
+ * used to be a raw {@link DependencyGraph}; now it is a
+ * {@link SerializedGraph} produced by {@link serializeGraphForJson}, so
+ * a hand-constructed `SerializedGraph` (matching either `mode`) must
+ * satisfy the payload's compile-time shape.
  */
-describe('StatusJsonPayload.graph type wiring (US10 Slice 1)', () => {
-  it('accepts a populated DependencyGraph as the graph field', () => {
+describe('StatusJsonPayload.graph type wiring', () => {
+  it('accepts a populated SerializedGraph (pending-only mode) as the graph field', () => {
     const fqId = 'specs/sample/sample.spec.md#US1';
-    const populated: DependencyGraph = {
+    const populated: SerializedGraph = {
+      mode: 'pending-only',
       nodes: {
         [fqId]: {
           record_path: 'specs/sample/sample.spec.md',
@@ -419,14 +421,12 @@ describe('StatusJsonPayload.graph type wiring (US10 Slice 1)', () => {
           status: 'not-started',
         },
       },
-      layers: [{ layer: 0, node_ids: [fqId] }],
+      layers: [
+        { mode: 'pending-only', layer: 0, node_ids: [fqId], complete_count: 0 },
+      ],
       cycles: [],
       dangling_refs: [],
     };
-    // Compile-time assertion: assigning a populated DependencyGraph
-    // to the `graph` field must typecheck. Under the previous inline
-    // type this would have produced TS2322 because `Record<string,
-    // DependencyNode>` is not assignable to `Record<string, never>`.
     const payload: StatusJsonPayload = {
       summary: {
         counts: emptyCounts(),
@@ -444,10 +444,57 @@ describe('StatusJsonPayload.graph type wiring (US10 Slice 1)', () => {
     expect(payload.graph.layers[0]?.node_ids).toEqual([fqId]);
   });
 
-  it('still accepts the zero-value runtime stub (Slice 1 emission unchanged)', () => {
-    // Mirrors the literal currently emitted by `statusAction` in JSON
-    // mode — Slice 3 swaps it for `buildDependencyGraph(records)`.
-    const stub: DependencyGraph = {
+  it('accepts a populated SerializedGraph (all mode) as the graph field', () => {
+    const fqId = 'specs/sample/sample.spec.md#US1';
+    const populated: SerializedGraph = {
+      mode: 'all',
+      nodes: {
+        [fqId]: {
+          record_path: 'specs/sample/sample.spec.md',
+          row: {
+            id: 'US1',
+            title: 'Sample story',
+            depends_on: [],
+            artifact_path: null,
+          },
+          status: 'done',
+        },
+      },
+      layers: [
+        {
+          mode: 'all',
+          layer: 0,
+          node_ids: [fqId],
+          pending_node_indexes: [],
+          complete_node_indexes: [0],
+        },
+      ],
+      cycles: [],
+      dangling_refs: [],
+    };
+    const payload: StatusJsonPayload = {
+      summary: {
+        counts: emptyCounts(),
+        orphan_count: 0,
+        broken_link_count: 0,
+        parse_error_count: 0,
+      },
+      records: [],
+      tree: { roots: [] },
+      graph: populated,
+    };
+    const firstLayer = payload.graph.layers[0]!;
+    expect(firstLayer.mode).toBe('all');
+    if (firstLayer.mode === 'all') {
+      expect(firstLayer.complete_node_indexes).toEqual([0]);
+    }
+  });
+
+  it('still accepts the zero-value runtime stub', () => {
+    // Mirrors the canonical empty-repo emission from `statusAction`
+    // after the JSON branch was rewired through `serializeGraphForJson`.
+    const stub: SerializedGraph = {
+      mode: 'pending-only',
       nodes: {},
       layers: [],
       cycles: [],
@@ -464,6 +511,7 @@ describe('StatusJsonPayload.graph type wiring (US10 Slice 1)', () => {
       tree: { roots: [] },
       graph: stub,
     };
+    expect(payload.graph.mode).toBe('pending-only');
     expect(payload.graph.nodes).toEqual({});
     expect(payload.graph.layers).toEqual([]);
     expect(payload.graph.cycles).toEqual([]);
@@ -608,11 +656,16 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
 
   // --- AS 10.5: JSON graph populated unconditionally ---
 
-  it('AS 10.5: JSON `graph` is populated from buildDependencyGraph (multi-row spec)', () => {
+  it('AS 10.5: JSON `graph` is populated from buildDependencyGraph (multi-row spec, --all reveals done nodes)', () => {
     writeFourStoryFixture();
-    statusAction({ root, format: 'json' });
+    // Pass `--all` so done nodes (US1 + its tasks file) survive the
+    // serializer's default hide-done filter — this test pins the
+    // builder wiring, not the filter.
+    statusAction({ root, format: 'json', all: true });
     const payload = JSON.parse(captured()) as StatusJsonPayload;
-    // Nodes contains every fully-qualified row.
+    // Nodes contains every fully-qualified row, including the done
+    // US1 row, because we asked for the full graph.
+    expect(payload.graph.mode).toBe('all');
     expect(Object.keys(payload.graph.nodes).length).toBeGreaterThan(0);
     expect(payload.graph.nodes['specs/sample/sample.spec.md#US1']).toBeDefined();
     // Layers carry node_ids, not `ids`.
@@ -641,7 +694,8 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
   it('AS 10.5: JSON `graph` is the canonical zero-value shape on an empty repo', () => {
     statusAction({ root, format: 'json' });
     const payload = JSON.parse(captured()) as StatusJsonPayload;
-    expect(payload.graph).toEqual<DependencyGraph>({
+    expect(payload.graph).toEqual<SerializedGraph>({
+      mode: 'pending-only',
       nodes: {},
       layers: [],
       cycles: [],
@@ -649,13 +703,77 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
     });
   });
 
-  it('AS 10.5: JSON `graph` reflects the pre-filter scan even when --status excludes some records (SD-010)', () => {
+  it('JSON `graph` empty-repo shape under `--all` reports mode `all`', () => {
+    statusAction({ root, format: 'json', all: true });
+    const payload = JSON.parse(captured()) as StatusJsonPayload;
+    expect(payload.graph).toEqual<SerializedGraph>({
+      mode: 'all',
+      nodes: {},
+      layers: [],
+      cycles: [],
+      dangling_refs: [],
+    });
+  });
+
+  it('default JSON `graph` hides done nodes and reports them via complete_count (matches text --graph)', () => {
+    // writeFourStoryFixture sets US1 (and its tasks file) to done; US2
+    // is in-progress; US3/US4 not-started. Without `--all` the
+    // serializer should drop US1 from layer node_ids and from the
+    // top-level nodes map, and surface the omission via complete_count.
+    writeFourStoryFixture();
+    statusAction({ root, format: 'json' });
+    const payload = JSON.parse(captured()) as StatusJsonPayload;
+    expect(payload.graph.mode).toBe('pending-only');
+    // US1 (done) is hidden from the top-level nodes map.
+    expect(payload.graph.nodes['specs/sample/sample.spec.md#US1']).toBeUndefined();
+    // US2/US3/US4 (pending) remain in the graph.
+    expect(payload.graph.nodes['specs/sample/sample.spec.md#US2']).toBeDefined();
+    expect(payload.graph.nodes['specs/sample/sample.spec.md#US3']).toBeDefined();
+    expect(payload.graph.nodes['specs/sample/sample.spec.md#US4']).toBeDefined();
+    // Every layer's node_ids excludes the done US1 node, and the
+    // complete_count across all layers covers the dropped done items
+    // (US1 spec row + US1 tasks-file rows).
+    const totalComplete = payload.graph.layers.reduce((sum, layer) => {
+      if (layer.mode === 'pending-only') return sum + layer.complete_count;
+      return sum;
+    }, 0);
+    expect(totalComplete).toBeGreaterThan(0);
+    for (const layer of payload.graph.layers) {
+      expect(layer.node_ids).not.toContain('specs/sample/sample.spec.md#US1');
+    }
+  });
+
+  it('default JSON `graph` omits fully-done layers entirely (matches text --graph)', () => {
+    // writeAllDoneFixture: every row in every artifact rolls up to done.
+    // Default mode should drop every layer; the all-mode JSON should
+    // keep them (proving that the omission is the serializer's choice,
+    // not the builder's).
+    writeAllDoneFixture();
+
+    statusAction({ root, format: 'json' });
+    const defaultPayload = JSON.parse(captured()) as StatusJsonPayload;
+    expect(defaultPayload.graph.layers).toEqual([]);
+    expect(defaultPayload.graph.nodes).toEqual({});
+
+    logSpy.mockClear();
+    statusAction({ root, format: 'json', all: true });
+    const allPayload = JSON.parse(captured()) as StatusJsonPayload;
+    expect(allPayload.graph.mode).toBe('all');
+    expect(allPayload.graph.layers.length).toBeGreaterThan(0);
+    expect(Object.keys(allPayload.graph.nodes).length).toBeGreaterThan(0);
+  });
+
+  it('AS 10.5: JSON `graph` reflects the pre-filter scan even when --status excludes some records (SD-010, with --all)', () => {
     writeFourStoryFixture();
     // US1's tasks file is fully checked → US1 rolls up to `done`.
     // Filtering by --status=in-progress would exclude it from the
     // `records` field, but the `graph` is built pre-filter so it must
-    // still carry the US1 node.
-    statusAction({ root, format: 'json', status: 'in-progress' });
+    // still carry the US1 node when the consumer asks for the full
+    // graph (`--all`). The default serializer hides done nodes on its
+    // own axis — that's covered by a separate test below; SD-010 here
+    // is about the `--status`/`--type` filters not leaking into the
+    // graph projection.
+    statusAction({ root, format: 'json', status: 'in-progress', all: true });
     const payload = JSON.parse(captured()) as StatusJsonPayload;
     // The filter dropped done records from `payload.records`...
     const filteredHasUs1 = payload.records.some(
@@ -705,9 +823,10 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
     // hint for the dim FQ id suffix when records are supplied. Lock
     // the FQ ids to the JSON payload so machine consumers still have
     // the canonical reference for every node, decoupled from text-mode
-    // styling decisions.
+    // styling decisions. Pass `--all` so done nodes (US1) survive the
+    // default hide-done filter.
     writeFourStoryFixture();
-    statusAction({ root, format: 'json' });
+    statusAction({ root, format: 'json', all: true });
     const payload = JSON.parse(captured()) as StatusJsonPayload;
     expect(payload.graph.nodes['specs/sample/sample.spec.md#US1']).toBeDefined();
     expect(payload.graph.nodes['specs/sample/sample.spec.md#US2']).toBeDefined();
@@ -904,5 +1023,146 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
     expect(stdout).toContain('Sample Spec');
     expect(stdout).toContain('smithy.forge specs/sample/');
     expect(stdout).not.toContain('specs/sample/sample.spec.md#US');
+  });
+});
+
+/**
+ * Direct coverage for `serializeGraphForJson`. Hand-built
+ * {@link DependencyGraph}s exercise the partition logic without going
+ * through the scanner pipeline, so the assertions stay focused on the
+ * serializer's two modes and on the asymmetries between them.
+ */
+describe('serializeGraphForJson', () => {
+  const SPEC = 'specs/x/x.spec.md';
+  const id = (row: string): string => `${SPEC}#${row}`;
+
+  function makeGraph(rows: Array<{ id: string; status: ArtifactRecord['status'] }>): DependencyGraph {
+    const nodes: DependencyGraph['nodes'] = {};
+    for (const r of rows) {
+      nodes[id(r.id)] = {
+        record_path: SPEC,
+        row: { id: r.id, title: r.id, depends_on: [], artifact_path: null },
+        status: r.status,
+      };
+    }
+    return {
+      nodes,
+      layers: [{ layer: 0, node_ids: rows.map((r) => id(r.id)) }],
+      cycles: [],
+      dangling_refs: [],
+    };
+  }
+
+  it('default mode (all=false) drops done nodes from node_ids and reports complete_count', () => {
+    const graph = makeGraph([
+      { id: 'US1', status: 'done' },
+      { id: 'US2', status: 'in-progress' },
+      { id: 'US3', status: 'done' },
+      { id: 'US4', status: 'not-started' },
+    ]);
+    const serialized = serializeGraphForJson(graph, { all: false });
+    expect(serialized.mode).toBe('pending-only');
+    expect(serialized.layers).toHaveLength(1);
+    const layer = serialized.layers[0]!;
+    expect(layer.mode).toBe('pending-only');
+    if (layer.mode === 'pending-only') {
+      expect(layer.node_ids).toEqual([id('US2'), id('US4')]);
+      expect(layer.complete_count).toBe(2);
+    }
+  });
+
+  it('default mode filters the top-level nodes map to match visible IDs', () => {
+    const graph = makeGraph([
+      { id: 'US1', status: 'done' },
+      { id: 'US2', status: 'in-progress' },
+    ]);
+    const serialized = serializeGraphForJson(graph, { all: false });
+    expect(Object.keys(serialized.nodes)).toEqual([id('US2')]);
+    expect(serialized.nodes[id('US1')]).toBeUndefined();
+  });
+
+  it('default mode omits a layer composed entirely of done nodes', () => {
+    const graph: DependencyGraph = {
+      nodes: {
+        [id('US1')]: {
+          record_path: SPEC,
+          row: { id: 'US1', title: 'US1', depends_on: [], artifact_path: null },
+          status: 'done',
+        },
+        [id('US2')]: {
+          record_path: SPEC,
+          row: { id: 'US2', title: 'US2', depends_on: [], artifact_path: null },
+          status: 'in-progress',
+        },
+      },
+      layers: [
+        { layer: 0, node_ids: [id('US1')] },
+        { layer: 1, node_ids: [id('US2')] },
+      ],
+      cycles: [],
+      dangling_refs: [],
+    };
+    const serialized = serializeGraphForJson(graph, { all: false });
+    // Layer 0 (all done) is omitted; Layer 1 survives, retaining its
+    // original `layer: 1` number — the serializer must not re-index.
+    expect(serialized.layers).toHaveLength(1);
+    expect(serialized.layers[0]?.layer).toBe(1);
+  });
+
+  it('--all mode keeps every node and partitions by status via indexes', () => {
+    const graph = makeGraph([
+      { id: 'US1', status: 'done' },
+      { id: 'US2', status: 'in-progress' },
+      { id: 'US3', status: 'done' },
+      { id: 'US4', status: 'not-started' },
+    ]);
+    const serialized = serializeGraphForJson(graph, { all: true });
+    expect(serialized.mode).toBe('all');
+    expect(Object.keys(serialized.nodes).sort()).toEqual([
+      id('US1'),
+      id('US2'),
+      id('US3'),
+      id('US4'),
+    ]);
+    expect(serialized.layers).toHaveLength(1);
+    const layer = serialized.layers[0]!;
+    expect(layer.mode).toBe('all');
+    if (layer.mode === 'all') {
+      expect(layer.node_ids).toEqual([id('US1'), id('US2'), id('US3'), id('US4')]);
+      expect(layer.pending_node_indexes).toEqual([1, 3]);
+      expect(layer.complete_node_indexes).toEqual([0, 2]);
+    }
+  });
+
+  it('--all mode preserves a fully-done layer that default mode would omit', () => {
+    const graph = makeGraph([
+      { id: 'US1', status: 'done' },
+      { id: 'US2', status: 'done' },
+    ]);
+    const defaultSerialized = serializeGraphForJson(graph, { all: false });
+    expect(defaultSerialized.layers).toHaveLength(0);
+    const allSerialized = serializeGraphForJson(graph, { all: true });
+    expect(allSerialized.layers).toHaveLength(1);
+    const layer = allSerialized.layers[0]!;
+    if (layer.mode === 'all') {
+      expect(layer.complete_node_indexes).toEqual([0, 1]);
+      expect(layer.pending_node_indexes).toEqual([]);
+    }
+  });
+
+  it('passes cycles and dangling_refs through verbatim in both modes', () => {
+    const graph: DependencyGraph = {
+      nodes: {},
+      layers: [],
+      cycles: [[id('US1'), id('US2')]],
+      dangling_refs: [{ source_id: id('US1'), missing_id: id('US9') }],
+    };
+    for (const all of [false, true]) {
+      const serialized = serializeGraphForJson(graph, { all });
+      expect(serialized.cycles).toEqual([[id('US1'), id('US2')]]);
+      expect(serialized.dangling_refs).toEqual([
+        { source_id: id('US1'), missing_id: id('US9') },
+      ]);
+    }
   });
 });

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -435,7 +435,6 @@ describe('StatusJsonPayload.graph type wiring', () => {
         parse_error_count: 0,
       },
       records: [],
-      tree: { roots: [] },
       graph: populated,
     };
     expect(payload.graph.nodes[fqId]?.record_path).toBe(
@@ -480,7 +479,6 @@ describe('StatusJsonPayload.graph type wiring', () => {
         parse_error_count: 0,
       },
       records: [],
-      tree: { roots: [] },
       graph: populated,
     };
     const firstLayer = payload.graph.layers[0]!;
@@ -508,7 +506,6 @@ describe('StatusJsonPayload.graph type wiring', () => {
         parse_error_count: 0,
       },
       records: [],
-      tree: { roots: [] },
       graph: stub,
     };
     expect(payload.graph.mode).toBe('pending-only');

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -16,17 +16,21 @@
  *   5. Emit either contract-shaped JSON (`--format json`) or a per-type
  *      roll-up summary header followed by a hierarchical tree with
  *      next-action hints (default, via {@link renderTree} with
- *      `renderHints: true`). The JSON `tree` field is populated via
- *      {@link buildTree} (US2 Slice 1); the JSON `graph` field is
- *      populated via {@link buildDependencyGraph} (US10 Slice 3) and
- *      always carries the canonical four keys (`nodes`, `layers`,
- *      `cycles`, `dangling_refs`) so machine consumers can depend on
- *      the top-level shape. `--graph` (US10 Slice 3) routes text
- *      mode through {@link renderGraph}, printing topological layers
- *      with done-layer collapsing, a cycle-warning fallback, and
- *      dangling-ref diagnostics. The summary header still prints
- *      above the graph view so users keep the per-type counts and
- *      `Next:` hint they get in the default text path.
+ *      `renderHints: true`). The JSON payload carries `summary`,
+ *      `records`, and `graph` — no hierarchical `tree`, since
+ *      `records` already exposes `parent_path` on every entry and any
+ *      consumer can reconstruct the tree locally via {@link buildTree}
+ *      without paying for the duplication on the wire. The JSON
+ *      `graph` field is populated via {@link buildDependencyGraph}
+ *      (US10 Slice 3) and always carries the canonical four keys
+ *      (`nodes`, `layers`, `cycles`, `dangling_refs`) so machine
+ *      consumers can depend on the top-level shape. `--graph` (US10
+ *      Slice 3) routes text mode through {@link renderGraph},
+ *      printing topological layers with done-layer collapsing, a
+ *      cycle-warning fallback, and dangling-ref diagnostics. The
+ *      summary header still prints above the graph view so users keep
+ *      the per-type counts and `Next:` hint they get in the default
+ *      text path.
  *   6. On an empty repo (no discovered artifacts), print a friendly hint
  *      pointing at `smithy.ignite` / `smithy.mark` and exit 0 — the
  *      contracts treat this as "not an error". The empty-repo hint
@@ -43,10 +47,13 @@
  * done-subtree collapsing in text mode via the pure `collapseTree`
  * transform inserted between `buildTree` and `renderTree` (US3) and
  * also disables done-layer collapsing inside {@link renderGraph}
- * (US10); JSON mode continues to emit the uncollapsed tree structure
- * unconditionally. `--no-color` is honored via {@link buildTheme}'s
- * `noColor` flag (also picked up from the ambient `NO_COLOR` env
- * var) so every painted surface respects it.
+ * (US10); JSON mode no longer emits a hierarchical `tree` field, so
+ * `--all` affects only `records` (via the `--status` / `--type`
+ * filter set the user passed) and `graph` (via
+ * {@link serializeGraphForJson}'s `mode` discriminator) on the wire.
+ * `--no-color` is honored via {@link buildTheme}'s `noColor` flag
+ * (also picked up from the ambient `NO_COLOR` env var) so every
+ * painted surface respects it.
  */
 
 import fs from 'node:fs';
@@ -90,10 +97,24 @@ export interface StatusOptions {
   /** Output format. Defaults to `text`. */
   format?: 'text' | 'json';
   /**
-   * Filter by status. Retains matching records and every ancestor by
-   * `parent_path` so the renderer keeps context (AS 6.1).
+   * Filter by status. Accepts either a single {@link Status} or a
+   * comma-separated list (e.g., `in-progress,not-started`). Retains
+   * matching records and every ancestor by `parent_path` so the
+   * renderer keeps context (AS 6.1). At the Commander layer this is a
+   * raw string (single value, or comma-joined); {@link statusAction}
+   * splits and validates it before handing the parsed `Status[]` to
+   * {@link filterRecords}.
    */
-  status?: Status;
+  status?: string;
+  /**
+   * Shorthand for `--status in-progress,not-started` — the set of
+   * artifacts that have outstanding work to dispatch. Mutually
+   * exclusive with `--status`: combining them is an error so the CLI
+   * never has to pick a winner. When set, the effective filter set is
+   * `['in-progress', 'not-started']` and the JSON / text emission
+   * shrinks accordingly.
+   */
+  pending?: boolean;
   /**
    * Filter by artifact type. Retains matching records and their
    * ancestors as headers (AS 6.3). Descendants are hidden.
@@ -109,9 +130,10 @@ export interface StatusOptions {
    * layer drops `done` nodes from `node_ids` and reports the omitted
    * count via `complete_count`; under `--all` the layer keeps every
    * member with `pending_node_indexes` / `complete_node_indexes`
-   * partitions. Has no effect on the `tree` or `records` fields in
-   * `--format json` output, which always emit the uncollapsed
-   * `buildTree(records)` / filtered record set.
+   * partitions. Has no effect on the `records` field in `--format
+   * json` output, which always reflects the filter set applied above.
+   * The JSON payload no longer carries a `tree` field — consumers
+   * reconstruct it locally via {@link buildTree} from `records`.
    */
   all?: boolean;
   /**
@@ -142,28 +164,39 @@ export interface StatusOptions {
 }
 
 /**
- * Contract-shaped JSON payload emitted by `--format json`. `tree` is
- * populated by {@link buildTree} (US2 Slice 1) over the post-filter
- * record set; `graph` is populated by {@link buildDependencyGraph}
- * (US10 Slice 3) over the *pre-filter* record set per SD-010 so the
- * graph reflects the full scan even when `--status` / `--type` are
- * present, then projected through {@link serializeGraphForJson} into
- * the wire-format {@link SerializedGraph}. The serializer honors the
- * CLI `--all` flag: by default (no `--all`) every layer drops its
- * `done` nodes from `node_ids` and reports the omitted count via
- * `complete_count`, and the top-level `nodes` map is filtered to match;
- * under `--all` the layer keeps every member with `pending_node_indexes`
- * / `complete_node_indexes` partitions, and `nodes` is complete. The
+ * Contract-shaped JSON payload emitted by `--format json`.
+ *
+ * `records` is the post-filter `ArtifactRecord[]` from
+ * {@link filterRecords} — the canonical flat representation every
+ * machine consumer reads. `graph` is populated by
+ * {@link buildDependencyGraph} (US10 Slice 3) over the *pre-filter*
+ * record set per SD-010 so the graph reflects the full scan even when
+ * `--status` / `--type` are present, then projected through
+ * {@link serializeGraphForJson} into the wire-format
+ * {@link SerializedGraph}. The serializer honors the CLI `--all` flag:
+ * by default (no `--all`) every layer drops its `done` nodes from
+ * `node_ids` and reports the omitted count via `complete_count`, and
+ * the top-level `nodes` map is filtered to match; under `--all` the
+ * layer keeps every member with `pending_node_indexes` /
+ * `complete_node_indexes` partitions, and `nodes` is complete. The
  * `mode` discriminator on the serialized graph and on each layer
- * mirrors which mode produced the payload. The top-level shape
- * (`summary`, `records`, `tree`, `graph` with `mode` / `nodes` /
- * `layers` / `cycles` / `dangling_refs`) is emitted unconditionally,
- * including for an empty repo — so machine consumers can depend on it.
+ * mirrors which mode produced the payload.
+ *
+ * Note: the hierarchical `tree` projection is **not** emitted in JSON.
+ * The flat `records` array carries `parent_path` on every entry, so
+ * any consumer can reconstruct the same tree locally via
+ * {@link buildTree} without paying for the duplication on the wire.
+ * Dropping it cuts the default payload roughly in half. The in-memory
+ * {@link StatusTree} is still computed for text-mode rendering.
+ *
+ * The top-level shape (`summary`, `records`, `graph` with `mode` /
+ * `nodes` / `layers` / `cycles` / `dangling_refs`) is emitted
+ * unconditionally, including for an empty repo — so machine consumers
+ * can depend on it.
  */
 export interface StatusJsonPayload {
   summary: ScanSummary;
   records: ArtifactRecord[];
-  tree: StatusTree;
   graph: SerializedGraph;
 }
 
@@ -193,13 +226,52 @@ export function statusAction(opts: StatusOptions = {}): void {
   // Validated here (not via Commander `.choices()`) because the
   // contracts mandate exit code 2 for these errors, while Commander's
   // built-in invalid-choice handler exits with code 1.
-  if (opts.status !== undefined && !VALID_STATUSES.includes(opts.status)) {
-    process.stderr.write(
-      `smithy status: invalid --status value '${opts.status}'. Valid values: ${VALID_STATUSES.join(', ')}\n`,
-    );
-    process.exitCode = 2;
-    return;
+  //
+  // `--status` accepts either a single value or a comma-separated set
+  // (e.g., `in-progress,not-started`). Split on commas, trim, and
+  // validate each token; an unknown token aborts the run with the
+  // standard exit-2 message. Empty tokens (`--status ,,in-progress`)
+  // and an entirely empty value are also rejected so the failure mode
+  // is loud.
+  let parsedStatuses: Status[] | undefined;
+  if (opts.status !== undefined) {
+    const tokens = opts.status
+      .split(',')
+      .map((token) => token.trim());
+    if (tokens.length === 0 || tokens.some((token) => token.length === 0)) {
+      process.stderr.write(
+        `smithy status: invalid --status value '${opts.status}'. Valid values: ${VALID_STATUSES.join(', ')}\n`,
+      );
+      process.exitCode = 2;
+      return;
+    }
+    for (const token of tokens) {
+      if (!VALID_STATUSES.includes(token as Status)) {
+        process.stderr.write(
+          `smithy status: invalid --status value '${token}'. Valid values: ${VALID_STATUSES.join(', ')}\n`,
+        );
+        process.exitCode = 2;
+        return;
+      }
+    }
+    parsedStatuses = tokens as Status[];
   }
+
+  // `--pending` is a shorthand for `--status in-progress,not-started`.
+  // Combining the two is an error: the user has stated two different
+  // status intents, and silently honoring one would mask the
+  // contradiction.
+  if (opts.pending === true) {
+    if (parsedStatuses !== undefined) {
+      process.stderr.write(
+        `smithy status: --pending cannot be combined with --status (--pending is a shorthand for --status in-progress,not-started).\n`,
+      );
+      process.exitCode = 2;
+      return;
+    }
+    parsedStatuses = ['in-progress', 'not-started'];
+  }
+
   if (opts.type !== undefined && !VALID_TYPES.includes(opts.type)) {
     process.stderr.write(
       `smithy status: invalid --type value '${opts.type}'. Valid values: ${VALID_TYPES.join(', ')}\n`,
@@ -272,9 +344,12 @@ export function statusAction(opts: StatusOptions = {}): void {
   };
   // Build a sparse options object — `exactOptionalPropertyTypes` in
   // tsconfig forbids assigning `undefined` to optional fields, so we
-  // only set each key when Commander actually populated it.
+  // only set each key when Commander actually populated it. `status`
+  // is the parsed `Status[]` (the validation block above split,
+  // trimmed, and validated each comma-separated token); the filter
+  // accepts both the array and the legacy single-value forms.
   const filterOpts: FilterRecordsOptions = { root: resolvedRoot };
-  if (opts.status !== undefined) filterOpts.status = opts.status;
+  if (parsedStatuses !== undefined) filterOpts.status = parsedStatuses;
   if (opts.type !== undefined) filterOpts.type = opts.type;
   const filteredRecords = filterRecords(records, filterOpts);
 
@@ -295,7 +370,6 @@ export function statusAction(opts: StatusOptions = {}): void {
     const payload: StatusJsonPayload = {
       summary,
       records: filteredRecords,
-      tree: buildTree(filteredRecords),
       graph: serializeGraphForJson(getGraph(), { all: opts.all === true }),
     };
     console.log(JSON.stringify(payload, null, 2));

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -61,6 +61,7 @@ import {
   renderGraph,
   renderTree,
   scan,
+  serializeGraphForJson,
 } from '../status/index.js';
 import type { FilterRecordsOptions, NextAction } from '../status/index.js';
 import { buildTheme, type Theme } from '../status/theme.js';
@@ -69,6 +70,7 @@ import type {
   ArtifactType,
   DependencyGraph,
   ScanSummary,
+  SerializedGraph,
   Status,
   StatusTree,
   TreeNode,
@@ -98,12 +100,18 @@ export interface StatusOptions {
    */
   type?: ArtifactType;
   /**
-   * Disable done-subtree collapsing in text mode. When truthy, every
-   * artifact surfaces in the rendered tree regardless of status —
-   * otherwise any `TreeNode` whose `record.status === 'done'` collapses
-   * to a single `DONE` line and its descendants are hidden. Has no
-   * effect on `--format json` output, which always emits the
-   * uncollapsed `buildTree(records)` structure.
+   * Disable done-subtree collapsing in text mode and disable done-hiding
+   * in the JSON `graph` field. When truthy, every artifact surfaces in
+   * the rendered tree regardless of status — otherwise any `TreeNode`
+   * whose `record.status === 'done'` collapses to a single `DONE` line
+   * and its descendants are hidden. The flag also flips the JSON `graph`
+   * serialization between its two modes: by default (no `--all`) each
+   * layer drops `done` nodes from `node_ids` and reports the omitted
+   * count via `complete_count`; under `--all` the layer keeps every
+   * member with `pending_node_indexes` / `complete_node_indexes`
+   * partitions. Has no effect on the `tree` or `records` fields in
+   * `--format json` output, which always emit the uncollapsed
+   * `buildTree(records)` / filtered record set.
    */
   all?: boolean;
   /**
@@ -113,8 +121,10 @@ export interface StatusOptions {
    * header (with the `Next:` hint) still prints above the graph view.
    * Honors `--all` for done-layer collapsing the same way the default
    * text path honors it for done-subtree collapsing. Has no effect on
-   * `--format json` output, which always emits the populated graph
-   * regardless of this flag.
+   * `--format json` output — the JSON payload is already graph-shaped
+   * (a populated `graph` field is always emitted), so `--graph` is a
+   * no-op there. `--all` is the lever that controls JSON graph
+   * filtering.
    */
   graph?: boolean;
   /**
@@ -137,17 +147,24 @@ export interface StatusOptions {
  * record set; `graph` is populated by {@link buildDependencyGraph}
  * (US10 Slice 3) over the *pre-filter* record set per SD-010 so the
  * graph reflects the full scan even when `--status` / `--type` are
- * present. All four `graph` keys (`nodes`, `layers`, `cycles`,
- * `dangling_refs`) are emitted unconditionally — including for an
- * empty repo, where they collapse to `{ nodes: {}, layers: [],
- * cycles: [], dangling_refs: [] }` — so machine consumers can depend
- * on the top-level shape.
+ * present, then projected through {@link serializeGraphForJson} into
+ * the wire-format {@link SerializedGraph}. The serializer honors the
+ * CLI `--all` flag: by default (no `--all`) every layer drops its
+ * `done` nodes from `node_ids` and reports the omitted count via
+ * `complete_count`, and the top-level `nodes` map is filtered to match;
+ * under `--all` the layer keeps every member with `pending_node_indexes`
+ * / `complete_node_indexes` partitions, and `nodes` is complete. The
+ * `mode` discriminator on the serialized graph and on each layer
+ * mirrors which mode produced the payload. The top-level shape
+ * (`summary`, `records`, `tree`, `graph` with `mode` / `nodes` /
+ * `layers` / `cycles` / `dangling_refs`) is emitted unconditionally,
+ * including for an empty repo — so machine consumers can depend on it.
  */
 export interface StatusJsonPayload {
   summary: ScanSummary;
   records: ArtifactRecord[];
   tree: StatusTree;
-  graph: DependencyGraph;
+  graph: SerializedGraph;
 }
 
 /**
@@ -268,11 +285,18 @@ export function statusAction(opts: StatusOptions = {}): void {
   // from the pre-filter scan per SD-010 — for an empty repo the
   // builder returns the canonical zero-value shape itself.
   if (opts.format === 'json') {
+    // The wire-format `graph` field is projected from the full
+    // {@link DependencyGraph} (pre-filter per SD-010) through
+    // {@link serializeGraphForJson}, which honors `--all`. Default
+    // mode drops `done` nodes from layer `node_ids` / the top-level
+    // `nodes` map and reports `complete_count` per layer, matching
+    // the text `--graph` renderer's hide-done behavior so the two
+    // outputs agree on what is and is not visible.
     const payload: StatusJsonPayload = {
       summary,
       records: filteredRecords,
       tree: buildTree(filteredRecords),
-      graph: getGraph(),
+      graph: serializeGraphForJson(getGraph(), { all: opts.all === true }),
     };
     console.log(JSON.stringify(payload, null, 2));
     return;

--- a/src/status/filter.test.ts
+++ b/src/status/filter.test.ts
@@ -421,3 +421,120 @@ describe('filterRecords — purity and ordering', () => {
     expect(result.map((r) => r.path).sort()).toEqual(['a.md', 'b.md']);
   });
 });
+
+describe('filterRecords — multi-value status predicate', () => {
+  it('treats Status[] as a set: a record matches when its status is any member', () => {
+    // Three independent specs with three distinct statuses. Asking
+    // for `[in-progress, not-started]` retains both pending statuses
+    // and drops `done`.
+    const records: ArtifactRecord[] = [
+      makeRecord({ path: 'a.spec.md', status: 'in-progress', parent_path: null }),
+      makeRecord({ path: 'b.spec.md', status: 'not-started', parent_path: null }),
+      makeRecord({ path: 'c.spec.md', status: 'done', parent_path: null }),
+    ];
+    const result = filterRecords(records, {
+      status: ['in-progress', 'not-started'],
+    });
+    expect(result.map((r) => r.path).sort()).toEqual(['a.spec.md', 'b.spec.md']);
+  });
+
+  it('retains ancestors of any multi-value match (ancestor retention applies to the union)', () => {
+    // Chain: rfc(done) → features(done) → spec(in-progress) → tasks(not-started).
+    // `[in-progress, not-started]` directly matches the spec and the
+    // tasks file; their done ancestors (rfc, features) are retained
+    // as headers.
+    const records: ArtifactRecord[] = [
+      makeRecord({
+        type: 'rfc',
+        path: 'rfc.md',
+        status: 'done',
+        parent_path: null,
+      }),
+      makeRecord({
+        type: 'features',
+        path: 'features.md',
+        status: 'done',
+        parent_path: 'rfc.md',
+      }),
+      makeRecord({
+        type: 'spec',
+        path: 'spec.md',
+        status: 'in-progress',
+        parent_path: 'features.md',
+      }),
+      makeRecord({
+        type: 'tasks',
+        path: 'tasks.md',
+        status: 'not-started',
+        parent_path: 'spec.md',
+      }),
+    ];
+    const result = filterRecords(records, {
+      status: ['in-progress', 'not-started'],
+    });
+    expect(result.map((r) => r.path)).toEqual([
+      'rfc.md',
+      'features.md',
+      'spec.md',
+      'tasks.md',
+    ]);
+  });
+
+  it('a single-element Status[] behaves identically to the legacy single-value form', () => {
+    const records = fullChain('in-progress');
+    const arrayForm = filterRecords(records, { status: ['in-progress'] });
+    const scalarForm = filterRecords(records, { status: 'in-progress' });
+    expect(arrayForm).toEqual(scalarForm);
+  });
+
+  it('an empty Status[] matches nothing (no records retained except --type ancestors)', () => {
+    const records = fullChain('in-progress');
+    const result = filterRecords(records, { status: [] });
+    expect(result).toEqual([]);
+  });
+});
+
+describe('filterRecords — multi-value status with --type intersection', () => {
+  it('record must satisfy both the status set AND --type to match directly', () => {
+    // Two specs and two tasks. `--status in-progress,not-started
+    // --type spec` matches only the two specs (regardless of tasks
+    // statuses); their ancestors are then retained.
+    const records: ArtifactRecord[] = [
+      makeRecord({
+        type: 'rfc',
+        path: 'rfc.md',
+        status: 'done',
+        parent_path: null,
+      }),
+      makeRecord({
+        type: 'spec',
+        path: 'a.spec.md',
+        status: 'in-progress',
+        parent_path: 'rfc.md',
+      }),
+      makeRecord({
+        type: 'spec',
+        path: 'b.spec.md',
+        status: 'not-started',
+        parent_path: 'rfc.md',
+      }),
+      makeRecord({
+        type: 'tasks',
+        path: 'a.tasks.md',
+        status: 'in-progress',
+        parent_path: 'a.spec.md',
+      }),
+    ];
+    const result = filterRecords(records, {
+      status: ['in-progress', 'not-started'],
+      type: 'spec',
+    });
+    // Direct matches: both specs. Ancestor retained: the RFC. Tasks
+    // record is dropped (wrong type).
+    expect(result.map((r) => r.path)).toEqual([
+      'rfc.md',
+      'a.spec.md',
+      'b.spec.md',
+    ]);
+  });
+});

--- a/src/status/filter.ts
+++ b/src/status/filter.ts
@@ -28,7 +28,14 @@
  *   on the `parent_path` chain of some record in the match set. Walks
  *   use only records present in the input array — a `parent_path` that
  *   does not resolve to an input record terminates the walk quietly
- *   (consistent with `buildTree`'s "Broken Links" handling).
+ *   (consistent with `buildTree`'s "Broken Links" handling). The field
+ *   accepts either a single {@link Status} (the legacy single-value
+ *   CLI shape) or a `Status[]` (the multi-value form exposed by
+ *   `--status not-started,in-progress` and by `--pending`); in the
+ *   array form a record matches when its `status` is any member of
+ *   the set. An empty array means "no status matches", so the only
+ *   surviving records are the ancestors of `--type` matches (or none,
+ *   if `--type` is also absent).
  *
  * - **`--type` projection.** Identical to `--status` but keyed off
  *   `record.type`. Ancestor retention still applies so the renderer can
@@ -66,8 +73,12 @@ import type { ArtifactRecord, ArtifactType, Status } from './types.js';
  * All fields are optional; an empty object yields identity behavior.
  */
 export interface FilterRecordsOptions {
-  /** Keep records with this status plus their ancestors. */
-  status?: Status;
+  /**
+   * Keep records whose status matches plus their ancestors. Accepts
+   * either a single {@link Status} or a `Status[]` set; in the array
+   * form a record matches when its status is any member of the set.
+   */
+  status?: Status | Status[];
   /** Keep records with this artifact type plus their ancestors. */
   type?: ArtifactType;
   /**
@@ -110,11 +121,23 @@ export function filterRecords(
     }
   }
 
+  // Normalize the status predicate to a Set lookup so the single- and
+  // multi-value forms share one match path. An empty array means
+  // "match nothing" (the caller asked for the intersection with no
+  // statuses), which is honored by leaving `statusSet` populated but
+  // empty so `has()` always returns false.
+  const statusSet: Set<Status> | null =
+    opts.status === undefined
+      ? null
+      : Array.isArray(opts.status)
+        ? new Set(opts.status)
+        : new Set<Status>([opts.status]);
+
   const retained = new Set<ArtifactRecord>();
 
   for (const record of records) {
     const statusMatches =
-      opts.status === undefined || record.status === opts.status;
+      statusSet === null || statusSet.has(record.status);
     const typeMatches = opts.type === undefined || record.type === opts.type;
     if (!statusMatches || !typeMatches) continue;
 

--- a/src/status/graph.ts
+++ b/src/status/graph.ts
@@ -115,6 +115,8 @@ import type {
   ArtifactRecord,
   DependencyGraph,
   DependencyNode,
+  SerializedGraph,
+  SerializedGraphLayer,
 } from './types.js';
 
 const SENTINEL_PATHS: ReadonlySet<string> = new Set([
@@ -393,6 +395,110 @@ export function buildDependencyGraph(
     layers,
     cycles,
     dangling_refs,
+  };
+}
+
+/**
+ * Project a {@link DependencyGraph} into the wire-format
+ * {@link SerializedGraph} that `smithy status --format json` emits.
+ *
+ * `opts.all` mirrors the CLI `--all` flag. The two modes match the text
+ * `--graph` renderer's behavior exactly:
+ *
+ * - Default (`all === false`): drop every `done` node from layer
+ *   `node_ids` and report the count via `complete_count`. Layers whose
+ *   members are all `done` are omitted entirely (mirrors
+ *   `formatLayerBlock`'s empty-string return at `renderGraph.ts:460`).
+ *   The top-level `nodes` map is shrunk to only the FQ IDs that survive
+ *   into some emitted layer's `node_ids`.
+ *
+ * - `--all` (`all === true`): every node stays on the wire. `node_ids`
+ *   keeps its builder-emitted order; the two index arrays partition it
+ *   by `done` vs. non-`done` so a consumer can read either set in O(k)
+ *   without re-deriving status from `nodes`.
+ *
+ * `cycles` and `dangling_refs` are passed through verbatim in both modes
+ * — they are rare and informational, and a `done` node inside a cycle
+ * is itself a signal worth showing.
+ *
+ * Pure: does no I/O, never mutates its input, returns the same
+ * `SerializedGraph` for the same input.
+ */
+export function serializeGraphForJson(
+  graph: DependencyGraph,
+  opts: { all: boolean },
+): SerializedGraph {
+  if (opts.all) {
+    const layers: SerializedGraphLayer[] = graph.layers.map((layer) => {
+      const pending_node_indexes: number[] = [];
+      const complete_node_indexes: number[] = [];
+      for (let i = 0; i < layer.node_ids.length; i++) {
+        const id = layer.node_ids[i];
+        if (id === undefined) continue;
+        const node = graph.nodes[id];
+        if (node !== undefined && node.status === 'done') {
+          complete_node_indexes.push(i);
+        } else {
+          pending_node_indexes.push(i);
+        }
+      }
+      return {
+        mode: 'all',
+        layer: layer.layer,
+        node_ids: layer.node_ids.slice(),
+        pending_node_indexes,
+        complete_node_indexes,
+      };
+    });
+    return {
+      mode: 'all',
+      nodes: { ...graph.nodes },
+      layers,
+      cycles: graph.cycles.map((c) => c.slice()),
+      dangling_refs: graph.dangling_refs.map((d) => ({ ...d })),
+    };
+  }
+
+  // Default mode: pending-only.
+  const visibleIds = new Set<string>();
+  const layers: SerializedGraphLayer[] = [];
+  for (const layer of graph.layers) {
+    const pending: string[] = [];
+    let complete_count = 0;
+    for (const id of layer.node_ids) {
+      const node = graph.nodes[id];
+      // Mirror `renderGraph.ts:435` exactly: a missing node is treated
+      // as visible (defensive — should not occur in practice, but we
+      // never want to silently drop an unresolved id).
+      if (node === undefined || node.status !== 'done') {
+        pending.push(id);
+        visibleIds.add(id);
+      } else {
+        complete_count += 1;
+      }
+    }
+    if (pending.length === 0 && layer.node_ids.length > 0) {
+      // Fully-done layer: omit entirely, matching the text renderer.
+      continue;
+    }
+    layers.push({
+      mode: 'pending-only',
+      layer: layer.layer,
+      node_ids: pending,
+      complete_count,
+    });
+  }
+  const nodes: Record<string, DependencyNode> = {};
+  for (const id of visibleIds) {
+    const node = graph.nodes[id];
+    if (node !== undefined) nodes[id] = node;
+  }
+  return {
+    mode: 'pending-only',
+    nodes,
+    layers,
+    cycles: graph.cycles.map((c) => c.slice()),
+    dangling_refs: graph.dangling_refs.map((d) => ({ ...d })),
   };
 }
 

--- a/src/status/graph.ts
+++ b/src/status/graph.ts
@@ -409,8 +409,14 @@ export function buildDependencyGraph(
  *   `node_ids` and report the count via `complete_count`. Layers whose
  *   members are all `done` are omitted entirely (mirrors
  *   `formatLayerBlock`'s empty-string return at `renderGraph.ts:460`).
- *   The top-level `nodes` map is shrunk to only the FQ IDs that survive
- *   into some emitted layer's `node_ids`.
+ *   The top-level `nodes` map is shrunk to every FQ ID in `graph.nodes`
+ *   whose status is not `done` — not just IDs that survive in some
+ *   emitted layer. This is what preserves the "an ID missing from
+ *   `graph.nodes` is already done" invariant the smithy.status skill
+ *   relies on, even for repos with cycles: Kahn's algorithm excludes
+ *   cycle participants (and nodes downstream of cycles) from `layers`,
+ *   but those IDs still appear in `graph.cycles`, and their metadata
+ *   must remain reachable in `nodes`.
  *
  * - `--all` (`all === true`): every node stays on the wire. `node_ids`
  *   keeps its builder-emitted order; the two index arrays partition it
@@ -460,7 +466,6 @@ export function serializeGraphForJson(
   }
 
   // Default mode: pending-only.
-  const visibleIds = new Set<string>();
   const layers: SerializedGraphLayer[] = [];
   for (const layer of graph.layers) {
     const pending: string[] = [];
@@ -472,7 +477,6 @@ export function serializeGraphForJson(
       // never want to silently drop an unresolved id).
       if (node === undefined || node.status !== 'done') {
         pending.push(id);
-        visibleIds.add(id);
       } else {
         complete_count += 1;
       }
@@ -488,10 +492,15 @@ export function serializeGraphForJson(
       complete_count,
     });
   }
+  // Populate `nodes` from every non-`done` entry in `graph.nodes`, not
+  // just the IDs surviving into emitted layers. This keeps metadata for
+  // cycle participants (and pending nodes downstream of cycles) on the
+  // wire — without this, `graph.cycles` would point at IDs that the
+  // consumer cannot resolve, and the skill's "missing ⇒ done" rule
+  // would be wrong in cyclic repos.
   const nodes: Record<string, DependencyNode> = {};
-  for (const id of visibleIds) {
-    const node = graph.nodes[id];
-    if (node !== undefined) nodes[id] = node;
+  for (const [id, node] of Object.entries(graph.nodes)) {
+    if (node.status !== 'done') nodes[id] = node;
   }
   return {
     mode: 'pending-only',

--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -26,4 +26,4 @@ export { collapseTree, type CollapseTreeOptions } from './collapse.js';
 export { renderTree, type RenderTreeOptions } from './render.js';
 export { renderGraph, type RenderGraphOptions } from './renderGraph.js';
 export { filterRecords, type FilterRecordsOptions } from './filter.js';
-export { buildDependencyGraph } from './graph.js';
+export { buildDependencyGraph, serializeGraphForJson } from './graph.js';

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -376,9 +376,13 @@ export interface DependencyGraph {
  * The `mode` discriminator mirrors the `--all` flag at the CLI:
  * - `'pending-only'` (default, no `--all`): every layer omits `done` nodes
  *   from `node_ids` and reports the omitted count via `complete_count`.
- *   The top-level `nodes` map carries only the FQ IDs that survive into
- *   some layer's `node_ids`. Fully-done layers are dropped entirely
- *   (matching the text renderer's behavior).
+ *   The top-level `nodes` map carries every non-`done` entry from the
+ *   in-memory graph — including pending nodes that Kahn's algorithm
+ *   excluded from `layers` (cycle participants and nodes downstream of
+ *   cycles). This preserves the "ID missing from `graph.nodes` ⇒
+ *   already `done`" invariant the smithy.status skill relies on.
+ *   Fully-done layers are dropped entirely (matching the text
+ *   renderer's behavior).
  * - `'all'` (`--all`): `node_ids` is the full layer membership; the
  *   `pending_node_indexes` / `complete_node_indexes` arrays partition it
  *   by status without re-stating IDs. The top-level `nodes` map is
@@ -396,10 +400,17 @@ export interface SerializedGraph {
 }
 
 /**
- * Per-layer wire shape. Discriminated by the parent {@link SerializedGraph}'s
- * `mode`. Modeled as a union so a consumer cannot read `complete_count` in
- * `--all` mode (where it would mean nothing) nor the partition indexes in
- * default mode (where the done set was never on the wire).
+ * Per-layer wire shape. Each layer carries its own `mode` field as the
+ * discriminator, so consumers can switch on `layers[i].mode` directly
+ * without threading the parent {@link SerializedGraph} through. The
+ * serializer keeps every layer's `mode` equal to the parent's `mode`;
+ * the TS union doesn't statically enforce that equality (the
+ * `SerializedGraph.layers: SerializedGraphLayer[]` element type accepts
+ * either shape), but {@link serializeGraphForJson} is the only producer
+ * and guarantees it. Modeled as a union so a consumer cannot read
+ * `complete_count` in `--all` mode (where it would mean nothing) nor
+ * the partition indexes in default mode (where the done set was never
+ * on the wire).
  */
 export type SerializedGraphLayer =
   | {

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -365,3 +365,58 @@ export interface DependencyGraph {
    */
   dangling_refs: Array<{ source_id: string; missing_id: string }>;
 }
+
+/**
+ * Wire-format graph emitted by `--format json`. Distinct from
+ * {@link DependencyGraph} so the in-memory full graph (which the text
+ * `--graph` renderer needs to compute "N done hidden" counts and per-layer
+ * dedup) can keep its current shape while the JSON consumer pays only for
+ * the slice it asked for.
+ *
+ * The `mode` discriminator mirrors the `--all` flag at the CLI:
+ * - `'pending-only'` (default, no `--all`): every layer omits `done` nodes
+ *   from `node_ids` and reports the omitted count via `complete_count`.
+ *   The top-level `nodes` map carries only the FQ IDs that survive into
+ *   some layer's `node_ids`. Fully-done layers are dropped entirely
+ *   (matching the text renderer's behavior).
+ * - `'all'` (`--all`): `node_ids` is the full layer membership; the
+ *   `pending_node_indexes` / `complete_node_indexes` arrays partition it
+ *   by status without re-stating IDs. The top-level `nodes` map is
+ *   complete.
+ *
+ * `cycles` and `dangling_refs` are mode-independent — they are rare and
+ * informational, and a `done` node inside a cycle is itself a signal.
+ */
+export interface SerializedGraph {
+  mode: 'pending-only' | 'all';
+  nodes: Record<string, DependencyNode>;
+  layers: SerializedGraphLayer[];
+  cycles: string[][];
+  dangling_refs: Array<{ source_id: string; missing_id: string }>;
+}
+
+/**
+ * Per-layer wire shape. Discriminated by the parent {@link SerializedGraph}'s
+ * `mode`. Modeled as a union so a consumer cannot read `complete_count` in
+ * `--all` mode (where it would mean nothing) nor the partition indexes in
+ * default mode (where the done set was never on the wire).
+ */
+export type SerializedGraphLayer =
+  | {
+      mode: 'pending-only';
+      layer: number;
+      /** Pending FQ node IDs (in-progress | not-started | unknown). */
+      node_ids: string[];
+      /** Count of `done` nodes omitted from this layer. */
+      complete_count: number;
+    }
+  | {
+      mode: 'all';
+      layer: number;
+      /** Every FQ node ID in this layer, in builder-emitted order. */
+      node_ids: string[];
+      /** Indexes into `node_ids` for nodes whose status is not `done`. */
+      pending_node_indexes: number[];
+      /** Indexes into `node_ids` for nodes whose status is `done`. */
+      complete_node_indexes: number[];
+    };

--- a/src/templates/agent-skills/skills/smithy.status/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.status/SKILL.prompt
@@ -98,26 +98,45 @@ The CLI's text renderer is authoritative.
 
 ## Question mode
 
-1. Run exactly one shell command:
+1. Run exactly one shell command. For most questions, prefer the
+   pending shorthand — it drops every `done` record from the payload
+   so you only pay for artifacts that still have work to dispatch:
 
    ```bash
-   smithy status --format json
+   smithy status --format json --pending
    ```
+
+   `--pending` is exactly equivalent to `--status in-progress,not-started`
+   (the `--status` flag now accepts a comma-separated set, e.g.
+   `--status in-progress,not-started,unknown` if you also want to see
+   parse errors). Drop `--pending` (i.e., run `smithy status --format
+   json`) only when the question actually requires done artifacts —
+   "how many tasks are done?", "show me everything", "is X complete?".
 
 2. Parse the JSON. The payload follows the `StatusJsonPayload` contract from
    `src/commands/status.ts`:
    - `summary` — per-type counts (`rfc`, `features`, `spec`, `tasks`) of
      `done` / `in-progress` / `not-started` / `unknown`, plus
-     `orphan_count`, `broken_link_count`, `parse_error_count`.
-   - `records` — every `ArtifactRecord` discovered, with `type`, `path`,
+     `orphan_count`, `broken_link_count`, `parse_error_count`. **The
+     summary is always aggregate over the full scan, regardless of
+     `--status` / `--pending` / `--type` (SD-010)** — so `done` counts
+     stay accurate even under `--pending`, and you can answer counting
+     questions like "how many tasks are done?" from the pending payload
+     directly without dropping the filter.
+   - `records` — the `ArtifactRecord` set surviving the filter (with
+     ancestors retained for context). Each record carries `type`, `path`,
      `title`, `status`, `parent_path`, optional `completed` / `total`
      (slice counts on `tasks` records), and `next_action`. The
      `next_action.command` and `next_action.arguments` fields are the
      authoritative "what to do next" hint for that artifact, and
-     `next_action.suppressed_by_ancestor` (when present) marks a hint that
-     was suppressed in the rendered tree because an ancestor is itself
-     not-started.
-   - `tree` — hierarchical view (`roots: TreeNode[]`).
+     `next_action.suppressed_by_ancestor` (when present) marks a hint
+     that was suppressed in the rendered tree because an ancestor is
+     itself not-started. Under `--pending`, the `records` list excludes
+     `done` artifacts but keeps their `done` ancestors as headers when a
+     pending descendant lives beneath them.
+   - There is no `tree` field on the wire. Every `ArtifactRecord` carries
+     `parent_path`, so the hierarchical view can be reconstructed locally
+     without paying for the duplication in the payload.
    - `graph` — cross-artifact dependency graph. The wire format mirrors
      the CLI `--all` flag via a top-level `mode` discriminator:
      - `mode: "pending-only"` (default, no `--all`): `nodes` is keyed
@@ -172,15 +191,18 @@ The CLI's text renderer is authoritative.
      dependency-blocked signal.)
    - **"how many tasks are done?"** → quote `summary.counts.tasks.done`
      directly.
-   - **"show me everything, including completed work"** → rerun with
-     `--all` (the only question for which `--all` is the right default;
-     for "what's next?" / "what's blocked?" / counts, the default
-     pending-only payload is both correct and cheaper).
+   - **"show me everything, including completed work"** → rerun
+     without `--pending` and with `--all`. `--pending` drops `done`
+     records from the wire entirely; `--all` keeps `done` graph nodes
+     visible with their partition indexes. Together they restore the
+     full payload — every record, every node — for the rare question
+     that genuinely needs it.
 
 4. **Do not invent data.** If the JSON does not contain enough information
    to answer the question, say so plainly and (if helpful) suggest the CLI
-   flag — `--type`, `--all`, `--root` — that would surface it. `--graph`
-   is a no-op in JSON mode and never needs to be suggested.
+   flag — `--type`, `--all`, `--status`, `--pending`, `--root` — that
+   would surface it. `--graph` is a no-op in JSON mode and never needs
+   to be suggested.
 
 5. **Do not chain extra invocations.** Issue exactly one `smithy status`
    call per user request — no follow-up runs with different flags. If a

--- a/src/templates/agent-skills/skills/smithy.status/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.status/SKILL.prompt
@@ -118,8 +118,21 @@ The CLI's text renderer is authoritative.
      was suppressed in the rendered tree because an ancestor is itself
      not-started.
    - `tree` — hierarchical view (`roots: TreeNode[]`).
-   - `graph` — cross-artifact dependency graph with `nodes`, `layers`
-     (topological), `cycles`, and `dangling_refs`.
+   - `graph` — cross-artifact dependency graph. The wire format mirrors
+     the CLI `--all` flag via a top-level `mode` discriminator:
+     - `mode: "pending-only"` (default, no `--all`): `nodes` is keyed
+       only by FQ IDs of `done`-free rows; every `layers[i].node_ids`
+       lists only the pending FQ IDs in that layer, and
+       `layers[i].complete_count` reports how many `done` nodes the
+       layer had. Layers that were entirely `done` are omitted from
+       `layers[]` (their work is fully accounted for via
+       `summary.counts`).
+     - `mode: "all"` (`--all`): `nodes` is the full graph; each
+       `layers[i].node_ids` is complete, with `pending_node_indexes`
+       and `complete_node_indexes` partitioning it by status.
+     `cycles` and `dangling_refs` are mode-independent.
+   - `--graph` is a **no-op** in JSON mode (the payload is always
+     graph-shaped). To change what is on the wire, use `--all`.
 
 3. Answer the user's question in **one to three sentences**, or a short
    bulleted list when enumerating multiple items. Quote concrete IDs, paths,
@@ -131,6 +144,9 @@ The CLI's text renderer is authoritative.
      first whose `next_action` is non-null and `next_action.suppressed_by_ancestor`
      is not `true`). Return its `next_action.command` plus
      `next_action.arguments`, along with the artifact's title and path.
+     In `pending-only` mode (the default), `layers[0].node_ids[0]` is
+     already the canonical answer because done nodes have been filtered
+     out.
    - **"how many slices for this tasks file?"** → find the matching `tasks`
      record from `records` and quote its `total` (and, when relevant, its
      `completed`) field. The CLI emits one `ArtifactRecord` per file — there
@@ -139,19 +155,27 @@ The CLI's text renderer is authoritative.
    - **"which user stories are left for this spec?"** → list `spec`-type
      records under that spec folder whose `status` is not `done`, with
      their paths.
-   - **"what's blocked?"** → walk `graph.nodes` and, for each node whose
-     owning record is not yet `done`, list it together with the IDs in
-     `node.row.depends_on` whose corresponding nodes still have a non-`done`
-     `status`. Those `depends_on` IDs are the actual blockers. (The
-     `next_action.suppressed_by_ancestor` flag only marks suppression by a
-     not-started ancestor in the rendered tree — it is not a
+   - **"what's blocked?"** → walk `graph.nodes` and, for each node, list
+     it together with the IDs in `node.row.depends_on` whose corresponding
+     entries are also present in `graph.nodes`. In `pending-only` mode an
+     ID that appears in `depends_on` but is *missing* from `graph.nodes`
+     is already `done` (the serializer drops only done nodes from
+     `nodes`), so it does not block; in `all` mode you can confirm via
+     each referenced node's `status` field directly. (The
+     `next_action.suppressed_by_ancestor` flag only marks suppression by
+     a not-started ancestor in the rendered tree — it is not a
      dependency-blocked signal.)
    - **"how many tasks are done?"** → quote `summary.counts.tasks.done`
      directly.
+   - **"show me everything, including completed work"** → rerun with
+     `--all` (the only question for which `--all` is the right default;
+     for "what's next?" / "what's blocked?" / counts, the default
+     pending-only payload is both correct and cheaper).
 
 4. **Do not invent data.** If the JSON does not contain enough information
    to answer the question, say so plainly and (if helpful) suggest the CLI
-   flag — `--graph`, `--type`, `--all`, `--root` — that would surface it.
+   flag — `--type`, `--all`, `--root` — that would surface it. `--graph`
+   is a no-op in JSON mode and never needs to be suggested.
 
 5. **Do not chain extra invocations.** Issue exactly one `smithy status`
    call per user request — no follow-up runs with different flags. If a

--- a/src/templates/agent-skills/skills/smithy.status/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.status/SKILL.prompt
@@ -139,14 +139,19 @@ The CLI's text renderer is authoritative.
    counts, titles, and `next_action` commands directly from the JSON.
 
    Examples:
-   - **"what's next?"** → cite the first actionable record from the lowest
-     non-empty `graph.layers[]` (or scan `records` in order, picking the
-     first whose `next_action` is non-null and `next_action.suppressed_by_ancestor`
-     is not `true`). Return its `next_action.command` plus
+   - **"what's next?"** → the canonical source is `records` plus
+     `next_action`: scan `records` in order and return the first whose
+     `next_action` is non-null and whose `next_action.suppressed_by_ancestor`
+     is not `true`. Quote its `next_action.command` plus
      `next_action.arguments`, along with the artifact's title and path.
-     In `pending-only` mode (the default), `layers[0].node_ids[0]` is
-     already the canonical answer because done nodes have been filtered
-     out.
+     `graph.layers[]` is a useful *candidate* list when the user is
+     thinking in dependency-graph terms, but it is **not** the canonical
+     answer on its own: fully-done leading layers are omitted in
+     `pending-only` mode (so `layers[0]` need not correspond to true
+     layer 0 — read `layers[0].layer` to know which layer it actually
+     is), and graph layering does not encode
+     `next_action.suppressed_by_ancestor`, so a graph-first pick may
+     still need filtering against the matching `records` entry.
    - **"how many slices for this tasks file?"** → find the matching `tasks`
      record from `records` and quote its `total` (and, when relevant, its
      `completed`) field. The CLI emits one `ArtifactRecord` per file — there


### PR DESCRIPTION
## Summary

- `smithy status --format json` now honors `--all`. Default payload drops `done` nodes from `graph.nodes`, reports `complete_count` per layer, and omits fully-done layers; `--all` returns the full graph with `pending_node_indexes` / `complete_node_indexes` partitioning each layer's `node_ids`.
- New `SerializedGraph` wire type with a `mode: 'pending-only' | 'all'` discriminator keeps the in-memory `DependencyGraph` full-fidelity for the text renderer while the JSON branch routes through a pure `serializeGraphForJson` serializer.
- `--graph` remains a no-op in JSON mode (the payload is already graph-shaped); `smithy.status` SKILL.prompt documents the new contract and the "missing from `graph.nodes` in pending-only mode ⇒ already done" rule.

## Motivation

The `smithy.status` skill feeds `--format json` straight to an LLM. Today's payload includes every `done` node and its `row` metadata regardless of `--all`, so the skill burns context on data it never asks about. On this repo the default payload shrinks ~23% (322 KB → 247 KB) and text `--graph` output is byte-identical to before.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 835/835 pass (new `serializeGraphForJson` describe + integration cases for hide-done default and fully-done-layer omission)
- [x] `node dist/cli.js status --format json | jq '.graph.layers[0]'` shows `mode: "pending-only"`, 8 pending `node_ids`, `complete_count: 131`
- [x] `node dist/cli.js status --format json --all | jq '.graph.layers[0]'` shows `mode: "all"`, 139 `node_ids`, `pending_node_indexes` (8) + `complete_node_indexes` (131) = 139
- [x] `node dist/cli.js status --graph --format json` byte-identical to `node dist/cli.js status --format json`
- [x] `node dist/cli.js status --graph` (text) unchanged — 8 visible layer-0 items, `131 done hidden`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
