### PR TITLE
fix(forge,strike): trim verbose PR descriptions to scannable sections

### DIFF
--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1083,6 +1083,113 @@ describe('getComposedTemplates', () => {
     expect(prIdx).toBeGreaterThan(strikeDocIdx);
   });
 
+  // Issue #385: PR descriptions are too verbose. The forge PR body must
+  // carry exactly four scannable sections — Source / Slice Summary /
+  // Addresses / Validation — in both .tasks.md and .strike.md modes.
+  // The dropped sections (Tasks completed / Review / Documentation) all
+  // duplicate information that lives in the commits, the artifact's
+  // ## Specification Debt table, or the maid commits, so reviewers can
+  // navigate to it from the Source link.
+  it('forge PR body has lean four sections in .tasks.md mode (issue #385)', () => {
+    const forge = composed.commands.get('smithy.forge.md')!;
+    expect(forge).toBeDefined();
+
+    // Scope assertions to the .tasks.md PR-body block so we measure the
+    // contract, not stray mentions elsewhere in the prompt.
+    const blockStart = forge.indexOf('### `.tasks.md` mode — PR body:');
+    expect(blockStart).toBeGreaterThan(-1);
+    const blockEnd = forge.indexOf('### `.strike.md` mode — PR body:', blockStart);
+    expect(blockEnd).toBeGreaterThan(blockStart);
+    const block = forge.slice(blockStart, blockEnd);
+
+    // The four kept sections.
+    expect(block).toContain('**Source**');
+    expect(block).toContain('**Slice Summary**');
+    expect(block).toContain('**Addresses**');
+    expect(block).toContain('**Validation**');
+
+    // The three dropped sections — must not appear as PR-body bullets.
+    expect(block).not.toMatch(/\*\*Tasks completed\*\*/);
+    expect(block).not.toMatch(/\*\*Review\*\*/);
+    expect(block).not.toMatch(/\*\*Documentation\*\*/);
+  });
+
+  it('forge PR body has lean four sections in .strike.md mode (issue #385)', () => {
+    const forge = composed.commands.get('smithy.forge.md')!;
+    expect(forge).toBeDefined();
+
+    const blockStart = forge.indexOf('### `.strike.md` mode — PR body:');
+    expect(blockStart).toBeGreaterThan(-1);
+    // The .strike.md mode block runs until the next `---` separator.
+    const blockEnd = forge.indexOf('\n---', blockStart);
+    expect(blockEnd).toBeGreaterThan(blockStart);
+    const block = forge.slice(blockStart, blockEnd);
+
+    expect(block).toContain('**Source**');
+    expect(block).toContain('**Slice Summary**');
+    expect(block).toContain('**Addresses**');
+    expect(block).toContain('**Validation**');
+
+    expect(block).not.toMatch(/\*\*Tasks completed\*\*/);
+    expect(block).not.toMatch(/\*\*Review\*\*/);
+    expect(block).not.toMatch(/\*\*Documentation\*\*/);
+  });
+
+  it('forge no longer routes review or maid findings into the PR body (issue #385)', () => {
+    const forge = composed.commands.get('smithy.forge.md')!;
+    expect(forge).toBeDefined();
+
+    // The legacy triage rows said "note the fix in the PR body" / "Flag in
+    // the PR body" / "Note in the PR body only". With the Review section
+    // gone from the PR body, those routes dangle and have been replaced by
+    // terminal-output-deliverable language.
+    expect(forge).not.toMatch(/note the fix in the PR body/i);
+    expect(forge).not.toMatch(/flag it in the PR body/i);
+    expect(forge).not.toMatch(/Note in the PR body only/i);
+
+    // The maid "Documentation Notes" PR-body section is gone.
+    expect(forge).not.toContain('Documentation Notes');
+
+    // The "No review findings" PR-body insertion is gone too.
+    expect(forge).not.toMatch(/include\s+"No review findings"\s+in the PR body/i);
+  });
+
+  it('strike PR body is Source + Slice Summary only — does not embed one-shot-output sections (issue #385)', () => {
+    const strike = composed.commands.get('smithy.strike.md')!;
+    expect(strike).toBeDefined();
+
+    // Scope to the "Create the PR" step in Phase 5 so we measure the PR-body
+    // contract, not stray section markers elsewhere (the {{>one-shot-output}}
+    // partial below still renders the same headers as the terminal output).
+    const stepStart = strike.indexOf('**Create the PR**');
+    expect(stepStart).toBeGreaterThan(-1);
+    const stepEnd = strike.indexOf('**Capture the PR URL**', stepStart);
+    expect(stepEnd).toBeGreaterThan(stepStart);
+    const step = strike.slice(stepStart, stepEnd);
+
+    // The two kept sections.
+    expect(step).toContain('**Source**');
+    expect(step).toContain('**Slice Summary**');
+
+    // The dropped embedding rule must be gone — the old text instructed the
+    // agent to populate `## Summary`, `## Assumptions`, and `## Specification
+    // Debt` sections in the PR body. Those headers belong in the
+    // terminal-output one-shot block, not the PR body.
+    expect(step).not.toMatch(/Populate the other sections/i);
+    expect(step).not.toMatch(/one-shot output content produced below/i);
+    expect(step).not.toMatch(/\*\*excluding the `## PR` section\*\*/i);
+  });
+
+  it('strike review triage no longer routes findings into the PR body (issue #385)', () => {
+    const strike = composed.commands.get('smithy.strike.md')!;
+    expect(strike).toBeDefined();
+
+    expect(strike).not.toMatch(/Note the fix in the PR body/i);
+    expect(strike).not.toMatch(/Flag in PR for the reviewer/i);
+    expect(strike).not.toMatch(/Note in the PR body only/i);
+    expect(strike).not.toMatch(/surface them prominently in the PR body/i);
+  });
+
   it('strike template includes all four one-shot output headers', () => {
     const strike = composed.commands.get('smithy.strike.md')!;
     expect(strike).toBeDefined();

--- a/src/templates/agent-skills/commands/smithy.forge.prompt
+++ b/src/templates/agent-skills/commands/smithy.forge.prompt
@@ -219,11 +219,11 @@ from the shared review protocol:
 
 | Severity | Confidence | Forge action |
 |----------|------------|--------------|
-| Critical | High | Apply the `proposed_fix` on disk, run the test suite, commit as `review: <description>`, and note the fix in the PR body. |
-| Critical | Low | Do not apply. Append the finding to the slice planning artifact's `## Specification Debt` section and flag it in the PR body for the reviewer. |
+| Critical | High | Apply the `proposed_fix` on disk, run the test suite, commit as `review: <description>`. |
+| Critical | Low | Do not apply. Append the finding to the slice planning artifact's `## Specification Debt` section. |
 | Important | High | Apply the `proposed_fix` on disk, run the test suite, commit as `review: <description>`. |
 | Important | Low | Do not apply. Append the finding to the slice planning artifact's `## Specification Debt` section. |
-| Minor | Any | Do not apply and do not record as debt. Note in the PR body only. |
+| Minor | Any | Do not apply and do not record as debt. Note in forge's terminal-output **Review Summary** deliverable so the user sees it; do not add to the PR body. |
 
 "Slice planning artifact" above means the `.tasks.md`, `.strike.md`,
 `.spec.md`, or equivalent planning file associated with the slice you were
@@ -241,21 +241,19 @@ When applying a High-confidence fix:
    `review: <brief description of fix>`.
 4. If tests fail, revert the edit, reclassify the finding as **Low
    confidence**, and handle it via the Low-confidence row of the table
-   above (debt for Critical/Important, PR note for Minor). Do not commit a
-   failing fix.
+   above (debt for Critical/Important, terminal-output note for Minor).
+   Do not commit a failing fix.
 
-After all findings have been processed, summarize the outcome:
+After all findings have been processed, summarize the outcome in forge's
+terminal-output **Review Summary** deliverable (not in the PR body):
 
-1. **Escalated items** — Low-confidence Critical findings surfaced to the
-   user in the PR body with the review agent's description.
-2. **Applied fixes** — the list of `review:` commits created by forge with
+1. **Applied fixes** — the list of `review:` commits created by forge with
    the corresponding findings they resolved.
-3. **PR notes** — Minor findings and other review summary content to
-   include in the PR body.
-4. **Recorded debt** — any Low-confidence Important (or reclassified
-   Critical) findings appended to the artifact's `## Specification Debt`
-   section, so reviewers can see them without reading the full agent
-   transcript.
+2. **Recorded debt** — any Low-confidence Critical or Important findings
+   appended to the artifact's `## Specification Debt` section, so future
+   readers see them without scanning the agent transcript.
+3. **Minor notes** — Minor findings that did not warrant a fix or a debt
+   row; surface them once in the terminal output for the user, then drop.
 
 Forge's existing error-handling STOP gates (test failure mid-slice, blocked
 task, complex-fix escalation) are unchanged by the review phase.
@@ -283,8 +281,8 @@ Use the **smithy-maid** sub-agent. Pass it:
 After the sub-agent returns:
 
 1. **Auto-fixable items**: Apply the suggested changes, commit as `maid: <description>`.
-2. **Flagged items**: Include in the PR body under a "Documentation Notes" section.
-3. **Clean**: If no findings, skip the Documentation Notes section in the PR.
+2. **Flagged items**: Surface them in forge's terminal-output **Review Summary** deliverable so the user can decide whether to file follow-up work. Do **not** add a section to the PR body.
+3. **Clean**: No further action needed.
 {{else}}
 Scan the files changed between BASE_SHA and HEAD for documentation staleness:
 
@@ -296,7 +294,7 @@ Scan the files changed between BASE_SHA and HEAD for documentation staleness:
 
 For each stale doc found:
 - If the fix is obvious (e.g., update a parameter name in JSDoc), apply it and commit as `maid: <description>`.
-- If the fix requires judgment (e.g., rewriting a README section), note it for the PR body under "Documentation Notes".
+- If the fix requires judgment (e.g., rewriting a README section), surface it once in the terminal-output deliverable for the user; do not add it to the PR body.
 {{/ifAgent}}
 
 ---
@@ -347,25 +345,27 @@ Create the PR with:
 
 - **Title**: `<slice goal>` — concise, under 70 characters, descriptive text only (do NOT reference FR numbers or acceptance scenario IDs in the title — those are spec-internal and meaningless to later readers)
 
+The PR body has **exactly four sections** in both `.tasks.md` and `.strike.md`
+modes — no more. Keep each section scannable: prefer one-line bullets and
+short prose. The diff, commit log, and linked artifact already carry the
+implementation detail; do not restate it in the PR body. In particular, do
+**not** add `## Tasks completed`, `## Review`, or `## Documentation` sections —
+those repeat information that lives in the commits, the artifact's
+`## Specification Debt` table, and the `maid:` commits respectively.
+
 ### `.tasks.md` mode — PR body:
   - **Source**: Link to the spec file and tasks file (relative paths)
-  - **Slice**: Which slice number and its goal
-  - **Addresses**: The FRs and acceptance scenarios covered
-  - **Tasks completed**: Checklist of what was implemented
-  - **Review**: Auto-fixes applied, notes for reviewer (important/minor findings)
-  - **Documentation**: Maid findings — auto-fixes applied and items flagged for review (omit section if clean)
-  - **Validation**: Summary of commands run and their results (run after all code and doc fixes are committed)
+  - **Slice Summary**: Slice number + one-line slice goal
+  - **Addresses**: The FRs and acceptance scenarios covered (one line, comma-separated)
+  - **Validation**: One-line summary of the validation commands and outcomes (e.g. `build ✅ · typecheck ✅ · test ✅ (N passed)`)
 
 This traceability lets reviewers navigate from PR → slice → spec to understand why the code exists.
 
 ### `.strike.md` mode — PR body:
   - **Source**: Link to the `.strike.md` file (relative path)
-  - **Slice**: "Single Slice" with its goal
-  - **Summary**: The strike's Summary section
-  - **Tasks completed**: Checklist of what was implemented
-  - **Review**: Auto-fixes applied, notes for reviewer (important/minor findings)
-  - **Documentation**: Maid findings — auto-fixes applied and items flagged for review (omit section if clean)
-  - **Validation**: Summary of commands run and their results (run after all code and doc fixes are committed)
+  - **Slice Summary**: One-paragraph summary from the strike doc + one-line goal
+  - **Addresses**: The FRs satisfied by the implementation (plus AS if the strike captured them; one line)
+  - **Validation**: One-line summary of the validation commands and outcomes (e.g. `build ✅ · typecheck ✅ · test ✅ (N passed)`)
 
 ---
 
@@ -384,8 +384,9 @@ This traceability lets reviewers navigate from PR → slice → spec to understa
 - **Sub-agent failure**: If a smithy-implement sub-agent fails after one retry,
   stop and report the issue to the user with the error details.
 {{/ifAgent}}
-- **Review finds no issues**: Proceed directly to PR creation — include
-  "No review findings" in the PR body.
+- **Review finds no issues**: Proceed directly to PR creation. No review
+  section exists in the PR body; the terminal-output **Review Summary**
+  deliverable will simply read "No review findings."
 
 ---
 

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -208,11 +208,11 @@ table from the contracts:
 
 | Severity  | Confidence | Action                                                                                                |
 |-----------|------------|-------------------------------------------------------------------------------------------------------|
-| Critical  | High       | Apply the `proposed_fix` to the strike document on disk. Note the fix in the PR body.                 |
-| Critical  | Low        | Do not apply. Append to the strike's `## Specification Debt` section. Flag in PR for the reviewer.    |
+| Critical  | High       | Apply the `proposed_fix` to the strike document on disk.                                              |
+| Critical  | Low        | Do not apply. Append to the strike's `## Specification Debt` section.                                 |
 | Important | High       | Apply the `proposed_fix` to the strike document on disk.                                              |
 | Important | Low        | Do not apply. Append to the strike's `## Specification Debt` section.                                 |
-| Minor     | Any        | Do not apply. Note in the PR body only.                                                               |
+| Minor     | Any        | Do not apply. Surface once in the terminal output for the user; do not add to the PR body.            |
 
 For each Low-confidence finding routed to debt, append a new row to the
 `## Specification Debt` table with the next available `SD-NNN` identifier
@@ -227,8 +227,11 @@ in place using the `proposed_fix`. The commit immediately below will capture
 both the original artifact and the applied fixes in the same diff.
 
 If the agent returns drift findings (assumption-output drift category),
-surface them prominently in the PR body so the reviewer can confirm the
-assumption itself rather than silently accepting an applied fix.
+treat them as Critical for routing — auto-fix only when High confidence and
+the underlying assumption is unambiguous; otherwise append to
+`## Specification Debt` so the reviewer (and future readers of the strike
+artifact) see the assumption flagged without scanning the agent transcript.
+Do not stash drift findings in the PR body.
 
 The review agent never modifies files itself — all on-disk changes are made
 here, by strike.
@@ -245,12 +248,14 @@ here, by strike.
 3. **Create the PR** using the same PR-creation pattern as `smithy-forge`
    ({{>pr-create-tool-choice}}):
    - **Title**: the strike goal, concise and under 70 characters.
-   - **Body**: include the strike summary, goal, link to the
-     `.strike.md` file, and the one-shot output content produced below
-     **excluding the `## PR` section**, since the PR URL is only known
-     after PR creation succeeds. Populate the other sections
-     (`## Summary`, `## Assumptions`, `## Specification Debt`) from the
-     run data captured during Phase 2 and Phase 3.
+   - **Body**: exactly two sections, kept scannable —
+     - **Source**: link to the `.strike.md` file (relative path).
+     - **Slice Summary**: the strike's Summary paragraph followed by the
+       one-line Goal.
+     Do **not** embed the one-shot output's `## Summary`, `## Assumptions`,
+     or `## Specification Debt` sections in the PR body — those already
+     live in the strike artifact (`Source` links to them) and in the run's
+     terminal output. Reviewers click through; the PR body stays parsable.
 4. **Capture the PR URL** returned by the PR-creation call.
 5. **Render the full one-shot output** as the terminal output of this
    run using the shared snippet below. Populate the placeholders from


### PR DESCRIPTION
## Issue
- Closes #385

## Summary
- Primary outcome: PR descriptions generated by `smithy.forge` and `smithy.strike` are trimmed to four scannable sections (Source / Slice Summary / Addresses / Validation) — roughly cutting a typical PR body from ~70 lines to ~15.
- Notable behaviour changes: forge and strike no longer emit `## Tasks completed`, `## Review`, or `## Documentation` sections in the PR body. Review findings, maid notes, and "no review findings" status are surfaced in forge's terminal-output **Review Summary** deliverable instead, where the user actually sees them at the end of the run.
- Follow-up work deferred: the `.claude/` snapshot is intentionally not regenerated in this PR per `CLAUDE.md`'s source-vs-deployed rule — it'll be refreshed in a later chore PR.

## Context
- Why now: the user observed that forge-generated PR descriptions (concrete example: [Balexda/March#103](https://github.com/Balexda/March/pull/103), ~70 lines / 7.8 KB) restate the diff, narrate the review process, and enumerate every maid commit. The signal-to-noise is low; reviewers skim or skip the body and miss the parts that matter.
- The user explicitly identified the three offending sections: "Tasks Completed is unnecessary and just repeats information from inside the PR. The Review section is non-value add since we already fixed them. Documentation is the same, it's a list of things already fixed" — and confirmed Source / Slice Summary / Addresses / Validation as the four valuable sections to keep.

## Implementation Notes
- **`src/templates/agent-skills/commands/smithy.forge.prompt`** — Replaced both `.tasks.md` and `.strike.md` PR-body specs with the four-section contract. Updated the review-triage table (Minor + Critical/Low rows), the post-review summary outcome list, the maid-flagged-items branch, and the "review finds no issues" edge case so each one routes findings into forge's terminal-output **Review Summary** deliverable rather than dangling references to PR sections that no longer exist.
- **`src/templates/agent-skills/commands/smithy.strike.prompt`** — Collapsed the PR body to two sections (Source + Slice Summary). Removed the rule that embedded the one-shot output's `## Summary`/`## Assumptions`/`## Specification Debt` sections into the PR body; those still render in the run's terminal output via the unchanged `{{>one-shot-output}}` partial, and the strike artifact itself remains the canonical source for reviewers. Slimmed the strike review-triage table and drift-finding routing the same way as forge.
- **`src/templates.test.ts`** — Added five assertions that lock the contract: forge's two PR-body blocks contain the four kept sections and reject the three dropped ones; forge no longer carries any "note … in the PR body" / "Documentation Notes" routing; strike's PR-creation step exposes only Source + Slice Summary and no longer instructs the agent to embed one-shot-output sections in the PR body.
- Boundaries: this PR does **not** touch `smithy.orders` issue body templates (different surface), `smithy.fix` (does not create PRs), `smithy.ignite` / `smithy.mark` / `smithy.render` / `smithy.cut` (they use `one-shot-output` as their *terminal* output, not the PR body), the `one-shot-output` snippet itself, or the `.claude/` deployed snapshot.

## Risks & Mitigations
- **Risk**: Reviewers used to seeing Review/Documentation sections in the PR body may miss findings now surfaced only in the terminal output. **Mitigation**: Critical/Low and Important/Low findings still flow into the artifact's `## Specification Debt` table (linked from the PR's Source section), so anything load-bearing remains discoverable from the PR. Minor findings — which by definition do not warrant follow-up — are mentioned once in the terminal output and then dropped, matching the user's stated intent.
- **Risk**: Existing CI tests could regress on assumed PR-body section names. **Mitigation**: grep confirmed no existing test asserted on `Tasks completed` / `## Review` / `## Documentation`; the existing phase-ordering tests check only that `gh pr create` appears in the right phase. Full `npm test` passes (830/830) with the five new assertions.
- **Risk**: Drifted `.claude/` snapshot could confuse contributors who run the snapshot directly. **Mitigation**: per the project rule, that snapshot is intentionally allowed to drift between releases and is refreshed in dedicated chore PRs.

## Rollback Plan
- Code: `git revert <merge sha>` is sufficient — the change is entirely in three source files (two prompts + one test file) and a single commit. No data migrations, no manifest changes, no `.claude/` deltas, no CLI behavior changes outside of what AI agents read from the prompts.
- Data: none.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npm run typecheck`)
- [ ] CLI `init` smoke test (`node dist/cli.js init`) — not run; this PR changes only prompt text and tests, no init-flow behavior changed.

### Template Generation
- [ ] Gemini Skills / Codex Prompts / Claude Prompts — not separately exercised; the composed-template tests in `src/templates.test.ts` cover the rendered output paths and all pass.
- [ ] GitHub Issue Templates — not touched (different surface from PR descriptions, called out as out of scope).

### Permissions & Configuration
- [ ] Gemini / Codex / Claude config — not touched.

### Manual Test Cases
- [ ] `tests/Agent.tests.md` / `tests/Manual.tests.md` — no init/uninit flows changed; not re-run.

### Automated Tests
- [x] `npm test` — **830/830 pass**, including the 5 new lean-PR-body assertions added in `src/templates.test.ts`.

### End-to-end PR-body verification (manual, deferred)
- [ ] Run `smithy.forge` against a real `.tasks.md` slice in a scratch repo where smithy is deployed and confirm the resulting PR body contains only `Source` / `Slice Summary` / `Addresses` / `Validation` and is ≤ 20 lines.
- [ ] Run `smithy.strike` against a small task in the same scratch repo and confirm the resulting PR body contains only `Source` and `Slice Summary` (no `## Assumptions` / `## Specification Debt` embedded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
