### PR TITLE
Spec F3: smithy.fix end-to-end eval scenario

### DIFF
--- a/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
+++ b/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
@@ -106,7 +106,7 @@ Recommended specification sequence:
 |----|-------|------------|----------|
 | F1 | Feature 1.3a: Per-Case Token Totals in EvalReport | — | specs/2026-05-18-007-per-case-token-totals-in-evalreport/ |
 | F2 | Feature 1.3b: Per-Sub-Agent Token Attribution | F1 | specs/2026-05-20-008-per-sub-agent-token-attribution/ |
-| F3 | Feature 1.4: smithy.fix End-to-End Eval Scenario | F1 | — |
+| F3 | Feature 1.4: smithy.fix End-to-End Eval Scenario | F1 | specs/2026-05-21-009-smithy-fix-end-to-end-eval-scenario/ |
 | F4 | Feature 1.5: smithy.forge End-to-End Eval Scenario + Runner git-init (RFC SD-002) | F1 | — |
 | F5 | Feature 1.6: JVM Multi-Language Fixture | — | — |
 | F6 | Feature 1.7: Forge-JVM Eval Scenario + M1 Baseline-Set Completeness Gate | F1, F4, F5 | — |

--- a/specs/2026-05-21-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.contracts.md
+++ b/specs/2026-05-21-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.contracts.md
@@ -1,0 +1,204 @@
+# Contracts: smithy.fix End-to-End Eval Scenario
+
+## Overview
+
+This feature touches the eval scenario, fixture-validation, runner invocation, sub-agent evidence, and baseline comparison boundaries. The contracts keep the scenario offline: all issue and CI-log context comes from committed fixtures, and token reporting reuses the F1.3a baseline and report contracts.
+
+## Interfaces
+
+### 1) Fix Scenario Definition
+
+**Purpose**: Defines the declarative scenario consumed by the eval loader.
+**Consumers**: Scenario loader, eval runner, report builder.
+**Providers**: Committed scenario YAML.
+
+#### Signature
+
+```ts
+type FixScenarioDefinition = EvalScenario & {
+  name: string
+  skill: '/smithy.fix'
+  prompt: string
+  structural_expectations: StructuralExpectations
+  sub_agent_evidence: SubAgentEvidence[]
+}
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Stable scenario name for reports and baseline lookup. |
+| `skill` | string | Yes | Smithy command invoked by the scenario. |
+| `prompt` | string | Yes | Offline issue and CI-log instructions passed to smithy.fix. |
+| `structural_expectations` | StructuralExpectations | Yes | Output-shape checks for the fix workflow. |
+| `sub_agent_evidence` | SubAgentEvidence[] | Yes | Helper evidence checks expected for the CI-log path. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `EvalScenario` | object | Loaded scenario passed to the runner. |
+| `scenario_name` | string | Name used for result and baseline association. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Required fixture reference is missing from the prompt | Reject or fail validation before execution. | The eval must not run with ambiguous live-data fallback. |
+| `sub_agent_evidence` is empty | Reject or fail validation. | F1.4 requires helper evidence for fix coverage. |
+| Scenario name collides with another scenario | Skip or reject according to existing loader behavior. | Baseline lookup must remain unambiguous. |
+
+### 2) Offline Fixture Availability
+
+**Purpose**: Verifies that the scenario's committed issue and CI-log inputs exist before smithy.fix is invoked.
+**Consumers**: Eval runner and scenario validation tests.
+**Providers**: Committed fixture files.
+
+#### Signature
+
+```ts
+validateFixFixtures(issuePath: string, ciLogPath: string): FixtureValidationResult
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `issuePath` | string | Yes | Repo-relative path to the offline issue fixture. |
+| `ciLogPath` | string | Yes | Repo-relative path to the offline CI-log fixture. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ok` | boolean | Whether both fixtures are present and readable. |
+| `issue` | OfflineIssueFixture | Parsed or loaded issue context when valid. |
+| `ci_log` | OfflineCiLogFixture | Loaded CI-log context when valid. |
+| `errors` | string[] | Human-readable validation failures. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Issue fixture is missing | Return `ok: false` with missing issue error. | The scenario cannot run deterministically. |
+| CI-log fixture is missing | Return `ok: false` with missing log error. | The high-cost path cannot be exercised. |
+| Fixture exists but is empty | Return `ok: false` with empty fixture error. | Empty inputs would produce misleading pass/fail results. |
+
+### 3) smithy.fix Offline Invocation
+
+**Purpose**: Defines how the scenario invokes smithy.fix without live GitHub lookup.
+**Consumers**: Eval runner.
+**Providers**: Scenario prompt and committed fixtures.
+
+#### Signature
+
+```text
+/smithy.fix <offline issue and CI-log instructions>
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| Offline issue context | markdown/text | Yes | Issue title, body, and relevant metadata from the fixture. |
+| Offline CI-log context | text | Yes | Failing check log content from the fixture. |
+| Network policy | enum | Yes | Scenario instruction that live GitHub calls are not part of the eval. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Canonical output | string | smithy.fix response extracted from the agent stream. |
+| Stream events | StreamEvent[] | Raw parsed events used for helper evidence and token totals. |
+| Exit status | integer | Process result used to classify pass, fail, timeout, or error. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| smithy.fix requests live GitHub data | Scenario fails structural or forbidden-pattern validation. | The eval must remain offline. |
+| smithy.fix cannot act on the fixture | Scenario reports fail or diagnostic output according to structural expectations. | This is a legitimate regression signal. |
+| Agent exits non-zero | Scenario status is `error`. | Existing runner status rules apply. |
+
+### 4) Helper Evidence Validation
+
+**Purpose**: Confirms that expected helper behavior appears in the fix run.
+**Consumers**: Eval report builder and sub-agent check logic.
+**Providers**: Parsed stream events and configured evidence patterns.
+
+#### Signature
+
+```ts
+validateSubAgentEvidence(events: StreamEvent[], evidence: SubAgentEvidence[]): CheckResult[]
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `events` | StreamEvent[] | Yes | Parsed stream events from the fix scenario run. |
+| `evidence` | SubAgentEvidence[] | Yes | Expected helper markers configured in the scenario. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `check_name` | string | Helper evidence check identifier. |
+| `passed` | boolean | Whether the marker was observed. |
+| `expected` | string | Expected helper/pattern pair. |
+| `actual` | string | Observed evidence or missing marker description. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Expected helper marker is absent | Return a failing check. | Missing fix orchestration is visible in the report. |
+| Stream contains no helper events | Return failing checks for all expected helpers. | The scenario should not silently pass without helper evidence. |
+| Pattern is invalid | Fail scenario validation before execution. | Runtime regex failures should not make report output nondeterministic. |
+
+### 5) Fix Baseline Comparison
+
+**Purpose**: Compares the fix scenario result against the committed token-aware baseline.
+**Consumers**: Eval report builder and contributors reading eval output.
+**Providers**: Fix baseline file and live scenario result.
+
+#### Signature
+
+```ts
+compareFixToBaseline(result: EvalResult, baseline: FixBaseline): CheckResult[]
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `result` | EvalResult | Yes | Live fix scenario result with structural checks and token totals. |
+| `baseline` | FixBaseline | Yes | Committed known-good baseline for the fix scenario. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Structural check results | CheckResult[] | Existing heading/table baseline checks. |
+| Token check result | CheckResult | F1.3a token-envelope comparison. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Baseline is missing | Render baseline as unavailable according to existing report behavior. | Scenario can still run, but F1.4 is not complete. |
+| Baseline scenario name differs | Fail baseline comparison. | Prevents accidental comparison to another scenario. |
+| Token totals exceed envelope | Return failing token check with expected and actual values. | Material token drift is visible. |
+
+## Events / Hooks
+
+No new external events or hooks are introduced. The scenario consumes committed fixture files and existing agent stream events only.
+
+## Integration Boundaries
+
+- **Scenario loader**: loads the new fix scenario and rejects malformed structural or helper evidence fields through the existing scenario-validation contract.
+- **Fixture files**: provide issue and CI-log context that replaces live GitHub lookups for this eval.
+- **smithy.fix invocation**: receives fixture context through the scenario prompt and must not depend on live GitHub APIs to complete.
+- **Sub-agent evidence checks**: validate helper behavior from parsed stream events.
+- **Baseline comparison**: uses the F1.3a token-aware baseline schema so structural and token drift both appear in eval reports.

--- a/specs/2026-05-21-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md
+++ b/specs/2026-05-21-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md
@@ -1,0 +1,139 @@
+# Data Model: smithy.fix End-to-End Eval Scenario
+
+## Overview
+
+This feature adds committed, file-backed eval inputs and a token-aware baseline for a deterministic smithy.fix scenario. The model extends the existing eval scenario and baseline concepts with offline fix-specific fixture records; it does not introduce a database or external storage system.
+
+## Entities
+
+### 1) FixEvalScenario (`fix_eval_scenario`)
+
+Purpose: Declarative scenario that invokes smithy.fix against committed offline issue and CI-log context.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | Stable scenario identifier, unique within the eval suite. |
+| `skill` | string | Yes | The invoked Smithy command, fixed to smithy.fix for this feature. |
+| `prompt` | string | Yes | Scenario prompt that points the command at offline issue and log context. |
+| `structural_expectations` | StructuralExpectations | Yes | Required headings, patterns, or tables that define successful fix output. |
+| `sub_agent_evidence` | SubAgentEvidence[] | Yes | Expected helper evidence for the CI-log path. |
+| `offline_issue` | OfflineIssueFixture | Yes | Issue fixture consumed by the prompt. |
+| `offline_ci_log` | OfflineCiLogFixture | Yes | CI-log fixture consumed by the prompt. |
+| `baseline` | FixBaseline | Yes | Token-aware baseline associated with the scenario. |
+
+Validation rules:
+
+- `name` must be non-empty and unique.
+- `offline_issue` and `offline_ci_log` must resolve to committed fixture files before the scenario runs.
+- The scenario must not require live GitHub data to satisfy any required field.
+- Structural expectations and sub-agent evidence must use stable markers rather than incidental model prose.
+
+### 2) OfflineIssueFixture (`offline_issue_fixture`)
+
+Purpose: Committed issue context that replaces live issue lookup during the eval.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `path` | string | Yes | Repo-relative path to the committed issue fixture. |
+| `title` | string | Yes | Human-readable issue title used by the scenario context. |
+| `body` | string | Yes | Issue body supplied to smithy.fix. |
+| `labels` | string[] | No | Optional labels included when useful for fix routing. |
+| `linked_log` | string | Yes | Reference to the paired offline CI-log fixture. |
+
+Validation rules:
+
+- `path`, `title`, `body`, and `linked_log` must be non-empty.
+- The body must include enough failure context for smithy.fix to choose the CI-log path.
+- `linked_log` must match the paired CI-log fixture identifier.
+
+### 3) OfflineCiLogFixture (`offline_ci_log_fixture`)
+
+Purpose: Committed failing-check log that exercises smithy.fix's expensive log-reading behavior.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `path` | string | Yes | Repo-relative path to the committed CI-log fixture. |
+| `check_name` | string | Yes | Name of the failing check represented by the log. |
+| `exit_status` | integer | Yes | Non-zero failing status for the represented command. |
+| `content` | string | Yes | Log payload supplied to smithy.fix. |
+| `captured_at` | string | No | Optional ISO 8601 timestamp for fixture provenance. |
+
+Validation rules:
+
+- `path`, `check_name`, and `content` must be non-empty.
+- `exit_status` must be a non-zero integer.
+- The log must include an identifiable failure marker and enough surrounding context for fix reasoning.
+
+### 4) FixBaseline (`fix_baseline`)
+
+Purpose: Token-aware known-good baseline for the fix scenario.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `scenario_name` | string | Yes | Must match the fix scenario name. |
+| `captured_at` | string | Yes | ISO 8601 timestamp for baseline capture. |
+| `headings` | string[] | Yes | Structural headings expected in canonical output. |
+| `tables` | TableExpectation[] | Yes | Structural table expectations, empty when not applicable. |
+| `token_envelope` | TokenEnvelope | Yes | Accepted input and output token bounds from F1.3a. |
+
+Validation rules:
+
+- `scenario_name` must match exactly one loaded scenario.
+- Structural expectations and token envelope are both authoritative; either can fail the baseline check.
+- Token bounds must be finite non-negative integers and should be broad enough for expected provider variance.
+
+### 5) SubAgentEvidence (`sub_agent_evidence`)
+
+Purpose: Stable helper-output marker used to verify smithy.fix orchestration during the scenario.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `agent` | string | Yes | Expected helper identifier. |
+| `pattern` | string | Yes | Regex or literal marker matched against dispatch evidence. |
+
+Validation rules:
+
+- `agent` and `pattern` must be non-empty.
+- Patterns should target template-stable output or dispatch descriptions.
+- Missing expected evidence fails the scenario.
+
+## Relationships
+
+- `FixEvalScenario` 1:1 `OfflineIssueFixture` via prompt-specified issue context.
+- `FixEvalScenario` 1:1 `OfflineCiLogFixture` via the issue fixture's linked log.
+- `FixEvalScenario` 1:1 `FixBaseline` via matching `scenario_name`.
+- `FixEvalScenario` 1:N `SubAgentEvidence` through the scenario's helper expectations.
+- `FixBaseline` 1:1 F1.3a token envelope through the shared baseline schema.
+
+## State Transitions
+
+### Scenario lifecycle
+
+1. `drafted` -> `fixture_validated`
+   - Trigger: scenario loading confirms issue and CI-log fixture availability.
+   - Effects: the scenario is eligible to invoke smithy.fix.
+
+2. `fixture_validated` -> `executed`
+   - Trigger: the eval runner invokes smithy.fix in a temp copy.
+   - Effects: canonical output, stream events, token totals, and helper evidence are captured for validation.
+
+3. `executed` -> `baselined`
+   - Trigger: a known-good run is captured in the token-aware baseline schema.
+   - Effects: future runs can compare structure and token totals against the committed baseline.
+
+### Fixture lifecycle
+
+1. `missing` -> `committed`
+   - Trigger: issue and CI-log fixture files are added to the repository.
+   - Effects: the scenario can run offline.
+
+2. `committed` -> `refreshed`
+   - Trigger: fixture content is intentionally updated to reflect a new known-good failure case.
+   - Effects: the associated baseline must be refreshed in the same feature or follow-up baseline update.
+
+## Identity & Uniqueness
+
+- The fix scenario is uniquely identified by its `name`.
+- The issue fixture is uniquely identified by its repo-relative `path`.
+- The CI-log fixture is uniquely identified by its repo-relative `path` and `check_name`.
+- The fix baseline is uniquely identified by its `scenario_name`.

--- a/specs/2026-05-21-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
+++ b/specs/2026-05-21-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
@@ -1,0 +1,165 @@
+# Feature Specification: smithy.fix End-to-End Eval Scenario
+
+**Spec Folder**: `2026-05-21-009-smithy-fix-end-to-end-eval-scenario`
+**Branch**: `2026-05-21-009-smithy-fix-end-to-end-eval-scenario`
+**Created**: 2026-05-21
+**Status**: Draft
+**Input**: `docs/rfcs/2026-001-token-savings/token-savings.rfc.md` - Milestone 1 measurement foundation feature for deterministic smithy.fix eval coverage.
+**Source Feature Map**: `docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md` - Feature 1.4: smithy.fix End-to-End Eval Scenario
+
+## Clarifications
+
+### Session 2026-05-21
+
+- This specification targets Dependency Order row `F3`, which corresponds to Feature 1.4 in the measurement-foundation feature map. `[Critical Assumption]`
+- Feature 1.3a is the prerequisite token baseline substrate; this feature consumes its token-aware baseline schema instead of redefining it.
+- The eval scenario must be fully offline and deterministic. It must not call live GitHub issue, pull request, or Actions APIs during the scenario run.
+- The F1.4 fixture layout is settled here: the offline issue and CI-log payloads are separate committed fixtures so either can be refreshed independently.
+- smithy.fix discovers the offline inputs through scenario-provided prompt context and fixture files, not through a new public command-line option.
+- The scenario represents the high-cost CI-log path of smithy.fix and intentionally excludes the later CI-log failure-extraction optimization owned by Milestone 3.
+
+## Artifact Hierarchy
+
+RFC -> Milestone -> Feature -> User Story -> Slice -> Tasks
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1: Provide Offline fix Inputs (Priority: P1)
+
+As a Smithy maintainer, I want a committed issue fixture and CI-log fixture for smithy.fix so that the eval can exercise the expensive fix path without network access.
+
+**Why this priority**: The scenario cannot be deterministic until its GitHub issue and CI-log dependencies are replaced with committed local inputs.
+
+**Independent Test**: Load the fix eval scenario in an environment with no GitHub network access and verify that the prompt references only committed fixture inputs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fix scenario is loaded, **When** its prompt is prepared, **Then** it identifies a committed issue fixture as the source issue context.
+2. **Given** a fix scenario is loaded, **When** its prompt is prepared, **Then** it identifies a committed CI-log fixture as the source failure context.
+3. **Given** GitHub network access is unavailable, **When** the fix scenario runs, **Then** the scenario still has all required issue and CI-log context.
+
+---
+
+### User Story 2: Run smithy.fix End to End (Priority: P1)
+
+As a Smithy contributor, I want smithy.fix covered by an end-to-end eval scenario so that changes near fix can be judged by measured structural output and token cost.
+
+**Why this priority**: smithy.fix is one of the highest-frequency cost drivers called out by the RFC. Measurement coverage for fix is required before later token-saving changes can claim a credible delta.
+
+**Independent Test**: Run the fix scenario against the standard eval fixture and verify it produces the expected fix workflow output without invoking live GitHub commands.
+
+**Acceptance Scenarios**:
+
+1. **Given** the offline issue and CI-log fixtures are present, **When** the fix scenario invokes smithy.fix, **Then** the run completes using the fixture context.
+2. **Given** smithy.fix produces its expected response, **When** structural validation runs, **Then** required fix output markers are present.
+3. **Given** the scenario runs in a clean temp copy, **When** the run completes, **Then** source fixtures outside the temp copy remain unchanged.
+
+---
+
+### User Story 3: Verify fix Helper Evidence (Priority: P2)
+
+As a Smithy maintainer, I want the fix eval to verify helper-agent evidence so that orchestration regressions in fix are visible in the eval report.
+
+**Why this priority**: The scenario should catch both output-shape regressions and missing helper dispatch behavior, but structural fix coverage is the prerequisite.
+
+**Independent Test**: Run the scenario against a captured stream with expected helper output and verify the sub-agent evidence checks pass.
+
+**Acceptance Scenarios**:
+
+1. **Given** smithy.fix dispatches helper agents for the CI-log path, **When** sub-agent evidence validation runs, **Then** the configured helper evidence patterns pass.
+2. **Given** an expected helper dispatch is absent, **When** sub-agent evidence validation runs, **Then** the scenario fails with a clear missing-evidence check.
+3. **Given** helper wording varies while retaining the configured stable marker, **When** evidence validation runs, **Then** the scenario remains stable.
+
+---
+
+### User Story 4: Commit the fix Token Baseline (Priority: P2)
+
+As a Smithy maintainer, I want a committed token-aware baseline for the fix scenario so that future fix changes can report token drift against a known-good envelope.
+
+**Why this priority**: The token-savings program needs a baseline for fix before M3 can demonstrate savings from CI-log failure extraction.
+
+**Independent Test**: Run the fix scenario after the baseline is committed and verify the report shows a passing baseline marker plus per-case token totals.
+
+**Acceptance Scenarios**:
+
+1. **Given** the fix baseline is committed in the token-aware schema, **When** the fix scenario runs within the accepted token envelope, **Then** its baseline check passes.
+2. **Given** the fix baseline is committed in the token-aware schema, **When** structural expectations drift, **Then** the baseline check fails even if token totals remain within the envelope.
+3. **Given** the fix scenario produces materially higher token totals than the envelope, **When** baseline comparison runs, **Then** the token baseline check fails with expected and actual totals visible.
+
+### Edge Cases
+
+- The CI log may be long enough to dominate prompt size; the scenario must preserve enough log content to exercise fix behavior without requiring live log retrieval.
+- The offline issue may describe a failing check whose log fixture is missing; scenario validation must fail before invoking smithy.fix.
+- The scenario may run in an environment where GitHub credentials exist; the scenario contract still forbids live GitHub access for issue or CI-log context.
+- smithy.fix may produce a blocked or diagnostic result instead of a patch when the fixture intentionally lacks enough context; structural expectations must target the intended high-cost CI-log workflow result.
+- The committed token envelope may need tolerance for model/provider variance while still catching material prompt-size regressions.
+
+## Dependency Order
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| US1 | Provide Offline fix Inputs | — | — |
+| US2 | Run smithy.fix End to End | US1 | — |
+| US3 | Verify fix Helper Evidence | US2 | — |
+| US4 | Commit the fix Token Baseline | US2 | — |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST include a committed offline issue fixture for the fix scenario.
+- **FR-002**: The system MUST include a committed offline CI-log fixture for the fix scenario.
+- **FR-003**: The fix scenario prompt MUST provide enough context for smithy.fix to use the committed issue and CI-log fixtures without live GitHub calls.
+- **FR-004**: The fix scenario MUST be loadable by the existing eval scenario loader as a deterministic scenario.
+- **FR-005**: The fix scenario MUST run against a temp fixture copy and MUST NOT mutate the committed source fixture inputs.
+- **FR-006**: The fix scenario MUST validate stable structural markers from the smithy.fix high-cost CI-log workflow.
+- **FR-007**: The fix scenario MUST include sub-agent evidence patterns for the helper behavior expected on the CI-log path.
+- **FR-008**: Missing required offline fixture inputs MUST fail the scenario deterministically before a misleading successful eval can be reported.
+- **FR-009**: Live GitHub issue, pull request, or Actions API calls MUST NOT be required for the scenario to pass.
+- **FR-010**: The fix scenario MUST produce per-case token totals through the F1.3a report substrate.
+- **FR-011**: The system MUST commit a token-aware baseline for the fix scenario after the scenario shape is stable.
+- **FR-012**: The fix baseline MUST preserve structural expectations and token-envelope checks together.
+- **FR-013**: Tests MUST cover scenario loading, fixture availability validation, no-network prompt behavior, structural checks, helper evidence checks, and token-aware baseline comparison.
+
+### Key Entities
+
+- **Fix Eval Scenario**: The declarative scenario that invokes smithy.fix against offline issue and CI-log context.
+- **Offline Issue Fixture**: The committed issue body and metadata used as the fix input.
+- **Offline CI Log Fixture**: The committed failing-check log used to exercise the high-cost fix path.
+- **Fix Baseline**: The committed token-aware known-good baseline for the fix scenario.
+- **Sub-Agent Evidence Pattern**: A stable marker used to verify expected helper behavior during the scenario.
+
+## Assumptions
+
+- Feature 1.3a has already introduced token-aware baselines and per-case token reporting before this feature lands.
+- Prompt-level fixture context is sufficient for smithy.fix eval coverage; adding a new public `--from-file` command option is unnecessary for M1.
+- The offline CI-log fixture should be realistic enough to exercise fix reasoning but small enough to keep eval runtime practical.
+- The fix eval should measure the current high-cost behavior, not pre-apply M3's CI-log extraction optimization.
+
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| — | None — all ambiguities resolved. | — | — | — | — | — |
+
+## Out of Scope
+
+- Implementing the M3 CI-log failure-extraction grep or reducing the fix prompt size.
+- Adding a public smithy.fix file-input option solely for this scenario.
+- Live GitHub issue, pull request, or Actions API integration inside the eval run.
+- Multi-issue, multi-check, or non-CI-log fix scenarios.
+- Changing smithy.fix template behavior beyond what is necessary to consume scenario-provided offline context.
+- Forge eval scenarios, JVM fixtures, or baseline-set completeness audits owned by other M1 features.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The eval suite includes a deterministic smithy.fix scenario for the high-cost CI-log path.
+- **SC-002**: The scenario passes without live GitHub network access.
+- **SC-003**: The scenario validates stable structural markers for smithy.fix output.
+- **SC-004**: The scenario validates expected helper evidence for the fix workflow.
+- **SC-005**: The fix scenario has a committed token-aware baseline.
+- **SC-006**: Future eval reports display token totals and a baseline marker for the fix scenario.


### PR DESCRIPTION
## Summary

Runs the `/smithy.mark` step for **F3 / Feature 1.4: smithy.fix End-to-End Eval Scenario** in the Milestone 1 measurement-foundation feature map.

Adds the three standard spec artifacts under `specs/2026-05-21-009-smithy-fix-end-to-end-eval-scenario/`:

- `*.spec.md` — feature specification (4 user stories, functional requirements, success criteria)
- `*.data-model.md` — entities, relationships, state transitions
- `*.contracts.md` — interfaces and integration boundaries

The spec describes a deterministic, fully offline smithy.fix eval scenario that exercises the high-cost CI-log path using committed issue and CI-log fixtures (no live GitHub API), reuses the F1.3a token-aware baseline schema, and verifies helper evidence.

## Completion signal

Per the feature-map Dependency Order convention (checkboxes were removed from these tables; the `Artifact` column is the started/not-started signal), F3's `Artifact` column is flipped from `—` to the new spec folder path in `docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md`.

**Assumption (no tasks.md to flip):** `/smithy.mark` produces spec-level artifacts only; task slices (`.tasks.md`) are a downstream artifact created by a later step. There is no tasks.md at this milestone level, so the durable "done" signal for this step is the Artifact-column flip above, matching how sibling features F1 and F2 were marked.

## Verification

These are pure Markdown planning artifacts (no source code), so the `npm` build/test tiers do not apply. Confirmed: complete artifact set, correct parent→child link, well-formed Dependency Order tables, and structural parity with the already-merged sibling F1/F2 specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
