### PR TITLE
Redirect virtual artifacts to their create-command in status next-action hints

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1777,7 +1777,11 @@ describe('CLI status', () => {
     //    that flag as a gate, so its hint line is also emitted —
     //    every actionable row stays self-describing in the text view.
     //    The flag still rides along on the JSON payload for machine
-    //    consumers.
+    //    consumers. Because the features map does not exist on disk yet,
+    //    the virtual record redirects to `smithy.render` (the command
+    //    that would create it from the RFC milestone) rather than
+    //    `smithy.mark` (which would fail on a missing file) — so both
+    //    the RFC and its virtual features child surface a render hint.
     //
     // 2. An independent spec whose only tasks child is fully checked
     //    off → both records classify as `done` → neither emits a hint
@@ -1831,6 +1835,14 @@ describe('CLI status', () => {
     expect(rfcRecord?.next_action?.command).toBe('smithy.render');
     expect(rfcRecord?.next_action?.suppressed_by_ancestor).toBeUndefined();
     expect(virtualFeatures?.status).toBe('not-started');
+    // The features map has no file on disk, so the virtual record
+    // redirects to `smithy.render` (against the parent RFC) rather than
+    // `smithy.mark` against the missing file.
+    expect(virtualFeatures?.next_action?.command).toBe('smithy.render');
+    expect(virtualFeatures?.next_action?.arguments).toEqual([
+      'docs/rfcs/active.rfc.md',
+      '1',
+    ]);
     expect(virtualFeatures?.next_action?.suppressed_by_ancestor).toBe(true);
     expect(finishedTasks?.status).toBe('done');
     expect(finishedTasks?.next_action).toBeNull();
@@ -1847,23 +1859,29 @@ describe('CLI status', () => {
     const lines = textOutput.split('\n');
 
     // AS 4.4: the actionable RFC emits a hint line containing
-    // `smithy.render` and its rfc path.
+    // `smithy.render` and its rfc path. The suppressed-by-ancestor
+    // virtual features record below it ALSO surfaces a render hint \u2014
+    // every actionable row must be self-describing even when its parent
+    // is `not-started`, and a feature map with no file on disk redirects
+    // to the `smithy.render` that would create it (not `smithy.mark`,
+    // which would fail on a missing file). Both render hints therefore
+    // point at the RFC path.
     const renderHintLines = lines.filter(
       (l) => l.includes('\u2192') && l.includes('smithy.render'),
     );
-    expect(renderHintLines).toHaveLength(1);
-    expect(renderHintLines[0]).toContain('docs/rfcs/active.rfc.md');
+    expect(renderHintLines).toHaveLength(2);
+    for (const line of renderHintLines) {
+      expect(line).toContain('docs/rfcs/active.rfc.md');
+    }
 
-    // The suppressed-by-ancestor features record still surfaces its own
-    // hint in the text view: every actionable row must be self-describing
-    // even when its parent is `not-started`. The `suppressed_by_ancestor`
-    // flag remains on the JSON payload (asserted above) for machine
-    // consumers, but the renderer no longer treats it as a gate.
+    // No `smithy.mark` hint is emitted: the only features record in this
+    // fixture is virtual (its `.features.md` does not exist), so it
+    // redirects to `smithy.render` rather than suggesting a mark against
+    // a file that isn't there.
     const markHintLines = lines.filter(
       (l) => l.includes('→') && l.includes('smithy.mark'),
     );
-    expect(markHintLines).toHaveLength(1);
-    expect(markHintLines[0]).toContain('docs/rfcs/active.features.md');
+    expect(markHintLines).toHaveLength(0);
 
     // Done records emit no hint line: the finished tasks file is done
     // and must not have an arrow beneath its rendered line.

--- a/src/status/nextAction.matrix.test.ts
+++ b/src/status/nextAction.matrix.test.ts
@@ -1,0 +1,527 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { scan } from './index.js';
+import type { ArtifactRecord, NextAction } from './index.js';
+
+/**
+ * End-to-end next-action coverage matrix for `smithy status`.
+ *
+ * The `status` command is the authoritative tracker of what work is done
+ * and what remains, so the next-action hint it prints for each artifact
+ * must be runnable: it has to name the command whose on-disk
+ * prerequisites are actually satisfied. The class of bug this suite
+ * guards against is a parent artifact suggesting an "operate-on-self"
+ * command (`smithy.mark` / `smithy.cut` / `smithy.forge`) against a child
+ * file that does not exist yet — the child must instead redirect to the
+ * "create-me" command one level up (`smithy.render` → `smithy.mark` →
+ * `smithy.cut`).
+ *
+ * These tests run the full `scan()` pipeline (walk → parse → virtual
+ * emission → classify → suggest) against real temp-dir fixtures so the
+ * scanner's virtual-record emission and the suggester's redirect rules
+ * are exercised together — the seam where the bug actually lived.
+ *
+ * Organized parent → child level, each with the on-disk-child axis the
+ * hierarchy shares:
+ *   - NONE   children exist  → every child is virtual → redirects up;
+ *                              parent points at the first child.
+ *   - SOME   children exist  → real children keep their own command,
+ *                              virtual children redirect; parent points
+ *                              at the first *virtual* child.
+ *   - ALL    children exist  → no redirects; parent emits null (features
+ *                              / spec) or the single-arg fallback (rfc).
+ * plus status nuances (done/in-progress), `—`-cell convention paths,
+ * first-virtual ordering, ancestor suppression, and fully-done rollup.
+ */
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'smithy-nextaction-'));
+});
+
+afterEach(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+});
+
+function write(relPath: string, contents: string): void {
+  const abs = join(root, relPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, contents);
+}
+
+function byPath(records: ArtifactRecord[], path: string): ArtifactRecord | undefined {
+  return records.find((r) => r.path === path);
+}
+
+/** Fetch the next_action for a record by path (asserting it exists). */
+function actionAt(records: ArtifactRecord[], path: string): NextAction | null {
+  const rec = byPath(records, path);
+  expect(rec, `expected a record at ${path}`).toBeDefined();
+  return rec!.next_action ?? null;
+}
+
+function expectAction(
+  action: NextAction | null,
+  command: string,
+  args: string[],
+): void {
+  expect(action).not.toBeNull();
+  expect(action!.command).toBe(command);
+  expect(action!.arguments).toEqual(args);
+}
+
+const TABLE_HEADER =
+  '| ID | Title | Depends On | Artifact |\n|----|-------|------------|----------|';
+
+/** Build an RFC body from milestone rows `[id, title, artifactCell]`. */
+function rfcBody(rows: Array<[string, string, string]>): string {
+  const body = rows
+    .map(([id, title, cell]) => `| ${id} | ${title} | — | ${cell} |`)
+    .join('\n');
+  return `# RFC: Demo\n\n## Dependency Order\n\n${TABLE_HEADER}\n${body}\n`;
+}
+
+/** Build a feature-map body from feature rows `[id, title, artifactCell]`. */
+function featuresBody(rows: Array<[string, string, string]>): string {
+  const body = rows
+    .map(([id, title, cell]) => `| ${id} | ${title} | — | ${cell} |`)
+    .join('\n');
+  return `# Feature Map: Demo\n\n## Dependency Order\n\n${TABLE_HEADER}\n${body}\n`;
+}
+
+/** Build a spec body from user-story rows `[id, title, artifactCell]`. */
+function specBody(rows: Array<[string, string, string]>): string {
+  const body = rows
+    .map(([id, title, cell]) => `| ${id} | ${title} | — | ${cell} |`)
+    .join('\n');
+  return `# Feature Specification: Demo\n\n## Dependency Order\n\n${TABLE_HEADER}\n${body}\n`;
+}
+
+/**
+ * Build a tasks body. `slices` is a list of `[id, title, taskMarks]`
+ * where `taskMarks` is the array of checkbox markers (`' '` or `'x'`)
+ * for that slice's task list. The dep-order table mirrors the slice ids.
+ */
+function tasksBody(slices: Array<[number, string, string[]]>): string {
+  const sliceSections = slices
+    .map(([n, title, marks]) => {
+      const checks = marks.map((m) => `- [${m}] Task`).join('\n');
+      return `## Slice ${n}: ${title}\n\n${checks}`;
+    })
+    .join('\n\n');
+  const tableRows = slices
+    .map(([n, title]) => `| S${n} | ${title} | — | — |`)
+    .join('\n');
+  return `# Tasks: Demo\n\n${sliceSections}\n\n## Dependency Order\n\n${TABLE_HEADER}\n${tableRows}\n`;
+}
+
+// ===========================================================================
+// LEVEL 1 — RFC → feature maps  (smithy.render is the create-child command)
+// ===========================================================================
+
+describe('next-action matrix — RFC → feature maps', () => {
+  const RFC = 'docs/rfcs/demo/demo.rfc.md';
+
+  it('NONE rendered: every milestone redirects to smithy.render; RFC points at the first', () => {
+    write(
+      RFC,
+      rfcBody([
+        ['M1', 'Milestone One', 'docs/rfcs/demo/01-one.features.md'],
+        ['M2', 'Milestone Two', 'docs/rfcs/demo/02-two.features.md'],
+      ]),
+    );
+    const records = scan(root);
+
+    // RFC itself is the root and points at the first un-rendered milestone.
+    expect(byPath(records, RFC)!.status).toBe('not-started');
+    expectAction(actionAt(records, RFC), 'smithy.render', [RFC, '1']);
+    expect(byPath(records, RFC)!.next_action!.suppressed_by_ancestor).toBeUndefined();
+
+    // Each milestone's feature map is virtual and redirects to render.
+    const m1 = byPath(records, 'docs/rfcs/demo/01-one.features.md')!;
+    const m2 = byPath(records, 'docs/rfcs/demo/02-two.features.md')!;
+    expect(m1.virtual).toBe(true);
+    expect(m2.virtual).toBe(true);
+    expectAction(m1.next_action ?? null, 'smithy.render', [RFC, '1']);
+    expectAction(m2.next_action ?? null, 'smithy.render', [RFC, '2']);
+    // Descendants of a not-started actionable RFC carry the suppression flag.
+    expect(m1.next_action!.suppressed_by_ancestor).toBe(true);
+    expect(m2.next_action!.suppressed_by_ancestor).toBe(true);
+  });
+
+  it('SOME rendered: RFC points at the first virtual milestone, real one keeps smithy.mark', () => {
+    write(
+      RFC,
+      rfcBody([
+        ['M1', 'Milestone One', 'docs/rfcs/demo/01-one.features.md'],
+        ['M2', 'Milestone Two', 'docs/rfcs/demo/02-two.features.md'],
+      ]),
+    );
+    // M1's feature map exists (with one unspecced feature); M2's does not.
+    write('docs/rfcs/demo/01-one.features.md', featuresBody([['F1', 'Feature One', '—']]));
+    const records = scan(root);
+
+    // RFC skips the rendered M1 and points at the virtual M2.
+    expectAction(actionAt(records, RFC), 'smithy.render', [RFC, '2']);
+
+    const m1 = byPath(records, 'docs/rfcs/demo/01-one.features.md')!;
+    expect(m1.virtual).not.toBe(true);
+    // A real feature map drives its own work — mark, never render.
+    expect(m1.next_action!.command).toBe('smithy.mark');
+
+    const m2 = byPath(records, 'docs/rfcs/demo/02-two.features.md')!;
+    expect(m2.virtual).toBe(true);
+    expectAction(m2.next_action ?? null, 'smithy.render', [RFC, '2']);
+  });
+
+  it('ALL rendered: no virtual feature maps; RFC degrades to the single-arg render fallback', () => {
+    write(
+      RFC,
+      rfcBody([
+        ['M1', 'Milestone One', 'docs/rfcs/demo/01-one.features.md'],
+        ['M2', 'Milestone Two', 'docs/rfcs/demo/02-two.features.md'],
+      ]),
+    );
+    write('docs/rfcs/demo/01-one.features.md', featuresBody([['F1', 'Feature One', '—']]));
+    write('docs/rfcs/demo/02-two.features.md', featuresBody([['F1', 'Feature Two', '—']]));
+    const records = scan(root);
+
+    // No virtual milestone digit to surface → bare RFC-path render hint.
+    expectAction(actionAt(records, RFC), 'smithy.render', [RFC]);
+
+    // Both feature maps are real and drive their own work (mark, not render).
+    expect(byPath(records, 'docs/rfcs/demo/01-one.features.md')!.virtual).not.toBe(true);
+    expect(byPath(records, 'docs/rfcs/demo/02-two.features.md')!.virtual).not.toBe(true);
+    expect(byPath(records, 'docs/rfcs/demo/01-one.features.md')!.next_action!.command).toBe('smithy.mark');
+    expect(byPath(records, 'docs/rfcs/demo/02-two.features.md')!.next_action!.command).toBe('smithy.mark');
+  });
+
+  it('`—` artifact cell: virtual feature map lands on the convention path and redirects to render', () => {
+    write(RFC, rfcBody([['M1', 'Spawn Backend', '—']]));
+    const records = scan(root);
+
+    const conventional = 'docs/rfcs/demo/01-spawn-backend.features.md';
+    const m1 = byPath(records, conventional);
+    expect(m1, 'virtual feature map should use <NN>-<slug>.features.md convention').toBeDefined();
+    expect(m1!.virtual).toBe(true);
+    expectAction(m1!.next_action ?? null, 'smithy.render', [RFC, '1']);
+  });
+
+  it('first-virtual selection: a rendered M1 followed by virtual M2, M3 → RFC points at M2', () => {
+    write(
+      RFC,
+      rfcBody([
+        ['M1', 'One', 'docs/rfcs/demo/01-one.features.md'],
+        ['M2', 'Two', 'docs/rfcs/demo/02-two.features.md'],
+        ['M3', 'Three', 'docs/rfcs/demo/03-three.features.md'],
+      ]),
+    );
+    write('docs/rfcs/demo/01-one.features.md', featuresBody([['F1', 'Feature One', '—']]));
+    const records = scan(root);
+    expectAction(actionAt(records, RFC), 'smithy.render', [RFC, '2']);
+  });
+});
+
+// ===========================================================================
+// LEVEL 2 — feature map → specs  (smithy.mark is the create-child command)
+// ===========================================================================
+
+describe('next-action matrix — feature map → specs', () => {
+  const FMAP = 'docs/rfcs/demo/demo.features.md';
+
+  it('NONE specced: every feature redirects to smithy.mark; map points at the first', () => {
+    write(
+      FMAP,
+      featuresBody([
+        ['F1', 'Feature One', 'specs/one/'],
+        ['F2', 'Feature Two', 'specs/two/'],
+      ]),
+    );
+    const records = scan(root);
+
+    expect(byPath(records, FMAP)!.status).toBe('not-started');
+    expectAction(actionAt(records, FMAP), 'smithy.mark', [FMAP, '1']);
+
+    const f1 = byPath(records, 'specs/one/')!;
+    const f2 = byPath(records, 'specs/two/')!;
+    expect(f1.virtual).toBe(true);
+    expect(f2.virtual).toBe(true);
+    expectAction(f1.next_action ?? null, 'smithy.mark', [FMAP, '1']);
+    expectAction(f2.next_action ?? null, 'smithy.mark', [FMAP, '2']);
+    expect(f1.next_action!.suppressed_by_ancestor).toBe(true);
+    expect(f2.next_action!.suppressed_by_ancestor).toBe(true);
+  });
+
+  it('SOME specced: map points at the first virtual feature, real spec keeps smithy.cut', () => {
+    write(
+      FMAP,
+      featuresBody([
+        ['F1', 'Feature One', 'specs/one/'],
+        ['F2', 'Feature Two', 'specs/two/'],
+      ]),
+    );
+    // F1's spec exists (with one uncut story); F2's does not.
+    write('specs/one/one.spec.md', specBody([['US1', 'Story One', '—']]));
+    const records = scan(root);
+
+    expectAction(actionAt(records, FMAP), 'smithy.mark', [FMAP, '2']);
+
+    const f1 = byPath(records, 'specs/one/one.spec.md')!;
+    expect(f1.virtual).not.toBe(true);
+    // A real spec drives its own work — cut, never mark.
+    expect(f1.next_action!.command).toBe('smithy.cut');
+
+    const f2 = byPath(records, 'specs/two/')!;
+    expect(f2.virtual).toBe(true);
+    expectAction(f2.next_action ?? null, 'smithy.mark', [FMAP, '2']);
+  });
+
+  it('ALL specced: no virtual specs; the feature map emits no hint of its own (null)', () => {
+    write(
+      FMAP,
+      featuresBody([
+        ['F1', 'Feature One', 'specs/one/'],
+        ['F2', 'Feature Two', 'specs/two/'],
+      ]),
+    );
+    write('specs/one/one.spec.md', specBody([['US1', 'Story One', '—']]));
+    write('specs/two/two.spec.md', specBody([['US1', 'Story Two', '—']]));
+    const records = scan(root);
+
+    // Every feature has a spec on disk → per-spec hints cover the work.
+    expect(actionAt(records, FMAP)).toBeNull();
+    expect(byPath(records, 'specs/one/one.spec.md')!.virtual).not.toBe(true);
+    expect(byPath(records, 'specs/two/two.spec.md')!.virtual).not.toBe(true);
+  });
+
+  it('`—` artifact cell: virtual spec lands on specs/<slug>/ and redirects to mark', () => {
+    write(FMAP, featuresBody([['F1', 'Webhooks Support', '—']]));
+    const records = scan(root);
+
+    const conventional = 'specs/webhooks-support/';
+    const f1 = byPath(records, conventional);
+    expect(f1, 'virtual spec should use specs/<slug>/ convention').toBeDefined();
+    expect(f1!.virtual).toBe(true);
+    expectAction(f1!.next_action ?? null, 'smithy.mark', [FMAP, '1']);
+  });
+
+  it('first-virtual selection: a real but uncut F1 spec precedes virtual F2 → map points at F2', () => {
+    write(
+      FMAP,
+      featuresBody([
+        ['F1', 'Feature One', 'specs/one/'],
+        ['F2', 'Feature Two', 'specs/two/'],
+      ]),
+    );
+    // F1's spec exists but is not-started; the map must still skip it
+    // (its own cut hint covers it) and point mark at the virtual F2.
+    write('specs/one/one.spec.md', specBody([['US1', 'Story One', '—']]));
+    const records = scan(root);
+    expectAction(actionAt(records, FMAP), 'smithy.mark', [FMAP, '2']);
+  });
+});
+
+// ===========================================================================
+// LEVEL 3 — spec → tasks  (smithy.cut is the create-child command)
+// ===========================================================================
+
+describe('next-action matrix — spec → tasks', () => {
+  const SPEC = 'specs/demo/demo.spec.md';
+  const FOLDER = 'specs/demo';
+
+  it('NONE cut: every story redirects to smithy.cut; spec points at the first', () => {
+    write(
+      SPEC,
+      specBody([
+        ['US1', 'Story One', 'specs/demo/01-one.tasks.md'],
+        ['US2', 'Story Two', 'specs/demo/02-two.tasks.md'],
+      ]),
+    );
+    const records = scan(root);
+
+    expect(byPath(records, SPEC)!.status).toBe('not-started');
+    expectAction(actionAt(records, SPEC), 'smithy.cut', [FOLDER, '1']);
+
+    const us1 = byPath(records, 'specs/demo/01-one.tasks.md')!;
+    const us2 = byPath(records, 'specs/demo/02-two.tasks.md')!;
+    expect(us1.virtual).toBe(true);
+    expect(us2.virtual).toBe(true);
+    expectAction(us1.next_action ?? null, 'smithy.cut', [FOLDER, '1']);
+    expectAction(us2.next_action ?? null, 'smithy.cut', [FOLDER, '2']);
+    expect(us1.next_action!.suppressed_by_ancestor).toBe(true);
+    expect(us2.next_action!.suppressed_by_ancestor).toBe(true);
+  });
+
+  it('SOME cut: spec points at the first virtual story, real tasks file keeps smithy.forge', () => {
+    write(
+      SPEC,
+      specBody([
+        ['US1', 'Story One', 'specs/demo/01-one.tasks.md'],
+        ['US2', 'Story Two', 'specs/demo/02-two.tasks.md'],
+      ]),
+    );
+    write('specs/demo/01-one.tasks.md', tasksBody([[1, 'One', [' ']]]));
+    const records = scan(root);
+
+    expectAction(actionAt(records, SPEC), 'smithy.cut', [FOLDER, '2']);
+
+    const us1 = byPath(records, 'specs/demo/01-one.tasks.md')!;
+    expect(us1.virtual).not.toBe(true);
+    expectAction(us1.next_action ?? null, 'smithy.forge', ['specs/demo/01-one.tasks.md', '1']);
+
+    const us2 = byPath(records, 'specs/demo/02-two.tasks.md')!;
+    expect(us2.virtual).toBe(true);
+    expectAction(us2.next_action ?? null, 'smithy.cut', [FOLDER, '2']);
+  });
+
+  it('ALL cut: no virtual tasks; the spec emits no hint of its own (null)', () => {
+    write(
+      SPEC,
+      specBody([
+        ['US1', 'Story One', 'specs/demo/01-one.tasks.md'],
+        ['US2', 'Story Two', 'specs/demo/02-two.tasks.md'],
+      ]),
+    );
+    write('specs/demo/01-one.tasks.md', tasksBody([[1, 'One', [' ']]]));
+    write('specs/demo/02-two.tasks.md', tasksBody([[1, 'Two', [' ']]]));
+    const records = scan(root);
+
+    expect(actionAt(records, SPEC)).toBeNull();
+    expect(byPath(records, 'specs/demo/01-one.tasks.md')!.virtual).not.toBe(true);
+    expect(byPath(records, 'specs/demo/02-two.tasks.md')!.virtual).not.toBe(true);
+  });
+
+  it('`—` artifact cell: virtual tasks file lands on the convention path and redirects to cut', () => {
+    write(SPEC, specBody([['US1', 'First Story', '—']]));
+    const records = scan(root);
+
+    const conventional = 'specs/demo/01-first-story.tasks.md';
+    const us1 = byPath(records, conventional);
+    expect(us1, 'virtual tasks file should use <NN>-<slug>.tasks.md convention').toBeDefined();
+    expect(us1!.virtual).toBe(true);
+    expectAction(us1!.next_action ?? null, 'smithy.cut', [FOLDER, '1']);
+  });
+
+  it('first-virtual selection: a real but unstarted US1 tasks file precedes virtual US2 → spec points at US2', () => {
+    write(
+      SPEC,
+      specBody([
+        ['US1', 'Story One', 'specs/demo/01-one.tasks.md'],
+        ['US2', 'Story Two', 'specs/demo/02-two.tasks.md'],
+      ]),
+    );
+    write('specs/demo/01-one.tasks.md', tasksBody([[1, 'One', [' ']]]));
+    const records = scan(root);
+    expectAction(actionAt(records, SPEC), 'smithy.cut', [FOLDER, '2']);
+  });
+});
+
+// ===========================================================================
+// LEVEL 4 — tasks → slices  (smithy.forge is the implement command)
+// ===========================================================================
+
+describe('next-action matrix — tasks → slices', () => {
+  const TASKS = 'specs/demo/01-task.tasks.md';
+
+  it('NONE done: forge points at the first slice; record is not-started', () => {
+    write(TASKS, tasksBody([[1, 'One', [' ', ' ']], [2, 'Two', [' ']]]));
+    const records = scan(root);
+    expect(byPath(records, TASKS)!.status).toBe('not-started');
+    expectAction(actionAt(records, TASKS), 'smithy.forge', [TASKS, '1']);
+  });
+
+  it('SOME done: forge skips the finished slice and points at the next; record is in-progress', () => {
+    write(TASKS, tasksBody([[1, 'One', ['x', 'x']], [2, 'Two', [' ']]]));
+    const records = scan(root);
+    expect(byPath(records, TASKS)!.status).toBe('in-progress');
+    expectAction(actionAt(records, TASKS), 'smithy.forge', [TASKS, '2']);
+  });
+
+  it('ALL done: record is done and emits no next action (null)', () => {
+    write(TASKS, tasksBody([[1, 'One', ['x']], [2, 'Two', ['x']]]));
+    const records = scan(root);
+    expect(byPath(records, TASKS)!.status).toBe('done');
+    expect(actionAt(records, TASKS)).toBeNull();
+  });
+
+  it('partially-checked slice: forge still points at that slice (first non-done)', () => {
+    // Slice 1 has one of two tasks checked → the slice is in-progress and
+    // is the first non-done slice, so forge resumes there.
+    write(TASKS, tasksBody([[1, 'One', ['x', ' ']], [2, 'Two', [' ']]]));
+    const records = scan(root);
+    expectAction(actionAt(records, TASKS), 'smithy.forge', [TASKS, '1']);
+    expect(byPath(records, TASKS)!.slices?.[0]?.status).toBe('in-progress');
+  });
+
+  it('no slice bodies: forge degrades to the single-arg fallback (no digit)', () => {
+    // A tasks file with a dep-order table but no `## Slice N:` bodies has
+    // no parsed slices, so the suggester cannot name a slice digit.
+    write(
+      TASKS,
+      `# Tasks: Demo\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | One | — | — |\n`,
+    );
+    const records = scan(root);
+    expectAction(actionAt(records, TASKS), 'smithy.forge', [TASKS]);
+  });
+});
+
+// ===========================================================================
+// CROSS-LEVEL — lineage suppression and fully-done rollup
+// ===========================================================================
+
+describe('next-action matrix — lineage suppression and rollup', () => {
+  // A real four-level chain where every file exists but no work has
+  // started. Each parent's own next_action is null (its single child is
+  // real, so per-child hints cover the work) EXCEPT the root RFC, which
+  // falls back to the single-arg render hint.
+  function writeChain(taskMarks: string[]): void {
+    write('docs/rfcs/demo/demo.rfc.md', rfcBody([['M1', 'Milestone', 'docs/rfcs/demo/01.features.md']]));
+    write('docs/rfcs/demo/01.features.md', featuresBody([['F1', 'Feature', 'specs/one/']]));
+    write('specs/one/one.spec.md', specBody([['US1', 'Story', 'specs/one/01-story.tasks.md']]));
+    write('specs/one/01-story.tasks.md', tasksBody([[1, 'Slice', taskMarks]]));
+  }
+
+  it('suppresses a deep descendant hint under a not-started actionable RFC, skipping null-action intermediates', () => {
+    writeChain([' ']); // not started
+    const records = scan(root);
+
+    const RFC = 'docs/rfcs/demo/demo.rfc.md';
+    const TASKS = 'specs/one/01-story.tasks.md';
+
+    // Root RFC: actionable, not suppressed.
+    expect(byPath(records, RFC)!.status).toBe('not-started');
+    expect(byPath(records, RFC)!.next_action!.command).toBe('smithy.render');
+    expect(byPath(records, RFC)!.next_action!.suppressed_by_ancestor).toBeUndefined();
+
+    // Intermediate parents have nothing of their own to suggest.
+    expect(byPath(records, 'docs/rfcs/demo/01.features.md')!.next_action).toBeNull();
+    expect(byPath(records, 'specs/one/one.spec.md')!.next_action).toBeNull();
+
+    // The leaf tasks file is the only actionable descendant. Its hint is
+    // emitted (every actionable row is self-describing) but flagged as
+    // suppressed because an actionable not-started ancestor (the RFC)
+    // exists — even though the spec/features intermediates carry no hint.
+    const tasks = byPath(records, TASKS)!;
+    expect(tasks.next_action!.command).toBe('smithy.forge');
+    expect(tasks.next_action!.suppressed_by_ancestor).toBe(true);
+  });
+
+  it('fully-done chain: every level rolls up to done with a null next action', () => {
+    writeChain(['x']); // the single slice is complete
+    const records = scan(root);
+
+    for (const path of [
+      'docs/rfcs/demo/demo.rfc.md',
+      'docs/rfcs/demo/01.features.md',
+      'specs/one/one.spec.md',
+      'specs/one/01-story.tasks.md',
+    ]) {
+      expect(byPath(records, path)!.status, `${path} status`).toBe('done');
+      expect(actionAt(records, path), `${path} next_action`).toBeNull();
+    }
+  });
+});

--- a/src/status/suggester.test.ts
+++ b/src/status/suggester.test.ts
@@ -437,6 +437,68 @@ describe('suggestNextAction — features records', () => {
     expect(action!.command).toBe('smithy.mark');
     expect(action!.arguments).toEqual(['docs/rfcs/foo.features.md']);
   });
+
+  it('redirects a virtual features record to smithy.render on its parent rfc', () => {
+    // A virtual features record has no `.features.md` on disk, so
+    // `smithy.mark` on its path would fail — the feature map has not
+    // been rendered from its RFC milestone yet. The scanner populates
+    // `parent_path` (the owning `.rfc.md`) and `parent_row_id` (`M<N>`)
+    // whenever it emits a virtual; the suggester must redirect to the
+    // `smithy.render` invocation that would create the feature map in
+    // the first place.
+    const record = makeRecord({
+      type: 'features',
+      status: 'not-started',
+      virtual: true,
+      path: 'docs/rfcs/2026-002-foo/02-subsystem-contract.features.md',
+      parent_path: 'docs/rfcs/2026-002-foo/foo.rfc.md',
+      parent_row_id: 'M2',
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.render');
+    expect(action!.arguments).toEqual([
+      'docs/rfcs/2026-002-foo/foo.rfc.md',
+      '2',
+    ]);
+    expect(action!.reason).toContain('M2');
+  });
+
+  it('falls back to smithy.render with rfc path only when a virtual features record lacks a row id', () => {
+    // Defensive: scanner emitted a virtual with `parent_path` but no
+    // usable `parent_row_id` digit. Still redirect to render (the file
+    // does not exist, so mark would fail) but drop the milestone digit.
+    const record = makeRecord({
+      type: 'features',
+      status: 'not-started',
+      virtual: true,
+      path: 'docs/rfcs/2026-002-foo/02-subsystem-contract.features.md',
+      parent_path: 'docs/rfcs/2026-002-foo/foo.rfc.md',
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.render');
+    expect(action!.arguments).toEqual(['docs/rfcs/2026-002-foo/foo.rfc.md']);
+  });
+
+  it('falls back to smithy.mark on a virtual features record missing parent fields', () => {
+    // Defensive guard: if the scanner ever emits a virtual features
+    // record without `parent_path` (shouldn't happen in practice), the
+    // suggester must still produce an action rather than crashing. Fall
+    // back to the legacy mark shape.
+    const record = makeRecord({
+      type: 'features',
+      status: 'not-started',
+      virtual: true,
+      path: 'docs/rfcs/2026-002-foo/02-subsystem-contract.features.md',
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.mark');
+    expect(action!.arguments).toEqual([
+      'docs/rfcs/2026-002-foo/02-subsystem-contract.features.md',
+    ]);
+  });
 });
 
 describe('suggestNextAction — spec records', () => {

--- a/src/status/suggester.test.ts
+++ b/src/status/suggester.test.ts
@@ -676,6 +676,97 @@ describe('suggestNextAction — spec records', () => {
     );
     expect(action!.arguments).toEqual(['specs/webhooks', '2']);
   });
+
+  it('redirects a virtual spec record to smithy.mark on its parent features map', () => {
+    // A virtual spec record has no `.spec.md` on disk, so `smithy.cut`
+    // on its folder would fail — the spec has not been marked from its
+    // feature map yet. The scanner populates `parent_path` (the owning
+    // `.features.md`) and `parent_row_id` (`F<N>`) whenever it emits a
+    // virtual; the suggester must redirect to the `smithy.mark`
+    // invocation that would create the spec in the first place.
+    const record = makeRecord({
+      type: 'spec',
+      status: 'not-started',
+      virtual: true,
+      path: 'specs/spawn-output-extraction/',
+      parent_path: 'docs/rfcs/2026-001-march/01-spawn.features.md',
+      parent_row_id: 'F5',
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.mark');
+    expect(action!.arguments).toEqual([
+      'docs/rfcs/2026-001-march/01-spawn.features.md',
+      '5',
+    ]);
+    expect(action!.reason).toContain('F5');
+  });
+
+  it('falls back to smithy.mark with features path only when a virtual spec record lacks a row id', () => {
+    // Defensive: scanner emitted a virtual with `parent_path` but no
+    // usable `parent_row_id` digit. Still redirect to mark (the file
+    // does not exist, so cut would fail) but drop the feature digit.
+    const record = makeRecord({
+      type: 'spec',
+      status: 'not-started',
+      virtual: true,
+      path: 'specs/spawn-output-extraction/',
+      parent_path: 'docs/rfcs/2026-001-march/01-spawn.features.md',
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.mark');
+    expect(action!.arguments).toEqual([
+      'docs/rfcs/2026-001-march/01-spawn.features.md',
+    ]);
+  });
+
+  it('falls back to smithy.cut on a virtual spec record missing parent fields', () => {
+    // Defensive guard: if the scanner ever emits a virtual spec record
+    // without `parent_path` (shouldn't happen in practice), the
+    // suggester must still produce an action rather than crashing. Fall
+    // back to the legacy cut shape against the folder.
+    const record = makeRecord({
+      type: 'spec',
+      status: 'not-started',
+      virtual: true,
+      path: 'specs/spawn-output-extraction/',
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.cut');
+    expect(action!.arguments).toEqual(['specs/spawn-output-extraction']);
+  });
+
+  it('keeps smithy.cut for a real (on-disk) spec with an uncut user story', () => {
+    // Regression guard for the F3/F4 case: a real spec (not virtual)
+    // whose feature map row resolves to an existing `.spec.md`. Its
+    // next-action must remain `smithy.cut <folder> <US#>` — the spec
+    // exists, so marking it again would be wrong; the next uncut user
+    // story is what needs decomposing.
+    const record = makeRecord({
+      type: 'spec',
+      status: 'not-started',
+      path: 'specs/2026-05-10-003-multi-backend/multi-backend.spec.md',
+      parent_path: 'docs/rfcs/2026-001-march/01-spawn.features.md',
+      parent_row_id: 'F3',
+      dependency_order: {
+        rows: [makeRow('US2', 'specs/2026-05-10-003-multi-backend/02-a.tasks.md'), makeRow('US3')],
+        id_prefix: 'US',
+        format: 'table',
+      },
+    });
+    const children: ArtifactRecord[] = [
+      makeChild('not-started', 'tasks'), // real — tasks file exists
+      makeRecord({ type: 'tasks', status: 'not-started', virtual: true }),
+    ];
+    const action = suggestNextAction(record, children, false);
+    expect(action!.command).toBe('smithy.cut');
+    expect(action!.arguments).toEqual([
+      'specs/2026-05-10-003-multi-backend',
+      '3',
+    ]);
+  });
 });
 
 describe('suggestNextAction — ancestor suppression flag', () => {

--- a/src/status/suggester.ts
+++ b/src/status/suggester.ts
@@ -25,7 +25,10 @@
  *   would fail, so redirect to the render that creates the file)
  * - `spec` → `smithy.cut <dirname(spec-path)> <first-virtual-US<N>-digits>`
  *   (only when at least one user-story row has no tasks file on disk;
- *   null otherwise so per-task hints below the spec drive the work)
+ *   null otherwise so per-task hints below the spec drive the work), or
+ *   `smithy.mark <features-path> <F<N>-digits>` for a virtual spec record
+ *   (a feature whose `.spec.md` does not yet exist — cut would fail, so
+ *   redirect to the mark that creates the file)
  * - `tasks` → `smithy.forge <tasks-path> <first-non-done-S<N>-digits>` for
  *   real tasks files (degrades to `smithy.forge <tasks-path>` when the
  *   record carries no parsed slices), or
@@ -94,27 +97,34 @@ function cutTargetFromVirtualTasks(
 }
 
 /**
- * Resolve the `smithy.render` target (RFC path + milestone digits) for a
- * virtual features record. Virtual features records carry the parent
- * RFC's path in `parent_path` and the canonical `M<N>` row id in
- * `parent_row_id`; both are populated by the scanner whenever it emits a
- * virtual.
+ * Resolve the parent-file redirect target (parent artifact path + the
+ * owning row's numeric digits) for a virtual record whose parent command
+ * takes the parent artifact's *file* path directly. Two redirects use
+ * this shape:
+ *
+ * - A virtual `features` record (a milestone whose `.features.md` does not
+ *   exist) → `smithy.render <rfc-file> <M<N>>`. Parent is the RFC file.
+ * - A virtual `spec` record (a feature whose `.spec.md` does not exist) →
+ *   `smithy.mark <features-file> <F<N>>`. Parent is the feature map file.
+ *
+ * Both carry the parent artifact's path in `parent_path` and the
+ * canonical owning-row id (`M<N>` / `F<N>`) in `parent_row_id`; the
+ * scanner populates both whenever it emits a virtual.
  *
  * Returns `null` when `parent_path` is missing or empty — in that case
- * the scanner left us without an RFC to target, so the caller falls back
- * to the legacy `smithy.mark` shape rather than producing a
- * `smithy.render` with no arguments. When `parent_path` is present but
+ * the scanner left us without a parent to target, so the caller falls
+ * back to the legacy operate-on-self command shape rather than producing
+ * a redirect with no arguments. When `parent_path` is present but
  * `parent_row_id` is missing or has no numeric suffix, returns
- * `{ rfcPath, digits: undefined }` so the caller emits an RFC-only
- * `smithy.render <rfc>` hint — the same no-digits fallback the RFC case
- * uses when every milestone is already rendered. Unlike the tasks→cut
- * redirect (which targets `dirname(parent_path)`), `smithy.render` takes
- * the RFC file path directly, so `parent_path` is passed through
- * verbatim.
+ * `{ parentPath, digits: undefined }` so the caller emits a parent-only
+ * hint. Unlike the tasks→cut redirect (which targets
+ * `dirname(parent_path)` because `smithy.cut` takes a folder),
+ * `smithy.render` and `smithy.mark` take the parent file path directly,
+ * so `parent_path` is passed through verbatim.
  */
-function renderTargetFromVirtualFeatures(
+function parentFileTargetFromVirtual(
   record: ArtifactRecord,
-): { rfcPath: string; digits: string | undefined } | null {
+): { parentPath: string; digits: string | undefined } | null {
   const parentPath = record.parent_path;
   if (typeof parentPath !== 'string' || parentPath.length === 0) {
     return null;
@@ -122,7 +132,7 @@ function renderTargetFromVirtualFeatures(
   const digits = record.parent_row_id !== undefined
     ? numericIdSuffix(record.parent_row_id)
     : undefined;
-  return { rfcPath: parentPath, digits };
+  return { parentPath, digits };
 }
 
 /**
@@ -227,7 +237,11 @@ function firstVirtualNotStartedRowDigits(
  *      when the record has zero rows but is itself `not-started`;
  *      `null` otherwise (every declared spec already exists, so the
  *      per-spec hints cover the remaining work).
- *    - `spec` → `smithy.cut [dirname(record.path), <first-virtual-row-digits>]`
+ *    - `spec` → `smithy.mark [parent_path, <parent_row_id-digits>]` for a
+ *      virtual spec record whose `.spec.md` does not yet exist (falling
+ *      back to the `smithy.cut` shape when the scanner did not populate
+ *      `parent_path`); otherwise
+ *      `smithy.cut [dirname(record.path), <first-virtual-row-digits>]`
  *      when a user story has no tasks file yet; `smithy.cut [dirname(record.path)]`
  *      only when the record has zero rows but is itself `not-started`;
  *      `null` otherwise (every declared tasks file already exists, so
@@ -305,12 +319,12 @@ export function suggestNextAction(
       // `smithy.mark` hint. This mirrors the virtual tasks → smithy.cut
       // redirect below.
       if (record.virtual === true) {
-        const renderTarget = renderTargetFromVirtualFeatures(record);
+        const renderTarget = parentFileTargetFromVirtual(record);
         if (renderTarget !== null) {
           command = 'smithy.render';
           args = renderTarget.digits !== undefined
-            ? [renderTarget.rfcPath, renderTarget.digits]
-            : [renderTarget.rfcPath];
+            ? [renderTarget.parentPath, renderTarget.digits]
+            : [renderTarget.parentPath];
           reason = renderTarget.digits !== undefined
             ? `Feature map ${record.title} does not exist yet; run smithy.render to create it from milestone M${renderTarget.digits}.`
             : `Feature map ${record.title} does not exist yet; run smithy.render to create it.`;
@@ -343,6 +357,29 @@ export function suggestNextAction(
       break;
     }
     case 'spec': {
+      // Virtual spec records point at a `.spec.md` that does not yet
+      // exist on disk, so `smithy.cut` would fail — the spec it would
+      // decompose hasn't been marked from its feature map yet. Redirect
+      // to the `smithy.mark` invocation that creates the spec in the
+      // first place. Real spec records keep the `smithy.cut` hint. This
+      // mirrors the virtual features → smithy.render redirect above and
+      // the virtual tasks → smithy.cut redirect below.
+      if (record.virtual === true) {
+        const markTarget = parentFileTargetFromVirtual(record);
+        if (markTarget !== null) {
+          command = 'smithy.mark';
+          args = markTarget.digits !== undefined
+            ? [markTarget.parentPath, markTarget.digits]
+            : [markTarget.parentPath];
+          reason = markTarget.digits !== undefined
+            ? `Spec ${record.title} does not exist yet; run smithy.mark to create it from feature F${markTarget.digits}.`
+            : `Spec ${record.title} does not exist yet; run smithy.mark to create it.`;
+          break;
+        }
+        // Defensive fallback: scanner didn't populate parent fields.
+        // Keep the legacy cut shape rather than crashing so the
+        // suggester stays total.
+      }
       command = 'smithy.cut';
       const folder = specFolderFromPath(record.path);
       const digits = firstVirtualNotStartedRowDigits(record, resolvedChildren);

--- a/src/status/suggester.ts
+++ b/src/status/suggester.ts
@@ -19,7 +19,10 @@
  *   RFC has zero rows or every milestone is already rendered
  * - `features` → `smithy.mark <features-path> <first-virtual-F<N>-digits>`
  *   (only when at least one feature row has no spec file on disk; null
- *   otherwise so per-spec hints below the features map drive the work)
+ *   otherwise so per-spec hints below the features map drive the work),
+ *   or `smithy.render <rfc-path> <M<N>-digits>` for a virtual features
+ *   record (a milestone whose `.features.md` does not yet exist — mark
+ *   would fail, so redirect to the render that creates the file)
  * - `spec` → `smithy.cut <dirname(spec-path)> <first-virtual-US<N>-digits>`
  *   (only when at least one user-story row has no tasks file on disk;
  *   null otherwise so per-task hints below the spec drive the work)
@@ -88,6 +91,38 @@ function cutTargetFromVirtualTasks(
     ? numericIdSuffix(record.parent_row_id)
     : undefined;
   return { folder, digits };
+}
+
+/**
+ * Resolve the `smithy.render` target (RFC path + milestone digits) for a
+ * virtual features record. Virtual features records carry the parent
+ * RFC's path in `parent_path` and the canonical `M<N>` row id in
+ * `parent_row_id`; both are populated by the scanner whenever it emits a
+ * virtual.
+ *
+ * Returns `null` when `parent_path` is missing or empty — in that case
+ * the scanner left us without an RFC to target, so the caller falls back
+ * to the legacy `smithy.mark` shape rather than producing a
+ * `smithy.render` with no arguments. When `parent_path` is present but
+ * `parent_row_id` is missing or has no numeric suffix, returns
+ * `{ rfcPath, digits: undefined }` so the caller emits an RFC-only
+ * `smithy.render <rfc>` hint — the same no-digits fallback the RFC case
+ * uses when every milestone is already rendered. Unlike the tasks→cut
+ * redirect (which targets `dirname(parent_path)`), `smithy.render` takes
+ * the RFC file path directly, so `parent_path` is passed through
+ * verbatim.
+ */
+function renderTargetFromVirtualFeatures(
+  record: ArtifactRecord,
+): { rfcPath: string; digits: string | undefined } | null {
+  const parentPath = record.parent_path;
+  if (typeof parentPath !== 'string' || parentPath.length === 0) {
+    return null;
+  }
+  const digits = record.parent_row_id !== undefined
+    ? numericIdSuffix(record.parent_row_id)
+    : undefined;
+  return { rfcPath: parentPath, digits };
 }
 
 /**
@@ -183,9 +218,13 @@ function firstVirtualNotStartedRowDigits(
  *    - `rfc` → `smithy.render [record.path, <first-virtual-row-digits>]`
  *      when a milestone has no feature map yet; `smithy.render [record.path]`
  *      otherwise (zero rows, or every milestone already rendered).
- *    - `features` → `smithy.mark [record.path, <first-virtual-row-digits>]`
- *      when a feature has no spec file yet; `smithy.mark [record.path]`
- *      only when the record has zero rows but is itself `not-started`;
+ *    - `features` → `smithy.render [parent_path, <parent_row_id-digits>]`
+ *      for a virtual features record whose `.features.md` does not yet
+ *      exist (falling back to the `smithy.mark` shape when the scanner
+ *      did not populate `parent_path`); otherwise
+ *      `smithy.mark [record.path, <first-virtual-row-digits>]` when a
+ *      feature has no spec file yet; `smithy.mark [record.path]` only
+ *      when the record has zero rows but is itself `not-started`;
  *      `null` otherwise (every declared spec already exists, so the
  *      per-spec hints cover the remaining work).
  *    - `spec` → `smithy.cut [dirname(record.path), <first-virtual-row-digits>]`
@@ -258,6 +297,29 @@ export function suggestNextAction(
       break;
     }
     case 'features': {
+      // Virtual features records point at a `.features.md` that does not
+      // yet exist on disk, so `smithy.mark` would fail — the feature map
+      // it would mark hasn't been rendered from its RFC milestone yet.
+      // Redirect to the `smithy.render` invocation that creates the
+      // feature map in the first place. Real features records keep the
+      // `smithy.mark` hint. This mirrors the virtual tasks → smithy.cut
+      // redirect below.
+      if (record.virtual === true) {
+        const renderTarget = renderTargetFromVirtualFeatures(record);
+        if (renderTarget !== null) {
+          command = 'smithy.render';
+          args = renderTarget.digits !== undefined
+            ? [renderTarget.rfcPath, renderTarget.digits]
+            : [renderTarget.rfcPath];
+          reason = renderTarget.digits !== undefined
+            ? `Feature map ${record.title} does not exist yet; run smithy.render to create it from milestone M${renderTarget.digits}.`
+            : `Feature map ${record.title} does not exist yet; run smithy.render to create it.`;
+          break;
+        }
+        // Defensive fallback: scanner didn't populate parent fields.
+        // Keep the legacy mark shape rather than crashing so the
+        // suggester stays total.
+      }
       command = 'smithy.mark';
       const digits = firstVirtualNotStartedRowDigits(record, resolvedChildren);
       if (digits !== undefined) {


### PR DESCRIPTION
## Problem

`smithy status` (graph and tree views) suggested **operate-on-self** commands against child artifact files that don't exist yet — unrunnable hints. Two levels were affected:

- A **milestone with no feature map** suggested `smithy.mark <missing.features.md>` instead of `smithy.render <rfc> <M#>` (which *creates* the feature map).
- A **feature with no spec** suggested `smithy.cut <missing-spec-folder>` instead of `smithy.mark <features> <F#>` (which *creates* the spec).

Real example (against a working repo):

```
F5 Spawn Output Extraction  ○  → smithy.cut specs/spawn-output-extraction        # no spec exists → can't cut
M1 Test Legibility ...      ○  → smithy.mark .../01-test-legibility...features.md  # no feature map → can't mark
```

## Root cause

When a child file is absent on disk, the scanner emits a **virtual** record (`virtual: true`, with `parent_path` + `parent_row_id`). The suggester's `features` and `spec` cases produced the operate-on-self command unconditionally — they never checked the virtual flag. The `tasks` case already had the analogous guard (virtual tasks → `smithy.cut`); the two upper levels were missing it.

## Fix

A virtual record now redirects to the command that **creates** it from its parent:

| Virtual record | Was (wrong) | Now |
|----------------|-------------|-----|
| `features` (no `.features.md`) | `smithy.mark <missing>` | `smithy.render <rfc> <M#>` |
| `spec` (no `.spec.md`) | `smithy.cut <missing>` | `smithy.mark <features> <F#>` |
| `tasks` (no `.tasks.md`) | — | `smithy.cut <folder> <US#>` (pre-existing) |

Real (on-disk) artifacts are untouched — a real spec still gets `smithy.cut` for its next uncut story, etc. The features→render and spec→mark redirects share one helper (`parentFileTargetFromVirtual`); tasks→cut keeps its own because cut targets the parent *folder*, not the parent *file*.

The fix lives in the per-record suggester, so both the graph view (reads the downstream record's `next_action`) and the tree view (reads the record's own `next_action`) pick it up.

## After

```
F3 Multi-Backend (real spec)   ○  → smithy.cut specs/.../multi-backend... 3   # unchanged, correct
F5 Spawn Output (no spec)      ○  → smithy.mark .../01-spawn.features.md 5     # fixed
M1 Test Legibility (no map)    ○  → smithy.render .../layered-testing.rfc.md 1  # fixed
```

## Tests

- **`nextAction.matrix.test.ts`** (new, 22 tests): end-to-end suite running the full `scan()` pipeline against real temp-dir fixtures, asserting the next-action hint at **every** parent→child level (RFC→features, features→specs, spec→tasks, tasks→slices) across the **none / some / all** on-disk-child axis — plus status nuances (done / in-progress / partially-checked slice), `—`-cell convention paths, first-virtual-vs-lower-index-real ordering, ancestor suppression across null-action intermediates, and fully-done rollup. `status` is the authoritative work tracker, so these lock in that every suggested command's on-disk prerequisites are satisfied.
- New `suggester.test.ts` unit tests for both redirects (with/without digit; defensive fallback when parent fields are absent; regression guard that a real spec keeps `smithy.cut`).
- Updated the `cli.test.ts` integration test that previously encoded the buggy `smithy.mark`-against-a-missing-file behavior.
- Full suite: **884 passing**; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
