### PR TITLE
spec: smithy.fix end-to-end eval scenario (M1 F3)

### DIFF
--- a/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
+++ b/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
@@ -106,7 +106,7 @@ Recommended specification sequence:
 |----|-------|------------|----------|
 | F1 | Feature 1.3a: Per-Case Token Totals in EvalReport | — | specs/2026-05-18-007-per-case-token-totals-in-evalreport/ |
 | F2 | Feature 1.3b: Per-Sub-Agent Token Attribution | F1 | specs/2026-05-20-008-per-sub-agent-token-attribution/ |
-| F3 | Feature 1.4: smithy.fix End-to-End Eval Scenario | F1 | — |
+| F3 | Feature 1.4: smithy.fix End-to-End Eval Scenario | F1 | specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/ |
 | F4 | Feature 1.5: smithy.forge End-to-End Eval Scenario + Runner git-init (RFC SD-002) | F1 | — |
 | F5 | Feature 1.6: JVM Multi-Language Fixture | — | — |
 | F6 | Feature 1.7: Forge-JVM Eval Scenario + M1 Baseline-Set Completeness Gate | F1, F4, F5 | — |

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.contracts.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.contracts.md
@@ -1,0 +1,192 @@
+# Contracts: smithy.fix End-to-End Eval Scenario
+
+## Overview
+
+This feature introduces a local-fixture contract for eval scenarios that need committed evidence files, then uses it to run smithy.fix against offline issue and CI-log inputs. The contracts are additive to the existing scenario loader, runner invocation, validation, and baseline flows.
+
+## Interfaces
+
+### 1) Scenario Local Fixture Declaration
+
+**Purpose**: Allows a scenario YAML file to declare local evidence files required for invocation.
+**Consumers**: Scenario loader, eval runner, scenario tests.
+**Providers**: Scenario YAML files under the eval cases directory.
+
+#### Signature
+
+```yaml
+local_fixtures:
+  issue: evals/fixture/issues/issue-001.md
+  ci_log: evals/fixture/ci-logs/run-001.log
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `local_fixtures.issue` | string | Yes | Repository-relative path to the issue fixture. |
+| `local_fixtures.ci_log` | string | Yes | Repository-relative path to the CI-log fixture. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `EvalScenario.local_fixtures` | object | Validated fixture declaration attached to the loaded scenario. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Field is absent on scenarios that do not need local evidence | Load without fixture injection. | Existing scenarios remain compatible. |
+| Field is malformed | Skip or reject the scenario with a validation error naming the field. | A malformed declaration cannot produce a deterministic invocation. |
+| Path escapes the allowed fixture area | Reject the scenario with a validation error. | Prevents arbitrary file reads through scenario metadata. |
+| Declared file does not exist or is unreadable | Fail scenario loading or invocation setup with a clear path-specific error. | Missing fixture evidence is a scenario authoring bug. |
+
+### 2) Local Fixture Prompt Injection
+
+**Purpose**: Renders resolved local fixture paths into the smithy.fix invocation.
+**Consumers**: Eval runner invocation builder and smithy.fix scenario prompt.
+**Providers**: Loaded scenario metadata and repository fixture files.
+
+#### Signature
+
+```ts
+buildInvocation(
+  scenario: EvalScenario,
+  agent: EvalAgent,
+  fixtureBindings?: LocalFixtureBindings,
+): string
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scenario.prompt` | string | Yes | Prompt template or prompt text for the scenario. |
+| `fixtureBindings.issue_path` | string | Conditional | Resolved path to the local issue fixture when declared. |
+| `fixtureBindings.ci_log_path` | string | Conditional | Resolved path to the local CI-log fixture when declared. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| invocation | string | Agent-specific command input that tells smithy.fix to use the local issue and CI-log fixture evidence. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Scenario declares fixtures but bindings are unavailable | Fail before spawning the agent. | The command should not start with unresolved local evidence. |
+| Binding path cannot be read in the execution context | Fail before spawning the agent. | smithy.fix must not fall back to live GitHub data by accident. |
+| Agent-specific invocation format differs | Preserve existing slash-command or skill-name wrapping and inject fixture references inside the prompt body. | Fixture injection must work for supported eval agents. |
+
+### 3) Offline smithy.fix Scenario Definition
+
+**Purpose**: Defines the committed smithy.fix case and its validation expectations.
+**Consumers**: Scenario loader, eval runner, report builder, baseline comparator.
+**Providers**: `fix-from-issue` scenario YAML and committed fixture files.
+
+#### Signature
+
+```yaml
+name: fix-from-issue
+skill: /smithy.fix
+prompt: |
+  Diagnose and fix the issue described in the local fixture evidence.
+  Issue fixture: {{issue_path}}
+  CI log fixture: {{ci_log_path}}
+local_fixtures:
+  issue: evals/fixture/issues/issue-001.md
+  ci_log: evals/fixture/ci-logs/run-001.log
+structural_expectations:
+  required_headings: [...]
+sub_agent_evidence:
+  - agent: <observed-helper>
+    pattern: <stable-evidence-pattern>
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Stable scenario name used for reporting and baseline lookup. |
+| `skill` | string | Yes | Smithy command under test. |
+| `prompt` | string | Yes | Prompt that names local fixture evidence. |
+| `local_fixtures` | object | Yes | Local issue and CI-log fixture declaration. |
+| `structural_expectations` | object | Yes | Existing structural validation rules. |
+| `sub_agent_evidence` | array | Yes | Helper evidence checks for the observed smithy.fix path. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `EvalResult` | object | Standard per-case result with status, structural checks, helper checks, duration, and token totals once F1.3a is present. |
+| `EvalReport` case line | string | Standard report row for `fix-from-issue`, including baseline marker and token totals after baseline creation. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| smithy.fix attempts to require live GitHub access | Scenario fails because the offline contract was not honored. | The eval must remain runnable without credentials. |
+| Structural marker is missing | Structural check fails. | The report should expose workflow regressions. |
+| Expected helper evidence is missing | Helper evidence check fails. | The report should expose dispatch-path regressions. |
+| Scenario times out or exits non-zero | Standard eval timeout/error status applies while preserving captured output and tokens. | Existing runner behavior remains authoritative. |
+
+### 4) Fix Baseline Contract
+
+**Purpose**: Stores and compares the known-good smithy.fix scenario output and token envelope.
+**Consumers**: Baseline loader, baseline comparator, report formatter, downstream token-delta work.
+**Providers**: Committed baseline JSON for `fix-from-issue`.
+
+#### Signature
+
+```json
+{
+  "scenario_name": "fix-from-issue",
+  "captured_at": "2026-06-03T00:00:00.000Z",
+  "headings": ["..."],
+  "tables": [],
+  "token_envelope": {
+    "input": { "min": 0, "max": 0 },
+    "output": { "min": 0, "max": 0 }
+  }
+}
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scenario_name` | string | Yes | Must match the scenario name `fix-from-issue`. |
+| `headings` | string[] | Yes | Structural headings expected from the known-good run. |
+| `tables` | array | No | Structural table expectations when present. |
+| `token_envelope` | object | Yes | Token bounds using the F1.3a schema. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Baseline` | object | Loaded structural and token baseline for the smithy.fix scenario. |
+| `CheckResult[]` | array | Structural checks plus token envelope check when compared with a live run. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Baseline is absent before the capture slice lands | Scenario can run without a baseline marker. | Baseline creation is the final story for this feature. |
+| Baseline scenario name mismatches | Reject the baseline. | Prevents comparing a run against the wrong committed envelope. |
+| Token envelope is malformed | Reject the baseline using F1.3a validation rules. | Invalid token bounds would make downstream deltas misleading. |
+| Live output drifts from structural baseline | Emit failing structural baseline checks. | Existing baseline semantics apply. |
+| Live token totals exceed envelope | Emit a failing token check. | Downstream token regressions become visible in the eval report. |
+
+## Events / Hooks
+
+No new runtime events or hooks are introduced. The feature uses the existing eval scenario load, runner invocation, validation, report, and baseline comparison flow.
+
+## Integration Boundaries
+
+- **Scenario YAML boundary**: adds optional `local_fixtures` metadata while preserving compatibility for scenarios that omit it.
+- **Filesystem fixture boundary**: reads committed issue and CI-log evidence from the eval fixture area only.
+- **Runner invocation boundary**: injects resolved local fixture references into the prompt before spawning the selected agent.
+- **smithy.fix command boundary**: exercises smithy.fix through its normal user-facing invocation path with local evidence text, without live GitHub calls.
+- **Baseline boundary**: consumes the token-aware baseline schema from F1.3a and commits a `fix-from-issue` baseline for downstream token-delta work.

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.contracts.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.contracts.md
@@ -114,7 +114,7 @@ sub_agent_evidence:
 | `prompt` | string | Yes | Prompt that names local fixture evidence. |
 | `local_fixtures` | object | Yes | Local issue and CI-log fixture declaration. |
 | `structural_expectations` | object | Yes | Existing structural validation rules. |
-| `sub_agent_evidence` | array | Yes | Helper evidence checks for the observed smithy.fix path. |
+| `sub_agent_evidence` | array | Conditional | Helper evidence checks for the observed smithy.fix path. Required only when the captured run actually dispatches helper agents; for the offline error-description path, which may dispatch none, this is empty or omitted. |
 
 #### Outputs
 
@@ -129,7 +129,7 @@ sub_agent_evidence:
 |-----------|----------|-------------|
 | smithy.fix attempts to require live GitHub access | Scenario fails because the offline contract was not honored. | The eval must remain runnable without credentials. |
 | Structural marker is missing | Structural check fails. | The report should expose workflow regressions. |
-| Expected helper evidence is missing | Helper evidence check fails. | The report should expose dispatch-path regressions. |
+| A declared helper evidence check is missing from the run | That helper evidence check fails. | The report should expose dispatch-path regressions. A run that legitimately dispatches no helpers declares no checks and does not fail on this condition. |
 | Scenario times out or exits non-zero | Standard eval timeout/error status applies while preserving captured output and tokens. | Existing runner behavior remains authoritative. |
 
 ### 4) Fix Baseline Contract

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md
@@ -15,7 +15,7 @@ Purpose: Represents the YAML scenario that invokes smithy.fix against offline fa
 | `name` | string | Yes | Stable scenario name. Expected value is `fix-from-issue`. |
 | `skill` | string | Yes | Smithy command under test. Expected value is `/smithy.fix`. |
 | `prompt` | string | Yes | Scenario prompt template that references the local fixture evidence exposed by the runner. |
-| `local_fixtures` | LocalFixtureSet | Yes | Declares the issue and CI-log fixture files needed for this scenario. |
+| `local_fixtures` | LocalFixtureSet | Conditional | Optional at the scenario-schema level (scenarios without local evidence omit it and remain compatible, per contracts.md §1); required for this `fix-from-issue` scenario, which declares the issue and CI-log fixture files it needs. |
 | `structural_expectations` | StructuralExpectations | Yes | Existing eval validation contract for required headings, patterns, tables, and forbidden patterns. |
 | `sub_agent_evidence` | HelperEvidenceCheck[] | No | Expected helper evidence for the observed smithy.fix path. |
 | `timeout` | integer | No | Existing per-scenario timeout override in seconds. |
@@ -24,7 +24,8 @@ Validation rules:
 
 - `name`, `skill`, and `prompt` must be non-empty strings.
 - `skill` must resolve to the deployed smithy.fix command.
-- `local_fixtures.issue` and `local_fixtures.ci_log` must resolve under the allowed eval fixture area.
+- `local_fixtures` is optional at the scenario-schema level; when absent the scenario loads without fixture injection (contracts.md §1). It is required for the `fix-from-issue` scenario.
+- When `local_fixtures` is present, `local_fixtures.issue` and `local_fixtures.ci_log` must resolve under the allowed eval fixture area.
 - Structural expectations must include at least one stable marker for diagnosis, fix action, and verification output.
 - Helper evidence is optional at schema-load time but required for the committed smithy.fix scenario once the observed helper path is known.
 

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md
@@ -1,0 +1,160 @@
+# Data Model: smithy.fix End-to-End Eval Scenario
+
+## Overview
+
+This feature adds data definitions for a deterministic smithy.fix eval scenario. The model extends scenario metadata with local fixture declarations, introduces committed issue and CI-log fixtures as repository artifacts, and consumes the token-aware baseline shape established by Feature 1.3a. No persistent database or external storage is introduced.
+
+## Entities
+
+### 1) Fix Eval Scenario (`fix_eval_scenario`)
+
+Purpose: Represents the YAML scenario that invokes smithy.fix against offline failure evidence.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | Stable scenario name. Expected value is `fix-from-issue`. |
+| `skill` | string | Yes | Smithy command under test. Expected value is `/smithy.fix`. |
+| `prompt` | string | Yes | Scenario prompt template that references the local fixture evidence exposed by the runner. |
+| `local_fixtures` | LocalFixtureSet | Yes | Declares the issue and CI-log fixture files needed for this scenario. |
+| `structural_expectations` | StructuralExpectations | Yes | Existing eval validation contract for required headings, patterns, tables, and forbidden patterns. |
+| `sub_agent_evidence` | HelperEvidenceCheck[] | No | Expected helper evidence for the observed smithy.fix path. |
+| `timeout` | integer | No | Existing per-scenario timeout override in seconds. |
+
+Validation rules:
+
+- `name`, `skill`, and `prompt` must be non-empty strings.
+- `skill` must resolve to the deployed smithy.fix command.
+- `local_fixtures.issue` and `local_fixtures.ci_log` must resolve under the allowed eval fixture area.
+- Structural expectations must include at least one stable marker for diagnosis, fix action, and verification output.
+- Helper evidence is optional at schema-load time but required for the committed smithy.fix scenario once the observed helper path is known.
+
+### 2) LocalFixtureSet (`local_fixture_set`)
+
+Purpose: Declares the local evidence files the runner makes available to the scenario invocation.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `issue` | string | Yes | Repository-relative path to the offline issue fixture. |
+| `ci_log` | string | Yes | Repository-relative path to the offline CI-log fixture. |
+
+Validation rules:
+
+- Paths must be relative repository paths.
+- Paths must not contain parent-directory segments or absolute-path syntax.
+- `issue` must point under `evals/fixture/issues/`.
+- `ci_log` must point under `evals/fixture/ci-logs/`.
+- Each path must resolve to a readable file before the scenario invocation is built.
+
+### 3) Issue Fixture (`issue_fixture`)
+
+Purpose: Provides deterministic issue or CI-failure context for smithy.fix without `gh issue view`.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `path` | string | Yes | Repository-relative Markdown fixture path. |
+| `title` | string | Yes | Human-readable problem title embedded in the fixture. |
+| `body` | markdown | Yes | Bug report or CI-failure description with enough context to drive diagnosis. |
+| `referenced_files` | string[] | No | Source or test files named by the fixture text. |
+
+Validation rules:
+
+- The fixture file must be UTF-8 text.
+- The fixture must include a concrete failure description.
+- Referenced files should exist in the eval fixture copy or be intentionally absent as part of the tested failure.
+
+### 4) CI Log Fixture (`ci_log_fixture`)
+
+Purpose: Provides deterministic failing build or test output for the smithy.fix high-cost CI-log path.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `path` | string | Yes | Repository-relative text fixture path. |
+| `content` | text | Yes | Captured or hand-authored CI log excerpt. |
+| `failure_markers` | string[] | Yes | Error, failure, or stack-trace markers expected to guide diagnosis. |
+
+Validation rules:
+
+- The fixture file must be UTF-8 text.
+- The fixture must contain at least one clear failure marker.
+- The fixture must not require network access or external artifact downloads to interpret.
+- The fixture should be bounded to the minimum log excerpt needed to exercise the high-cost path.
+
+### 5) Local Fixture Injection (`local_fixture_injection`)
+
+Purpose: Captures the resolved local fixture paths that the runner provides to the prompt invocation.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `issue_path` | string | Yes | Absolute or temp-copy-local path to the issue fixture visible during scenario execution. |
+| `ci_log_path` | string | Yes | Absolute or temp-copy-local path to the CI-log fixture visible during scenario execution. |
+| `prompt_bindings` | object | Yes | Stable placeholders or rendered references inserted into the scenario prompt. |
+
+Validation rules:
+
+- Injected paths must point at files copied into or readable from the scenario execution context.
+- Prompt bindings must be deterministic for the same scenario and fixture root.
+- Injection must not expose paths outside the repository fixture area except for the runner's own temp-copy location.
+
+### 6) Fix Baseline (`fix_baseline`)
+
+Purpose: Stores the known-good smithy.fix scenario output and token envelope once F1.3a's baseline schema is available.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `scenario_name` | string | Yes | Must match `fix-from-issue`. |
+| `captured_at` | string | Yes | ISO 8601 capture timestamp. |
+| `headings` | string[] | Yes | Structural heading expectations inherited from the baseline contract. |
+| `tables` | object[] | No | Structural table expectations inherited from the baseline contract. |
+| `token_envelope` | TokenEnvelope | Yes | Accepted token bounds using the F1.3a token-aware schema. |
+
+Validation rules:
+
+- The baseline must satisfy the F1.3a token-aware baseline validation rules.
+- Structural expectations must remain present alongside the token envelope.
+- Baseline scenario name must match the scenario definition.
+
+## Relationships
+
+- `Fix Eval Scenario` 1:1 `LocalFixtureSet` via the scenario's local fixture declaration.
+- `LocalFixtureSet` 1:1 `Issue Fixture` via `local_fixtures.issue`.
+- `LocalFixtureSet` 1:1 `CI Log Fixture` via `local_fixtures.ci_log`.
+- `LocalFixtureSet` 1:1 `Local Fixture Injection` during runner invocation assembly.
+- `Fix Eval Scenario` 0..N `HelperEvidenceCheck` through existing sub-agent evidence validation.
+- `Fix Eval Scenario` 1:1 `Fix Baseline` after the first clean token-aware capture.
+
+## State Transitions
+
+### Scenario lifecycle
+
+1. `declared` -> `fixtures_resolved`
+   - Trigger: the scenario loader validates local fixture declarations.
+   - Effects: issue and CI-log fixture paths are checked for allowed location and readability.
+
+2. `fixtures_resolved` -> `invocation_built`
+   - Trigger: the runner renders the smithy.fix invocation.
+   - Effects: local fixture paths are injected into the prompt in a deterministic form.
+
+3. `invocation_built` -> `validated`
+   - Trigger: smithy.fix completes and report validation runs.
+   - Effects: structural and helper evidence checks are attached to the eval result.
+
+4. `validated` -> `baselined`
+   - Trigger: a clean scenario run is captured after the token-aware baseline schema exists.
+   - Effects: the fix baseline is committed with structural expectations and a token envelope.
+
+### Fixture lifecycle
+
+1. `authored` -> `committed`
+   - Trigger: fixture files are added to the repository.
+   - Effects: offline scenario evidence becomes available to every eval runner.
+
+2. `committed` -> `refreshed`
+   - Trigger: the intended smithy.fix path changes and the scenario is intentionally recalibrated.
+   - Effects: fixture text and baseline expectations are updated together.
+
+## Identity & Uniqueness
+
+- The scenario is uniquely identified by `name: fix-from-issue`.
+- Fixture declarations are uniquely identified by their repository-relative paths.
+- The baseline is uniquely identified by `scenario_name: fix-from-issue`.
+- Helper evidence checks are identified by the expected helper agent name plus evidence pattern.

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md
@@ -27,7 +27,7 @@ Validation rules:
 - `local_fixtures` is optional at the scenario-schema level; when absent the scenario loads without fixture injection (contracts.md §1). It is required for the `fix-from-issue` scenario.
 - When `local_fixtures` is present, `local_fixtures.issue` and `local_fixtures.ci_log` must resolve under the allowed eval fixture area.
 - Structural expectations must include at least one stable marker for diagnosis, fix action, and verification output.
-- Helper evidence is optional at schema-load time but required for the committed smithy.fix scenario once the observed helper path is known.
+- Helper evidence is optional. It is populated for the committed smithy.fix scenario only when the captured run actually dispatches helper agents; if the observed offline error-description path dispatches none, `sub_agent_evidence` is empty or omitted and the scenario must not fail for lack of helper checks.
 
 ### 2) LocalFixtureSet (`local_fixture_set`)
 

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
@@ -1,0 +1,168 @@
+# Feature Specification: smithy.fix End-to-End Eval Scenario
+
+**Spec Folder**: `2026-06-03-009-smithy-fix-end-to-end-eval-scenario`
+**Branch**: `2026-06-03-009-smithy-fix-end-to-end-eval-scenario`
+**Created**: 2026-06-03
+**Status**: Draft
+**Input**: `docs/rfcs/2026-001-token-savings/token-savings.rfc.md` - Milestone 1 measurement-foundation feature for deterministic smithy.fix end-to-end eval coverage.
+**Source Feature Map**: `docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md` - Feature 1.4: smithy.fix End-to-End Eval Scenario
+
+## Clarifications
+
+### Session 2026-06-03
+
+- This specification targets the Dependency Order row `F3`, which corresponds to Feature 1.4 in the measurement-foundation feature map. `[Critical Assumption]`
+- Feature 1.3a is the prerequisite token-baseline substrate; this feature consumes its token-aware baseline schema instead of redefining token extraction or comparison.
+- The smithy.fix eval is offline and deterministic: it must not call live GitHub issue, PR, or Actions APIs during scenario execution.
+- The offline issue fixture is a Markdown file under `evals/fixture/issues/`, and the offline CI-log fixture is a text log under `evals/fixture/ci-logs/`.
+- Fixture discovery is settled as a scenario-level local-fixture injection contract: a scenario may declare an issue fixture and a CI-log fixture, and the runner exposes their paths to the prompt invocation so smithy.fix can exercise its existing error-description path without network access.
+- This feature does not edit `smithy.fix.prompt`; M3 owns CI-log prompt optimizations. The eval prompt may name the local fixture paths and ask smithy.fix to diagnose that local issue/log evidence.
+
+## Artifact Hierarchy
+
+RFC -> Milestone -> Feature -> User Story -> Slice -> Tasks
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1: Provide Offline smithy.fix Fixtures (Priority: P1)
+
+As a Smithy maintainer, I want a committed issue fixture and CI-log fixture for smithy.fix so that the eval can reproduce the high-cost failure path without network access.
+
+**Why this priority**: The scenario cannot be deterministic until its GitHub issue and CI-log inputs are committed as local evidence.
+
+**Independent Test**: Load the fixtures from the repository and verify they contain a fixable issue description, CI failure context, and enough file references for smithy.fix to diagnose the intended problem.
+
+**Acceptance Scenarios**:
+
+1. **Given** the eval fixture set is checked out, **When** the smithy.fix scenario loads its issue fixture, **Then** the fixture contains a concrete bug report or CI-failure description that can drive smithy.fix without `gh issue view`.
+2. **Given** the eval fixture set is checked out, **When** the smithy.fix scenario loads its CI-log fixture, **Then** the fixture contains deterministic failing-test or build-output evidence that can drive diagnosis without `gh run view`.
+3. **Given** a developer runs the eval offline, **When** fixture loading succeeds, **Then** no live GitHub issue, pull-request, or Actions API access is required to assemble the smithy.fix prompt.
+
+---
+
+### User Story 2: Run smithy.fix Against Local Failure Evidence (Priority: P1)
+
+As a Smithy contributor, I want the eval runner to invoke smithy.fix with local issue and CI-log evidence so that the command follows its fix workflow in a repeatable fixture copy.
+
+**Why this priority**: The user-facing value is end-to-end fix coverage, not just committed fixture files. The runner must place the local evidence into the scenario invocation in a stable way.
+
+**Independent Test**: Run only the smithy.fix scenario against the reference fixture and verify the command consumes local fixture paths, produces a patch-oriented fix response, and does not require network credentials.
+
+**Acceptance Scenarios**:
+
+1. **Given** a smithy.fix scenario declares local issue and CI-log fixtures, **When** the runner builds the scenario invocation, **Then** the prompt includes stable references to those local fixture paths.
+2. **Given** the scenario invocation includes local fixture paths, **When** smithy.fix executes in the temp fixture copy, **Then** it diagnoses the failure from the committed evidence instead of calling live GitHub commands.
+3. **Given** GitHub credentials are absent, **When** the smithy.fix eval scenario runs, **Then** the scenario can still complete using only repository-local fixture evidence.
+
+---
+
+### User Story 3: Validate smithy.fix Output Structure and Helper Evidence (Priority: P1)
+
+As a Smithy maintainer, I want structural and sub-agent checks for the smithy.fix eval so that regressions in the fix workflow are visible in the standard eval report.
+
+**Why this priority**: A measured token count is useful only when paired with a quality signal that the command still performed the expected diagnosis and fix behavior.
+
+**Independent Test**: Run the smithy.fix scenario and verify the report includes passing structural checks for diagnosis/fix/verification content plus helper evidence for the agents smithy.fix dispatches in this path.
+
+**Acceptance Scenarios**:
+
+1. **Given** smithy.fix completes against the offline fixtures, **When** structural validation runs, **Then** the output includes the expected diagnosis, fix action, and verification result markers for the scenario.
+2. **Given** smithy.fix dispatches helper agents for this path, **When** sub-agent evidence validation runs, **Then** the report records passing evidence checks for each expected helper.
+3. **Given** smithy.fix changes its wording while preserving the workflow, **When** validation runs, **Then** the checks rely on stable workflow markers and fixture-specific evidence rather than brittle full-output snapshots.
+
+---
+
+### User Story 4: Commit the smithy.fix Token-Aware Baseline (Priority: P1)
+
+As a Smithy maintainer, I want a committed smithy.fix baseline in the token-aware schema so that downstream token-savings work can compare prompt changes against a known high-cost fix path.
+
+**Why this priority**: M3's CI-log token-reduction work depends on a committed smithy.fix baseline from M1. Without it, later PRs cannot make credible token-delta claims.
+
+**Independent Test**: Run the smithy.fix scenario after F1.3a lands, refresh its baseline, and verify a subsequent eval run reports both structural and token baseline checks.
+
+**Acceptance Scenarios**:
+
+1. **Given** the smithy.fix scenario has completed successfully, **When** its baseline is refreshed, **Then** the committed baseline records the structural expectations and token envelope for the scenario.
+2. **Given** the committed smithy.fix baseline exists, **When** the scenario runs again within the token envelope, **Then** the eval report shows a passing baseline marker for the case.
+3. **Given** a later prompt change materially increases tokens or breaks structure, **When** the scenario is compared to the baseline, **Then** the baseline checks expose the drift in the report.
+
+### Edge Cases
+
+- The local CI-log fixture may be large enough to exercise token-cost behavior but must remain small enough for deterministic repository checkout and test runtime.
+- The issue fixture and CI-log fixture can disagree if edited independently; the scenario must fail clearly when required fixture evidence is missing or inconsistent.
+- A developer may run evals without GitHub credentials; this scenario must not treat missing credentials as a scenario failure.
+- smithy.fix may choose a simple-fix path for the fixture; the expectations should assert the command's diagnosis and verification behavior without requiring a particular implementation diff shape beyond the fixture's intended fix.
+- If F1.3a's token-aware baseline schema changes during implementation, this feature consumes the landed schema and does not introduce a competing baseline shape.
+
+## Dependency Order
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| US1 | Provide Offline smithy.fix Fixtures | — | — |
+| US2 | Run smithy.fix Against Local Failure Evidence | US1 | — |
+| US3 | Validate smithy.fix Output Structure and Helper Evidence | US2 | — |
+| US4 | Commit the smithy.fix Token-Aware Baseline | US3 | — |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST include a committed offline issue fixture for the smithy.fix eval scenario.
+- **FR-002**: The system MUST include a committed offline CI-log fixture for the smithy.fix eval scenario.
+- **FR-003**: The smithy.fix eval scenario MUST be runnable without live GitHub issue, pull-request, or Actions API access.
+- **FR-004**: The scenario definition MUST identify the local issue fixture and CI-log fixture needed for the invocation.
+- **FR-005**: The runner MUST expose declared local fixture paths to the scenario invocation in a deterministic way.
+- **FR-006**: The smithy.fix scenario prompt MUST direct the command to use the local fixture evidence rather than fetching live issue or CI data.
+- **FR-007**: The scenario MUST validate stable structural markers for diagnosis, fix action, and verification output.
+- **FR-008**: The scenario MUST validate expected helper-agent evidence for the smithy.fix path exercised by the fixture.
+- **FR-009**: The scenario MUST fail clearly when a declared local fixture is missing, unreadable, or outside the allowed fixture area.
+- **FR-010**: The scenario MUST leave the source fixture checksum invariant intact; any modifications happen only inside the runner's temp copy.
+- **FR-011**: The system MUST commit a token-aware baseline for the smithy.fix scenario after the F1.3a baseline schema is available.
+- **FR-012**: The committed baseline MUST preserve structural expectations and include a token envelope compatible with the F1.3a schema.
+- **FR-013**: Unit tests MUST cover fixture declaration loading, local fixture path injection, missing-fixture failures, offline execution behavior, structural checks, helper evidence checks, and baseline loading for the smithy.fix scenario.
+
+### Key Entities
+
+- **Fix Eval Scenario**: The scenario definition that invokes smithy.fix against committed local failure evidence.
+- **Issue Fixture**: A Markdown fixture containing the issue or CI-failure description used to seed smithy.fix.
+- **CI Log Fixture**: A text fixture containing deterministic build or test failure output for the high-cost CI-log path.
+- **Local Fixture Injection**: The runner contract that resolves scenario-declared fixture paths and makes them available to the invocation prompt.
+- **Fix Baseline**: The committed token-aware baseline for the smithy.fix scenario.
+- **Helper Evidence Check**: The sub-agent evidence assertion proving the expected smithy.fix helper path still ran.
+
+## Assumptions
+
+- Feature 1.3a lands before the smithy.fix baseline is committed, so this feature can consume the established token-envelope schema.
+- The existing eval runner temp-copy model is sufficient for smithy.fix to edit files, run verification, and keep source fixtures unchanged.
+- Prompt-level local fixture references are enough to exercise smithy.fix's error-description path without editing `smithy.fix.prompt`.
+- The fixture should model the high-cost CI-log path that M3 will later optimize, but M3 owns the prompt changes that reduce CI-log token use.
+- The expected helper-agent list is finalized from observed smithy.fix behavior at implementation time so the scenario checks the actual exercised path.
+
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | The exact helper-agent evidence set for the offline smithy.fix path is not known until the fixture is run against current smithy.fix behavior. The implementation must record the observed helper path and choose stable evidence patterns from that output. | Integration Points | Medium | Medium | open | — |
+| SD-002 | The initial token envelope for the smithy.fix baseline cannot be calibrated until F1.3a's token-aware baseline schema is available and the scenario has a clean captured run. Implementers should choose a conservative initial envelope and document the captured totals in the implementation PR. | Non-Functional Quality | Medium | Medium | open | — |
+
+## Out of Scope
+
+- Editing `smithy.fix.prompt` to change CI-log handling or reduce token usage.
+- Implementing the M3 CI-log failure-extraction grep or build-output protocol changes.
+- Live GitHub issue, PR review, or Actions log integration inside this eval scenario.
+- New eval scenarios for smithy.forge, JVM fixtures, or planning commands.
+- Per-sub-agent token attribution or per-agent token baselines.
+- Refreshing `.claude/` or `.smithy/` deployed snapshots.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A committed smithy.fix eval scenario runs from local issue and CI-log fixtures without GitHub credentials.
+- **SC-002**: Missing or invalid local fixture declarations produce clear scenario-loading or runner errors.
+- **SC-003**: The eval report includes structural pass/fail checks for the smithy.fix scenario's diagnosis, fix, and verification markers.
+- **SC-004**: The eval report includes helper evidence checks for the observed smithy.fix helper path.
+- **SC-005**: A token-aware `fix-from-issue` baseline is committed and passes against a clean scenario run.
+- **SC-006**: Unit tests cover the scenario loader, runner fixture injection, offline scenario behavior, validation checks, and baseline compatibility paths.

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
@@ -116,7 +116,7 @@ Recommended implementation sequence:
 - **FR-005**: The runner MUST expose declared local fixture paths to the scenario invocation in a deterministic way.
 - **FR-006**: The smithy.fix scenario prompt MUST direct the command to use the local fixture evidence rather than fetching live issue or CI data.
 - **FR-007**: The scenario MUST validate stable structural markers for diagnosis, fix action, and verification output.
-- **FR-008**: The scenario MUST validate expected helper-agent evidence for the smithy.fix path exercised by the fixture.
+- **FR-008**: When the smithy.fix path exercised by the fixture dispatches helper agents, the scenario MUST validate the expected helper-agent evidence for each. If the observed offline path dispatches no helpers, the scenario MUST NOT require helper evidence (no fabricated or brittle dispatch patterns).
 - **FR-009**: The scenario MUST fail clearly when a declared local fixture is missing, unreadable, or outside the allowed fixture area.
 - **FR-010**: The scenario MUST leave the source fixture checksum invariant intact; any modifications happen only inside the runner's temp copy.
 - **FR-011**: The system MUST commit a token-aware baseline for the smithy.fix scenario after the F1.3a baseline schema is available.
@@ -144,7 +144,7 @@ Recommended implementation sequence:
 
 | ID | Description | Source Category | Impact | Confidence | Status | Resolution |
 |----|-------------|-----------------|--------|------------|--------|------------|
-| SD-001 | The exact helper-agent evidence set for the offline smithy.fix path is not known until the fixture is run against current smithy.fix behavior. The implementation must record the observed helper path and choose stable evidence patterns from that output. | Integration Points | Medium | Medium | open | — |
+| SD-001 | The exact helper-agent evidence set for the offline smithy.fix path is not known until the fixture is run against current smithy.fix behavior. The error-description path may dispatch no helpers at all. The implementation must record the observed helper path and choose stable evidence patterns from that output, or — if the run dispatches none — leave `sub_agent_evidence` empty rather than fabricating patterns. | Integration Points | Medium | Medium | open | — |
 | SD-002 | The initial token envelope for the smithy.fix baseline cannot be calibrated until F1.3a's token-aware baseline schema is available and the scenario has a clean captured run. Implementers should choose a conservative initial envelope and document the captured totals in the implementation PR. | Non-Functional Quality | Medium | Medium | open | — |
 
 ## Out of Scope
@@ -163,6 +163,6 @@ Recommended implementation sequence:
 - **SC-001**: A committed smithy.fix eval scenario runs from local issue and CI-log fixtures without GitHub credentials.
 - **SC-002**: Missing or invalid local fixture declarations produce clear scenario-loading or runner errors.
 - **SC-003**: The eval report includes structural pass/fail checks for the smithy.fix scenario's diagnosis, fix, and verification markers.
-- **SC-004**: The eval report includes helper evidence checks for the observed smithy.fix helper path.
+- **SC-004**: When the observed smithy.fix path dispatches helpers, the eval report includes helper evidence checks for them; when it dispatches none, the report records no helper checks rather than failing.
 - **SC-005**: A token-aware `fix-from-issue` baseline is committed and passes against a clean scenario run.
 - **SC-006**: Unit tests cover the scenario loader, runner fixture injection, offline scenario behavior, validation checks, and baseline compatibility paths.


### PR DESCRIPTION
## Summary

`/smithy.mark` step for **F3 (Feature 1.4: smithy.fix End-to-End Eval Scenario)** in the token-savings measurement-foundation feature map.

Produces the three mark artifacts for the feature and records the feature as started in the parent feature map:

- `specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md`
- `…/smithy-fix-end-to-end-eval-scenario.data-model.md`
- `…/smithy-fix-end-to-end-eval-scenario.contracts.md`
- Updates the `F3` row's **Artifact** column in `docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md` from `—` to the new spec folder path.

## Scope

One Smithy step only (mark). No chaining into `smithy.cut` or implementation. Smallest coherent patch: 4 files, +521/−1.

## Verification

Docs-only change. Verified structurally:
- All three artifacts present, non-empty, and follow the README schema (Dependency Order table, FR-/SC-/SD- identifiers, mandatory sections).
- File naming matches sibling spec folders (bare-slug `.spec.md` / `.data-model.md` / `.contracts.md`).
- Spec's Critical Assumption correctly targets Dependency Order row `F3` / Feature 1.4.
- `F3` Artifact column now points at the spec folder.

## Completion signal note

A `/smithy.mark` step has **no `tasks.md` rows to flip** — task slices are produced by the later `smithy.cut` step. Per the project's artifact convention, feature-map `## Dependency Order` sections use the table format (no checkboxes); the durable "this feature is started/specced" signal is the populated **Artifact** column, which this patch sets for `F3`. There were no `[ ]` checkboxes in the feature map to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
