### PR TITLE
chore(tasks): mark US3 S2 complete in tasks.md

### DIFF
--- a/specs/2026-03-21-002-smithy-orders-issue-templates/03-deployment-location-honored-end-to-end.tasks.md
+++ b/specs/2026-03-21-002-smithy-orders-issue-templates/03-deployment-location-honored-end-to-end.tasks.md
@@ -43,7 +43,7 @@
 
 ### Tasks
 
-- [ ] **Assert orders prompt routes by `deployLocation` and surfaces missing-manifest error**
+- [x] **Assert orders prompt routes by `deployLocation` and surfaces missing-manifest error**
 
   Extend the existing `smithy.orders command delegates GitHub ops to smithy.gh-issue scripts` block in `src/templates.test.ts` with structural assertions on the composed `smithy.orders.md` content: (a) the prompt names the manifest's persisted `deployLocation` field as the source of `<manifestDir>` resolution (catches a regression to a hardcoded location); (b) both `'repo'` and `'user'` appear as inputs that drive `resolveManifestDir` (or the equivalent routing call) so neither location value is silently dropped — assert the routing of both values, not two distinct literal path-string branches, since US2's manifest-load prose may emit a single deploy-location-agnostic `<manifestDir>` placeholder rather than two location-specific path strings; (c) the prompt references `smithy init` in the missing-manifest error path. Match by content substrings, not line numbers, consistent with the convention US2 Slice 1 Task 3 establishes. Satisfies the structural side of AS 3.3, AS 3.4, and AS 3.5.
 


### PR DESCRIPTION
## Summary

Checkbox-only cleanup PR for US3 Slice 2. The structural assertions for
deploy-location routing in the `smithy.orders` prompt already shipped
(PR #375, with the earlier related work in #348), but the matching row
in `03-deployment-location-honored-end-to-end.tasks.md` was never
flipped from `[ ]` to `[x]`. That left `smithy status` reporting the
slice as ready and triggered a recovery dispatch.

## Verification

Confirmed via `grep` that `src/templates.test.ts` already contains the
required assertions for AS 3.3 / AS 3.4 / AS 3.5:

- `resolveManifestDir(targetDir, 'repo')` is asserted as an input
- `resolveManifestDir(targetDir, 'user')` is asserted as an input
- `deployLocation` is named as the field driving manifest resolution
- The missing-manifest error path references `` `smithy init` ``

No production code changes; only the tasks.md row is updated.

## Notes

- `npm test` was not run locally because this worktree has no
  `node_modules` installed. Risk is low for a single-character markdown
  change; CI will validate.

## Test plan

- [ ] CI passes on this branch
- [ ] `smithy status` no longer reports US3 S2 as ready after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
