### PR TITLE
fix(forge): gate PR creation on slice-completion checkbox flip

### DIFF
--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1197,6 +1197,43 @@ describe('getComposedTemplates', () => {
     expect(forge).not.toContain('{{');
   });
 
+  // Issue #380: merged PRs were landing with unchecked `- [ ]` rows in the
+  // target slice, wedging the downstream dispatch loop. Forge owns the
+  // checkbox-flip gate, so the composed prompt must contain a hard pre-PR
+  // re-read of the target slice that STOPs if any task is still unchecked.
+  it('forge prompt enforces a pre-PR slice-completion checkbox gate', () => {
+    const forge = composed.commands.get('smithy.forge.md')!;
+    expect(forge).toBeDefined();
+    expect(forge).toContain('Slice Completion Check');
+    expect(forge).toContain('Forge owns the checkbox flip');
+    expect(forge).toContain('STOP gate');
+    expect(forge).toContain('wedges the downstream dispatch loop');
+    expect(forge).toContain('Unchecked tasks at PR time');
+  });
+
+  // Issue #380: the implementation commit must include the `- [ ]` → `- [x]`
+  // flip in the same commit as the code change, and the smithy-implement
+  // sub-agent must not report `success` if the checkbox is still unchecked.
+  it('smithy-implement sub-agent output contract requires checkbox flip with success', async () => {
+    const claudeComposed = await getComposedTemplates('claude');
+    const implement = claudeComposed.agents.get('smithy.implement.md')!;
+    expect(implement).toBeDefined();
+    expect(implement).toContain('flips this task\'s checkbox per TDD protocol step 5');
+    expect(implement).toContain('never return `success` with the checkbox still');
+  });
+
+  // Issue #380: the shared TDD protocol snippet — used by both the
+  // sub-agent and the no-agent forge variants — must flag the checkbox
+  // flip as a mandatory part of the implementation commit (not a follow-up
+  // commit and not optional bookkeeping).
+  it('TDD protocol snippet flags the checkbox flip as mandatory in the implementation commit', () => {
+    const forge = composed.commands.get('smithy.forge.md')!;
+    expect(forge).toBeDefined();
+    // The snippet is inlined into the no-agent forge variant.
+    expect(forge).toContain('Include this edit in the implementation commit');
+    expect(forge).toContain('mandatory');
+  });
+
   it('forge with claude variant renders sub-agent dispatch', async () => {
     const claudeComposed = await getComposedTemplates('claude');
     const forge = claudeComposed.commands.get('smithy.forge.md')!;

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1214,8 +1214,7 @@ describe('getComposedTemplates', () => {
   // Issue #380: the implementation commit must include the `- [ ]` → `- [x]`
   // flip in the same commit as the code change, and the smithy-implement
   // sub-agent must not report `success` if the checkbox is still unchecked.
-  it('smithy-implement sub-agent output contract requires checkbox flip with success', async () => {
-    const claudeComposed = await getComposedTemplates('claude');
+  it('smithy-implement sub-agent output contract requires checkbox flip with success', () => {
     const implement = claudeComposed.agents.get('smithy.implement.md')!;
     expect(implement).toBeDefined();
     expect(implement).toContain('flips this task\'s checkbox per TDD protocol step 5');

--- a/src/templates/agent-skills/agents/smithy.implement.prompt
+++ b/src/templates/agent-skills/agents/smithy.implement.prompt
@@ -78,6 +78,15 @@ When done, return a structured summary to the parent agent:
 
 1. **Status** — `success`, `blocked`, or `failure`
 2. **Commit SHA** — the SHA of the implementation commit (if success)
-3. **Files changed** — list of files created or modified
+3. **Files changed** — list of files created or modified (must include the
+   tasks/strike file when `Status` is `success`, because the implementation
+   commit flips this task's checkbox per TDD protocol step 5)
 4. **Blockers** — description of any issues that prevented completion (if blocked/failure)
 5. **Notes** — any observations for the orchestrator (discovered scope, risks, etc.)
+
+A `success` response **must** correspond to a single commit that contains
+both the implementation and the `- [ ]` → `- [x]` flip for this task in the
+tasks/strike file. If the work is genuinely incomplete, return `blocked`
+with the gap described — never return `success` with the checkbox still
+unflipped, since the parent forge orchestrator gates PR creation on every
+task in the slice reading `- [x]` at HEAD.

--- a/src/templates/agent-skills/commands/smithy.forge.prompt
+++ b/src/templates/agent-skills/commands/smithy.forge.prompt
@@ -312,10 +312,13 @@ checkbox in the target slice is now `- [x]`**.
 git show HEAD:<tasks-file-path>
 ```
 
-Forge owns the checkbox flip. The implementation sub-agents are instructed to
-flip each task's checkbox in the same commit that lands the implementation
-(see TDD protocol step 5). This re-read is the orchestrator's gate: if any
-`- [ ]` rows remain in the target slice, the slice is **not** ready to ship.
+Forge owns the checkbox flip. The implementer must flip each task's
+checkbox in the same commit that lands the implementation
+{{#ifAgent}}— in the claude variant, this is the smithy-implement
+sub-agent's responsibility per its output contract —{{/ifAgent}}
+(see TDD protocol step 5). This re-read is the orchestrator's gate:
+if any `- [ ]` rows remain in the target slice, the slice is **not**
+ready to ship.
 
 **STOP gate.** If any task in the target slice is still `- [ ]`:
 

--- a/src/templates/agent-skills/commands/smithy.forge.prompt
+++ b/src/templates/agent-skills/commands/smithy.forge.prompt
@@ -301,6 +301,40 @@ For each stale doc found:
 
 ---
 
+## Slice Completion Check
+
+Before opening the PR, **re-read the target slice's task list** from the
+`.tasks.md` or `.strike.md` file at HEAD and verify that **every task
+checkbox in the target slice is now `- [x]`**.
+
+```bash
+# Inspect the target slice's task list at the current HEAD
+git show HEAD:<tasks-file-path>
+```
+
+Forge owns the checkbox flip. The implementation sub-agents are instructed to
+flip each task's checkbox in the same commit that lands the implementation
+(see TDD protocol step 5). This re-read is the orchestrator's gate: if any
+`- [ ]` rows remain in the target slice, the slice is **not** ready to ship.
+
+**STOP gate.** If any task in the target slice is still `- [ ]`:
+
+1. Identify the unchecked task(s) and re-examine whether the implementation
+   actually covered them.
+2. If the work is genuinely done but the checkbox was never flipped, edit the
+   file to flip the box and commit as
+   `forge: mark slice <N> task <M> complete`.
+3. If the work is **not** done, do **not** flip the box and do **not** open
+   the PR. Report the gap to the user and either dispatch the missing task
+   or escalate. A merged PR with unchecked rows wedges the downstream
+   dispatch loop (`smithy status` reports the slice as still in progress
+   while the merge-archive blocks re-dispatch) — never ship past this gate.
+
+Only after every task in the target slice reads `- [x]` at HEAD may you
+proceed to the Pull Request step.
+
+---
+
 ## Story Completion Cascade
 
 Forge makes **no writes** to any `## Dependency Order` table. Slice completion
@@ -375,6 +409,11 @@ This traceability lets reviewers navigate from PR → slice → spec to understa
 - **Slice number out of range**: Stop and list available slices with their goals.
 - **Branch already exists**: Ask the user whether to continue on the existing branch or abort.
 - **Slice already forged (PR exists)**: Warn the user and confirm before proceeding.
+- **Unchecked tasks at PR time**: If the Slice Completion Check finds any
+  `- [ ]` rows in the target slice at HEAD, do **not** open the PR. Either
+  flip the checkbox in a `forge: ...` commit (if the work is actually done)
+  or stop and report the missing work to the user. Shipping a merged PR
+  with unchecked rows wedges the downstream dispatch loop.
 - **Test failure mid-slice**: Stop, report the failure, and do not proceed to the next task.
 - **`.strike.md` with all tasks already complete**: Warn and confirm before proceeding.
 - **Cross-story dependency not met**: If a required story/slice hasn't been

--- a/src/templates/agent-skills/snippets/tdd-protocol.md
+++ b/src/templates/agent-skills/snippets/tdd-protocol.md
@@ -32,7 +32,15 @@ behavior).
 ### 5. Mark the task complete
 
 Update the task checkbox from `- [ ]` to `- [x]` in the tasks or strike file.
-Include this edit in the implementation commit.
+**Include this edit in the implementation commit — not a follow-up commit.**
+
+The checkbox flip is **mandatory**, not bookkeeping. The slice's parent
+orchestrator (`smithy.forge`) gates PR creation on every task in the slice
+reading `- [x]` at HEAD; a merged PR that leaves rows unchecked wedges the
+downstream dispatch loop (`smithy status` keeps the slice in progress while
+the merge-archive blocks re-dispatch). If you cannot legitimately mark the
+task complete (work is blocked, requirements unclear), do not fake the flip
+— stop and report the blocker per the constraints below.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a hard **Slice Completion Check** to `smithy.forge` that re-reads the target slice at HEAD before opening the PR and STOPs if any task is still `- [ ]`. The orchestrator now owns the gate even if a sub-agent skipped step 5.
- Strengthens the shared TDD protocol snippet so the `- [ ]` → `- [x]` flip is flagged as mandatory in the **implementation commit** (not a follow-up, not optional bookkeeping). Explains the downstream impact (wedged dispatch loop, `smithy status` keeps the slice "in progress") so workers understand why.
- Tightens the `smithy-implement` sub-agent's output contract: a `success` response **must** correspond to a single commit containing both the implementation and the checkbox flip. If the work is genuinely incomplete, the sub-agent must return `blocked` — never `success` with an unflipped row.
- Adds three template tests in `src/templates.test.ts` locking down the new contract so regressions in the prompts are caught by `npm test`.

Ownership decision per the issue's first ask: **forge (and its `smithy-implement` sub-agent) owns the checkbox flip**, not a post-merge sweep. The orchestrator gate is the safety net; a post-merge sweep would have to guess which slice row a PR satisfied, and would still leave the dispatch loop wedged until it ran.

Closes #380.

## Test plan

- [x] `npm test` — all 828 template tests pass, including the three new assertions for the slice-completion gate, the implement output contract, and the TDD-protocol mandatory-flip language.
- [x] `npm run typecheck` — clean.
- [ ] Next forge run on a real slice should refuse to open a PR if any task in the slice is still `- [ ]` at HEAD, and should flip the box in a `forge:` commit when the work is genuinely complete but the sub-agent missed step 5.
