### PR TITLE
feat(skills): add smithy.helper-voice for voice & audience guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ group together alphabetically and stand visually apart from slash commands
 
 - **smithy.pr-review** — GitHub PR review operations (find-pr, list inline comments, reply to comment) backed by shell scripts in `scripts/`. Used by `smithy.fix` when handling review feedback. Predates the `helper-` convention.
 - **smithy.helper-docker** — Diagnostic procedures for Docker container failures: bound waits, inspect/log triage, recover-vs-escalate rules, pre-flight checks. Body-only (no scripts). Advertised by `smithy.forge` so it can fall back when validation hits docker problems.
-- **smithy.helper-voice** — Voice and audience guidance for any prose (planning artifacts, migration plans, ADRs, runbooks, READMEs, inline documentation). Provides a Role × Diátaxis-mode taxonomy, conciseness budgets, diagram-first framing, depth-control rules, and an `<!-- audience: ... -->` per-section tagging grammar enforced by `smithy.audit`. Body-only; lazy-loaded for both draft and review/cleanup modes.
+- **smithy.helper-voice** — Voice and audience guidance for any prose (planning artifacts, migration plans, ADRs, runbooks, READMEs, inline documentation). Provides a Role × Diátaxis-mode taxonomy, conciseness budgets, diagram-first framing, depth-control rules, and an `<!-- audience: ... -->` per-section tagging grammar that future `smithy.audit` lint rules will enforce (planned in slice 4 of EPIC #419). Body-only; lazy-loaded for both draft and review/cleanup modes.
 
 ## Key Concepts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ group together alphabetically and stand visually apart from slash commands
 
 - **smithy.pr-review** — GitHub PR review operations (find-pr, list inline comments, reply to comment) backed by shell scripts in `scripts/`. Used by `smithy.fix` when handling review feedback. Predates the `helper-` convention.
 - **smithy.helper-docker** — Diagnostic procedures for Docker container failures: bound waits, inspect/log triage, recover-vs-escalate rules, pre-flight checks. Body-only (no scripts). Advertised by `smithy.forge` so it can fall back when validation hits docker problems.
+- **smithy.helper-voice** — Voice and audience guidance for any prose (planning artifacts, migration plans, ADRs, runbooks, READMEs, inline documentation). Provides a Role × Diátaxis-mode taxonomy, conciseness budgets, diagram-first framing, depth-control rules, and an `<!-- audience: ... -->` per-section tagging grammar enforced by `smithy.audit`. Body-only; lazy-loaded for both draft and review/cleanup modes.
 
 ## Key Concepts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to Smithy CLI
 
 ## Development Setup
+<!-- audience: builder; mode: how-to; length: 3-6 commands; diagram: optional; examples: required -->
 
 ```bash
 npm install
@@ -12,6 +13,7 @@ npm test             # Run all tests
 Always use `npm run` scripts. Do not use `npx tsx`, `npx vitest`, or similar direct invocations.
 
 ## Testing
+<!-- audience: builder; mode: reference; length: 3 subsections, one per tier; diagram: optional; examples: discouraged -->
 
 Smithy has three testing tiers that each require different strategies:
 
@@ -65,10 +67,12 @@ Pending:
 See **[specs/2026-04-06-003-smithy-evals-framework/](specs/2026-04-06-003-smithy-evals-framework/)** for the feature specification.
 
 ## Automated Dependency Updates
+<!-- audience: builder; mode: reference; length: 1-2 paragraphs; diagram: optional; examples: discouraged -->
 
 This repo runs Dependabot on a monthly schedule (plus immediate security advisories) and pings GitHub Copilot Coding Agent to fix CI failures on Dependabot PRs. See **[docs/automated-dependency-updates.md](docs/automated-dependency-updates.md)** for the day-to-day flow and the one-time repo settings required.
 
 ## Pre-Release Checklist
+<!-- audience: builder; mode: how-to; length: 5 ordered steps; diagram: optional; examples: discouraged -->
 
 Before publishing a new version:
 
@@ -79,5 +83,6 @@ Before publishing a new version:
 5. Trigger the **Publish to npm** workflow with both test gate checkboxes checked
 
 ## Pull Requests
+<!-- audience: builder; mode: how-to; length: 1-2 sentences; diagram: optional; examples: discouraged -->
 
 Use the [PR template](.github/pull_request_template.md) when opening PRs. Populate the Testing section with actual outcomes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,23 +48,11 @@ Tests that templates compose correctly (snippet/partial resolution, frontmatter 
 
 ### Tier 3: Agent-Skill Execution Behavior (evals)
 
-Tests that the deployed skills actually *work* when invoked by an AI agent — slash commands trigger, output has the correct structure, sub-agents are dispatched, and results meet quality expectations. Run via `npm run eval` (local on-demand, not CI).
+Tests that the deployed skills actually *work* when invoked by an AI agent — slash commands trigger, output has the correct structure, sub-agents are dispatched, and results meet quality expectations. Run via `npm run eval` (local on-demand, not CI — LLM cost).
 
-The evals framework (under `evals/`) — implemented:
-- Executes skills via a selected headless agent CLI (`claude`, `gemini`, or local `codex exec`) against a reference fixture codebase
-- Runs locally on demand (`npm run eval`), not in CI, due to LLM cost
-- Structural output validation (`validateStructure` — required headings, patterns, tables, forbidden patterns)
-- Sub-agent invocation verification (`verifySubAgents` — pattern matching against extracted text and dispatch events)
-- Eval summary report library (`scenarioRunToResult`, `buildReport`, `formatReport`, `EvalReport` — pure, fully unit-tested)
-- Baseline regression library (`loadBaseline`, `compareToBaseline` — convention-based JSON loader and pure structural diff; wired into the orchestrator with a committed `strike-health-check.json` baseline)
-- Dedicated evals test suite runnable via `npm run test:evals` (independent of `npm test`)
-- Strike and scout end-to-end scenarios (`strikeScenario`, `scoutScenario`) wired into the orchestrator; `--case <name>` filter selects a single scenario by name
-- Reference fixture carries documented planted inconsistencies (`evals/fixture/README.md` — Planted Inconsistencies section) that the scout scenario asserts are detected
+The framework (`evals/`) runs scenarios through a selected headless agent CLI (`claude`, `gemini`, or `codex exec`) against the reference fixture codebase. It validates structural output, sub-agent dispatch, and token / baseline regressions. Scenarios are loaded from `evals/cases/*.yaml`; the `--case <name>` filter selects a single scenario. The framework's own unit tests run independently via `npm run test:evals`.
 
-Pending:
-- YAML-defined scenario loading (`evals/cases/`)
-
-See **[specs/2026-04-06-003-smithy-evals-framework/](specs/2026-04-06-003-smithy-evals-framework/)** for the feature specification.
+See **[specs/2026-04-06-003-smithy-evals-framework/](specs/2026-04-06-003-smithy-evals-framework/)** for the feature specification and per-user-story status.
 
 ## Automated Dependency Updates
 <!-- audience: builder; mode: reference; length: 1-2 paragraphs; diagram: optional; examples: discouraged -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
 # Contributing to Smithy CLI
 
 ## Development Setup
-<!-- audience: builder; mode: how-to; length: 3-6 commands; diagram: optional; examples: required -->
 
 ```bash
 npm install
@@ -13,7 +12,6 @@ npm test             # Run all tests
 Always use `npm run` scripts. Do not use `npx tsx`, `npx vitest`, or similar direct invocations.
 
 ## Testing
-<!-- audience: builder; mode: reference; length: 3 subsections, one per tier; diagram: optional; examples: discouraged -->
 
 Smithy has three testing tiers that each require different strategies:
 
@@ -55,12 +53,10 @@ The framework (`evals/`) runs scenarios through a selected headless agent CLI (`
 See **[specs/2026-04-06-003-smithy-evals-framework/](specs/2026-04-06-003-smithy-evals-framework/)** for the feature specification and per-user-story status.
 
 ## Automated Dependency Updates
-<!-- audience: builder; mode: reference; length: 1-2 paragraphs; diagram: optional; examples: discouraged -->
 
 This repo runs Dependabot on a monthly schedule (plus immediate security advisories) and pings GitHub Copilot Coding Agent to fix CI failures on Dependabot PRs. See **[docs/automated-dependency-updates.md](docs/automated-dependency-updates.md)** for the day-to-day flow and the one-time repo settings required.
 
 ## Pre-Release Checklist
-<!-- audience: builder; mode: how-to; length: 5 ordered steps; diagram: optional; examples: discouraged -->
 
 Before publishing a new version:
 
@@ -71,6 +67,5 @@ Before publishing a new version:
 5. Trigger the **Publish to npm** workflow with both test gate checkboxes checked
 
 ## Pull Requests
-<!-- audience: builder; mode: how-to; length: 1-2 sentences; diagram: optional; examples: discouraged -->
 
 Use the [PR template](.github/pull_request_template.md) when opening PRs. Populate the Testing section with actual outcomes.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 An initialization tool for the **Smithy Agentic Development Workflow**. This package provides a CLI that easily sets up the `smithy` prompt templates for various AI assistant workflows, including Claude, Gemini CLI, and Codex.
 
 ## Installation
+<!-- audience: builder; mode: how-to; length: 2-5 commands; diagram: optional; examples: required -->
 
 You can run Smithy directly via `npx` (recommended):
 
@@ -18,12 +19,14 @@ smithy init
 ```
 
 ## Supported AI Assistants
+<!-- audience: stakeholder; mode: reference; length: 3-5 bullets; diagram: optional; examples: discouraged -->
 
 - **Claude:** Installs commands, prompts, and sub-agents into `.claude/` for use within your Claude Code workflows.
 - **Gemini CLI:** Installs workspace skills (`.gemini/skills/`) so you can type `/skills reload` and immediately use Smithy workflow commands.
 - **Codex:** Installs project skills into `.agents/skills/` and reference prompts into `tools/codex/prompts/`, with `smithy.forge` and `smithy.fix` ready for Codex-driven implementation and repair workflows.
 
 ## Workflow Industrial Pipeline
+<!-- audience: stakeholder; mode: explanation; length: 1 paragraph + table + diagram; diagram: required; examples: discouraged -->
 
 The Smithy Industrial Pipeline follows a structured path from broad ideas to verified implementations, incorporating "Fast Track" shortcuts and built-in "Review Loops" at every stage.
 
@@ -78,5 +81,6 @@ graph TD
 ```
 
 ## Contributing
+<!-- audience: builder; mode: how-to; length: 1 line (link); diagram: optional; examples: discouraged -->
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing strategy, and pre-release checklist.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Smithy CLI
 
-An initialization tool for the **Smithy Agentic Development Workflow**. This package provides a CLI that easily sets up the `smithy` prompt templates for various AI assistant workflows, including Claude, Gemini CLI, and Codex.
+Stop hand-crafting the same RFC → spec → tasks → PR scaffolding for every AI-assisted change. **Smithy** installs a structured pipeline of slash commands — `/smithy.ignite`, `/smithy.render`, `/smithy.mark`, `/smithy.cut`, `/smithy.forge`, plus the `/smithy.strike` fast track — into your repo so Claude Code, Gemini CLI, or Codex can drive it. One `smithy init` deploys the same prompts, permissions, and skills across every supported assistant.
 
 ## Installation
 <!-- audience: builder; mode: how-to; length: 2-5 commands; diagram: optional; examples: required -->
@@ -44,7 +44,7 @@ The Smithy Industrial Pipeline follows a structured path from broad ideas to ver
 | **Shortcut** | `smithy.strike` | **Direct**: Strike while the iron is hot (Idea -> Tasks). |
 | **Review** | `smithy.audit` | **Audit**: Universal auditor for any Smithy artifact. |
 
-### Visualization
+### Pipeline Diagram
 
 ```mermaid
 graph TD

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Stop hand-crafting the same RFC → spec → tasks → PR scaffolding for every AI-assisted change. **Smithy** installs a structured pipeline of slash commands — `/smithy.ignite`, `/smithy.render`, `/smithy.mark`, `/smithy.cut`, `/smithy.forge`, plus the `/smithy.strike` fast track — into your repo so Claude Code, Gemini CLI, or Codex can drive it. One `smithy init` deploys the same prompts, permissions, and skills across every supported assistant.
 
 ## Installation
-<!-- audience: builder; mode: how-to; length: 2-5 commands; diagram: optional; examples: required -->
 
 You can run Smithy directly via `npx` (recommended):
 
@@ -19,14 +18,12 @@ smithy init
 ```
 
 ## Supported AI Assistants
-<!-- audience: stakeholder; mode: reference; length: 3-5 bullets; diagram: optional; examples: discouraged -->
 
 - **Claude:** Installs commands, prompts, and sub-agents into `.claude/` for use within your Claude Code workflows.
 - **Gemini CLI:** Installs workspace skills (`.gemini/skills/`) so you can type `/skills reload` and immediately use Smithy workflow commands.
 - **Codex:** Installs project skills into `.agents/skills/` and reference prompts into `tools/codex/prompts/`, with `smithy.forge` and `smithy.fix` ready for Codex-driven implementation and repair workflows.
 
 ## Workflow Industrial Pipeline
-<!-- audience: stakeholder; mode: explanation; length: 1 paragraph + table + diagram; diagram: required; examples: discouraged -->
 
 The Smithy Industrial Pipeline follows a structured path from broad ideas to verified implementations, incorporating "Fast Track" shortcuts and built-in "Review Loops" at every stage.
 
@@ -81,6 +78,5 @@ graph TD
 ```
 
 ## Contributing
-<!-- audience: builder; mode: how-to; length: 1 line (link); diagram: optional; examples: discouraged -->
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing strategy, and pre-release checklist.

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.contracts.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.contracts.md
@@ -1,10 +1,12 @@
 # Contracts: smithy.fix End-to-End Eval Scenario
 
 ## Overview
+<!-- audience: reviewer; mode: explanation; length: 1 paragraph; diagram: optional; examples: discouraged -->
 
 This feature introduces a local-fixture contract for eval scenarios that need committed evidence files, then uses it to run smithy.fix against offline issue and CI-log inputs. The contracts are additive to the existing scenario loader, runner invocation, validation, and baseline flows.
 
 ## Interfaces
+<!-- audience: builder+ai-input; mode: reference; length: 4 interfaces, each Purpose/Signature/Inputs/Outputs/Errors; diagram: optional; examples: required -->
 
 ### 1) Scenario Local Fixture Declaration
 
@@ -180,10 +182,12 @@ sub_agent_evidence:
 | Live token totals exceed envelope | Emit a failing token check. | Downstream token regressions become visible in the eval report. |
 
 ## Events / Hooks
+<!-- audience: builder; mode: reference; length: 1 line; diagram: forbidden; examples: forbidden; applicability: features that introduce new runtime events or webhooks -->
 
-No new runtime events or hooks are introduced. The feature uses the existing eval scenario load, runner invocation, validation, report, and baseline comparison flow.
+**N/A** — no new runtime events or hooks. The feature reuses the existing eval scenario load, runner invocation, validation, report, and baseline-comparison flow.
 
 ## Integration Boundaries
+<!-- audience: builder; mode: reference; length: 3-6 bullets; diagram: optional; examples: discouraged -->
 
 - **Scenario YAML boundary**: adds optional `local_fixtures` metadata while preserving compatibility for scenarios that omit it.
 - **Filesystem fixture boundary**: reads committed issue and CI-log evidence from the eval fixture area only.

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.contracts.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.contracts.md
@@ -1,12 +1,10 @@
 # Contracts: smithy.fix End-to-End Eval Scenario
 
 ## Overview
-<!-- audience: reviewer; mode: explanation; length: 1 paragraph; diagram: optional; examples: discouraged -->
 
 This feature introduces a local-fixture contract for eval scenarios that need committed evidence files, then uses it to run smithy.fix against offline issue and CI-log inputs. The contracts are additive to the existing scenario loader, runner invocation, validation, and baseline flows.
 
 ## Interfaces
-<!-- audience: builder+ai-input; mode: reference; length: 4 interfaces, each Purpose/Signature/Inputs/Outputs/Errors; diagram: optional; examples: required -->
 
 ### 1) Scenario Local Fixture Declaration
 
@@ -182,12 +180,10 @@ sub_agent_evidence:
 | Live token totals exceed envelope | Emit a failing token check. | Downstream token regressions become visible in the eval report. |
 
 ## Events / Hooks
-<!-- audience: builder; mode: reference; length: 1 line; diagram: forbidden; examples: forbidden; applicability: features that introduce new runtime events or webhooks -->
 
 **N/A** — no new runtime events or hooks. The feature reuses the existing eval scenario load, runner invocation, validation, report, and baseline-comparison flow.
 
 ## Integration Boundaries
-<!-- audience: builder; mode: reference; length: 3-6 bullets; diagram: optional; examples: discouraged -->
 
 - **Scenario YAML boundary**: adds optional `local_fixtures` metadata while preserving compatibility for scenarios that omit it.
 - **Filesystem fixture boundary**: reads committed issue and CI-log evidence from the eval fixture area only.

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md
@@ -1,10 +1,12 @@
 # Data Model: smithy.fix End-to-End Eval Scenario
 
 ## Overview
+<!-- audience: reviewer; mode: explanation; length: 1 paragraph; diagram: optional; examples: discouraged -->
 
 This feature adds data definitions for a deterministic smithy.fix eval scenario. The model extends scenario metadata with local fixture declarations, introduces committed issue and CI-log fixtures as repository artifacts, and consumes the token-aware baseline shape established by Feature 1.3a. No persistent database or external storage is introduced.
 
 ## Entities
+<!-- audience: builder+ai-input; mode: reference; length: 6 entities with field tables + validation rules; diagram: required (ER, in the Relationships section below); examples: required -->
 
 ### 1) Fix Eval Scenario (`fix_eval_scenario`)
 
@@ -115,45 +117,60 @@ Validation rules:
 - Baseline scenario name must match the scenario definition.
 
 ## Relationships
+<!-- audience: builder+ai-input; mode: reference; length: ER diagram + cardinality legend; diagram: required; examples: forbidden -->
 
-- `Fix Eval Scenario` 1:1 `LocalFixtureSet` via the scenario's local fixture declaration.
-- `LocalFixtureSet` 1:1 `Issue Fixture` via `local_fixtures.issue`.
-- `LocalFixtureSet` 1:1 `CI Log Fixture` via `local_fixtures.ci_log`.
-- `LocalFixtureSet` 1:1 `Local Fixture Injection` during runner invocation assembly.
-- `Fix Eval Scenario` 0..N `HelperEvidenceCheck` through existing sub-agent evidence validation.
-- `Fix Eval Scenario` 1:1 `Fix Baseline` after the first clean token-aware capture.
+```mermaid
+erDiagram
+    FixEvalScenario      ||--|| LocalFixtureSet        : declares
+    LocalFixtureSet      ||--|| IssueFixture           : "local_fixtures.issue"
+    LocalFixtureSet      ||--|| CILogFixture           : "local_fixtures.ci_log"
+    LocalFixtureSet      ||--|| LocalFixtureInjection  : "resolved at invocation"
+    FixEvalScenario      ||--o{ HelperEvidenceCheck    : validates
+    FixEvalScenario      ||--o| FixBaseline            : "captured after F1.3a"
+```
+
+Cardinality notes — `FixEvalScenario` 0..1 `FixBaseline` (the baseline does not exist until the F1.3a-aware capture lands); `FixEvalScenario` 0..N `HelperEvidenceCheck` (zero when the observed offline path dispatches no helpers, per FR-008).
 
 ## State Transitions
+<!-- audience: builder+ai-input; mode: reference; length: 2 state diagrams + trigger/effect tables; diagram: required; examples: forbidden -->
 
 ### Scenario lifecycle
 
-1. `declared` -> `fixtures_resolved`
-   - Trigger: the scenario loader validates local fixture declarations.
-   - Effects: issue and CI-log fixture paths are checked for allowed location and readability.
+```mermaid
+stateDiagram-v2
+    [*] --> declared
+    declared        --> fixtures_resolved : loader validates local fixtures
+    fixtures_resolved --> invocation_built : runner renders prompt
+    invocation_built  --> validated        : smithy.fix completes, checks attach
+    validated        --> baselined         : clean F1.3a-aware capture committed
+    baselined        --> [*]
+```
 
-2. `fixtures_resolved` -> `invocation_built`
-   - Trigger: the runner renders the smithy.fix invocation.
-   - Effects: local fixture paths are injected into the prompt in a deterministic form.
-
-3. `invocation_built` -> `validated`
-   - Trigger: smithy.fix completes and report validation runs.
-   - Effects: structural and helper evidence checks are attached to the eval result.
-
-4. `validated` -> `baselined`
-   - Trigger: a clean scenario run is captured after the token-aware baseline schema exists.
-   - Effects: the fix baseline is committed with structural expectations and a token envelope.
+| Transition | Trigger | Effects |
+|---|---|---|
+| `declared` → `fixtures_resolved` | Scenario loader validates local fixture declarations. | Issue and CI-log fixture paths are checked for allowed location and readability. |
+| `fixtures_resolved` → `invocation_built` | Runner renders the smithy.fix invocation. | Local fixture paths are injected into the prompt in a deterministic form. |
+| `invocation_built` → `validated` | smithy.fix completes and report validation runs. | Structural and helper evidence checks are attached to the eval result. |
+| `validated` → `baselined` | A clean scenario run is captured after the token-aware baseline schema exists. | The fix baseline is committed with structural expectations and a token envelope. |
 
 ### Fixture lifecycle
 
-1. `authored` -> `committed`
-   - Trigger: fixture files are added to the repository.
-   - Effects: offline scenario evidence becomes available to every eval runner.
+```mermaid
+stateDiagram-v2
+    [*] --> authored
+    authored  --> committed : added to repo
+    committed --> refreshed : intentional recalibration
+    refreshed --> committed
+    committed --> [*]
+```
 
-2. `committed` -> `refreshed`
-   - Trigger: the intended smithy.fix path changes and the scenario is intentionally recalibrated.
-   - Effects: fixture text and baseline expectations are updated together.
+| Transition | Trigger | Effects |
+|---|---|---|
+| `authored` → `committed` | Fixture files are added to the repository. | Offline scenario evidence becomes available to every eval runner. |
+| `committed` → `refreshed` | The intended smithy.fix path changes and the scenario is intentionally recalibrated. | Fixture text and baseline expectations are updated together. |
 
 ## Identity & Uniqueness
+<!-- audience: builder; mode: reference; length: 3-5 bullets; diagram: optional; examples: discouraged -->
 
 - The scenario is uniquely identified by `name: fix-from-issue`.
 - Fixture declarations are uniquely identified by their repository-relative paths.

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md
@@ -1,12 +1,10 @@
 # Data Model: smithy.fix End-to-End Eval Scenario
 
 ## Overview
-<!-- audience: reviewer; mode: explanation; length: 1 paragraph; diagram: optional; examples: discouraged -->
 
 This feature adds data definitions for a deterministic smithy.fix eval scenario. The model extends scenario metadata with local fixture declarations, introduces committed issue and CI-log fixtures as repository artifacts, and consumes the token-aware baseline shape established by Feature 1.3a. No persistent database or external storage is introduced.
 
 ## Entities
-<!-- audience: builder+ai-input; mode: reference; length: 6 entities with field tables + validation rules; diagram: required (ER, in the Relationships section below); examples: required -->
 
 ### 1) Fix Eval Scenario (`fix_eval_scenario`)
 
@@ -117,7 +115,6 @@ Validation rules:
 - Baseline scenario name must match the scenario definition.
 
 ## Relationships
-<!-- audience: builder+ai-input; mode: reference; length: ER diagram + cardinality legend; diagram: required; examples: forbidden -->
 
 ```mermaid
 erDiagram
@@ -132,7 +129,6 @@ erDiagram
 Cardinality notes — `FixEvalScenario` 0..1 `FixBaseline` (the baseline does not exist until the F1.3a-aware capture lands); `FixEvalScenario` 0..N `HelperEvidenceCheck` (zero when the observed offline path dispatches no helpers, per FR-008).
 
 ## State Transitions
-<!-- audience: builder+ai-input; mode: reference; length: 2 state diagrams + trigger/effect tables; diagram: required; examples: forbidden -->
 
 ### Scenario lifecycle
 
@@ -170,7 +166,6 @@ stateDiagram-v2
 | `committed` → `refreshed` | The intended smithy.fix path changes and the scenario is intentionally recalibrated. | Fixture text and baseline expectations are updated together. |
 
 ## Identity & Uniqueness
-<!-- audience: builder; mode: reference; length: 3-5 bullets; diagram: optional; examples: discouraged -->
 
 - The scenario is uniquely identified by `name: fix-from-issue`.
 - Fixture declarations are uniquely identified by their repository-relative paths.

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
@@ -4,8 +4,8 @@
 **Branch**: `2026-06-03-009-smithy-fix-end-to-end-eval-scenario`
 **Created**: 2026-06-03
 **Status**: Draft
-**Input**: `docs/rfcs/2026-001-token-savings/token-savings.rfc.md` - Milestone 1 measurement-foundation feature for deterministic smithy.fix end-to-end eval coverage.
-**Source Feature Map**: `docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md` - Feature 1.4: smithy.fix End-to-End Eval Scenario
+**Input**: `docs/rfcs/2026-001-token-savings/token-savings.rfc.md` — Milestone 1: deterministic smithy.fix end-to-end eval coverage.
+**Source Feature Map**: `docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md` — Feature 1.4: smithy.fix End-to-End Eval Scenario.
 
 ## Clarifications
 <!-- audience: reviewer; mode: reference; length: 6-10 bullets; diagram: optional; examples: discouraged -->
@@ -14,10 +14,10 @@
 
 - This specification targets the Dependency Order row `F3`, which corresponds to Feature 1.4 in the measurement-foundation feature map. `[Critical Assumption]`
 - Feature 1.3a is the prerequisite token-baseline substrate; this feature consumes its token-aware baseline schema instead of redefining token extraction or comparison.
-- The smithy.fix eval is offline and deterministic: it must not call live GitHub issue, PR, or Actions APIs during scenario execution.
-- The offline issue fixture is a Markdown file under `evals/fixture/issues/`, and the offline CI-log fixture is a text log under `evals/fixture/ci-logs/`.
-- Fixture discovery is settled as a scenario-level local-fixture injection contract: a scenario may declare an issue fixture and a CI-log fixture, and the runner exposes their paths to the prompt invocation so smithy.fix can exercise its existing error-description path without network access.
-- This feature does not edit `smithy.fix.prompt`; M3 owns CI-log prompt optimizations. The eval prompt may name the local fixture paths and ask smithy.fix to diagnose that local issue/log evidence.
+- The smithy.fix eval is offline and deterministic — no live GitHub issue, PR, or Actions APIs during scenario execution.
+- Fixtures live at fixed locations: issue Markdown under `evals/fixture/issues/`, CI log text under `evals/fixture/ci-logs/`.
+- Scenarios declare an issue fixture and a CI-log fixture; the runner exposes their paths to the invocation prompt so smithy.fix can run its error-description path offline.
+- This feature does not edit `smithy.fix.prompt` (M3 owns CI-log prompt optimizations). The eval prompt names the local fixture paths and asks smithy.fix to diagnose them.
 
 ## Artifact Hierarchy
 <!-- audience: builder+ai-input; mode: reference; length: 1 line; diagram: optional; examples: forbidden -->
@@ -91,11 +91,11 @@ As a Smithy maintainer, I want a committed smithy.fix baseline in the token-awar
 
 ### Edge Cases
 
-- The local CI-log fixture may be large enough to exercise token-cost behavior but must remain small enough for deterministic repository checkout and test runtime.
-- The issue fixture and CI-log fixture can disagree if edited independently; the scenario must fail clearly when required fixture evidence is missing or inconsistent.
-- A developer may run evals without GitHub credentials; this scenario must not treat missing credentials as a scenario failure.
-- smithy.fix may choose a simple-fix path for the fixture; the expectations should assert the command's diagnosis and verification behavior without requiring a particular implementation diff shape beyond the fixture's intended fix.
-- If F1.3a's token-aware baseline schema changes during implementation, this feature consumes the landed schema and does not introduce a competing baseline shape.
+- The CI-log fixture must exercise token-cost behavior while staying small enough for deterministic checkout and test runtime.
+- Issue and CI-log fixtures can drift if edited independently; the scenario must fail clearly when required evidence is missing or inconsistent.
+- A developer may run evals without GitHub credentials; missing credentials are not a scenario failure for this case.
+- smithy.fix may choose a simple-fix path; assertions check diagnosis and verification behavior, not a specific implementation diff.
+- If F1.3a's token-aware baseline schema changes during implementation, this feature consumes the landed schema rather than defining a competing one.
 
 ## Dependency Order
 <!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: optional; examples: forbidden -->

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
@@ -8,6 +8,7 @@
 **Source Feature Map**: `docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md` - Feature 1.4: smithy.fix End-to-End Eval Scenario
 
 ## Clarifications
+<!-- audience: reviewer; mode: reference; length: 6-10 bullets; diagram: optional; examples: discouraged -->
 
 ### Session 2026-06-03
 
@@ -19,10 +20,12 @@
 - This feature does not edit `smithy.fix.prompt`; M3 owns CI-log prompt optimizations. The eval prompt may name the local fixture paths and ask smithy.fix to diagnose that local issue/log evidence.
 
 ## Artifact Hierarchy
+<!-- audience: builder+ai-input; mode: reference; length: 1 line; diagram: optional; examples: forbidden -->
 
 RFC -> Milestone -> Feature -> User Story -> Slice -> Tasks
 
 ## User Scenarios & Testing *(mandatory)*
+<!-- audience: reviewer; mode: explanation; length: 1 paragraph per story; diagram: optional; examples: discouraged -->
 
 ### User Story 1: Provide Offline smithy.fix Fixtures (Priority: P1)
 
@@ -95,6 +98,7 @@ As a Smithy maintainer, I want a committed smithy.fix baseline in the token-awar
 - If F1.3a's token-aware baseline schema changes during implementation, this feature consumes the landed schema and does not introduce a competing baseline shape.
 
 ## Dependency Order
+<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: optional; examples: forbidden -->
 
 Recommended implementation sequence:
 
@@ -106,6 +110,7 @@ Recommended implementation sequence:
 | US4 | Commit the smithy.fix Token-Aware Baseline | US3 | — |
 
 ## Requirements *(mandatory)*
+<!-- audience: builder+ai-input; mode: reference; length: 10-20 bullets per subsection; diagram: recommended (entity relationships); examples: discouraged -->
 
 ### Functional Requirements
 
@@ -124,15 +129,31 @@ Recommended implementation sequence:
 - **FR-013**: Unit tests MUST cover fixture declaration loading, local fixture path injection, missing-fixture failures, offline execution behavior, structural checks, helper evidence checks, and baseline loading for the smithy.fix scenario.
 
 ### Key Entities
+<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: required (ER / flow); examples: required -->
 
-- **Fix Eval Scenario**: The scenario definition that invokes smithy.fix against committed local failure evidence.
-- **Issue Fixture**: A Markdown fixture containing the issue or CI-failure description used to seed smithy.fix.
-- **CI Log Fixture**: A text fixture containing deterministic build or test failure output for the high-cost CI-log path.
-- **Local Fixture Injection**: The runner contract that resolves scenario-declared fixture paths and makes them available to the invocation prompt.
-- **Fix Baseline**: The committed token-aware baseline for the smithy.fix scenario.
-- **Helper Evidence Check**: The sub-agent evidence assertion proving the expected smithy.fix helper path still ran.
+```mermaid
+flowchart LR
+    IF[Issue Fixture]
+    CL[CI Log Fixture]
+    LFI[Local Fixture Injection]
+    LFI --> S[Fix Eval Scenario]
+    IF --> LFI
+    CL --> LFI
+    S --> FB[Fix Baseline]
+    S --> HEC[Helper Evidence Check]
+```
+
+| Entity | Shape | Relationships |
+|--------|-------|---------------|
+| Fix Eval Scenario | Scenario definition that invokes smithy.fix against committed local failure evidence. | Consumes Issue Fixture and CI Log Fixture via Local Fixture Injection; produces Fix Baseline. |
+| Issue Fixture | Markdown fixture under `evals/fixture/issues/` containing the issue or CI-failure description used to seed smithy.fix. | Read by Fix Eval Scenario through Local Fixture Injection. |
+| CI Log Fixture | Text fixture under `evals/fixture/ci-logs/` containing deterministic build or test failure output for the high-cost CI-log path. | Read by Fix Eval Scenario through Local Fixture Injection. |
+| Local Fixture Injection | Runner contract that resolves scenario-declared fixture paths and exposes them to the invocation prompt. | Resolves Issue Fixture and CI Log Fixture; feeds Fix Eval Scenario. |
+| Fix Baseline | Committed token-aware baseline for the smithy.fix scenario, conforming to the F1.3a schema. | Produced by a clean run of Fix Eval Scenario; consumed by later runs for comparison. |
+| Helper Evidence Check | Sub-agent evidence assertion proving the expected smithy.fix helper path still ran. | Evaluated against Fix Eval Scenario output. |
 
 ## Assumptions
+<!-- audience: reviewer; mode: reference; length: 3-6 bullets; diagram: optional; examples: forbidden -->
 
 - Feature 1.3a lands before the smithy.fix baseline is committed, so this feature can consume the established token-envelope schema.
 - The existing eval runner temp-copy model is sufficient for smithy.fix to edit files, run verification, and keep source fixtures unchanged.
@@ -141,6 +162,7 @@ Recommended implementation sequence:
 - The expected helper-agent list is finalized from observed smithy.fix behavior at implementation time so the scenario checks the actual exercised path.
 
 ## Specification Debt
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: forbidden -->
 
 | ID | Description | Source Category | Impact | Confidence | Status | Resolution |
 |----|-------------|-----------------|--------|------------|--------|------------|
@@ -148,6 +170,7 @@ Recommended implementation sequence:
 | SD-002 | The initial token envelope for the smithy.fix baseline cannot be calibrated until F1.3a's token-aware baseline schema is available and the scenario has a clean captured run. Implementers should choose a conservative initial envelope and document the captured totals in the implementation PR. | Non-Functional Quality | Medium | Medium | open | — |
 
 ## Out of Scope
+<!-- audience: reviewer; mode: reference; length: 5-10 bullets; diagram: optional; examples: forbidden -->
 
 - Editing `smithy.fix.prompt` to change CI-log handling or reduce token usage.
 - Implementing the M3 CI-log failure-extraction grep or build-output protocol changes.
@@ -157,6 +180,7 @@ Recommended implementation sequence:
 - Refreshing `.claude/` or `.smithy/` deployed snapshots.
 
 ## Success Criteria *(mandatory)*
+<!-- audience: reviewer; mode: reference; length: bullets; diagram: optional; examples: forbidden -->
 
 ### Measurable Outcomes
 

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
@@ -8,7 +8,6 @@
 **Source Feature Map**: `docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md` — Feature 1.4: smithy.fix End-to-End Eval Scenario.
 
 ## Clarifications
-<!-- audience: reviewer; mode: reference; length: 6-10 bullets; diagram: optional; examples: discouraged -->
 
 ### Session 2026-06-03
 
@@ -20,12 +19,10 @@
 - This feature does not edit `smithy.fix.prompt` (M3 owns CI-log prompt optimizations). The eval prompt names the local fixture paths and asks smithy.fix to diagnose them.
 
 ## Artifact Hierarchy
-<!-- audience: builder+ai-input; mode: reference; length: 1 line; diagram: optional; examples: forbidden -->
 
 RFC -> Milestone -> Feature -> User Story -> Slice -> Tasks
 
 ## User Scenarios & Testing *(mandatory)*
-<!-- audience: reviewer; mode: explanation; length: 1 paragraph per story; diagram: optional; examples: discouraged -->
 
 ### User Story 1: Provide Offline smithy.fix Fixtures (Priority: P1)
 
@@ -98,7 +95,6 @@ As a Smithy maintainer, I want a committed smithy.fix baseline in the token-awar
 - If F1.3a's token-aware baseline schema changes during implementation, this feature consumes the landed schema rather than defining a competing one.
 
 ## Dependency Order
-<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: optional; examples: forbidden -->
 
 Recommended implementation sequence:
 
@@ -110,7 +106,6 @@ Recommended implementation sequence:
 | US4 | Commit the smithy.fix Token-Aware Baseline | US3 | — |
 
 ## Requirements *(mandatory)*
-<!-- audience: builder+ai-input; mode: reference; length: 10-20 bullets per subsection; diagram: recommended (entity relationships); examples: discouraged -->
 
 ### Functional Requirements
 
@@ -129,7 +124,6 @@ Recommended implementation sequence:
 - **FR-013**: Unit tests MUST cover fixture declaration loading, local fixture path injection, missing-fixture failures, offline execution behavior, structural checks, helper evidence checks, and baseline loading for the smithy.fix scenario.
 
 ### Key Entities
-<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: required (ER / flow); examples: required -->
 
 ```mermaid
 flowchart LR
@@ -153,7 +147,6 @@ flowchart LR
 | Helper Evidence Check | Sub-agent evidence assertion proving the expected smithy.fix helper path still ran. | Evaluated against Fix Eval Scenario output. |
 
 ## Assumptions
-<!-- audience: reviewer; mode: reference; length: 3-6 bullets; diagram: optional; examples: forbidden -->
 
 - Feature 1.3a lands before the smithy.fix baseline is committed, so this feature can consume the established token-envelope schema.
 - The existing eval runner temp-copy model is sufficient for smithy.fix to edit files, run verification, and keep source fixtures unchanged.
@@ -162,7 +155,6 @@ flowchart LR
 - The expected helper-agent list is finalized from observed smithy.fix behavior at implementation time so the scenario checks the actual exercised path.
 
 ## Specification Debt
-<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: forbidden -->
 
 | ID | Description | Source Category | Impact | Confidence | Status | Resolution |
 |----|-------------|-----------------|--------|------------|--------|------------|
@@ -170,7 +162,6 @@ flowchart LR
 | SD-002 | The initial token envelope for the smithy.fix baseline cannot be calibrated until F1.3a's token-aware baseline schema is available and the scenario has a clean captured run. Implementers should choose a conservative initial envelope and document the captured totals in the implementation PR. | Non-Functional Quality | Medium | Medium | open | — |
 
 ## Out of Scope
-<!-- audience: reviewer; mode: reference; length: 5-10 bullets; diagram: optional; examples: forbidden -->
 
 - Editing `smithy.fix.prompt` to change CI-log handling or reduce token usage.
 - Implementing the M3 CI-log failure-extraction grep or build-output protocol changes.
@@ -180,7 +171,6 @@ flowchart LR
 - Refreshing `.claude/` or `.smithy/` deployed snapshots.
 
 ## Success Criteria *(mandatory)*
-<!-- audience: reviewer; mode: reference; length: bullets; diagram: optional; examples: forbidden -->
 
 ### Measurable Outcomes
 

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -539,6 +539,7 @@ export const claudeToolPermissions: string[] = [
   "Skill(smithy.forge *)",
   "Skill(smithy.gh-issue *)",
   "Skill(smithy.helper-docker *)",
+  "Skill(smithy.helper-voice *)",
   "Skill(smithy.ignite *)",
   "Skill(smithy.mark *)",
   "Skill(smithy.orders *)",

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -819,7 +819,7 @@ describe('getComposedTemplates', () => {
     expect(skill.prompt).toContain('## 5. Embedded examples — when code helps vs. hurts');
     expect(skill.prompt).toContain('## 6. Reference-prose anti-pattern');
     expect(skill.prompt).toContain('## 7. Depth-control rule');
-    expect(skill.prompt).toContain('## 8. Audience-tagging convention');
+    expect(skill.prompt).toContain('## 8. Audience tag grammar');
     expect(skill.prompt).toContain('## 9. Three worked before/after examples');
     expect(skill.prompt).toContain('## 10. Application beyond Smithy');
   });

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -301,15 +301,16 @@ describe('getTemplateFilesByCategory', () => {
     expect(byCategory.commands).toHaveLength(10);
     expect(byCategory.prompts).toHaveLength(2);
     expect(byCategory.agents).toHaveLength(13);
-    expect(byCategory.skills).toHaveLength(4);
+    expect(byCategory.skills).toHaveLength(5);
   });
 
-  it('skills includes smithy.pr-review, smithy.status, smithy.gh-issue, and smithy.helper-docker', () => {
+  it('skills includes smithy.pr-review, smithy.status, smithy.gh-issue, smithy.helper-docker, and smithy.helper-voice', () => {
     const { skills } = getTemplateFilesByCategory();
     expect(skills).toContain('smithy.pr-review');
     expect(skills).toContain('smithy.status');
     expect(skills).toContain('smithy.gh-issue');
     expect(skills).toContain('smithy.helper-docker');
+    expect(skills).toContain('smithy.helper-voice');
   });
 
   it('commands includes expected template files', () => {
@@ -774,6 +775,104 @@ describe('getComposedTemplates', () => {
     const forge = composed.commands.get('smithy.forge.md')!;
     expect(forge).toBeDefined();
     expect(forge).toContain('smithy.helper-docker');
+  });
+
+  // Issue #420: smithy.helper-voice is a new body-only operational skill
+  // that distributes the voice & audience taxonomy (EPIC #419). These
+  // assertions back-stop the deployment contract (body-only, frontmatter
+  // retained, auto-trigger description) and the 10-section outline so a
+  // regression that drops a section, removes the auto-trigger phrases, or
+  // accidentally adds a `scripts/` subdirectory fails the suite.
+  it('smithy.helper-voice is body-only (no scripts) with frontmatter retained', () => {
+    const skill = composed.skills.get('smithy.helper-voice');
+    expect(skill).toBeDefined();
+    expect(skill!.prompt).toMatch(/^---\s*\n/);
+    expect(skill!.prompt).toContain('name: smithy.helper-voice');
+    expect(skill!.scripts.size).toBe(0);
+  });
+
+  it('smithy.helper-voice description triggers on draft and review/cleanup phrasing', () => {
+    const skill = composed.skills.get('smithy.helper-voice')!;
+    // Auto-trigger description (frontmatter) must name the two invocation
+    // surfaces and the deliverable types the skill covers, so calling
+    // agents recognize when to lazy-load it.
+    expect(skill.prompt).toMatch(/drafting or reviewing prose/i);
+    expect(skill.prompt).toContain('migration plans');
+    expect(skill.prompt).toContain('ADRs');
+    expect(skill.prompt).toContain('runbooks');
+    expect(skill.prompt).toContain('READMEs');
+    // The Role × Diátaxis-mode framing is the load-bearing claim of the
+    // description — if it disappears, the skill no longer advertises its
+    // actual content.
+    expect(skill.prompt).toMatch(/Role × Diátaxis-mode taxonomy/i);
+  });
+
+  it('smithy.helper-voice body covers the 10-section outline', () => {
+    const skill = composed.skills.get('smithy.helper-voice')!;
+    // Per issue #420, the body must cover all ten sections of the
+    // outline. Anchor on the numbered heading prefix so a regression that
+    // renumbers or drops one section is caught.
+    expect(skill.prompt).toContain('## 1. The two axes');
+    expect(skill.prompt).toContain('## 2. The four anti-patterns');
+    expect(skill.prompt).toContain('## 3. Voice rules per Role × Mode combination');
+    expect(skill.prompt).toContain('## 4. Diagram guidance');
+    expect(skill.prompt).toContain('## 5. Embedded examples — when code helps vs. hurts');
+    expect(skill.prompt).toContain('## 6. Reference-prose anti-pattern');
+    expect(skill.prompt).toContain('## 7. Depth-control rule');
+    expect(skill.prompt).toContain('## 8. Audience-tagging convention');
+    expect(skill.prompt).toContain('## 9. Three worked before/after examples');
+    expect(skill.prompt).toContain('## 10. Application beyond Smithy');
+  });
+
+  it('smithy.helper-voice documents both invocation modes', () => {
+    const skill = composed.skills.get('smithy.helper-voice')!;
+    // Two first-class modes per issue #420. Both must be documented in
+    // the body so any agent loading the skill knows it can draft *or*
+    // review/cleanup.
+    expect(skill.prompt).toMatch(/Draft mode/);
+    expect(skill.prompt).toMatch(/Review \/ cleanup mode/);
+    // The side-by-side compare is the primary validation path for the
+    // cleanup mode and must be called out explicitly. Either spelling
+    // (hyphenated or whitespace-separated, potentially wrapped across a
+    // newline) counts as documenting the compare protocol.
+    expect(skill.prompt).toMatch(/side[\s-]+by[\s-]+side/i);
+  });
+
+  it('smithy.helper-voice documents the audience-tag grammar with all directive keys', () => {
+    const skill = composed.skills.get('smithy.helper-voice')!;
+    // Tagging-grammar directive keys (issue #420). Every key must appear
+    // in the body so authors of new templates have one source of truth
+    // for the convention.
+    expect(skill.prompt).toContain('audience:');
+    expect(skill.prompt).toContain('mode:');
+    expect(skill.prompt).toContain('length:');
+    expect(skill.prompt).toContain('diagram:');
+    expect(skill.prompt).toContain('examples:');
+    expect(skill.prompt).toContain('applicability:');
+    // The +ai-input flag is additive on the base role and must be named.
+    expect(skill.prompt).toContain('+ai-input');
+    // The inline HTML-comment carrier and the N/A fallback for
+    // non-code-shaped Reference sections are both load-bearing pieces of
+    // the taxonomy, per issue #420 sections 6 and 8.
+    expect(skill.prompt).toMatch(/<!-- audience:/);
+    expect(skill.prompt).toMatch(/N\/A —/);
+  });
+
+  it('smithy.helper-voice is provider-neutral (no Claude/Gemini/Codex syntax in the body)', () => {
+    const skill = composed.skills.get('smithy.helper-voice')!;
+    // Strip frontmatter before checking — the deploy-target name in
+    // frontmatter is "smithy.helper-voice", not a Claude-specific term.
+    const body = skill.prompt.replace(/^---\s*\n[\s\S]*?\n---\s*\n/, '');
+    // Provider-specific surfaces must not leak into the body.
+    expect(body).not.toMatch(/\$ARGUMENTS\b/);
+    expect(body).not.toMatch(/allowed-tools\s*:/);
+    expect(body).not.toMatch(/CLAUDE_SKILL_DIR/);
+    expect(body).not.toMatch(/\.gemini\/skills/);
+    expect(body).not.toMatch(/\.agents\/skills/);
+    // The body must explicitly assert its provider-neutrality so a
+    // future edit that quietly adds provider-specific syntax has to
+    // also remove the assertion.
+    expect(body).toMatch(/Provider-neutral/i);
   });
 
   it('categorizes templates correctly', () => {

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -144,8 +144,9 @@ Keys:
 Authoring rule: when adding a new `##` section to a planning-artifact
 template, drop the tag immediately under the heading inside the
 template's markdown code fence. `smithy.audit` and future lint commands
-read these tags to enforce voice rules; until every template surface
-is wired through, the audit command carries a hard-coded copy of the
+will read these tags to enforce voice rules (planned in slice 4 of EPIC
+#419). Until that slice lands and every template surface is wired
+through, the audit command will carry a hard-coded copy of the
 per-section specs that matches the eventual template-driven one. See
 `src/templates/agent-skills/skills/smithy.helper-voice/SKILL.prompt`
 for the per-cell rules, three worked before/after examples, and the

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -108,6 +108,43 @@ section in every artifact**, using the same 4-column Markdown table schema:
   features, user stories, and slices, so the authoring commands and the
   scanner share one implementation.
 
+## Voice and Audience Tagging Convention
+
+Every `##` section in a Smithy planning artifact, forge deliverable, or
+ad-hoc planning prose carries an inline HTML-comment tag immediately under
+the heading. The full taxonomy — Reader role × Diátaxis mode plus
+conciseness budgets, diagram-first framing, and depth-control rules —
+lives in the `smithy.helper-voice` skill body. Authors of new command
+templates should follow it rather than redefining voice rules inline.
+
+The tag grammar:
+
+```
+## <Section title>
+<!-- audience: <role>[+ai-input]; mode: <mode>; length: <budget>; diagram: <required|recommended|optional>; examples: <required|recommended|discouraged|forbidden>[; applicability: <free-text>] -->
+```
+
+Keys:
+
+| Key | Values |
+|-----|--------|
+| `audience` | `stakeholder` \| `reviewer` \| `builder`; append `+ai-input` when a Smithy sub-agent is the primary consumer (e.g., `builder+ai-input`). |
+| `mode` | `explanation` \| `reference` \| `how-to` \| `tutorial`. |
+| `length` | Sentence or paragraph budget (`2-3 sentences`, `3-6 paragraphs`, `tables only`, `5-15 steps`). |
+| `diagram` | `required` \| `recommended` \| `optional`. |
+| `examples` | `required` \| `recommended` \| `discouraged` \| `forbidden`. |
+| `applicability` (optional) | Free-text condition under which the section legitimately resolves to `N/A` (e.g., `code-shaped features only` on `.data-model.md` / `.contracts.md`). |
+
+The comment renders invisibly in GitHub/Markdown preview, is grep-able
+for lint, and travels with the section across reorderings. Tag every new
+`##` section you author; in review mode, insert missing tags and revise
+prose that violates the budget. `smithy.audit` and future lint commands
+read these tags to enforce voice rules — see
+`src/templates/agent-skills/skills/smithy.helper-voice/SKILL.prompt` for
+the per-cell rules, three worked before/after examples, and the
+"application beyond Smithy" appendix (migration plans, ADRs, runbooks,
+READMEs, inline documentation).
+
 ## Sub-Agent Roles
 
 Sub-agents are invoked by parent commands, not directly by users:

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -110,14 +110,20 @@ section in every artifact**, using the same 4-column Markdown table schema:
 
 ## Voice and Audience Tagging Convention
 
-Every `##` section in a Smithy planning artifact, forge deliverable, or
-ad-hoc planning prose carries an inline HTML-comment tag immediately under
-the heading. The full taxonomy — Reader role × Diátaxis mode plus
-conciseness budgets, diagram-first framing, and depth-control rules —
-lives in the `smithy.helper-voice` skill body. Authors of new command
-templates should follow it rather than redefining voice rules inline.
+Each `##` section in a Smithy planning artifact carries a voice spec —
+audience, mode, length budget, diagram requirement, examples policy —
+recorded by an HTML-comment tag with the grammar below. **The tag lives
+in the planning-artifact template** (the markdown code-fence block that
+`smithy.ignite`, `smithy.render`, `smithy.mark`, and `smithy.cut` emit
+as the artifact shape), **not in every generated artifact instance**.
+That keeps the spec in one place, lets template authors edit it
+centrally, and gives `smithy.audit` a single file to read when checking
+voice. The full Role × Mode taxonomy — conciseness budgets, diagram-
+first framing, depth-control rules — lives in the `smithy.helper-voice`
+skill body. Authors of new command templates should follow it rather
+than redefining voice rules inline.
 
-The tag grammar:
+The tag grammar (as it appears in templates):
 
 ```
 ## <Section title>
@@ -135,15 +141,18 @@ Keys:
 | `examples` | `required` \| `recommended` \| `discouraged` \| `forbidden`. |
 | `applicability` (optional) | Free-text condition under which the section legitimately resolves to `N/A` (e.g., `code-shaped features only` on `.data-model.md` / `.contracts.md`). |
 
-The comment renders invisibly in GitHub/Markdown preview, is grep-able
-for lint, and travels with the section across reorderings. Tag every new
-`##` section you author; in review mode, insert missing tags and revise
-prose that violates the budget. `smithy.audit` and future lint commands
-read these tags to enforce voice rules — see
-`src/templates/agent-skills/skills/smithy.helper-voice/SKILL.prompt` for
-the per-cell rules, three worked before/after examples, and the
+Authoring rule: when adding a new `##` section to a planning-artifact
+template, drop the tag immediately under the heading inside the
+template's markdown code fence. `smithy.audit` and future lint commands
+read these tags to enforce voice rules; until every template surface
+is wired through, the audit command carries a hard-coded copy of the
+per-section specs that matches the eventual template-driven one. See
+`src/templates/agent-skills/skills/smithy.helper-voice/SKILL.prompt`
+for the per-cell rules, three worked before/after examples, and the
 "application beyond Smithy" appendix (migration plans, ADRs, runbooks,
-READMEs, inline documentation).
+READMEs, inline documentation) — those non-Smithy targets have no
+template to inherit from, so the taxonomy is used as authoring
+discipline rather than a metadata convention.
 
 ## Sub-Agent Roles
 

--- a/src/templates/agent-skills/skills/smithy.helper-voice/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.helper-voice/SKILL.prompt
@@ -140,7 +140,7 @@ audit command knows when `N/A` is legitimate:
 
 ```
 ## Contracts
-<!-- audience: builder; mode: reference; applicability: code-shaped features only; examples: required -->
+<!-- audience: builder; mode: reference; length: tables only; diagram: recommended; examples: required; applicability: code-shaped features only -->
 ```
 
 In review mode, treat any multi-paragraph Reference section without
@@ -176,11 +176,11 @@ Each section's voice is described by a small set of keys: `audience`,
 used by the generating command (`smithy.ignite`, `smithy.render`,
 `smithy.mark`, `smithy.cut`) — not inline in every generated artifact.
 One source of truth, no per-file drift; the artifact itself stays
-clean prose. `smithy.audit` reads the same template files to know
-what voice spec to enforce per section. Until the template surface is
-fully wired through, the audit command carries a hard-coded copy of
-the specs so the enforcement surface matches the eventual
-template-driven one.
+clean prose. `smithy.audit` will read the same template files to know
+what voice spec to enforce per section (planned in slice 4 of EPIC
+#419). Until the template surface is wired through and that slice
+lands, the audit command will carry a hard-coded copy of the specs so
+the enforcement surface matches the eventual template-driven one.
 
 **For non-Smithy prose** (READMEs, ADRs, migration plans, runbooks,
 inline documentation), there is no template to inherit from. Use the
@@ -258,7 +258,7 @@ artifacts the specs live in the template, not in the rendered file):
 
 ```
 ## Goals
-<!-- audience: reviewer; mode: explanation; length: 1-2 paragraphs; examples: discouraged -->
+<!-- audience: reviewer; mode: explanation; length: 1-2 paragraphs; diagram: optional; examples: discouraged -->
 
 Users should be able to see status across all artifacts in one place,
 stable enough to wire into CI.

--- a/src/templates/agent-skills/skills/smithy.helper-voice/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.helper-voice/SKILL.prompt
@@ -1,0 +1,320 @@
+---
+name: smithy.helper-voice
+description: "Voice and audience guidance for any prose: RFC/spec/PRD narrative, migration plans, ADRs, runbooks, READMEs, design docs, change notes, inline documentation. Use when drafting or reviewing prose for readers spanning stakeholders, reviewers, implementers, or AI agents. Provides a Role × Diátaxis-mode taxonomy, conciseness budgets, diagram-first framing, depth-control rules, and AI-vs-human audience separation."
+---
+# smithy.helper-voice
+
+Voice and audience taxonomy for any prose a Smithy agent produces —
+planning artifacts (RFCs, feature maps, specs, tasks), forge deliverables
+(READMEs, ADRs, migration plans, runbooks, inline documentation), and the
+narrative paragraphs that thread them together. Provider-neutral: no
+Claude-, Gemini-, or Codex-specific syntax. Load this skill in either of
+two modes:
+
+- **Draft mode** — given a section, audience, and length budget, write
+  prose to convention from scratch.
+- **Review / cleanup mode** — given an existing artifact, produce a
+  revised version that applies the taxonomy, fixes anti-patterns,
+  suggests diagrams, compresses dense Reference prose, and inserts
+  audience tags. Return the original and the revised version side by
+  side so a human can judge whether the new voice is an improvement —
+  the side-by-side compare is the primary validation path.
+
+---
+
+## 1. The two axes
+
+Pick both axes before drafting or reviewing.
+
+**Reader role.** *Stakeholder* — non-author humans who decide whether the
+work should happen (product, leadership, on-call triage); they read for
+impact. *Reviewer* — peer engineers who approve or block; they read for
+correctness, scope, risk. *Builder* — the engineer (human or AI) who
+turns the doc into code; they read for what to do next.
+
+**`+ai-input` flag (additive).** Append when a Smithy sub-agent or other
+LLM is the primary consumer (e.g., a `Requirements` block read by
+`smithy-slice`, a `.tasks.md` slice consumed by `smithy-implement`). The
+base role still applies; `+ai-input` tightens structure, removes
+rhetorical flourish, and prefers tables/signatures over prose.
+
+**Diátaxis mode.** *Explanation* — understanding-oriented, narrative
+prose. *Reference* — information-oriented, tables and structured
+artifacts. *How-to* — task-oriented, ordered steps. *Tutorial* —
+learning-oriented end-to-end walk-throughs (rare in planning, common in
+onboarding docs).
+
+A single `##` section serves exactly one Role × Mode pair. If you find
+yourself blending two, split the section.
+
+---
+
+## 2. The four anti-patterns
+
+The taxonomy is built to remedy these. Flag each explicitly in review
+mode.
+
+1. **Missing diagrams.** A block, sequence, or ER diagram would carry
+   the same information in less space, but the section is wall-of-text.
+2. **Verbosity.** More detail than the chosen reader needs at this
+   depth. Often shows up as restating the goal in three sentences.
+3. **Depth-first tangents.** Prose dives into implementation detail
+   inside a Stakeholder×Explanation, then climbs back out.
+4. **Commingled audiences.** One section serves humans (review,
+   approval) and AI sub-agents (input to `smithy-slice`,
+   `smithy-implement`) with no signal of which paragraph is which.
+
+---
+
+## 3. Voice rules per Role × Mode combination
+
+| Role × Mode | Length | Diagram | Examples | Notes |
+|---|---|---|---|---|
+| Stakeholder × Explanation | 2-3 paragraphs | recommended | discouraged | Lead with impact, no implementation detail. |
+| Reviewer × Explanation | 3-6 paragraphs | optional | recommended | Cover alternatives and tradeoffs; cite evidence. |
+| Builder × Reference | tables / signatures | recommended (ER/class) | required | Compress prose into schemas, contracts, types. |
+| Builder × Reference + ai-input | tables / signatures | optional | required | Machine-parseable preferred — no rhetorical bridges. |
+| Builder × How-to | 5-15 ordered steps | recommended (flow/seq) | discouraged | One action per step; validate at the end. |
+| Reviewer × Reference | tables | optional | recommended | Acceptance criteria, success metrics, scope rows. |
+
+When in doubt, drop one axis to its simplest case: Reviewer × Explanation
+is a reasonable default for narrative without an obvious owner.
+
+---
+
+## 4. Diagram guidance
+
+A diagram beats prose when the content describes structure, flow, or
+relationships between three or more named entities. Default to Mermaid —
+it renders inline on GitHub and most documentation platforms — and place
+the diagram immediately after the section heading, before the supporting
+paragraphs. Do not invent boxes that aren't in the system: three real
+nodes beat eight that include "future work".
+
+Typical diagrams per mode:
+
+- **Explanation** — block / architecture (`flowchart LR`, `graph TD`).
+- **Reference** — entity-relationship (`erDiagram`) or class
+  (`classDiagram`).
+- **How-to** — flowchart (`flowchart TD`) or sequence
+  (`sequenceDiagram`).
+- **Tutorial** — sequence diagrams or annotated walkthroughs.
+
+---
+
+## 5. Embedded examples — when code helps vs. hurts
+
+Code and interface snippets are not uniformly good. The choice is
+governed by the section's mode and recorded in the `examples:` directive
+(§8):
+
+- **Reference (contracts, data models)** — `examples: required`.
+  Signatures, schemas, and shape declarations *are* the deliverable.
+- **How-to (`.tasks.md` slices)** — `examples: forbidden`. Concrete code
+  in task bodies over-prescribes implementation and traps the builder
+  into a specific approach. Describe the contract; let the implementer
+  choose the body.
+- **Explanation (Motivation, Personas)** — `examples: discouraged`. A
+  code snippet usually signals the author drifted into implementation;
+  cut it or move it to a child Reference section.
+- **Explanation (Proposal, API sketch)** — `examples: recommended`. A
+  small interface sketch grounds an abstract proposal — keep it under
+  ten lines.
+
+---
+
+## 6. Reference-prose anti-pattern
+
+A Reference-mode section that emits narrative prose has chosen the wrong
+form. Two valid fixes:
+
+1. **Compress** to a structured artifact — a table of fields, a
+   TypeScript signature, a JSON schema, an ER diagram. The Reference
+   deliverable is the structure, not the description of it.
+2. **Mark `N/A`.** Some features have no code-shaped contract: a
+   docs-only change, a process update, a configuration toggle. The
+   section is one line: `N/A — <one-sentence reason>`.
+
+Record applicability in the section tag so reviewers and linters know
+when `N/A` is legitimate:
+
+```
+## Contracts
+<!-- audience: builder; mode: reference; applicability: code-shaped features only; examples: required -->
+```
+
+In review mode, treat any multi-paragraph Reference section without
+tables, signatures, or `N/A` as an automatic finding.
+
+---
+
+## 7. Depth-control rule
+
+One level of detail per section. Stay in your Diátaxis mode; resist
+"just briefly explain how" inside an Explanation, or "just sketch the
+why" inside a Reference. When deeper detail is genuinely needed:
+
+- Push Reference detail into a child file (e.g., `.data-model.md`
+  splits entities and schemas out of `.spec.md`; `.contracts.md` splits
+  interfaces and integration boundaries).
+- Push procedural detail into a How-to child section or a sibling
+  `.tasks.md`.
+- Push background context into a linked ADR or RFC — do not inline it.
+
+If a section's prose moves up and down the abstraction ladder more than
+once, split it.
+
+---
+
+## 8. Audience-tagging convention
+
+Every `##` section gets an inline HTML-comment tag immediately under the
+heading. The comment is invisible in rendered Markdown, grep-able for
+lint, and travels with the section through reorderings.
+
+Grammar:
+
+```
+## <Section title>
+<!-- audience: <role>[+ai-input]; mode: <mode>; length: <budget>; diagram: <required|recommended|optional>; examples: <required|recommended|discouraged|forbidden>[; applicability: <free-text>] -->
+```
+
+Keys:
+
+- `audience` — `stakeholder` | `reviewer` | `builder`. Append
+  `+ai-input` when a sub-agent is the primary consumer
+  (e.g., `builder+ai-input`).
+- `mode` — `explanation` | `reference` | `how-to` | `tutorial`.
+- `length` — sentence or paragraph budget (`2-3 sentences`,
+  `3-6 paragraphs`, `tables only`, `5-15 steps`).
+- `diagram` — `required` | `recommended` | `optional`.
+- `examples` — `required` | `recommended` | `discouraged` | `forbidden`.
+- `applicability` (optional) — free-text condition under which the
+  section legitimately resolves to `N/A` (e.g., `code-shaped features
+  only`).
+
+Example:
+
+```
+## Summary
+<!-- audience: stakeholder; mode: explanation; length: 2-3 sentences; diagram: optional; examples: discouraged -->
+```
+
+Linters and `smithy.audit` read these tags to enforce budgets, diagram
+requirements, and `examples:` rules.
+
+---
+
+## 9. Three worked before/after examples
+
+### (a) Wordy / depth-first Motivation
+
+**Before** — Stakeholder×Explanation drifting into Builder×Reference:
+
+> The current system has a number of issues. The manual reconciliation
+> between three config files takes about an hour each sprint. The
+> reconciliation script is written in bash and uses `jq` to diff the
+> JSON, which is brittle when fields are added. Specifically, the
+> `services.yaml` file has a `replicas` field that defaults to 1, but
+> some teams override it to 3 in their staging branch...
+
+**After** — stays in Stakeholder×Explanation:
+
+> Each sprint, teams lose roughly an hour reconciling three config
+> files by hand. The brittleness compounds as the team scales: every
+> new service multiplies the diff surface, and three P1 incidents last
+> quarter traced back to drift the manual process missed.
+
+The `jq` script and the `replicas` field belong in a child Reference
+section, not in the Motivation.
+
+### (b) Commingled Requirements section
+
+**Before** — Reviewer×Explanation mixed with Builder×Reference+ai-input:
+
+> Users should be able to see status across all artifacts. The CLI must
+> emit JSON with a `nodes[]` array where each node has `id`, `kind`,
+> `state`, `path`. Reviewers will want to confirm the JSON shape is
+> stable before we wire status into CI.
+
+**After** — split into two sections, each with its own tag:
+
+```
+## Goals
+<!-- audience: reviewer; mode: explanation; length: 1-2 paragraphs; examples: discouraged -->
+
+Users should be able to see status across all artifacts in one place,
+stable enough to wire into CI.
+
+## Status JSON Schema
+<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: recommended; examples: required -->
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id`   | string | Canonical artifact ID |
+| `kind` | enum   | `rfc` \| `spec` \| `tasks` |
+| `state`| enum   | `pending` \| `done` |
+| `path` | string | Repo-relative path |
+```
+
+### (c) Dense-prose `.contracts.md` that should have been signatures or N/A
+
+**Before** — Reference mode emitting Explanation prose:
+
+> The voice helper skill exposes two operations to its callers. The
+> first, draft mode, takes an idea and a target audience and returns
+> prose. The second, review mode, takes an existing artifact and
+> returns a revised version. Internally, the skill does not make any
+> function calls; it is a body of guidance the calling agent reads.
+
+**After option 1** — compress to a signature table:
+
+| Operation | Input | Output |
+|-----------|-------|--------|
+| draft  | section assignment, audience, length budget | prose |
+| review | existing artifact path                      | revised artifact + findings |
+
+**After option 2** — mark `N/A` if no code-shaped contract:
+
+> N/A — `smithy.helper-voice` is a prose-only skill; it exposes no
+> function or CLI surface for other agents to call.
+
+---
+
+## 10. Application beyond Smithy
+
+The same axes apply to non-Smithy prose. Pick Role × Mode first;
+everything else follows.
+
+- **Migration plan** — Reviewer × How-to. 10-20 ordered steps with a
+  rollback per phase. Diagram: recommended (timeline or sequence).
+  Examples: discouraged in the steps themselves; recommended in a
+  prerequisite Reference child.
+- **ADR (Architecture Decision Record)** — Reviewer × Explanation.
+  1-2 paragraphs per Context / Decision / Consequences section.
+  Diagram: recommended for Context. Examples: discouraged — an ADR
+  records the choice, not the code.
+- **Runbook** — Builder × How-to. Numbered steps with a validation
+  command per step. Diagram: optional (sequence for multi-system
+  flows). Examples: required — actual command lines.
+- **README landing page** — Stakeholder × Explanation up top (what is
+  this, why use it), Builder × How-to below (install / quick start).
+  Two sections, two tags.
+- **Inline code documentation** — Builder × Reference. One paragraph;
+  diagram: optional; examples: recommended for API entry points.
+
+For any prose deliverable, the workflow is the same: pick the role,
+pick the mode, write the tag, write to the budget. When in doubt about
+the right cell, draft first, then run review mode on yourself and
+update the tag.
+
+---
+
+## Coexistence with `smithy.prose`
+
+`smithy.prose` (sub-agent) keeps its section-specific drafting protocol
+for Summary / Motivation / Personas. This skill is the canonical home
+for the shared principles (lead-with-impact, no invented figures, no
+bullet-enumeration in prose) and the cross-cutting taxonomy. When both
+apply, `smithy.prose` is the *how* for a specific RFC section, and this
+skill is the *what voice* across every section.

--- a/src/templates/agent-skills/skills/smithy.helper-voice/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.helper-voice/SKILL.prompt
@@ -135,8 +135,8 @@ form. Two valid fixes:
    docs-only change, a process update, a configuration toggle. The
    section is one line: `N/A — <one-sentence reason>`.
 
-Record applicability in the section tag so reviewers and linters know
-when `N/A` is legitimate:
+Record applicability in the template's tag for this section so the
+audit command knows when `N/A` is legitimate:
 
 ```
 ## Contracts
@@ -166,13 +166,29 @@ once, split it.
 
 ---
 
-## 8. Audience-tagging convention
+## 8. Audience tag grammar
 
-Every `##` section gets an inline HTML-comment tag immediately under the
-heading. The comment is invisible in rendered Markdown, grep-able for
-lint, and travels with the section through reorderings.
+Each section's voice is described by a small set of keys: `audience`,
+`mode`, `length`, `diagram`, `examples`, and an optional
+`applicability`. **For Smithy planning artifacts** (`.rfc.md`,
+`.features.md`, `.spec.md`, `.tasks.md`, `.contracts.md`,
+`.data-model.md`), the spec for each section lives in the *template*
+used by the generating command (`smithy.ignite`, `smithy.render`,
+`smithy.mark`, `smithy.cut`) — not inline in every generated artifact.
+One source of truth, no per-file drift; the artifact itself stays
+clean prose. `smithy.audit` reads the same template files to know
+what voice spec to enforce per section. Until the template surface is
+fully wired through, the audit command carries a hard-coded copy of
+the specs so the enforcement surface matches the eventual
+template-driven one.
 
-Grammar:
+**For non-Smithy prose** (READMEs, ADRs, migration plans, runbooks,
+inline documentation), there is no template to inherit from. Use the
+taxonomy as authoring discipline — pick Role × Mode before drafting
+and stay in it — but do not litter the file with HTML-comment
+metadata.
+
+Grammar (the syntax templates use):
 
 ```
 ## <Section title>
@@ -193,15 +209,14 @@ Keys:
   section legitimately resolves to `N/A` (e.g., `code-shaped features
   only`).
 
-Example:
+Example — the `## Summary` section's voice spec, as it would appear
+in a `.spec.md` template (and as the audit command would cite it in a
+finding):
 
 ```
 ## Summary
 <!-- audience: stakeholder; mode: explanation; length: 2-3 sentences; diagram: optional; examples: discouraged -->
 ```
-
-Linters and `smithy.audit` read these tags to enforce budgets, diagram
-requirements, and `examples:` rules.
 
 ---
 
@@ -237,7 +252,9 @@ section, not in the Motivation.
 > `state`, `path`. Reviewers will want to confirm the JSON shape is
 > stable before we wire status into CI.
 
-**After** — split into two sections, each with its own tag:
+**After** — split into two sections, each governed by its own template
+voice spec (shown inline below for the reader's benefit; in real Smithy
+artifacts the specs live in the template, not in the rendered file):
 
 ```
 ## Goals


### PR DESCRIPTION
## Summary

Anchor slice of EPIC #419: a new lazy-loaded operational skill
(`smithy.helper-voice`) that distributes the unified voice & audience
taxonomy so any agent (Claude / Gemini / Codex) can pick it up when
drafting OR reviewing prose — Smithy planning artifacts as well as
non-Smithy deliverables (migration plans, ADRs, runbooks, READMEs,
inline documentation).

- Adds `src/templates/agent-skills/skills/smithy.helper-voice/SKILL.prompt`
  with the full 10-section body and auto-trigger description.
- Provider-neutral body: no Claude-, Gemini-, or Codex-specific syntax.
- Two first-class invocation modes: **Draft** ("write new prose to
  convention") and **Review / cleanup** ("revise existing prose, insert
  audience tags, suggest diagrams, compress dense Reference prose,
  return original + revised side by side").
- Announces the skill in `CLAUDE.md` under Operational Skills and
  documents the `<!-- audience: ... -->` per-section tagging grammar in
  `src/templates/agent-skills/README.md`.
- Adds `Skill(smithy.helper-voice *)` to the Claude allow-list so the
  permission deploys alongside existing skills.

## What's in the skill body

The body covers the 10-section outline from #420 verbatim:

1. The two axes — Reader role (Stakeholder / Reviewer / Builder + `+ai-input`
   flag) × Diátaxis mode (Explanation / Reference / How-to / Tutorial).
2. The four anti-patterns being remedied — missing diagrams, verbosity,
   depth-first tangents, commingled audiences.
3. Voice rules per Role × Mode (six common cells, table form).
4. Diagram guidance — when to use Mermaid; typical diagrams per mode.
5. Embedded examples — when code helps vs. hurts; the `examples:` directive
   grammar.
6. Reference-prose anti-pattern — compress to structured artifact OR mark
   `N/A — <reason>`; documents the `applicability:` directive.
7. Depth-control rule — one level of detail per section; push deeper detail
   into child files.
8. Audience-tagging convention — full grammar for the
   `<!-- audience: ... -->` HTML comment with every directive key.
9. Three worked before/after examples — wordy Motivation, commingled
   Requirements, dense-prose `.contracts.md`.
10. Application beyond Smithy — migration plan, ADR, runbook, README, inline
    code documentation.

## Coexistence with `smithy.prose`

This slice intentionally does not modify `smithy.prose`. The skill is the
canonical home for the shared principles; the sub-agent keeps its
section-specific drafting protocol. Slice 3 (#423) trims `smithy.prose`
to delegate; this slice only adds the new skill.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test` — 890 / 890 passing, including:
  - `getTemplateFilesByCategory` skill count bumped from 4 → 5
  - `smithy.helper-voice` body-only assertion (no scripts, frontmatter
    retained at deploy)
  - 10-section outline assertion
  - Draft + Review/cleanup mode assertion
  - Tag-grammar assertion (every directive key + `+ai-input`)
  - Provider-neutrality assertion (no `$ARGUMENTS`, `allowed-tools`,
    `CLAUDE_SKILL_DIR`, `.gemini/skills`, `.agents/skills` in the body)
  - Updated `Skill(smithy.helper-voice *)` permission assertion in the
    Claude allow-list test
- [x] Smoke test: `node dist/cli.js init -a claude -l repo --permissions -y`
  deploys `.claude/skills/smithy.helper-voice/SKILL.md` (320 lines, full
  frontmatter, no `scripts/` subdirectory) and adds
  `Skill(smithy.helper-voice *)` to `.claude/settings.json`.

## Out of scope (deferred to later slices in EPIC #419)

- #422 — Audience comments on existing templates; tighten
  `.contracts.md` / `.data-model.md` to Reference (deps #420).
- #423 — Trim `smithy.prose` to delegate to this skill (deps #422).
- #424 — Extend `smithy.audit` with voice/audience lint rules (deps #422).

Per `CLAUDE.md`, the `.claude/` snapshot and
`.smithy/smithy-manifest.json` are intentionally NOT regenerated here.

Closes #420
Part of #419

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzBmRgvE1e33EhFqoTkeCw)_