### PR TITLE
spec: smithy.forge end-to-end eval scenario + runner git-init (M1 F4)

### DIFF
--- a/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
+++ b/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
@@ -107,7 +107,7 @@ Recommended specification sequence:
 | F1 | Feature 1.3a: Per-Case Token Totals in EvalReport | — | specs/2026-05-18-007-per-case-token-totals-in-evalreport/ |
 | F2 | Feature 1.3b: Per-Sub-Agent Token Attribution | F1 | specs/2026-05-20-008-per-sub-agent-token-attribution/ |
 | F3 | Feature 1.4: smithy.fix End-to-End Eval Scenario | F1 | specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/ |
-| F4 | Feature 1.5: smithy.forge End-to-End Eval Scenario + Runner git-init (RFC SD-002) | F1 | — |
+| F4 | Feature 1.5: smithy.forge End-to-End Eval Scenario + Runner git-init (RFC SD-002) | F1 | specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/ |
 | F5 | Feature 1.6: JVM Multi-Language Fixture | — | — |
 | F6 | Feature 1.7: Forge-JVM Eval Scenario + M1 Baseline-Set Completeness Gate | F1, F4, F5 | — |
 

--- a/specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/smithy-forge-end-to-end-eval-scenario-runner-git-init.contracts.md
+++ b/specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/smithy-forge-end-to-end-eval-scenario-runner-git-init.contracts.md
@@ -1,0 +1,196 @@
+# Contracts: smithy.forge End-to-End Eval Scenario + Runner git-init
+
+## Overview
+
+This feature introduces an explicit git requirement contract for eval scenarios that need repository operations, then uses it to run smithy.forge against the existing JavaScript fixture. The contracts are additive to the existing scenario loader, runner invocation, validation, and baseline flows.
+
+## Interfaces
+
+### 1) Scenario Git Requirement Declaration
+
+**Purpose**: Allows a scenario YAML file to declare that its temp execution copy must be a git repository.
+**Consumers**: Scenario loader, eval runner, scenario tests.
+**Providers**: Scenario YAML files under the eval cases directory.
+
+#### Signature
+
+```yaml
+requires_git: true
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `requires_git` | boolean | No | True when the scenario command performs git operations inside the temp copy. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `EvalScenario.requires_git` | boolean | Loaded scenario flag. Defaults to false when omitted. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Field is absent | Load the scenario with no explicit git requirement and do not request runner git setup. | Existing scenarios remain compatible. |
+| Field is non-boolean | Skip or reject the scenario with a validation error naming `requires_git`. | The runner must not infer git behavior from malformed metadata. |
+| Field is true but git initialization fails | Fail before spawning the agent with a clear runner error. | A forge scenario cannot produce deterministic output without git. |
+
+### 2) Temp-Copy Git Initialization
+
+**Purpose**: Prepares the copied fixture as a clean git repository before spawning scenarios that require git.
+**Consumers**: Eval runner and forge scenario.
+**Providers**: Runner filesystem and git subprocess orchestration.
+
+#### Signature
+
+```ts
+runScenario(
+  scenario: EvalScenario,
+  fixtureDir: string,
+  agent?: EvalAgent,
+): Promise<RunOutput>
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scenario.requires_git` | boolean | No | Signals that the temp copy must support `git status`, `git checkout -b`, and `git commit`. |
+| `fixtureDir` | string | Yes | Source fixture directory copied into a temp execution directory. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| temp git repository | filesystem state | A git repository with local identity, disabled hooks, a deterministic non-default branch, and a HEAD commit before agent spawn. |
+| `RunOutput` | object | Standard runner output after the agent exits or times out. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| `git` CLI is unavailable | Fail before spawning the agent. | Forge cannot run without git operations. |
+| Git identity is missing globally | Continue with repo-local eval identity. | Eval behavior must not depend on developer config. |
+| Git hooks are configured globally | Continue with hooks neutralized in the temp repository. | Eval runs must be deterministic and non-interactive. |
+| Scenario omits `requires_git` | Skip git setup for that scenario. | Git setup is opt-in through scenario metadata. |
+| Source fixture checksum changes | Fail with the existing checksum error. | Forge writes must stay isolated to the temp copy. |
+| Temp cleanup runs after failure | Remove the temp directory. | Existing cleanup behavior remains authoritative. |
+
+### 3) Offline smithy.forge Scenario Definition
+
+**Purpose**: Defines the committed forge case and its validation expectations.
+**Consumers**: Scenario loader, eval runner, report builder, baseline comparator.
+**Providers**: `forge-tdd-slice` scenario YAML and committed fixture task input.
+
+#### Signature
+
+```yaml
+name: forge-tdd-slice
+skill: /smithy.forge
+prompt: specs/forge-eval/01-forge-tdd-slice.tasks.md 1
+requires_git: true
+timeout: 900
+structural_expectations:
+  required_headings: [...]
+  required_patterns: [...]
+sub_agent_evidence:
+  - agent: smithy-implement
+    pattern: <stable-implementation-evidence>
+  - agent: smithy-implementation-review
+    pattern: <stable-review-evidence>
+```
+
+The concrete task path may differ at implementation time, but it must resolve inside the copied JavaScript fixture and represent a deterministic single-slice forge workflow.
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Stable scenario name used for reporting and baseline lookup. |
+| `skill` | string | Yes | Smithy command under test. |
+| `prompt` | string | Yes | Forge task file path and slice number. |
+| `requires_git` | boolean | Yes | Must be true for this scenario. |
+| `structural_expectations` | object | Yes | Existing structural validation rules. |
+| `sub_agent_evidence` | array | Yes | Helper evidence checks for the observed forge path. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `EvalResult` | object | Standard per-case result with status, structural checks, helper checks, duration, and token totals once F1.3a is present. |
+| `EvalReport` case line | string | Standard report row for `forge-tdd-slice`, including baseline marker and token totals after baseline creation. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| The task file path does not resolve | Scenario fails before useful forge output. | The committed scenario input is invalid. |
+| smithy.forge cannot create a branch or commit | Scenario fails. | The runner git contract was not satisfied. |
+| PR creation fails because credentials are absent | Accept the documented PR-failure terminal path when artifacts remain on disk. | Offline eval runs must remain useful. |
+| Structural marker is missing | Structural check fails. | The report should expose workflow regressions. |
+| A declared helper evidence check is missing from the run | That helper evidence check fails. | The report should expose dispatch-path regressions. |
+| Scenario times out or exits non-zero | Standard eval timeout/error status applies while preserving captured output and tokens. | Existing runner behavior remains authoritative. |
+
+### 4) Forge Baseline Contract
+
+**Purpose**: Stores and compares the known-good forge scenario output and token envelope.
+**Consumers**: Baseline loader, baseline comparator, report formatter, downstream token-delta work.
+**Providers**: Committed baseline JSON for `forge-tdd-slice`.
+
+#### Signature
+
+```json
+{
+  "scenario_name": "forge-tdd-slice",
+  "captured_at": "2026-06-05T00:00:00.000Z",
+  "headings": ["..."],
+  "tables": [],
+  "token_envelope": {
+    "input": { "min": 0, "max": 0 },
+    "output": { "min": 0, "max": 0 }
+  }
+}
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scenario_name` | string | Yes | Must match the scenario name `forge-tdd-slice`. |
+| `headings` | string[] | Yes | Structural headings expected from the known-good run. |
+| `tables` | array | No | Structural table expectations when present. |
+| `token_envelope` | object | Yes | Token bounds using the F1.3a schema. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Baseline` | object | Loaded structural and token baseline for the forge scenario. |
+| `CheckResult[]` | array | Structural checks plus token envelope check when compared with a live run. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Baseline is absent before the capture story lands | Scenario can run without a baseline marker. | Baseline creation is the final story for this feature. |
+| Baseline scenario name mismatches | Reject the baseline. | Prevents comparing a run against the wrong committed envelope. |
+| Token envelope is malformed | Reject the baseline using F1.3a validation rules. | Invalid token bounds would make downstream deltas misleading. |
+| Live output drifts from structural baseline | Emit failing structural baseline checks. | Existing baseline semantics apply. |
+| Live token totals exceed envelope | Emit a failing token check. | Downstream token regressions become visible in the eval report. |
+
+## Events / Hooks
+
+No new runtime event stream is introduced. The feature uses the existing eval scenario load, runner invocation, validation, report, and baseline comparison flow.
+
+Git hooks inside the temp repository must be disabled or bypassed for runner-created commits. Developer machine hooks must not run during eval execution.
+
+## Integration Boundaries
+
+- **Scenario YAML boundary**: adds optional `requires_git` metadata while preserving compatibility for scenarios that omit it.
+- **Runner filesystem boundary**: copies the fixture to a temp directory, initializes git only in that temp copy, and keeps checksum validation against the source fixture.
+- **Git CLI boundary**: uses local temp-repository config or per-command config for identity and hook neutralization; never writes global git config.
+- **smithy.forge command boundary**: exercises forge through its normal user-facing invocation path with a `.tasks.md` path and slice number.
+- **Baseline boundary**: consumes the token-aware baseline schema from F1.3a and commits a `forge-tdd-slice` baseline for downstream token-delta work.

--- a/specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/smithy-forge-end-to-end-eval-scenario-runner-git-init.data-model.md
+++ b/specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/smithy-forge-end-to-end-eval-scenario-runner-git-init.data-model.md
@@ -1,0 +1,174 @@
+# Data Model: smithy.forge End-to-End Eval Scenario + Runner git-init
+
+## Overview
+
+This feature adds data definitions for a deterministic smithy.forge eval scenario and the git-backed runner execution context it requires. The model extends scenario metadata with an optional `requires_git` flag, defines the temp git repository lifecycle, and consumes the token-aware baseline shape established by Feature 1.3a. No persistent database or external storage is introduced.
+
+## Entities
+
+### 1) Forge Eval Scenario (`forge_eval_scenario`)
+
+Purpose: Represents the YAML scenario that invokes smithy.forge against the existing JavaScript fixture.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | Stable scenario name. Expected value is `forge-tdd-slice`. |
+| `skill` | string | Yes | Smithy command under test. Expected value is `/smithy.forge`. |
+| `prompt` | string | Yes | Scenario prompt or argument string pointing at the deterministic forge task input. |
+| `requires_git` | boolean | Yes for this scenario | Optional at the schema level; this scenario sets it to `true`. |
+| `structural_expectations` | StructuralExpectations | Yes | Existing eval validation contract for required headings, patterns, tables, and forbidden patterns. |
+| `sub_agent_evidence` | ForgeHelperEvidenceCheck[] | Yes | Expected helper evidence for `smithy-implement` and `smithy-implementation-review`. |
+| `timeout` | integer | No | Existing per-scenario timeout override in seconds. Forge may need a longer budget than simple read-only scenarios. |
+
+Validation rules:
+
+- `name`, `skill`, and `prompt` must be non-empty strings.
+- `skill` must resolve to the deployed smithy.forge command.
+- `requires_git`, when present, must be boolean.
+- The forge scenario must set `requires_git: true`.
+- Structural expectations must include stable markers for forge completion, validation, and PR-delivery output.
+- Sub-agent evidence must include `smithy-implement` and `smithy-implementation-review` checks for the observed forge path.
+
+### 2) Git Requirement Flag (`git_requirement_flag`)
+
+Purpose: Declares that a scenario needs git operations in its execution temp copy.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `requires_git` | boolean | No | Defaults to false when absent unless the runner intentionally preserves always-on git initialization as an implementation detail. |
+
+Validation rules:
+
+- The value must be boolean when present.
+- The flag must not change scenario sorting, duplicate-name detection, structural expectations, or sub-agent evidence loading.
+- Scenarios that omit the flag remain compatible.
+
+### 3) Temp Git Repository (`temp_git_repository`)
+
+Purpose: Represents the per-scenario copied fixture after runner git initialization.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `path` | string | Yes | Temp directory created for a single scenario run. |
+| `initialized` | boolean | Yes | True after `git init` succeeds. |
+| `baseline_commit` | string | Yes | Commit created after copying the fixture. |
+| `working_branch` | string | Yes | Deterministic non-default branch used as the starting branch for forge. |
+| `post_init_commit` | string | Conditional | Commit created after `smithy init` deploys skills, when deployment writes files. |
+| `user_email` | string | Yes | Repo-local eval identity, not global config. |
+| `user_name` | string | Yes | Repo-local eval identity, not global config. |
+| `hooks_disabled` | boolean | Yes | True when hooks are neutralized for temp-copy commits. |
+
+Validation rules:
+
+- The temp repository must have a valid HEAD before the agent is spawned for a git-requiring scenario.
+- The temp repository must start forge from a deterministic non-default branch.
+- The worktree must be clean after skill deployment baseline commits.
+- Git identity and hook configuration must be local to the temp repository or supplied via per-command config.
+- Git initialization must not mutate the source fixture.
+
+### 4) Forge Task Input (`forge_task_input`)
+
+Purpose: Provides the deterministic `.tasks.md` input that drives smithy.forge.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `path` | string | Yes | Fixture-relative or temp-copy-visible path to the forge task file. |
+| `slice_number` | integer | Yes | Single slice number passed to forge. |
+| `fixture_scope` | string | Yes | Existing JavaScript fixture for F1.5. |
+| `expected_workflow` | string[] | Yes | High-level markers such as implement, validate, review, and final summary. |
+
+Validation rules:
+
+- The path must resolve inside the scenario execution context.
+- The input must drive a single deterministic slice.
+- The task must be suitable for the JavaScript fixture and must not depend on JVM or future fixture-selection work.
+
+### 5) Forge Helper Evidence Check (`forge_helper_evidence_check`)
+
+Purpose: Verifies helper dispatch behavior for the forge scenario.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `agent` | string | Yes | Expected helper agent name. |
+| `pattern` | string | Yes | Stable regex pattern matched against dispatch description or result text. |
+
+Validation rules:
+
+- Required helper agents are `smithy-implement` and `smithy-implementation-review`.
+- Patterns should target stable dispatch descriptions or template markers, not full-output snapshots.
+- Missing helper evidence produces a failed eval check, not a loader error.
+
+### 6) Forge Baseline (`forge_baseline`)
+
+Purpose: Stores the known-good forge scenario output and token envelope once F1.3a's baseline schema is available.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `scenario_name` | string | Yes | Must match `forge-tdd-slice`. |
+| `captured_at` | string | Yes | ISO 8601 capture timestamp. |
+| `headings` | string[] | Yes | Structural heading expectations inherited from the baseline contract. |
+| `tables` | object[] | No | Structural table expectations inherited from the baseline contract. |
+| `token_envelope` | TokenEnvelope | Yes | Accepted token bounds using the F1.3a token-aware schema. |
+
+Validation rules:
+
+- The baseline must satisfy the F1.3a token-aware baseline validation rules.
+- Structural expectations must remain present alongside the token envelope.
+- Baseline scenario name must match the scenario definition.
+
+## Relationships
+
+- `Forge Eval Scenario` 1:1 `Git Requirement Flag` through the scenario YAML.
+- `Forge Eval Scenario` 1:1 `Forge Task Input` through the scenario prompt.
+- `Forge Eval Scenario` 1:1 `Temp Git Repository` during runner execution when git is required.
+- `Forge Eval Scenario` 1..N `Forge Helper Evidence Check` through existing sub-agent evidence validation.
+- `Forge Eval Scenario` 1:1 `Forge Baseline` after the first clean token-aware capture.
+
+## State Transitions
+
+### Scenario lifecycle
+
+1. `declared` -> `loaded`
+   - Trigger: the scenario loader validates the YAML.
+   - Effects: `requires_git`, structural expectations, timeout, and sub-agent evidence are attached to the scenario.
+
+2. `loaded` -> `temp_repo_ready`
+   - Trigger: the runner prepares the copied fixture for a git-requiring scenario.
+   - Effects: the temp copy has a git repository, local identity, disabled hooks, and a HEAD commit.
+
+3. `temp_repo_ready` -> `invocation_built`
+   - Trigger: the runner renders the smithy.forge invocation.
+   - Effects: the forge task path and slice number are visible to the agent.
+
+4. `invocation_built` -> `validated`
+   - Trigger: smithy.forge completes and report validation runs.
+   - Effects: structural and helper evidence checks are attached to the eval result.
+
+5. `validated` -> `baselined`
+   - Trigger: a clean scenario run is captured after the token-aware baseline schema exists.
+   - Effects: the forge baseline is committed with structural expectations and a token envelope.
+
+### Temp repository lifecycle
+
+1. `created` -> `copied`
+   - Trigger: the runner copies the source fixture into a temp directory.
+   - Effects: scenario writes are isolated from the source fixture.
+
+2. `copied` -> `git_initialized`
+   - Trigger: git initialization runs.
+   - Effects: `.git/` exists only in the temp copy, a deterministic non-default branch is selected, and a baseline commit is created.
+
+3. `git_initialized` -> `post_init_clean`
+   - Trigger: `smithy init` writes deployed artifacts and the runner commits them.
+   - Effects: forge starts from a clean worktree.
+
+4. `post_init_clean` -> `removed`
+   - Trigger: runner cleanup after completion or failure.
+   - Effects: temp files and git metadata are deleted.
+
+## Identity & Uniqueness
+
+- The scenario is uniquely identified by `name: forge-tdd-slice`.
+- The baseline is uniquely identified by `scenario_name: forge-tdd-slice`.
+- The temp git repository is unique per scenario run by temp path.
+- Helper evidence checks are identified by expected helper agent name plus evidence pattern.

--- a/specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/smithy-forge-end-to-end-eval-scenario-runner-git-init.data-model.md
+++ b/specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/smithy-forge-end-to-end-eval-scenario-runner-git-init.data-model.md
@@ -35,7 +35,7 @@ Purpose: Declares that a scenario needs git operations in its execution temp cop
 
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
-| `requires_git` | boolean | No | Defaults to false when absent unless the runner intentionally preserves always-on git initialization as an implementation detail. |
+| `requires_git` | boolean | No | Defaults to false when absent; an omitted flag MUST NOT receive git setup (see FR-008/SC-004). |
 
 Validation rules:
 

--- a/specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/smithy-forge-end-to-end-eval-scenario-runner-git-init.spec.md
+++ b/specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/smithy-forge-end-to-end-eval-scenario-runner-git-init.spec.md
@@ -1,0 +1,196 @@
+# Feature Specification: smithy.forge End-to-End Eval Scenario + Runner git-init
+
+**Spec Folder**: `2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init`
+**Branch**: `2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init`
+**Created**: 2026-06-05
+**Status**: Draft
+**Input**: `docs/rfcs/2026-001-token-savings/token-savings.rfc.md` - Milestone 1 measurement-foundation feature for deterministic smithy.forge end-to-end eval coverage and temp-copy git initialization.
+**Source Feature Map**: `docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md` - Feature 1.5: smithy.forge End-to-End Eval Scenario + Runner git-init (RFC SD-002)
+
+## Clarifications
+
+### Session 2026-06-05
+
+- This specification targets the Dependency Order row `F4`, which corresponds to Feature 1.5 in the measurement-foundation feature map. `[Critical Assumption]`
+- The scenario targets the existing JavaScript fixture. The JVM fixture and JVM forge scenario are owned by F1.6 and F1.7.
+- Feature 1.3a is the prerequisite token-baseline substrate; this feature consumes its token-aware baseline schema instead of redefining token extraction or comparison.
+- The runner git initialization must make the temp fixture copy a working repository with a HEAD commit before forge starts. This closes RFC SD-002 for forge-shaped scenarios.
+- The current runner already initializes every temp copy as a git repository for planning-command evals. This feature tightens that into an explicit `requires_git: true` contract so git setup is requested by scenario metadata instead of by runner-wide assumption.
+- The forge scenario must be deterministic, offline, and path-stable. It must not rely on live GitHub operations, a developer's global git identity, or source fixture mutation.
+
+## Artifact Hierarchy
+
+RFC -> Milestone -> Feature -> User Story -> Slice -> Tasks
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1: Declare Forge Scenarios That Require Git (Priority: P1)
+
+As a Smithy maintainer, I want forge eval scenarios to declare that they need a git-backed temp copy so that runner behavior is explicit instead of inferred from command failure.
+
+**Why this priority**: smithy.forge performs branch and commit operations. The scenario cannot be stable until the runner knows the temp copy must be a real git repository.
+
+**Independent Test**: Load a forge scenario YAML with `requires_git: true` and verify the scenario loader preserves the flag without affecting scenarios that omit it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scenario YAML includes `requires_git: true`, **When** `loadScenarios` parses it, **Then** the loaded scenario exposes the git requirement to the runner.
+2. **Given** existing scenarios omit `requires_git`, **When** they are loaded, **Then** they remain valid and keep their current non-git behavior.
+3. **Given** a malformed `requires_git` value is present, **When** scenario loading validates the YAML, **Then** the scenario is rejected or skipped with a field-specific validation error.
+
+---
+
+### User Story 2: Initialize the Temp Fixture Copy for Forge (Priority: P1)
+
+As a Smithy contributor, I want the eval runner to initialize the scenario temp copy as a clean git repository before forge starts so that forge can run its normal branch and commit workflow.
+
+**Why this priority**: Without a git repository and baseline commit, forge fails before any meaningful eval output can be captured, leaving M2 without a forge baseline.
+
+**Independent Test**: Run a `requires_git` scenario through the runner and verify the spawned agent sees a git worktree with a clean HEAD commit and repo-local identity.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scenario requires git, **When** the runner copies the fixture into a temp directory, **Then** it initializes a git repository before spawning the agent.
+2. **Given** the temp repository is initialized, **When** forge starts, **Then** `git status`, `git checkout -b`, and `git commit` can run without requiring the developer's global git config.
+3. **Given** Smithy skills are deployed into the temp copy before execution, **When** the agent is spawned, **Then** the temp repository has a clean post-init baseline commit so forge starts from a deterministic working tree.
+4. **Given** the temp repository is prepared for forge, **When** the baseline commit is created, **Then** it sits on a deterministic non-default working branch so forge's branch-creation behavior is exercised from the same starting state each run.
+5. **Given** a scenario does not require git, **When** the runner executes it, **Then** the runner does not perform git setup for that scenario and existing source-fixture checksum and cleanup behavior remains unchanged.
+
+---
+
+### User Story 3: Run smithy.forge Against the JavaScript Fixture (Priority: P1)
+
+As a Smithy maintainer, I want a committed forge eval scenario against the existing JavaScript fixture so that forge changes have end-to-end structural and token coverage.
+
+**Why this priority**: M2's forge cost reductions need a measured baseline for the high-frequency forge workflow before any prompt or orchestration optimization lands.
+
+**Independent Test**: Run only the forge scenario against the JavaScript fixture and verify it completes the slice workflow, produces a forge-shaped terminal summary, and leaves the source fixture unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** the forge scenario is loaded, **When** the runner invokes it against the JavaScript fixture, **Then** it exercises `/smithy.forge` on a deterministic single-slice task file.
+2. **Given** forge completes successfully, **When** structural validation runs, **Then** the output includes stable slice-completion, validation, and PR-delivery markers.
+3. **Given** the source fixture checksum is recorded before execution, **When** forge modifies files inside the temp copy, **Then** the source fixture checksum remains unchanged after the scenario.
+4. **Given** GitHub credentials are absent, **When** the forge scenario runs, **Then** it can still complete to the documented PR-created or PR-creation-failed terminal path without live network requirements.
+
+---
+
+### User Story 4: Validate Forge Sub-Agent Evidence (Priority: P1)
+
+As a Smithy maintainer, I want the forge eval to verify the expected implementation and review helper path so that token numbers stay paired with a quality signal.
+
+**Why this priority**: A lower token count is not useful if forge stops dispatching the work needed to implement and review the slice.
+
+**Independent Test**: Run the forge scenario and verify sub-agent evidence checks pass for the helper agents actually required by the current forge workflow.
+
+**Acceptance Scenarios**:
+
+1. **Given** forge dispatches the implementation helper for a task, **When** sub-agent evidence validation runs, **Then** the report records passing evidence for `smithy-implement`.
+2. **Given** forge dispatches implementation review for the slice, **When** sub-agent evidence validation runs, **Then** the report records passing evidence for `smithy-implementation-review`.
+3. **Given** forge wording changes while preserving helper behavior, **When** validation runs, **Then** evidence patterns rely on stable dispatch descriptions or template markers rather than full-output snapshots.
+
+---
+
+### User Story 5: Commit the smithy.forge Token-Aware Baseline (Priority: P1)
+
+As a Smithy maintainer, I want a committed forge baseline in the token-aware schema so that downstream forge optimization work can compare prompt changes against a known cost envelope.
+
+**Why this priority**: M2's per-task reread, inline helper, and review-skip work all depend on a committed forge baseline from M1.
+
+**Independent Test**: Run the forge scenario after F1.3a lands, refresh its baseline, and verify a subsequent eval run reports structural and token baseline checks.
+
+**Acceptance Scenarios**:
+
+1. **Given** the forge scenario has completed successfully, **When** its baseline is refreshed, **Then** the committed baseline records structural expectations and the token envelope for the scenario.
+2. **Given** the committed forge baseline exists, **When** the scenario runs again within the token envelope, **Then** the eval report shows a passing baseline marker for the case.
+3. **Given** a later forge prompt change materially increases tokens or breaks structure, **When** the scenario is compared to the baseline, **Then** the baseline checks expose the drift in the report.
+
+### Edge Cases
+
+- Git initialization must not read, write, or depend on the developer's global or system git config.
+- Git hooks must not run inside eval temp copies.
+- The temp copy may already contain files ignored by checksum logic; `.git/` must not cause source-fixture checksum drift.
+- Forge can create commits and branches only inside the temp copy; source fixture content and repository metadata remain untouched.
+- PR creation may fail in offline or unauthenticated environments; the scenario should accept the existing one-shot failure path when artifacts are left on disk.
+- If F1.3a's token-aware baseline schema changes during implementation, this feature consumes the landed schema and does not introduce a competing baseline shape.
+
+## Dependency Order
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| US1 | Declare Forge Scenarios That Require Git | - | - |
+| US2 | Initialize the Temp Fixture Copy for Forge | US1 | - |
+| US3 | Run smithy.forge Against the JavaScript Fixture | US2 | - |
+| US4 | Validate Forge Sub-Agent Evidence | US3 | - |
+| US5 | Commit the smithy.forge Token-Aware Baseline | US3, US4 | - |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The scenario schema MUST support an optional `requires_git` boolean.
+- **FR-002**: Existing scenarios that omit `requires_git` MUST continue to load and run.
+- **FR-003**: Malformed `requires_git` values MUST produce a clear scenario-validation error.
+- **FR-004**: The forge scenario MUST declare `requires_git: true`.
+- **FR-005**: The runner MUST ensure the execution temp copy is a git repository with a HEAD commit before spawning a scenario that requires git.
+- **FR-006**: The runner MUST use repo-local git identity and hook-neutralizing configuration for temp-copy commits.
+- **FR-007**: The runner MUST keep source-fixture checksum validation and temp-directory cleanup intact when git initialization is enabled.
+- **FR-008**: Git initialization MUST be gated by the scenario's `requires_git` flag; scenarios that omit the flag MUST NOT receive git setup merely because they are loaded by the same runner.
+- **FR-009**: The temp repository baseline commit MUST be created on a deterministic non-default working branch before forge is spawned.
+- **FR-010**: The forge scenario MUST use the existing JavaScript fixture and a deterministic single-slice task input.
+- **FR-011**: The forge scenario MUST be runnable without live GitHub credentials or network access.
+- **FR-012**: Structural expectations MUST validate stable forge completion, validation, and PR-delivery markers.
+- **FR-013**: Sub-agent evidence MUST validate `smithy-implement` and `smithy-implementation-review` for the observed forge path.
+- **FR-014**: The system MUST commit a token-aware baseline for the forge scenario after the F1.3a baseline schema is available.
+- **FR-015**: The committed baseline MUST preserve structural expectations and include a token envelope compatible with the F1.3a schema.
+- **FR-016**: Unit tests MUST cover scenario loading for `requires_git`, malformed flag rejection, gated git initialization, non-default branch setup, clean post-init worktree behavior, source-fixture immutability, forge scenario loading, structural checks, sub-agent evidence checks, and baseline loading.
+
+### Key Entities
+
+- **Forge Eval Scenario**: The scenario definition that invokes smithy.forge against the JavaScript fixture.
+- **Git Requirement Flag**: The optional scenario metadata that tells the runner the temp copy must support git operations.
+- **Temp Git Repository**: The per-scenario copied fixture after git initialization and baseline commits.
+- **Forge Task Input**: The deterministic single-slice task file consumed by smithy.forge.
+- **Forge Baseline**: The committed token-aware baseline for the forge scenario.
+- **Forge Helper Evidence Check**: The sub-agent evidence assertion proving the implementation and review helper path still ran.
+
+## Assumptions
+
+- Feature 1.3a lands before the forge baseline is committed, so this feature can consume the established token-envelope schema.
+- The existing JavaScript fixture is sufficient for the first forge baseline; JVM coverage is deliberately deferred to F1.6/F1.7.
+- The current runner's temp-copy git initialization can be reused after it is reconciled with this feature's explicit `requires_git` gating contract.
+- The forge scenario should assert terminal behavior and helper evidence, not a brittle exact diff shape.
+- Offline PR creation failure is acceptable only when the standard terminal output makes the artifact location and failure reason visible.
+
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | The current runner initializes every temp copy as a git repository to support planning-command evals. This feature introduces an explicit `requires_git` scenario contract. Implementers must move forge and any other git-dependent scenarios onto the flag without regressing existing planning-command evals, and must document which existing scenarios require the flag. | Integration Points | Medium | High | open | - |
+| SD-002 | The exact single-slice forge task input path is finalized at implementation time. It should reuse the existing JavaScript fixture and avoid planting unrelated language fixtures or multi-slice stories. | Scope Within Milestone | Medium | Medium | open | - |
+| SD-003 | The initial token envelope for the forge baseline cannot be calibrated until F1.3a's token-aware baseline schema is available and the scenario has a clean captured run. Implementers should choose a conservative initial envelope and document the captured totals in the implementation PR. | Non-Functional Quality | Medium | Medium | open | - |
+
+## Out of Scope
+
+- JVM fixture creation or JVM forge scenario coverage.
+- Editing F1.6's future `fixture:` scenario-selection mechanism.
+- Any per-task spec reread reduction, inline helper change, or review-skip heuristic.
+- Any edit to `smithy.implement.prompt`, `smithy.implementation-review.prompt`, or `smithy.forge.prompt` for cost reduction.
+- New scenarios for smithy.fix, planning commands, or additional languages.
+- Per-sub-agent token attribution or per-agent token baselines.
+- Refreshing `.claude/` or `.smithy/` deployed snapshots.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A committed `smithy.forge` eval scenario runs against the JavaScript fixture in a git-backed temp copy.
+- **SC-002**: The runner provides a clean temp git repository without relying on global git identity or hooks.
+- **SC-003**: The source fixture checksum remains unchanged after forge modifies the temp copy.
+- **SC-004**: Scenarios without `requires_git` continue to run without runner git setup.
+- **SC-005**: The eval report includes structural pass/fail checks for forge completion, validation, and PR-delivery markers.
+- **SC-006**: The eval report includes sub-agent evidence checks for `smithy-implement` and `smithy-implementation-review`.
+- **SC-007**: A token-aware `forge-tdd-slice` baseline is committed and passes against a clean scenario run.
+- **SC-008**: Unit tests cover the scenario loader, runner git behavior, offline scenario behavior, validation checks, and baseline compatibility paths.

--- a/specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/smithy-forge-end-to-end-eval-scenario-runner-git-init.spec.md
+++ b/specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/smithy-forge-end-to-end-eval-scenario-runner-git-init.spec.md
@@ -120,11 +120,11 @@ Recommended implementation sequence:
 
 | ID | Title | Depends On | Artifact |
 |----|-------|------------|----------|
-| US1 | Declare Forge Scenarios That Require Git | - | - |
-| US2 | Initialize the Temp Fixture Copy for Forge | US1 | - |
-| US3 | Run smithy.forge Against the JavaScript Fixture | US2 | - |
-| US4 | Validate Forge Sub-Agent Evidence | US3 | - |
-| US5 | Commit the smithy.forge Token-Aware Baseline | US3, US4 | - |
+| US1 | Declare Forge Scenarios That Require Git | — | — |
+| US2 | Initialize the Temp Fixture Copy for Forge | US1 | — |
+| US3 | Run smithy.forge Against the JavaScript Fixture | US2 | — |
+| US4 | Validate Forge Sub-Agent Evidence | US3 | — |
+| US5 | Commit the smithy.forge Token-Aware Baseline | US3, US4 | — |
 
 ## Requirements *(mandatory)*
 

--- a/specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/smithy-forge-end-to-end-eval-scenario-runner-git-init.spec.md
+++ b/specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/smithy-forge-end-to-end-eval-scenario-runner-git-init.spec.md
@@ -15,7 +15,7 @@
 - The scenario targets the existing JavaScript fixture. The JVM fixture and JVM forge scenario are owned by F1.6 and F1.7.
 - Feature 1.3a is the prerequisite token-baseline substrate; this feature consumes its token-aware baseline schema instead of redefining token extraction or comparison.
 - The runner git initialization must make the temp fixture copy a working repository with a HEAD commit before forge starts. This closes RFC SD-002 for forge-shaped scenarios.
-- The current runner already initializes every temp copy as a git repository for planning-command evals. This feature tightens that into an explicit `requires_git: true` contract so git setup is requested by scenario metadata instead of by runner-wide assumption.
+- The current runner already initializes every temp copy as a git repository unconditionally for all scenarios (the planning commands are simply the ones that rely on it today). This feature tightens that into an explicit `requires_git: true` contract so git setup is requested by scenario metadata instead of by runner-wide assumption.
 - The forge scenario must be deterministic, offline, and path-stable. It must not rely on live GitHub operations, a developer's global git identity, or source fixture mutation.
 
 ## Artifact Hierarchy
@@ -168,9 +168,9 @@ Recommended implementation sequence:
 
 | ID | Description | Source Category | Impact | Confidence | Status | Resolution |
 |----|-------------|-----------------|--------|------------|--------|------------|
-| SD-001 | The current runner initializes every temp copy as a git repository to support planning-command evals. This feature introduces an explicit `requires_git` scenario contract. Implementers must move forge and any other git-dependent scenarios onto the flag without regressing existing planning-command evals, and must document which existing scenarios require the flag. | Integration Points | Medium | High | open | - |
-| SD-002 | The exact single-slice forge task input path is finalized at implementation time. It should reuse the existing JavaScript fixture and avoid planting unrelated language fixtures or multi-slice stories. | Scope Within Milestone | Medium | Medium | open | - |
-| SD-003 | The initial token envelope for the forge baseline cannot be calibrated until F1.3a's token-aware baseline schema is available and the scenario has a clean captured run. Implementers should choose a conservative initial envelope and document the captured totals in the implementation PR. | Non-Functional Quality | Medium | Medium | open | - |
+| SD-001 | The current runner initializes every temp copy as a git repository to support planning-command evals. This feature introduces an explicit `requires_git` scenario contract. Implementers must move forge and any other git-dependent scenarios onto the flag without regressing existing planning-command evals, and must document which existing scenarios require the flag. | Integration Points | Medium | High | open | — |
+| SD-002 | The exact single-slice forge task input path is finalized at implementation time. It should reuse the existing JavaScript fixture and avoid planting unrelated language fixtures or multi-slice stories. | Scope Within Milestone | Medium | Medium | open | — |
+| SD-003 | The initial token envelope for the forge baseline cannot be calibrated until F1.3a's token-aware baseline schema is available and the scenario has a clean captured run. Implementers should choose a conservative initial envelope and document the captured totals in the implementation PR. | Non-Functional Quality | Medium | Medium | open | — |
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

`smithy.mark` step for **Feature 1.5 (F4)** of the token-savings RFC
measurement-foundation feature map
(`docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md`, arg `4`).

Specifies a deterministic, offline **smithy.forge end-to-end eval scenario**
plus an explicit **`requires_git` runner contract** that initializes the temp
fixture copy as a clean git repository before forge starts (closes RFC SD-002
for forge-shaped scenarios).

## Changes

- New spec folder `specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/`:
  - `*.spec.md` — 5 user stories (US1–US5), FR-001…FR-016, success criteria, 3 spec-debt items.
  - `*.data-model.md` — scenario / git-flag / temp-repo / task-input / helper-evidence / baseline entities + lifecycles.
  - `*.contracts.md` — `requires_git` declaration, temp-copy git init, forge scenario definition, forge baseline contract.
- Links the spec folder in the **F4 Dependency Order** row of the feature map
  (Artifact column `—` → spec folder path).

## Completion signal

This is a `smithy.mark` (feature-spec) step, not an implementation step. There is
no `tasks.md` at the feature-map level — per the repo's artifact rules the
**Artifact column** in the Dependency Order table replaces the legacy checkbox as
the started/not-started signal. The F4 row's Artifact column is flipped in this
patch, which is the loop's durable "this slice is done" signal. `grep` confirms
the feature map contains no checkbox-style rows.

## Verification

Markdown-only spec artifacts. Verified: the three mark artifacts exist and are
internally consistent; the F4 spec-folder name matches the linked Artifact path
exactly; arg `4` → row `F4` → "Feature 1.5" mapping is correct; Dependency Order
tables are well-formed; working tree contains only the 4 intended files.

No code, build, or test surface is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
