### PR TITLE
spec(token-savings/M1/F2): per-sub-agent token attribution

### DIFF
--- a/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
+++ b/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
@@ -105,7 +105,7 @@ Recommended specification sequence:
 | ID | Title | Depends On | Artifact |
 |----|-------|------------|----------|
 | F1 | Feature 1.3a: Per-Case Token Totals in EvalReport | — | specs/2026-05-18-007-per-case-token-totals-in-evalreport/ |
-| F2 | Feature 1.3b: Per-Sub-Agent Token Attribution | F1 | — |
+| F2 | Feature 1.3b: Per-Sub-Agent Token Attribution | F1 | specs/2026-05-20-008-per-sub-agent-token-attribution/ |
 | F3 | Feature 1.4: smithy.fix End-to-End Eval Scenario | F1 | — |
 | F4 | Feature 1.5: smithy.forge End-to-End Eval Scenario + Runner git-init (RFC SD-002) | F1 | — |
 | F5 | Feature 1.6: JVM Multi-Language Fixture | — | — |

--- a/specs/2026-05-20-008-per-sub-agent-token-attribution/per-sub-agent-token-attribution.contracts.md
+++ b/specs/2026-05-20-008-per-sub-agent-token-attribution/per-sub-agent-token-attribution.contracts.md
@@ -1,0 +1,206 @@
+# Contracts: Per-Sub-Agent Token Attribution
+
+## Overview
+
+This feature extends eval-framework contracts at the stream evidence, attribution, result assembly, and report rendering boundaries. The contracts are conditional: if committed evidence supports dispatch-level attribution, optional attribution data flows through the report. If evidence proves parent-only attribution, report contracts remain on the F1.3a per-case token surface and the feature closes through RFC documentation updates.
+
+## Interfaces
+
+### 1) Dispatch Usage Evidence Classification
+
+**Purpose**: Determines whether the agent stream supports per-sub-agent attribution.
+**Consumers**: Feature implementation and RFC debt closure.
+**Providers**: Committed eval stream captures.
+
+#### Signature
+
+```ts
+classifyDispatchUsageEvidence(events: StreamEvent[]): DispatchUsageEvidence
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `events` | StreamEvent[] | Yes | Parsed committed capture events from a representative eval scenario. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `classification` | enum | `dispatch_attributable` when stable dispatch-level usage exists; otherwise `parent_only`. |
+| `observed_relationship` | string | The relationship used for attribution, or the reason attribution is unavailable. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Capture has no usage metadata | Return `parent_only` with missing-usage rationale. | The implementation must not invent attribution. |
+| Capture has ambiguous identifiers | Return `parent_only` with ambiguity rationale. | Ambiguous data is not sufficient for per-agent reporting. |
+| Capture has stable dispatch identifiers | Return `dispatch_attributable`. | The attribution path may proceed. |
+
+### 2) Sub-Agent Token Attribution
+
+**Purpose**: Converts dispatch-attributable usage records into per-sub-agent token totals for one scenario.
+**Consumers**: Scenario result assembly and report rendering.
+**Providers**: Parsed stream events and extracted sub-agent dispatches.
+
+#### Signature
+
+```ts
+extractSubAgentTokenTotals(events: StreamEvent[]): SubAgentTokenTotals[]
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `events` | StreamEvent[] | Yes | Parsed stream events for one scenario run. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agent` | string | Stable sub-agent display name. |
+| `input` | integer | Summed attributed input token count. |
+| `output` | integer | Summed attributed output token count. |
+| `dispatch_count` | integer | Count of dispatches represented by the aggregate row. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| No dispatch-level usage exists | Return an empty list. | Per-case totals remain authoritative. |
+| Usage value is malformed | Ignore that value and continue. | Invalid usage must not fail the scenario. |
+| Dispatch name is missing | Use a stable fallback display name. | Rendering remains deterministic. |
+| Dispatch failed with usage present | Include the usage. | Cost reporting does not depend on pass status. |
+
+#### Attribution Rule
+
+The extractor MUST create sub-agent totals only from usage records that can be matched to a known sub-agent dispatch through a stable dispatch identifier relationship. Parent-level usage records, terminal per-case totals, and usage records without a reliable dispatch relationship MUST NOT be included in `sub_agent_tokens`.
+
+### 3) Scenario Result Assembly
+
+**Purpose**: Carries optional per-sub-agent token totals into the per-case eval result.
+**Consumers**: Report aggregation and report formatting.
+**Providers**: Scenario runner output and attribution extraction.
+
+#### Signature
+
+```ts
+scenarioRunToResult(
+  scenario: EvalScenario,
+  output: RunOutput,
+  structuralChecks: CheckResult[],
+  subAgentChecks?: CheckResult[],
+  baselineChecks?: CheckResult[],
+  subAgentTokens?: SubAgentTokenTotals[],
+): EvalResult
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `subAgentTokens` | SubAgentTokenTotals[] | No | Optional attribution totals for the scenario. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sub_agent_tokens` | SubAgentTokenTotals[] | Present only when the input contains one or more attribution rows. |
+| `status` | enum | Existing status behavior is preserved. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Attribution input is absent | Omit `sub_agent_tokens`. | Existing reports remain compatible. |
+| Attribution input is empty | Omit `sub_agent_tokens`. | Empty sections are not rendered. |
+| Scenario fails, errors, or times out | Preserve any supplied attribution rows. | Available usage remains useful for cost analysis. |
+
+### 4) Report Rendering
+
+**Purpose**: Renders nested per-sub-agent token rows under case lines when attribution data exists.
+**Consumers**: CLI users running evals and downstream reviewers reading token deltas.
+**Providers**: Eval reports containing per-case results.
+
+#### Signature
+
+```ts
+formatReport(report: EvalReport): string
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `results[].sub_agent_tokens` | SubAgentTokenTotals[] | No | Optional per-case attribution rows. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| formatted nested row | string | A sub-agent display name plus `input: <N>, output: <N>` rendered beneath the owning case. |
+
+#### Rendering Contract
+
+Each nested attribution row uses this semantic shape:
+
+```text
+    <agent>: input: <non-negative integer>, output: <non-negative integer>
+```
+
+Rows render directly below their owning scenario case line. They render only for cases with one or more attribution rows. Existing case-line status tokens, per-case token totals, durations, baseline markers, total elapsed line, and final result line remain present.
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| No case has attribution data | Render no nested attribution rows. | F1.3a report shape remains stable. |
+| Some cases have attribution data | Render rows only for those cases. | Mixed reports stay compact. |
+| Attribution row has zero totals | Render it only if it came from a matched dispatch. | Zero can mean observed usage of zero, not missing evidence. |
+
+### 5) Parent-Only Fallback Closure
+
+**Purpose**: Defines the documentation contract when dispatch-level attribution is unavailable.
+**Consumers**: RFC readers and downstream feature authors.
+**Providers**: Evidence classification.
+
+#### Signature
+
+```text
+resolveParentOnlyFallback(evidence: DispatchUsageEvidence) -> DocumentationUpdate
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `evidence.classification` | enum | Yes | Must be `parent_only` for this path. |
+| `evidence.observed_relationship` | string | Yes | Explanation of why dispatch-level attribution is unavailable. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| RFC goal update | markdown change | States that M1 relies on per-case totals and baselines while per-sub-agent attribution is deferred. |
+| RFC SD-001 resolution | markdown change | Records the observed parent-only stream contract. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Evidence is dispatch-attributable | Do not use fallback. | The implementation path should ship attribution. |
+| Evidence is parent-only | Apply documentation closure. | The feature closes without misleading report fields. |
+
+## Events / Hooks
+
+No new external events or hooks are introduced. Attribution is derived from existing stream events and carried through the existing eval report pipeline.
+
+## Integration Boundaries
+
+- **Agent stream output**: usage metadata is consumed only when it can be reliably tied to a dispatch identifier.
+- **Eval result assembly**: attribution data is optional and additive; scenario status semantics remain unchanged.
+- **Eval report stdout**: nested attribution rows extend the report only for cases with attribution data.
+- **RFC governance**: the parent-only fallback path updates the RFC goal and SD-001 resolution instead of changing report output.

--- a/specs/2026-05-20-008-per-sub-agent-token-attribution/per-sub-agent-token-attribution.contracts.md
+++ b/specs/2026-05-20-008-per-sub-agent-token-attribution/per-sub-agent-token-attribution.contracts.md
@@ -29,7 +29,9 @@ classifyDispatchUsageEvidence(events: StreamEvent[]): DispatchUsageEvidence
 | Field | Type | Description |
 |-------|------|-------------|
 | `classification` | enum | `dispatch_attributable` when stable dispatch-level usage exists; otherwise `parent_only`. |
+| `source_capture` | string | The committed capture path reviewed for evidence. |
 | `observed_relationship` | string | The relationship used for attribution, or the reason attribution is unavailable. |
+| `reviewed_at` | string | ISO 8601 timestamp recorded when the classification was made. |
 
 #### Error Conditions
 

--- a/specs/2026-05-20-008-per-sub-agent-token-attribution/per-sub-agent-token-attribution.data-model.md
+++ b/specs/2026-05-20-008-per-sub-agent-token-attribution/per-sub-agent-token-attribution.data-model.md
@@ -1,0 +1,127 @@
+# Data Model: Per-Sub-Agent Token Attribution
+
+## Overview
+
+This feature extends the eval report model with optional per-sub-agent token totals when the agent stream can reliably tie usage metadata to a sub-agent dispatch. The additions are transient report data only; no new persistent database or external storage is introduced. If the stream evidence is parent-only, the data model remains unchanged and the feature closes through the documented fallback path.
+
+## Entities
+
+### 1) DispatchUsageEvidence (`dispatch_usage_evidence`)
+
+Purpose: Records whether the committed stream evidence supports per-sub-agent token attribution.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `classification` | enum | Yes | Either `dispatch_attributable` or `parent_only`. |
+| `source_capture` | string | Yes | The committed capture reviewed for evidence. |
+| `observed_relationship` | string | Yes | The stable event relationship used for attribution, or the reason no such relationship exists. |
+| `reviewed_at` | string | Yes | ISO 8601 timestamp for the evidence review. |
+
+Validation rules:
+
+- The classification must be based on committed capture evidence.
+- `dispatch_attributable` requires a stable identifier relationship between a usage record and a dispatch.
+- `parent_only` requires a documented reason that dispatch-level attribution is unavailable.
+
+### 2) SubAgentTokenTotals (`sub_agent_token_totals`)
+
+Purpose: Represents measured token usage for one sub-agent within one eval scenario.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `agent` | string | Yes | Stable display name for the sub-agent. |
+| `input` | integer | Yes | Non-negative input token count attributed to the sub-agent. |
+| `output` | integer | Yes | Non-negative output token count attributed to the sub-agent. |
+| `dispatch_count` | integer | Yes | Number of dispatches aggregated into this row. |
+
+Validation rules:
+
+- `agent` must be non-empty after fallback display-name resolution.
+- `input`, `output`, and `dispatch_count` must be finite non-negative integers.
+- Repeated dispatches for the same agent aggregate by `agent`.
+- Unknown, malformed, or unattributable usage records are excluded from this entity.
+
+### 3) DispatchUsageRecord (`dispatch_usage_record`)
+
+Purpose: Transient normalized usage record tied to a specific sub-agent dispatch before aggregation.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `dispatch_id` | string | Yes | Stable identifier for the associated sub-agent dispatch. |
+| `agent` | string | Yes | Display name derived from the dispatch metadata. |
+| `input` | integer | Yes | Non-negative input token count for this record. |
+| `output` | integer | Yes | Non-negative output token count for this record. |
+
+Validation rules:
+
+- A record is created only when `dispatch_id` can be matched to a known dispatch.
+- Invalid token values are ignored rather than coerced.
+- Records for failed dispatches remain valid when usage metadata is otherwise parseable.
+
+### 4) EvalResult (`eval_result`)
+
+Purpose: Existing per-case report result extended with optional sub-agent token totals.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `sub_agent_tokens` | SubAgentTokenTotals[] | No | Present only when at least one sub-agent has attributed usage totals. |
+
+Validation rules:
+
+- Absence means no attribution data is available for the case.
+- An empty array should be omitted to avoid implying an explicit zero-cost attribution set.
+- Scenario status is independent of this field.
+
+### 5) EvalReport (`eval_report`)
+
+Purpose: Existing aggregate report that renders optional nested attribution rows for each result.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `results[].sub_agent_tokens` | SubAgentTokenTotals[] | No | Per-case attribution data consumed by report formatting. |
+
+Validation rules:
+
+- Report aggregation preserves per-result attribution arrays without computing a cross-case per-agent total.
+- Rendering order follows the scenario result order, then stable agent-name order within each result.
+- Cases with no attribution data render no nested attribution rows.
+
+## Relationships
+
+- `DispatchUsageEvidence` 1:1 implementation path selection for the feature.
+- `Agent Dispatch` 1:N `DispatchUsageRecord` via dispatch identifier matching.
+- `DispatchUsageRecord` N:1 `SubAgentTokenTotals` via per-scenario aggregation by agent display name.
+- `SubAgentTokenTotals` N:1 `EvalResult` as optional per-case attribution detail.
+- `EvalResult` N:1 `EvalReport` through the existing report aggregation flow.
+
+## State Transitions
+
+### Evidence lifecycle
+
+1. `unreviewed` -> `classified`
+   - Trigger: committed capture evidence is inspected.
+   - Effects: the feature selects either the attribution implementation path or the parent-only fallback path.
+
+2. `classified` -> `resolved`
+   - Trigger: implementation or documentation fallback lands.
+   - Effects: RFC SD-001 is either proven supported by implementation or resolved as parent-only fallback.
+
+### Attribution lifecycle
+
+1. `raw_usage` -> `matched`
+   - Trigger: a usage record is tied to a known dispatch identifier.
+   - Effects: a dispatch usage record is created.
+
+2. `matched` -> `aggregated`
+   - Trigger: all records for one scenario are grouped by sub-agent display name.
+   - Effects: per-agent input, output, and dispatch counts are summed.
+
+3. `aggregated` -> `rendered`
+   - Trigger: the eval report is formatted.
+   - Effects: nested attribution rows appear beneath the owning scenario case line.
+
+## Identity & Uniqueness
+
+- A dispatch usage record is uniquely identified by scenario name, dispatch identifier, and the source usage event.
+- A sub-agent token total is uniquely identified by scenario name and sub-agent display name.
+- Evidence classification is unique per feature implementation because only one path can close the feature.

--- a/specs/2026-05-20-008-per-sub-agent-token-attribution/per-sub-agent-token-attribution.spec.md
+++ b/specs/2026-05-20-008-per-sub-agent-token-attribution/per-sub-agent-token-attribution.spec.md
@@ -1,0 +1,164 @@
+# Feature Specification: Per-Sub-Agent Token Attribution
+
+**Spec Folder**: `2026-05-20-008-per-sub-agent-token-attribution`
+**Branch**: `2026-05-20-008-per-sub-agent-token-attribution`
+**Created**: 2026-05-20
+**Status**: Draft
+**Input**: `docs/rfcs/2026-001-token-savings/token-savings.rfc.md` - Milestone 1 measurement foundation feature for attributing eval token usage to dispatched sub-agents when the agent stream supports it.
+**Source Feature Map**: `docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md` - Feature 1.3b: Per-Sub-Agent Token Attribution
+
+## Clarifications
+
+### Session 2026-05-20
+
+- This specification targets the Dependency Order row `F2`, which corresponds to Feature 1.3b in the measurement-foundation feature map. `[Critical Assumption]`
+- Feature 1.3a is the prerequisite measurement substrate; this feature consumes its per-case token totals and report rendering surface instead of redefining them.
+- The feature has a dual-path outcome: ship per-sub-agent attribution when captured stream evidence contains dispatch-level usage records, or ship a documentation-only descope when the evidence proves parent-only attribution.
+- The report rendering format is settled here: per-sub-agent token lines render as nested rows beneath the owning case row, and only when at least one sub-agent has usage data.
+- Per-sub-agent token baselines are out of scope. F1.3a's per-case token envelope remains the committed baseline contract for M1 and downstream token deltas.
+- Parent-only fallback must not block M1. If dispatch-level usage is unavailable, this feature closes by documenting the fallback, updating the RFC goal language, and resolving the RFC's SD-001.
+
+## Artifact Hierarchy
+
+RFC -> Milestone -> Feature -> User Story -> Slice -> Tasks
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1: Verify Dispatch-Level Usage Evidence (Priority: P1)
+
+As a Smithy maintainer, I want the captured eval stream inspected for dispatch-level usage records so that the implementation path is based on observed agent output rather than an assumption.
+
+**Why this priority**: Every other story depends on knowing whether usage can be tied to a sub-agent dispatch. The RFC explicitly makes this feature contingent on that evidence.
+
+**Independent Test**: Analyze a committed eval capture and classify it as either dispatch-attributable or parent-only, with the classification recorded in the feature implementation notes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a captured eval stream includes usage metadata tied to a dispatched sub-agent invocation, **When** evidence classification runs, **Then** the feature is marked eligible for per-sub-agent attribution.
+2. **Given** a captured eval stream includes usage metadata only on parent-level events, **When** evidence classification runs, **Then** the feature is marked parent-only and the documentation fallback path is selected.
+3. **Given** a captured eval stream contains malformed or partial usage metadata, **When** evidence classification runs, **Then** the classification identifies the usable records and does not infer attribution from ambiguous data.
+
+---
+
+### User Story 2: Attribute Token Totals to Sub-Agent Dispatches (Priority: P1)
+
+As a Smithy contributor, I want token totals grouped by dispatched sub-agent so that I can see which helpers are responsible for a scenario's cost.
+
+**Why this priority**: The user-facing value of this feature is not additional per-case totals; it is explaining which dispatched agent consumed those tokens when the stream carries enough evidence.
+
+**Independent Test**: Run token attribution over a fixture event stream containing multiple sub-agent dispatches and verify the result groups input and output totals under the correct sub-agent names.
+
+**Acceptance Scenarios**:
+
+1. **Given** a stream contains an Agent dispatch and usage metadata tied to that dispatch, **When** attribution runs, **Then** the matching sub-agent receives the usage record's input and output token totals.
+2. **Given** a stream contains multiple dispatches of the same sub-agent, **When** attribution runs, **Then** their token totals are summed under one sub-agent row for the scenario.
+3. **Given** a stream contains usage metadata that cannot be tied to a dispatch, **When** attribution runs, **Then** the per-case total remains available and no synthetic sub-agent row is created.
+
+---
+
+### User Story 3: Render Nested Sub-Agent Token Rows (Priority: P1)
+
+As a Smithy contributor, I want each eval report to show sub-agent token rows beneath a case so that expensive helper dispatches are visible without reading raw captures.
+
+**Why this priority**: Attribution has to be visible in the standard eval report to support model-downgrade and orchestration decisions in later milestones.
+
+**Independent Test**: Format an eval report containing per-sub-agent token totals and verify nested rows render below the relevant case while reports without attribution keep the existing per-case shape.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scenario result contains sub-agent token totals, **When** the report is formatted, **Then** each sub-agent renders as a nested row with input and output token counts below that scenario.
+2. **Given** a report contains scenarios with and without sub-agent token totals, **When** the report is formatted, **Then** nested rows render only under scenarios that have attribution data.
+3. **Given** a scenario result has per-case token totals and no sub-agent token totals, **When** the report is formatted, **Then** the case line still displays per-case totals and no empty attribution section is rendered.
+
+---
+
+### User Story 4: Document Parent-Only Fallback (Priority: P1)
+
+As a Smithy maintainer, I want a formal fallback when dispatch-level usage is unavailable so that M1 can close without pretending per-sub-agent attribution exists.
+
+**Why this priority**: The RFC allows parent-only fallback, but it must be explicitly closed so downstream features consume the correct measurement contract.
+
+**Independent Test**: Use a parent-only capture classification and verify the RFC goal language and specification debt record are updated to state that per-sub-agent attribution is deferred beyond M1.
+
+**Acceptance Scenarios**:
+
+1. **Given** dispatch-level usage is unavailable, **When** this feature lands, **Then** the RFC goal language states that M1 relies on per-case totals and committed baselines.
+2. **Given** dispatch-level usage is unavailable, **When** this feature lands, **Then** the RFC SD-001 row is resolved with the observed parent-only evidence.
+3. **Given** dispatch-level usage is unavailable, **When** eval reports are formatted, **Then** no empty or misleading sub-agent token rows are rendered.
+
+### Edge Cases
+
+- A single sub-agent type may be dispatched more than once in one scenario; totals should aggregate by sub-agent display name for report readability.
+- A usage record may appear before its matching tool result is observed; attribution must not depend on event order beyond the dispatch identifier relationship.
+- A sub-agent dispatch may fail or return an error while still producing usage metadata; available tokens remain attributable.
+- Some events may carry parent usage and dispatch usage in the same stream; attribution must avoid double-counting parent totals as sub-agent totals.
+- Unknown agent names, missing descriptions, or non-string dispatch labels should fall back to a stable display name rather than failing report generation.
+
+## Dependency Order
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| US1 | Verify Dispatch-Level Usage Evidence | — | — |
+| US2 | Attribute Token Totals to Sub-Agent Dispatches | US1 | — |
+| US3 | Render Nested Sub-Agent Token Rows | US2 | — |
+| US4 | Document Parent-Only Fallback | US1 | — |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST classify the committed stream evidence as dispatch-attributable or parent-only before selecting the implementation path.
+- **FR-002**: When dispatch-level usage exists, the system MUST represent per-sub-agent token totals as separate non-negative integer input and output counts.
+- **FR-003**: When dispatch-level usage exists, each scenario result MUST carry zero or more per-sub-agent token totals.
+- **FR-004**: Usage metadata MUST be attributed only when a reliable dispatch identifier relationship exists between the usage record and the sub-agent invocation.
+- **FR-005**: Multiple dispatches for the same sub-agent within one scenario MUST aggregate into a single rendered sub-agent total.
+- **FR-006**: Unattributable usage metadata MUST remain covered by the per-case token total and MUST NOT create a misleading sub-agent row.
+- **FR-007**: Per-sub-agent attribution MUST NOT affect scenario pass, fail, timeout, or error status.
+- **FR-008**: The formatted eval report MUST render nested per-sub-agent rows beneath each case that has attribution data.
+- **FR-009**: The formatted eval report MUST omit nested attribution rows for cases with no attribution data.
+- **FR-010**: Existing per-case token totals, baseline markers, and aggregate report status rendering MUST remain visible when nested rows render.
+- **FR-011**: When evidence proves parent-only attribution, the implementation MUST update the RFC goal language and resolve RFC SD-001 instead of adding report fields that imply unavailable precision.
+- **FR-012**: Unit tests MUST cover dispatch-attributable streams, parent-only streams, repeated sub-agent dispatches, malformed usage records, failed dispatches with usage, and rendering with mixed attributed and unattributed cases.
+
+### Key Entities
+
+- **SubAgentTokenTotals**: The per-scenario aggregate input and output token counts for one dispatched sub-agent display name.
+- **DispatchUsageEvidence**: The classification record that determines whether a captured stream supports dispatch-level attribution or only parent-level totals.
+- **Agent Dispatch**: The existing sub-agent invocation record used to map usage metadata back to a named helper.
+- **Eval Result**: The per-case eval result extended with optional per-sub-agent token totals when evidence supports attribution.
+- **Eval Report**: The aggregate eval report whose case rendering may include nested attribution rows.
+- **Fallback Resolution**: The documentation-only closure path used when parent-only attribution is the observed stream contract.
+
+## Assumptions
+
+- Feature 1.3a has already introduced per-case token totals and the report rendering surface this feature extends.
+- Dispatch-level attribution is only trustworthy when stream events carry a stable relationship to a specific Agent dispatch.
+- Per-case totals are the authoritative cost signal in all paths; per-sub-agent totals are explanatory detail when available.
+- Nested rows are sufficient for M2 and M3 reviewers because they preserve case-local context and do not require a new report mode.
+- Resolving the parent-only fallback in documentation is an acceptable completed outcome for this feature under the RFC.
+
+## Specification Debt
+
+None - all ambiguities resolved.
+
+## Out of Scope
+
+- Per-sub-agent token baseline envelopes or committed per-agent baseline files.
+- Changing F1.3a's per-case token extraction, per-case baseline comparison, or aggregate token totals contract.
+- New eval scenarios for smithy.fix, smithy.forge, or JVM forge coverage.
+- Sub-agent model downgrades, prompt cost reductions, or any M2/M3 optimization work.
+- Public CLI flags or opt-in report modes for token detail.
+- Inferring attribution from prompt text, result text, or event order when no stable dispatch identifier exists.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The committed capture evidence is classified as dispatch-attributable or parent-only.
+- **SC-002**: If dispatch-attributable, scenario results include per-sub-agent input and output token totals.
+- **SC-003**: If dispatch-attributable, formatted reports render nested sub-agent rows only for cases with attribution data.
+- **SC-004**: If parent-only, the RFC goal language and SD-001 row are updated to document the post-M1 descope.
+- **SC-005**: Per-case token totals and baseline markers continue to render in all attribution and fallback paths.
+- **SC-006**: Unit tests cover attribution, fallback classification, aggregation, and mixed report rendering paths.

--- a/specs/2026-05-20-008-per-sub-agent-token-attribution/per-sub-agent-token-attribution.spec.md
+++ b/specs/2026-05-20-008-per-sub-agent-token-attribution/per-sub-agent-token-attribution.spec.md
@@ -141,7 +141,9 @@ Recommended implementation sequence:
 
 ## Specification Debt
 
-None - all ambiguities resolved.
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| — | None — all ambiguities resolved. | — | — | — | — | — |
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

- Adds the F2 spec set (`*.spec.md`, `*.data-model.md`, `*.contracts.md`) for **Feature 1.3b: Per-Sub-Agent Token Attribution** under the 2026-001 token-savings RFC's measurement-foundation milestone.
- Flips the `## Dependency Order` row for F2 in `01-measurement-foundation.features.md` from `—` to `specs/2026-05-20-008-per-sub-agent-token-attribution/`. Per the project artifact schema in `CLAUDE.md`, the `Artifact` column is the started/not-started signal at the feature-map level — there are no `[ ]`/`[x]` checkboxes in `## Dependency Order` to flip, so the path update is the equivalent completion signal.

## Spec highlights

- 4 user stories (US1 evidence classification, US2 attribution extraction, US3 nested report rendering, US4 parent-only fallback documentation).
- 12 functional requirements covering both the dispatch-attributable implementation path and the parent-only RFC-documentation fallback path; success criteria SC-001..SC-006 map back to those FRs.
- Data model introduces three transient entities — `DispatchUsageEvidence`, `SubAgentTokenTotals`, `DispatchUsageRecord` — plus optional `sub_agent_tokens` extensions on `EvalResult` / `EvalReport`; no persistent storage.
- Contracts define `classifyDispatchUsageEvidence`, `extractSubAgentTokenTotals`, an additive optional `subAgentTokens?` parameter on `scenarioRunToResult`, `formatReport` nested-row rendering, and a `resolveParentOnlyFallback` documentation closure path.

## Verification

- `git diff --cached --check` clean (no whitespace issues).
- Spec/data-model/contracts cross-check: every FR has at least one acceptance scenario; every contract surface (evidence, attribution, assembly, rendering, fallback) appears in both data-model and spec; rendering shape matches the F1.3a per-case envelope (nested rows only when attribution exists).
- No code paths touched in this slice — pure planning artifact. Tier-1/2/3 tests not exercised because none apply to a spec-only mark step.

## Test plan

- [ ] Reviewer confirms the spec's parent-only fallback path is acceptable as an M1-closing outcome (matches RFC SD-001 framing).
- [ ] Downstream `/smithy.cut` for F2 can derive a tasks.md from the included Dependency Order and Acceptance Scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
