### PR TITLE
fix(mark): normalize M1 feature IDs and link RFC artifacts

### DIFF
--- a/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
+++ b/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
@@ -104,16 +104,14 @@ Recommended specification sequence:
 
 | ID | Title | Depends On | Artifact |
 |----|-------|------------|----------|
-| F1.1 | Reference Baseline Evals Infrastructure | — | — |
-| F1.2 | Expand-Evals Planning-Command Coverage (cross-RFC) | — | — |
-| F1.3a | Per-Case Token Totals in EvalReport | F1.1 | specs/2026-05-18-007-per-case-token-totals-in-evalreport/ |
-| F1.3b | Per-Sub-Agent Token Attribution | F1.3a | — |
-| F1.4 | smithy.fix End-to-End Eval Scenario | F1.3a | — |
-| F1.5 | smithy.forge End-to-End Eval Scenario + Runner git-init (RFC SD-002) | F1.3a | — |
-| F1.6 | JVM Multi-Language Fixture | F1.1 | — |
-| F1.7 | Forge-JVM Eval Scenario + M1 Baseline-Set Completeness Gate | F1.3a, F1.5, F1.6 | — |
+| F1 | Feature 1.3a: Per-Case Token Totals in EvalReport | — | specs/2026-05-18-007-per-case-token-totals-in-evalreport/ |
+| F2 | Feature 1.3b: Per-Sub-Agent Token Attribution | F1 | — |
+| F3 | Feature 1.4: smithy.fix End-to-End Eval Scenario | F1 | — |
+| F4 | Feature 1.5: smithy.forge End-to-End Eval Scenario + Runner git-init (RFC SD-002) | F1 | — |
+| F5 | Feature 1.6: JVM Multi-Language Fixture | — | — |
+| F6 | Feature 1.7: Forge-JVM Eval Scenario + M1 Baseline-Set Completeness Gate | F1, F4, F5 | — |
 
-F1.1 and F1.2 are referenced-only rows with no implementation work (their `Artifact` column will remain `—` because no spec will be authored against them in this milestone — they are inherited substrate / cross-RFC dependency).
+Feature 1.1 and Feature 1.2 are referenced-only rows with no implementation work, so they are intentionally omitted from the Dependency Order table. No spec will be authored against them in this milestone because they are inherited substrate / cross-RFC dependency.
 
 Parallel-startable on day one: F1.3a, F1.3b, F1.4, F1.5, F1.6 (five-way concurrency). F1.3b can begin in parallel with F1.3a because it primarily consumes the already-captured `evals/captures/strike-health-check.events.jsonl` evidence; its code path joins F1.3a's rendering surface. F1.4 and F1.5 each depend on F1.3a only for their committed baseline files. F1.6's fixture authoring and `fixture:` field plumbing are independent of every other feature. F1.7 fans in last as the M1 closer. The M1-close `.claude/` snapshot-refresh chore PR follows F1.7 — it is not a feature row in this map.
 

--- a/docs/rfcs/2026-001-token-savings/token-savings.rfc.md
+++ b/docs/rfcs/2026-001-token-savings/token-savings.rfc.md
@@ -189,6 +189,6 @@ Each file, file section, or shared snippet has exactly one owning milestone for 
 
 | ID | Title | Depends On | Artifact |
 |----|-------|------------|----------|
-| M1 | Measurement Foundation | — | — |
-| M2 | Architectural Cost Reductions | M1 | — |
-| M3 | Early Cost Savings | M1 | — |
+| M1 | Measurement Foundation | — | docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md |
+| M2 | Architectural Cost Reductions | M1 | docs/rfcs/2026-001-token-savings/02-architectural-cost-reductions.features.md |
+| M3 | Early Cost Savings | M1 | docs/rfcs/2026-001-token-savings/03-early-cost-savings.features.md |


### PR DESCRIPTION
## Summary

Recovery follow-up to #372. That PR authored the F1.3a spec at
`specs/2026-05-18-007-per-case-token-totals-in-evalreport/` and pointed
the feature row at it, but two reporting gaps remained:

- **M1 feature IDs were unparseable.** The map used IDs like `F1.1`,
  `F1.3a`, `F1.3b`, etc. — smithy CLI's ID validator only accepts
  `F<N>` (no leading zeros, no dotted suffixes), so `smithy status`
  silently dropped every row in this map. The merged F1.3a spec was
  invisible to status reporting.
- **RFC milestone rows were not linked to their feature maps.** M1/M2/M3
  in `token-savings.rfc.md` had `Artifact: ` even though all three
  features.md files exist on disk (rendered by #334 / #350 / #351).

## Changes

- `01-measurement-foundation.features.md`:
  - Renumber rows from `F1.1 / F1.2 / F1.3a / F1.3b / F1.4 / F1.5 / F1.6 / F1.7`
    -> `F1..F6`. Human-readable names are preserved in the Title column
    (`Feature 1.3a: Per-Case Token Totals in EvalReport`, etc.), so the
    surrounding prose's `F1.3a` / `F1.7` references still resolve via
    the Title column.
  - Drop referenced-only rows F1.1 and F1.2 from the table (they own no
    implementation work - they're inherited substrate / cross-RFC
    dependency). The explanatory paragraph below the table now states
    this explicitly instead of carrying empty rows.
  - Remap `Depends On` to the new IDs.
- `token-savings.rfc.md`:
  - Set M1/M2/M3 Artifact columns to their existing features.md paths,
    flipping the milestone rows from not-started to linked.

## Verification

- `npm test` - 825/825 pass.
- `smithy status --format json` for the M1 features map now reports
  `warnings: []` and the F1 row's `artifact_path` resolves to
  `specs/2026-05-18-007-per-case-token-totals-in-evalreport/`. Before
  this patch the map carried the equivalent of "row 1 has invalid ID
  'F1.1' - dropped" for every row.
- M2/M3 feature maps still emit the same invalid-ID warnings they had
  before this PR (`F2.3`, `F2.4`, `F2.5`, `F3.1`, `F3.2`, `F3.3`). That
  is out of scope here - those maps belong to their own future cleanup
  PRs; touching them would expand this recovery beyond its slice.

## Notes on the "tasks.md checkbox" rule

This slice (`smithy.mark`) does not own any `tasks.md` rows - mark
produces specs, not tasks. The equivalent "completion signal" for a
mark slice is the parent features-map row's `Artifact` column going
from not-started to the spec path. That flip already shipped in #372
for F1.3a; this PR re-establishes the visibility of that flip by
making the row IDs parseable, and additionally flips the upstream
RFC's M1 row to its features.md path. No `[ ]` -> `[x]` checkbox was
in scope to flip.
