### PR TITLE
chore(evals): mark US3 S2 cut-from-spec scenario complete

### DIFF
--- a/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/03-cut-eval-inherits-spec-debt.tasks.md
+++ b/specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/03-cut-eval-inherits-spec-debt.tasks.md
@@ -54,7 +54,7 @@
 
 ### Tasks
 
-- [ ] **Author the cut-from-spec YAML scenario**
+- [x] **Author the cut-from-spec YAML scenario**
 
   Create `evals/cases/cut-from-spec.yaml` per the `EvalScenario` shape in `evals/lib/types.ts`, mirroring the precedent in `evals/cases/strike-health-check.yaml` and the planned `evals/cases/mark-from-features.yaml`. Set `skill: /smithy.cut` and `prompt` to the exact repo-relative path of the Slice 1 spec plant followed by the explicit user-story number (per FR-005). Anchor `required_headings` to the literal one-shot-snippet section headings stamped by cut's Phase output. Anchor `required_patterns` to (a) the literal `inherited from spec:` substring — carry an inline YAML comment pinning the cross-reference to Phase 1 step 3 of `src/templates/agent-skills/commands/smithy.cut.prompt` (the upstream-debt inheritance step) so future template drift is caught (AS 3.1, proxy for AS 3.2 per SD-010); (b) the `**Spec folder**:` bullet; (c) a regex alternation accepting either the PR success-branch URL marker or the documented PR-creation-failure paragraph wording (resolves inherited SD-008 via the regex-alternation option). Author `sub_agent_evidence` covering smithy-scout, smithy-clarify, and smithy-plan-review using the marker conventions from contracts §3. Include the strike-convention `forbidden_patterns` (FR-011). Calibrate `timeout:` empirically during scenario authoring and record the observed cut run-time in an inline YAML comment.
 


### PR DESCRIPTION
## Summary

Recovery PR for US3 Slice 2 of the expand-evals-coverage-planning-and-audit feature. The cut-from-spec YAML scenario was shipped in PR #353 and the prompt path was corrected in PR #373, but the matching Slice 2 task row in `03-cut-eval-inherits-spec-debt.tasks.md` was never flipped from `[ ]` to `[x]`. `smithy status` therefore still reported the slice as ready, triggering a recovery dispatch.

## What changed

- Flips the single Slice 2 task row in `specs/2026-05-03-005-expand-evals-coverage-planning-and-audit/03-cut-eval-inherits-spec-debt.tasks.md` from `[ ]` to `[x]`.

No code or fixture changes — every acceptance criterion for the slice was already satisfied by prior merged PRs:

- `evals/cases/cut-from-spec.yaml` exists with the correct `name`, `skill`, `prompt`, `required_headings`, `required_patterns` (including `inherited from spec:`, `**Spec folder**`, and the PR success/failure regex alternation), `sub_agent_evidence` for smithy-scout / smithy-clarify / smithy-plan-review, strike-convention `forbidden_patterns`, and an empirically calibrated `timeout: 600` with the observed wall-clock recorded inline.
- The plant fixtures under `evals/fixture/specs/cut-eval/` are in place (shipped earlier as Slice 1).
- `npm run test:evals` passes (10 files, 187 tests) with the YAML auto-discovered by `loadScenarios`.

## Test plan

- [x] `npm run test:evals` — 187 tests pass
- [x] `git diff` confirms the change is the single checkbox flip
