### PR TITLE
Voice: audience tags on artifact templates; tighten data-model/contracts to Reference

### DIFF
--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1351,6 +1351,192 @@ describe('getComposedTemplates', () => {
     expect(strike).not.toContain('{{>');
   });
 
+  // Issue #422: every `##` heading inside the artifact code-fence template
+  // of each artifact-producing command must carry an `<!-- audience: ... -->`
+  // comment immediately below it. The tag grammar lives in
+  // `smithy.helper-voice` (#420) and the convention is documented in
+  // `src/templates/agent-skills/README.md`. These assertions back-stop the
+  // contract so a regression that drops a tag or breaks the grammar is
+  // caught at test time rather than at audit time.
+
+  // Helper: extract a specific ```markdown ... ``` fence from a composed
+  // command template by an anchor substring that uniquely identifies the
+  // canonical artifact-template fence (e.g., `# Strike: <Title>`). Each
+  // composed prompt contains multiple markdown fences (write-back examples,
+  // PRD header snippets, indented inner fences inside the one-shot-output
+  // snippet, etc.); a regex-based scan would miscount nested fences, so we
+  // walk line-by-line and track fence depth instead. The anchor pins us
+  // to the single fence that defines the artifact's section structure.
+  function extractFenceByAnchor(template: string, anchor: string): string {
+    const lines = template.split('\n');
+    const fences: string[] = [];
+    let inFence = false;
+    let fenceLines: string[] = [];
+    for (const line of lines) {
+      const trimmed = line.trimStart();
+      if (!inFence && trimmed.startsWith('```markdown')) {
+        inFence = true;
+        fenceLines = [];
+        continue;
+      }
+      if (inFence && trimmed.startsWith('```')) {
+        fences.push(fenceLines.join('\n'));
+        inFence = false;
+        continue;
+      }
+      if (inFence) {
+        fenceLines.push(line);
+      }
+    }
+    const match = fences.find(b => b.includes(anchor));
+    expect(match, `no markdown fence contains anchor "${anchor}"`).toBeDefined();
+    return match!;
+  }
+
+  // Helper: return the list of `## Heading` titles inside a markdown fence
+  // string. We ignore `###` and deeper because the voice tag convention
+  // attaches to top-level `##` sections only.
+  function h2Headings(fence: string): string[] {
+    const matches = [...fence.matchAll(/^## ([^\n]+)$/gm)];
+    return matches.map(m => m[1]!.trim());
+  }
+
+  // Helper: assert that each `## Heading` inside a fence is immediately
+  // followed (after at most a blank line) by an audience-tag HTML comment
+  // matching the issue #422 grammar.
+  function expectAudienceTagPerH2(fence: string, label: string) {
+    // Matches: `## <title>\n\n<!-- audience: <role>[+ai-input]; mode: <mode>; ... -->`
+    // We allow zero or one blank lines between the heading and the tag.
+    const headingsWithTag = [...fence.matchAll(
+      /^## ([^\n]+)\n(?:\n)?<!--\s*audience:\s*(stakeholder|reviewer|builder)(\+ai-input)?\s*;\s*mode:\s*(explanation|reference|how-to|tutorial)\s*;[^\n]*-->/gm
+    )];
+    const tagged = new Set(headingsWithTag.map(m => m[1]!.trim()));
+    const all = h2Headings(fence);
+    const missing = all.filter(h => !tagged.has(h));
+    expect(missing, `${label}: ## headings missing audience tag: ${missing.join(', ')}`).toEqual([]);
+  }
+
+  it('strike artifact template tags every ## section with an audience comment (issue #422)', () => {
+    const strike = composed.commands.get('smithy.strike.md')!;
+    const fence = extractFenceByAnchor(strike, '# Strike: <Title>');
+    expectAudienceTagPerH2(fence, 'smithy.strike');
+    // Spot-check section→role mapping called out in the issue.
+    expect(fence).toMatch(/## Summary\n+<!-- audience: stakeholder; mode: explanation;/);
+    expect(fence).toMatch(/## Data Model\n+<!-- audience: builder; mode: reference;[^>]*applicability: code-shaped features only/);
+    expect(fence).toMatch(/## Contracts\n+<!-- audience: builder; mode: reference;[^>]*applicability: code-shaped features only/);
+    // Issue #422: tasks slice bodies use examples: forbidden.
+    expect(fence).toMatch(/## Single Slice\n+<!-- audience: builder; mode: how-to;[^>]*examples: forbidden/);
+  });
+
+  it('spark PRD template tags every ## section with an audience comment (issue #422)', () => {
+    const spark = composed.commands.get('smithy.spark.md')!;
+    // Anchor on the PRD template reference fence — not the header-only
+    // fence used by the Phase 3 PRD File Creation step.
+    const fence = extractFenceByAnchor(spark, '## Problem Statement');
+    expectAudienceTagPerH2(fence, 'smithy.spark');
+    expect(fence).toMatch(/## Problem Statement\n+<!-- audience: stakeholder; mode: explanation;/);
+    expect(fence).toMatch(/## Alternatives \/ Build-vs-Buy\n+<!-- audience: reviewer; mode: explanation;[^>]*examples: recommended/);
+  });
+
+  it('ignite RFC template tags every ## section with an audience comment (issue #422)', () => {
+    const ignite = composed.commands.get('smithy.ignite.md')!;
+    const fence = extractFenceByAnchor(ignite, '## Motivation / Problem Statement');
+    expectAudienceTagPerH2(fence, 'smithy.ignite');
+    // Issue #422 mapping: RFC Proposal → diagram: recommended; examples: recommended.
+    expect(fence).toMatch(/## Proposal\n+<!-- audience: reviewer; mode: explanation;[^>]*diagram: recommended;[^>]*examples: recommended/);
+    // Dependency Order is the LLM-consumed graph table.
+    expect(fence).toMatch(/## Dependency Order\n+<!-- audience: builder\+ai-input; mode: reference;/);
+  });
+
+  it('render feature-map template tags every ## section with an audience comment (issue #422)', () => {
+    const render = composed.commands.get('smithy.render.md')!;
+    const fence = extractFenceByAnchor(render, '# Feature Map: <Milestone Title>');
+    expectAudienceTagPerH2(fence, 'smithy.render');
+    // Issue #422 mapping: Cross-Milestone Deps → diagram: recommended.
+    expect(fence).toMatch(/## Cross-Milestone Dependencies\n+<!-- audience: reviewer; mode: reference;[^>]*diagram: recommended/);
+  });
+
+  it('mark spec template tags every ## section with an audience comment (issue #422)', () => {
+    const mark = composed.commands.get('smithy.mark.md')!;
+    const fence = extractFenceByAnchor(mark, '# Feature Specification: <Title>');
+    expectAudienceTagPerH2(fence, 'smithy.mark spec');
+    // Issue #422 mapping: Spec Acceptance Scenarios → examples: optional.
+    expect(fence).toMatch(/## User Scenarios & Testing[^\n]*\n+<!-- audience: builder\+ai-input; mode: reference;[^>]*examples: optional/);
+    expect(fence).toMatch(/## Requirements[^\n]*\n+<!-- audience: builder\+ai-input; mode: reference;[^>]*examples: recommended/);
+  });
+
+  it('mark data-model template is Reference-voice with applicability and N/A fallback (issue #422)', () => {
+    const mark = composed.commands.get('smithy.mark.md')!;
+    // Scope to Phase 4 so we are measuring the data-model template fences,
+    // not the spec fence.
+    const phase4Idx = mark.indexOf('## Phase 4: Model');
+    expect(phase4Idx).toBeGreaterThan(-1);
+    const phase5Idx = mark.indexOf('## Phase 5: Contract', phase4Idx);
+    expect(phase5Idx).toBeGreaterThan(phase4Idx);
+    const phase4 = mark.slice(phase4Idx, phase5Idx);
+
+    // Applicability directive applied at the file top of the rendered
+    // data-model.md template.
+    expect(phase4).toMatch(/# Data Model: <Title>\n<!-- applicability: code-shaped features only -->/);
+    // Section-level voice tags applied to every ## section, all carrying
+    // the same applicability constraint.
+    expect(phase4).toMatch(/## Entities\n<!-- audience: builder; mode: reference;[^>]*applicability: code-shaped features only/);
+    expect(phase4).toMatch(/## Relationships\n<!-- audience: builder; mode: reference;[^>]*applicability: code-shaped features only/);
+    expect(phase4).toMatch(/## State Transitions\n<!-- audience: builder; mode: reference;[^>]*applicability: code-shaped features only/);
+    expect(phase4).toMatch(/## Identity & Uniqueness\n<!-- audience: builder; mode: reference;[^>]*applicability: code-shaped features only/);
+    // Issue #422 directive mapping for Data Model Entities.
+    expect(phase4).toMatch(/## Entities\n<!-- audience: builder; mode: reference;[^>]*diagram: required;[^>]*examples: recommended/);
+    // N/A fallback documented in the template itself, not just in prose.
+    expect(phase4).toMatch(/N\/A — <one-sentence reason this feature has no code-shaped data changes/);
+    // The dense-prose `## Overview` heading that emitted Explanation prose
+    // is gone.
+    expect(phase4).not.toMatch(/```markdown[\s\S]*?## Overview[\s\S]*?```/);
+    // Non-overlap with .contracts.md is stated in the prompt text itself so
+    // the drafting agent has the rule visible without consulting the skill.
+    expect(phase4).toMatch(/entities,\s*schema,\s*validation,\s*lifecycle,\s*and state transitions/i);
+  });
+
+  it('mark contracts template is Reference-voice with applicability and N/A fallback (issue #422)', () => {
+    const mark = composed.commands.get('smithy.mark.md')!;
+    // Scope to Phase 5 — Phase 0/Phase 6/Phase 0c also touch contracts in
+    // prose, but we are measuring the contracts.md template fences here.
+    const phase5Idx = mark.indexOf('## Phase 5: Contract');
+    expect(phase5Idx).toBeGreaterThan(-1);
+    const phase6Idx = mark.indexOf('## Phase 6:', phase5Idx);
+    expect(phase6Idx).toBeGreaterThan(phase5Idx);
+    const phase5 = mark.slice(phase5Idx, phase6Idx);
+
+    expect(phase5).toMatch(/# Contracts: <Title>\n<!-- applicability: code-shaped features only -->/);
+    // Issue #422 directive mapping for Contracts Interfaces.
+    expect(phase5).toMatch(/## Interfaces\n<!-- audience: builder; mode: reference;[^>]*examples: required;[^>]*applicability: code-shaped features only/);
+    expect(phase5).toMatch(/## Events \/ Hooks\n<!-- audience: builder; mode: reference;[^>]*examples: required;[^>]*applicability: code-shaped features only/);
+    expect(phase5).toMatch(/## Integration Boundaries\n<!-- audience: builder; mode: reference;[^>]*examples: required;[^>]*applicability: code-shaped features only/);
+    // N/A fallback documented in the template itself.
+    expect(phase5).toMatch(/N\/A — <one-sentence reason this feature has no code-shaped interface changes/);
+    // The dense-prose `## Overview` heading that emitted Explanation prose
+    // is gone.
+    expect(phase5).not.toMatch(/```markdown[\s\S]*?## Overview[\s\S]*?```/);
+    // Non-overlap with .data-model.md is stated in the prompt text itself.
+    expect(phase5).toMatch(/interfaces,\s*signatures,\s*integration boundaries,\s*and event\/hook surfaces/i);
+  });
+
+  it('cut tasks template tags every ## section and forbids examples in slice bodies (issue #422)', () => {
+    const cut = composed.commands.get('smithy.cut.md')!;
+    const fence = extractFenceByAnchor(cut, '# Tasks: <User Story Title>');
+    expectAudienceTagPerH2(fence, 'smithy.cut');
+    // Issue #422 mapping: Tasks slice bodies → examples: forbidden.
+    // Slice 1 and Slice 2 must both carry the forbidden directive.
+    const sliceTags = [...fence.matchAll(/## Slice \d+: [^\n]+\n<!-- ([^\n]+) -->/g)].map(m => m[1]!);
+    expect(sliceTags.length).toBeGreaterThanOrEqual(2);
+    for (const tag of sliceTags) {
+      expect(tag).toMatch(/audience: builder/);
+      expect(tag).toMatch(/mode: how-to/);
+      expect(tag).toMatch(/examples: forbidden/);
+    }
+    // Issue #422 mapping: Tasks Dependency Order → diagram: recommended.
+    expect(fence).toMatch(/## Dependency Order\n<!-- audience: builder\+ai-input; mode: reference;[^>]*diagram: recommended/);
+  });
+
   it('prompt templates are included without modification', () => {
     const titles = composed.prompts.get('smithy.titles.md')!;
     expect(titles).toBeDefined();

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1361,12 +1361,17 @@ describe('getComposedTemplates', () => {
 
   // Helper: extract a specific ```markdown ... ``` fence from a composed
   // command template by an anchor substring that uniquely identifies the
-  // canonical artifact-template fence (e.g., `# Strike: <Title>`). Each
-  // composed prompt contains multiple markdown fences (write-back examples,
-  // PRD header snippets, indented inner fences inside the one-shot-output
-  // snippet, etc.); a regex-based scan would miscount nested fences, so we
-  // walk line-by-line and track fence depth instead. The anchor pins us
-  // to the single fence that defines the artifact's section structure.
+  // canonical artifact-template fence (e.g., `# Strike: <Title>`). The
+  // anchor is the artifact's H1 (e.g., `# Feature Map: <Milestone Title>`),
+  // which only appears inside the template fence — not in surrounding
+  // prose, where prompts use code-quoted forms like
+  // `` `## Problem Statement` `` instead.
+  //
+  // The implementation walks line-by-line tracking fence depth, then picks
+  // the fence whose body contains the anchor. This handles composed
+  // snippets (like `one-shot-output`) that bring additional indented
+  // ` ```markdown ` / ` ``` ` blocks into the template downstream of the
+  // artifact fence.
   function extractFenceByAnchor(template: string, anchor: string): string {
     const lines = template.split('\n');
     const fences: string[] = [];
@@ -1389,8 +1394,20 @@ describe('getComposedTemplates', () => {
       }
     }
     const match = fences.find(b => b.includes(anchor));
-    expect(match, `no markdown fence contains anchor "${anchor}"`).toBeDefined();
-    return match!;
+    if (!match) {
+      // Surface a diagnostic the next reader (or CI) can act on rather than
+      // hiding behind a bare assertion failure.
+      const firstLines = fences.map((b, i) =>
+        `  [${i}] (${b.length} chars) first line: ${b.split('\n')[0]?.slice(0, 80) ?? '(empty)'}`,
+      ).join('\n');
+      const containsAnchorAtAll = template.includes(anchor);
+      throw new Error(
+        `no markdown fence contains anchor "${anchor}"\n` +
+        `  template.includes(anchor) = ${containsAnchorAtAll}\n` +
+        `  fences found: ${fences.length}\n${firstLines}`,
+      );
+    }
+    return match;
   }
 
   // Helper: return the list of `## Heading` titles inside a markdown fence

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1403,10 +1403,20 @@ describe('getComposedTemplates', () => {
         `  [${i}] (${b.length} chars) first line: ${b.split('\n')[0]?.slice(0, 80) ?? '(empty)'}`,
       ).join('\n');
       const containsAnchorAtAll = template.includes(anchor);
+      // Also dump every line whose trimStart() starts with ``` so we can
+      // see what the walker actually had to work with — particularly when
+      // CI sees a different fence layout than a local run.
+      const fenceLines = lines
+        .map((l, i) => [i, l] as const)
+        .filter(([, l]) => l.trimStart().startsWith('```'))
+        .map(([i, l]) => `  line ${i}: ${JSON.stringify(l)}`)
+        .join('\n');
       throw new Error(
         `no markdown fence contains anchor "${anchor}"\n` +
         `  template.includes(anchor) = ${containsAnchorAtAll}\n` +
-        `  fences found: ${fences.length}\n${firstLines}`,
+        `  template length = ${template.length}\n` +
+        `  fences found: ${fences.length}\n${firstLines}\n` +
+        `  all \`\`\` lines:\n${fenceLines}`,
       );
     }
     return match;

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1422,17 +1422,38 @@ describe('getComposedTemplates', () => {
 
   // Helper: assert that each `## Heading` inside a fence is immediately
   // followed (after at most a blank line) by an audience-tag HTML comment
-  // matching the issue #422 grammar.
+  // matching the full issue #422 / #420 grammar. The regex enforces that
+  // every directive key documented by `smithy.helper-voice` is present and
+  // in canonical order: `audience` (enum) → `mode` (enum) → `length`
+  // (free text) → `diagram` (enum) → `examples` (enum), with the optional
+  // `applicability` clause trailing. Values for `length` are free-form so
+  // section authors can write `2-3 sentences`, `tables only`,
+  // `5-15 steps`, `bullets or table`, etc., per the skill's grammar.
   function expectAudienceTagPerH2(fence: string, label: string) {
-    // Matches: `## <title>\n\n<!-- audience: <role>[+ai-input]; mode: <mode>; ... -->`
-    // We allow zero or one blank lines between the heading and the tag.
-    const headingsWithTag = [...fence.matchAll(
-      /^## ([^\n]+)\n(?:\n)?<!--\s*audience:\s*(stakeholder|reviewer|builder)(\+ai-input)?\s*;\s*mode:\s*(explanation|reference|how-to|tutorial)\s*;[^\n]*-->/gm
-    )];
+    const audienceTagRe = new RegExp(
+      String.raw`^## ([^\n]+)\n(?:\n)?<!--\s*` +
+        // audience: stakeholder|reviewer|builder, optional +ai-input
+        String.raw`audience:\s*(?:stakeholder|reviewer|builder)(?:\+ai-input)?\s*;\s*` +
+        // mode: explanation|reference|how-to|tutorial
+        String.raw`mode:\s*(?:explanation|reference|how-to|tutorial)\s*;\s*` +
+        // length: free-form value (everything up to the next ;)
+        String.raw`length:\s*[^;]+;\s*` +
+        // diagram: required|recommended|optional
+        String.raw`diagram:\s*(?:required|recommended|optional)\s*;\s*` +
+        // examples: required|recommended|discouraged|forbidden|optional
+        // (`optional` is used by sections like Spec Acceptance Scenarios
+        // per the issue #422 directive mapping, beyond the four values
+        // listed in the helper-voice grammar table)
+        String.raw`examples:\s*(?:required|recommended|discouraged|forbidden|optional)\s*` +
+        // optional trailing applicability clause
+        String.raw`(?:;\s*applicability:\s*[^>]+)?\s*-->`,
+      'gm',
+    );
+    const headingsWithTag = [...fence.matchAll(audienceTagRe)];
     const tagged = new Set(headingsWithTag.map(m => m[1]!.trim()));
     const all = h2Headings(fence);
     const missing = all.filter(h => !tagged.has(h));
-    expect(missing, `${label}: ## headings missing audience tag: ${missing.join(', ')}`).toEqual([]);
+    expect(missing, `${label}: ## headings missing well-formed audience tag: ${missing.join(', ')}`).toEqual([]);
   }
 
   it('strike artifact template tags every ## section with an audience comment (issue #422)', () => {

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1367,11 +1367,13 @@ describe('getComposedTemplates', () => {
   // prose, where prompts use code-quoted forms like
   // `` `## Problem Statement` `` instead.
   //
-  // The implementation walks line-by-line tracking fence depth, then picks
-  // the fence whose body contains the anchor. This handles composed
-  // snippets (like `one-shot-output`) that bring additional indented
-  // ` ```markdown ` / ` ``` ` blocks into the template downstream of the
-  // artifact fence.
+  // The implementation walks line-by-line toggling an in-fence flag at
+  // every ` ```markdown ` opener and ` ``` ` closer (it does not track
+  // nested-fence depth — composed snippets like `one-shot-output` are
+  // emitted with indented inner fences but each one is paired, so a flat
+  // toggle still produces the right outer-fence boundaries). After
+  // collecting every top-level markdown fence, pick the one whose body
+  // contains the anchor.
   function extractFenceByAnchor(template: string, anchor: string): string {
     const lines = template.split('\n');
     const fences: string[] = [];

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1553,33 +1553,38 @@ describe('getComposedTemplates', () => {
   // prose, where prompts use code-quoted forms like
   // `` `## Problem Statement` `` instead.
   //
-  // The implementation walks line-by-line toggling an in-fence flag at
-  // every ` ```markdown ` opener and ` ``` ` closer (it does not track
-  // nested-fence depth — composed snippets like `one-shot-output` are
-  // emitted with indented inner fences but each one is paired, so a flat
-  // toggle still produces the right outer-fence boundaries). After
-  // collecting every top-level markdown fence, pick the one whose body
-  // contains the anchor.
+  // The implementation follows CommonMark fence matching: an opener uses
+  // **N backticks** (3 or more) followed by `markdown`, and is closed only
+  // by a line of **at least N backticks** with no other content. This
+  // handles fences that wrap content already containing 3-backtick
+  // yaml/bash blocks — e.g., render's artifact template uses a 4-backtick
+  // wrapper because it now embeds 3-backtick `\`\`\`yaml metadata blocks
+  // from the `feature-kinds` snippet. A flat 3-backtick toggle would
+  // mistake those inner blocks for the outer fence's closer.
   function extractFenceByAnchor(template: string, anchor: string): string {
     const lines = template.split('\n');
     const fences: string[] = [];
-    let inFence = false;
+    let openerCount = 0; // 0 == not in fence; >0 == number of opening backticks
     let fenceLines: string[] = [];
+    const fenceOpenerRe = /^(`{3,})markdown\b/;
+    const bareFenceRe = /^(`{3,})\s*$/;
     for (const line of lines) {
       const trimmed = line.trimStart();
-      if (!inFence && trimmed.startsWith('```markdown')) {
-        inFence = true;
-        fenceLines = [];
+      if (openerCount === 0) {
+        const openMatch = trimmed.match(fenceOpenerRe);
+        if (openMatch) {
+          openerCount = openMatch[1]!.length;
+          fenceLines = [];
+        }
         continue;
       }
-      if (inFence && trimmed.startsWith('```')) {
+      const closeMatch = trimmed.match(bareFenceRe);
+      if (closeMatch && closeMatch[1]!.length >= openerCount) {
         fences.push(fenceLines.join('\n'));
-        inFence = false;
+        openerCount = 0;
         continue;
       }
-      if (inFence) {
-        fenceLines.push(line);
-      }
+      fenceLines.push(line);
     }
     const match = fences.find(b => b.includes(anchor));
     if (!match) {
@@ -1589,10 +1594,7 @@ describe('getComposedTemplates', () => {
         `  [${i}] (${b.length} chars) first line: ${b.split('\n')[0]?.slice(0, 80) ?? '(empty)'}`,
       ).join('\n');
       const containsAnchorAtAll = template.includes(anchor);
-      // Also dump every line whose trimStart() starts with ``` so we can
-      // see what the walker actually had to work with — particularly when
-      // CI sees a different fence layout than a local run.
-      const fenceLines = lines
+      const fenceLineDump = lines
         .map((l, i) => [i, l] as const)
         .filter(([, l]) => l.trimStart().startsWith('```'))
         .map(([i, l]) => `  line ${i}: ${JSON.stringify(l)}`)
@@ -1602,7 +1604,7 @@ describe('getComposedTemplates', () => {
         `  template.includes(anchor) = ${containsAnchorAtAll}\n` +
         `  template length = ${template.length}\n` +
         `  fences found: ${fences.length}\n${firstLines}\n` +
-        `  all \`\`\` lines:\n${fenceLines}`,
+        `  all \`\`\` lines:\n${fenceLineDump}`,
       );
     }
     return match;

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -337,6 +337,7 @@ Draft the tasks file with this structure:
 ---
 
 ## Slice 1: <Title>
+<!-- audience: builder; mode: how-to; length: 5-15 steps; diagram: optional; examples: forbidden -->
 
 **Goal**: <What this slice delivers as a standalone working increment.>
 
@@ -360,12 +361,14 @@ Draft the tasks file with this structure:
 ---
 
 ## Slice 2: <Title>
+<!-- audience: builder; mode: how-to; length: 5-15 steps; diagram: optional; examples: forbidden -->
 
 ...
 
 ---
 
 ## Specification Debt
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 | ID | Description | Source Category | Impact | Confidence | Status | Resolution |
 |----|-------------|-----------------|--------|------------|--------|------------|
@@ -376,6 +379,7 @@ _If no debt items, write: "None — all ambiguities resolved."_
 ---
 
 ## Dependency Order
+<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: recommended; examples: discouraged -->
 
 Recommended implementation sequence:
 

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -642,46 +642,57 @@ duplicates the debt table in a less structured format.
 **Created**: YYYY-MM-DD  |  **Status**: Draft
 
 ## Summary
+<!-- audience: stakeholder; mode: explanation; length: 2-3 sentences; diagram: optional; examples: discouraged -->
 
 <High-level pitch — what this is and why it matters, in 2-3 sentences.>
 
 ## Motivation / Problem Statement
+<!-- audience: stakeholder; mode: explanation; length: 2-3 paragraphs; diagram: optional; examples: discouraged -->
 
 <What problem does this solve? Why does it need solving now? What is the impact
 of not solving it?>
 
 ## Goals
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 - <Outcome 1 — what this RFC commits to delivering, stated as a result a stakeholder can evaluate. Do NOT reference milestone IDs (M1, M-A, etc.) or the word "milestone"; milestones realize goals, not the reverse.>
 - <Outcome 2>
 - <Outcome 3>
 
 ## Out of Scope
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 - <Capability 1 this RFC will NOT deliver — must be a true exclusion, not deferred work. Bad: "Eval rubrics — deferred to M-F or later". Good: "Production observability — lives in operations-doc territory, not in this RFC.">
 - <Capability 2>
 
 ## Personas
+<!-- audience: stakeholder; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 - <Persona 1 — role and how they benefit from this RFC>
 - <Persona 2 — role and how they benefit>
 
 ## Proposal
+<!-- audience: reviewer; mode: explanation; length: 3-6 paragraphs; diagram: recommended; examples: recommended -->
 
 <The "WHAT" — describe what will be built at a high level. Focus on outcomes
-and capabilities, not implementation details.>
+and capabilities, not implementation details. A block or sequence diagram of
+the proposed architecture beats wall-of-text whenever three or more named
+components or steps are involved.>
 
 ## Design Considerations
+<!-- audience: reviewer; mode: explanation; length: 3-6 paragraphs; diagram: optional; examples: discouraged -->
 
 <High-level architectural thoughts, tradeoffs, and constraints that will
 influence downstream design decisions. Keep this at "WHAT not HOW" level.>
 
 ## Decisions
+<!-- audience: reviewer; mode: explanation; length: 1-3 paragraphs; diagram: optional; examples: discouraged -->
 
 - <Decision 1 — what was decided and the rationale>
 - <Decision 2>
 
 ## Specification Debt
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 | ID | Description | Source Category | Impact | Confidence | Status | Resolution |
 |----|-------------|-----------------|--------|------------|--------|------------|
@@ -690,6 +701,7 @@ influence downstream design decisions. Keep this at "WHAT not HOW" level.>
 _If no debt items, write: "None — all ambiguities resolved."_
 
 ## Milestones
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 ### Milestone 1: <Title>
 
@@ -708,6 +720,7 @@ _If no debt items, write: "None — all ambiguities resolved."_
 - <Measurable outcome 2>
 
 ## Dependency Order
+<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 Recommended implementation sequence:
 

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -228,6 +228,7 @@ invoked inside a linked worktree)*
 **Source Feature Map**: `<path-to-.features.md>` — Feature <N>: <Title> *(include only when input is a `.features.md`)*
 
 ## Clarifications
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 ### Session YYYY-MM-DD
 
@@ -235,10 +236,12 @@ invoked inside a linked worktree)*
 - _Assumption text_
 
 ## Artifact Hierarchy
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 RFC → Milestone → Feature → User Story → Slice → Tasks
 
 ## User Scenarios & Testing *(mandatory)*
+<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: optional; examples: optional -->
 
 ### User Story 1: <Title> (Priority: P<N>)
 
@@ -263,6 +266,7 @@ As a <persona>, I want <goal> so that <benefit>.
 - ...
 
 ## Dependency Order
+<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 Recommended implementation sequence:
 
@@ -273,6 +277,7 @@ Recommended implementation sequence:
 | USN | <Title> | — | — |
 
 ## Requirements *(mandatory)*
+<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: optional; examples: recommended -->
 
 ### Functional Requirements
 
@@ -285,10 +290,12 @@ Recommended implementation sequence:
 - ...
 
 ## Assumptions
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 - ...
 
 ## Specification Debt
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 | ID | Description | Source Category | Impact | Confidence | Status | Resolution |
 |----|-------------|-----------------|--------|------------|--------|------------|
@@ -297,10 +304,12 @@ Recommended implementation sequence:
 _If no debt items, write: "None — all ambiguities resolved."_
 
 ## Out of Scope
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 - ...
 
 ## Success Criteria *(mandatory)*
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 ### Measurable Outcomes
 
@@ -336,20 +345,37 @@ Guidelines for the spec:
 
 Draft the `<slug>.data-model.md` file.
 
+**Reference voice only.** `.data-model.md` is a Builder × Reference artifact: its
+body is tables, schema definitions, validation rules, and state-transition
+matrices — never narrative prose explaining what the entities mean. If a
+section would otherwise be a paragraph of Explanation, either compress it
+into the structured artifact (the table, the schema literal) or drop it.
+
+**Non-overlap with `.contracts.md`.** `.data-model.md` covers **entities,
+schema, validation, lifecycle, and state transitions**. Interfaces,
+signatures, integration boundaries, and event/hook surfaces belong in
+`.contracts.md` instead — do not restate them here. If the same concept
+shows up in both files, the data-model row defines the persisted shape and
+the contracts row defines the call/event surface; they are complementary,
+not duplicative.
+
+**Applicability — code-shaped features only.** `.data-model.md` is
+mandatory only when the feature introduces or modifies persisted entities,
+types, or state. For non-code-shaped features (docs-only changes,
+template/prompt refactors, configuration toggles, process updates), the
+file MUST still exist but its body is a single `N/A` line with a
+one-sentence reason. Do not invent prose entities to fill the section.
+
 If the feature implies data storage, new types, or state management:
 
 ```markdown
 # Data Model: <Title>
-
-## Overview
-
-<One paragraph describing what this model supports.>
+<!-- applicability: code-shaped features only -->
 
 ## Entities
+<!-- audience: builder; mode: reference; length: tables only; diagram: required; examples: recommended; applicability: code-shaped features only -->
 
 ### 1) <Entity Name> (`<storage_name>`)
-
-Purpose: <what this entity represents and why it exists>
 
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
@@ -363,11 +389,13 @@ Validation rules:
 ### 2) ...
 
 ## Relationships
+<!-- audience: builder; mode: reference; length: tables only; diagram: required; examples: recommended; applicability: code-shaped features only -->
 
 - <Entity A> 1:N <Entity B> via `foreign_key`.
 - ...
 
 ## State Transitions
+<!-- audience: builder; mode: reference; length: tables only; diagram: required; examples: recommended; applicability: code-shaped features only -->
 
 ### <Entity/Process> lifecycle
 
@@ -378,17 +406,20 @@ Validation rules:
 2. ...
 
 ## Identity & Uniqueness
+<!-- audience: builder; mode: reference; length: tables only; diagram: optional; examples: recommended; applicability: code-shaped features only -->
 
 - <How entities are uniquely identified and deduplicated.>
 ```
 
-If the feature does NOT involve data changes, write a minimal file:
+If the feature does NOT involve data changes, write a one-line fallback —
+do not invent prose entities, do not pad the file with explanatory
+paragraphs:
 
 ```markdown
 # Data Model: <Title>
+<!-- applicability: code-shaped features only -->
 
-No new data entities, storage changes, or type definitions are required for this feature.
-Existing data structures are sufficient as-is.
+N/A — <one-sentence reason this feature has no code-shaped data changes (e.g., "docs-only change to README", "template refactor with no persisted state", "configuration toggle with no schema impact").>
 ```
 
 ---
@@ -397,16 +428,35 @@ Existing data structures are sufficient as-is.
 
 Draft the `<slug>.contracts.md` file.
 
+**Reference voice only.** `.contracts.md` is a Builder × Reference artifact:
+its body is signatures, input/output tables, and error-condition tables —
+the signatures *are* the deliverable. Never wrap the interfaces in
+narrative paragraphs explaining what they do; the signature itself, plus
+the input/output tables next to it, is the contract.
+
+**Non-overlap with `.data-model.md`.** `.contracts.md` covers **interfaces,
+signatures, integration boundaries, and event/hook surfaces**. Entity
+shapes, validation rules, lifecycles, and state transitions belong in
+`.data-model.md` instead — do not restate them here. The contracts file
+describes the call/event surface; the data-model file describes the
+persisted shape.
+
+**Applicability — code-shaped features only.** `.contracts.md` is
+mandatory only when the feature introduces or modifies an interface, API
+boundary, or integration surface. For non-code-shaped features (docs-only
+changes, template/prompt refactors, configuration toggles, process
+updates), the file MUST still exist but its body is a single `N/A` line
+with a one-sentence reason. Do not invent prose interfaces to fill the
+section.
+
 If the feature involves interfaces, API boundaries, or integration points:
 
 ```markdown
 # Contracts: <Title>
-
-## Overview
-
-<One paragraph describing the integration boundaries this feature touches.>
+<!-- applicability: code-shaped features only -->
 
 ## Interfaces
+<!-- audience: builder; mode: reference; length: tables only; diagram: optional; examples: required; applicability: code-shaped features only -->
 
 ### <Interface/Contract Name>
 
@@ -440,22 +490,28 @@ Use language-appropriate pseudo-signatures — not full implementation code.>
 ### ...
 
 ## Events / Hooks
+<!-- audience: builder; mode: reference; length: tables only; diagram: optional; examples: required; applicability: code-shaped features only -->
 
-<If the feature publishes or subscribes to events, document them here.>
+<If the feature publishes or subscribes to events, document them here as a
+table of event name → trigger → payload shape. No narrative wrappers.>
 
 ## Integration Boundaries
+<!-- audience: builder; mode: reference; length: tables only; diagram: optional; examples: required; applicability: code-shaped features only -->
 
-<Describe where this feature touches external systems, third-party APIs,
-or other internal modules — and what the contract is at each boundary.>
+<List external systems, third-party APIs, or other internal modules this
+feature touches, with the contract at each boundary. Table format
+preferred — boundary | direction | contract | failure mode.>
 ```
 
-If the feature does NOT involve contracts or interfaces, write a minimal file:
+If the feature does NOT involve contracts or interfaces, write a one-line
+fallback — do not invent prose interfaces, do not pad the file with
+explanatory paragraphs:
 
 ```markdown
 # Contracts: <Title>
+<!-- applicability: code-shaped features only -->
 
-No new interfaces, API contracts, or integration boundaries are introduced by this feature.
-Existing contracts remain unchanged.
+N/A — <one-sentence reason this feature has no code-shaped interface changes (e.g., "docs-only change to README", "template refactor with no new API surface", "configuration toggle that reuses existing CLI flag handling").>
 ```
 
 ---

--- a/src/templates/agent-skills/commands/smithy.render.prompt
+++ b/src/templates/agent-skills/commands/smithy.render.prompt
@@ -275,6 +275,7 @@ this format:
 **Created**: YYYY-MM-DD
 
 ## Features
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 ### Feature 1: <Title>
 
@@ -300,6 +301,7 @@ this format:
 
 <!-- Specification Debt appears here for templates without ## Assumptions sections -->
 ## Specification Debt
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 | ID | Description | Source Category | Impact | Confidence | Status | Resolution |
 |----|-------------|-----------------|--------|------------|--------|------------|
@@ -308,6 +310,7 @@ this format:
 _If no debt items, write: "None — all ambiguities resolved."_
 
 ## Dependency Order
+<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 Recommended specification sequence:
 
@@ -317,6 +320,7 @@ Recommended specification sequence:
 | F2 | <Title> | — | — |
 
 ## Cross-Milestone Dependencies
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: recommended; examples: discouraged -->
 
 Direction must be either `depends on` or `depended upon by`.
 

--- a/src/templates/agent-skills/commands/smithy.spark.prompt
+++ b/src/templates/agent-skills/commands/smithy.spark.prompt
@@ -395,25 +395,30 @@ path to trigger another Phase 0 review loop.
 **Created**: YYYY-MM-DD  |  **Status**: Draft
 
 ## Problem Statement
+<!-- audience: stakeholder; mode: explanation; length: 2-3 paragraphs; diagram: optional; examples: discouraged -->
 
 <2–3 paragraphs from smithy-prose. Concrete user pain leading to the outcome
 we want.>
 
 ## Proposed Solution
+<!-- audience: stakeholder; mode: explanation; length: 1-2 paragraphs; diagram: optional; examples: discouraged -->
 
 <1–2 paragraphs, WHAT-not-HOW. The capability the user will observe.>
 
 ## Target Users
+<!-- audience: stakeholder; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 - <Named user or role 1 — how they encounter the problem today>
 - <Named user or role 2>
 
 ## Success Signals
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: optional -->
 
 - <Observable outcome 1>
 - <Observable outcome 2>
 
 ## Alternatives / Build-vs-Buy
+<!-- audience: reviewer; mode: explanation; length: 3-6 paragraphs; diagram: optional; examples: recommended -->
 
 ### Alternatives Considered
 
@@ -426,11 +431,13 @@ we want.>
 <1–2 paragraph narrative citing concrete gaps of the closest candidate.>
 
 ## Assumptions
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 - [Critical Assumption] <promoted Critical+High item, if any>
 - <ordinary assumption>
 
 ## Specification Debt
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 | ID | Description | Source Category | Impact | Confidence | Status | Resolution |
 |----|-------------|-----------------|--------|------------|--------|------------|
@@ -439,6 +446,7 @@ we want.>
 _If no debt items, write: "None — all ambiguities resolved."_
 
 ## Open Questions
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 - <Genuinely unresolved item that needs stakeholder input or experimentation>
 ```

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -131,19 +131,19 @@ with this format:
 <Single meaningful outcome this strike delivers.>
 
 ## Out of Scope
-<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
+<!-- audience: reviewer; mode: reference; length: bullets or table; diagram: optional; examples: discouraged -->
 
 - <Explicitly excluded item 1>
 - <Explicitly excluded item 2>
 
 ## Requirements
-<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: optional; examples: recommended -->
+<!-- audience: builder+ai-input; mode: reference; length: bullets or table; diagram: optional; examples: recommended -->
 
 - **FR-001**: <Numbered functional requirement>
 - **FR-002**: <Numbered functional requirement>
 
 ## Success Criteria
-<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: optional -->
+<!-- audience: reviewer; mode: reference; length: bullets or table; diagram: optional; examples: optional -->
 
 - **SC-001**: <Numbered testable outcome>
 - **SC-002**: <Numbered testable outcome>

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -121,45 +121,55 @@ with this format:
 **Date:** YYYY-MM-DD  |  **Branch:** <resolved-branch>  |  **Status:** Ready
 
 ## Summary
+<!-- audience: stakeholder; mode: explanation; length: 2-3 sentences; diagram: optional; examples: discouraged -->
 
 <What is being built and why, in plain English.>
 
 ## Goal
+<!-- audience: stakeholder; mode: explanation; length: 1 sentence; diagram: optional; examples: discouraged -->
 
 <Single meaningful outcome this strike delivers.>
 
 ## Out of Scope
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 - <Explicitly excluded item 1>
 - <Explicitly excluded item 2>
 
 ## Requirements
+<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: optional; examples: recommended -->
 
 - **FR-001**: <Numbered functional requirement>
 - **FR-002**: <Numbered functional requirement>
 
 ## Success Criteria
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: optional -->
 
 - **SC-001**: <Numbered testable outcome>
 - **SC-002**: <Numbered testable outcome>
 
 ## User Flow
+<!-- audience: stakeholder; mode: explanation; length: 1-3 paragraphs; diagram: recommended; examples: discouraged -->
 
 <Behavior from the user's point of view — what the user does and what happens.>
 
 ## Data Model
+<!-- audience: builder; mode: reference; length: tables only; diagram: recommended; examples: recommended; applicability: code-shaped features only -->
 
-<Inline, minimal description of any data changes. Write "N/A" if not needed.>
+<Inline, minimal description of any data changes. Write `N/A — <one-sentence reason>` if the strike has no code-shaped data changes.>
 
 ## Contracts
+<!-- audience: builder; mode: reference; length: tables only; diagram: optional; examples: required; applicability: code-shaped features only -->
 
-<Inline, minimal description of any interface changes. Write "N/A" if not needed.>
+<Inline, minimal description of any interface changes. Write `N/A — <one-sentence reason>` if the strike has no code-shaped interface changes.>
 
 ## Decisions
+<!-- audience: reviewer; mode: explanation; length: 1-3 paragraphs; diagram: optional; examples: discouraged -->
 
 <Important decisions and tradeoffs made during the planning phase.>
 
 ## Specification Debt
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
 
 | ID | Description | Source Category | Impact | Confidence | Status | Resolution |
 |----|-------------|-----------------|--------|------------|--------|------------|
@@ -168,6 +178,7 @@ with this format:
 _If no debt items, write: "None — all ambiguities resolved."_
 
 ## Single Slice
+<!-- audience: builder; mode: how-to; length: 5-15 steps; diagram: optional; examples: forbidden -->
 
 **Goal**: <What this slice delivers as a standalone increment.>
 


### PR DESCRIPTION
## Summary
- Primary outcome: Apply the `smithy.helper-voice` (#420) tagging convention to every `##` section of the six artifact-producing command templates (strike, spark, ignite, render, mark, cut), and tighten `smithy.mark`'s `.data-model.md` and `.contracts.md` templates to Reference voice with the `applicability: code-shaped features only` directive and an inline `N/A — <reason>` fallback.
- Notable behaviour changes: Drafting agents now have a per-section voice spec (audience, mode, length, diagram, examples, applicability) immediately under every artifact-template heading. The `.data-model.md` and `.contracts.md` `## Overview` prose sections are removed; their bodies now lead directly with structured artifacts (tables, signatures, schemas) or a one-line `N/A — <reason>` fallback when the feature is not code-shaped.
- Follow-up work deferred (if any): Slice 4 of EPIC #419 — `smithy.audit` voice lint that reads these tags to enforce voice rules — remains future work; until then the tags are authoring hints rendered invisibly by GitHub.

## Context
- Why are we doing this work now? Part of EPIC #419 (voice & audience taxonomy). Depends on #420, which shipped the `smithy.helper-voice` skill defining the grammar this slice applies. The two specific fixes are (a) one-source-of-truth voice specs in templates so future audit lint runs from a single surface, and (b) the documented failure mode where `.contracts.md` / `.data-model.md` emit dense overlapping prose for non-code-shaped features (Smithy itself being the canonical example).
- What user story or scenario does it unlock or improve? Improves every downstream `smithy.mark` run on non-code-shaped features (template work, docs-only changes, configuration toggles) — the agent now writes one `N/A —` line instead of inventing prose entities. Improves every artifact draft going forward by making the intended voice and length per section explicit in the template, not implicit in the agent's training.

## Implementation Notes
- Key architectural choices (include trade-offs or alternatives considered): Voice tags live inside the markdown code-fence template that each command emits (i.e., the artifact-shape definition), not in every generated artifact instance. This keeps the spec in one place per artifact type, lets template authors edit it centrally, and gives the future `smithy.audit` voice lint a single file to read. Alternative considered: per-instance tags in every generated `.spec.md` etc. — rejected because it (1) duplicates the spec across thousands of files and (2) lets per-file drift creep in.
- Impacted modules or boundaries: `src/templates/agent-skills/commands/{strike,spark,ignite,render,mark,cut}.prompt` (template content); `src/templates.test.ts` (8 new tests covering tag presence, the issue's directive mappings, the `N/A` fallback, and the non-overlap clarification).
- Template / Agentic CLI specifics: Tags use HTML comments (`<!-- audience: ... -->`) so GitHub renders them invisibly while raw view shows them — verified by `node dist/cli.js init` smoke test deploying updated templates to a clean repo.

## Risks & Mitigations
- Risk: A drafting agent ignores the per-section voice spec and reverts to dense prose. | Mitigation: Slice 4 of EPIC #419 will wire `smithy.audit` to lint the tags; for now the tags are authoring hints that the agent reads alongside the section heading.
- Risk: A future PR rewrites the artifact templates and silently drops a tag. | Mitigation: The 8 new tests in `src/templates.test.ts` walk every `##` heading in each artifact code-fence and fail if any heading is missing the audience comment grammar.

## Rollback Plan
- Steps to back out the change safely (code and data): Revert the single commit on this branch — the change is template content only (no schema migrations, no committed artifact regeneration). Downstream artifacts (`.rfc.md`, `.spec.md`, etc.) already on disk in consumer repos are unaffected because the tags live in the **emitting** templates, not in past output.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npx tsc --noEmit`)
- [x] CLI `init` smoke test (`node dist/cli.js init`)

### Template Generation
- [ ] Gemini Skills: `.gemini/skills/` folders and `SKILL.md` validity.
- [ ] Codex Prompts: `tools/codex/prompts/` file content.
- [x] Claude Prompts: `.claude/prompts/` file content. *(verified via smoke test — audience comments present in deployed templates, applicability directives and `N/A —` fallback present in deployed `smithy.mark.md`)*
- [ ] GitHub Issue Templates: `.github/ISSUE_TEMPLATE/` content.

### Permissions & Configuration
- [ ] Gemini Config: `.gemini/config.json` correctly formed and merged.
- [ ] Codex Config: `.codex/config.toml` contains correct `[[approvals.rules]]`.
- [ ] Claude Config: `.claude/settings.json` correctly formed.

### Manual Test Cases
- [ ] Reviewed applicable cases in [`tests/Agent.tests.md`](tests/Agent.tests.md) and [`tests/Manual.tests.md`](tests/Manual.tests.md) (if init/uninit flows changed) *(init/uninit flows unchanged)*

### Automated coverage added in this PR
- [x] 8 new tests in `src/templates.test.ts` covering: (a) every `##` heading in each of the six artifact code-fences carries a well-formed audience comment, (b) the issue's directive mappings (RFC Proposal `diagram: recommended`, `.data-model.md` Entities `diagram: required`, Tasks Dependency Order `diagram: recommended`, Cross-Milestone Deps `diagram: recommended`, `.contracts.md` Interfaces `examples: required`, Tasks slice bodies `examples: forbidden`, Spec Acceptance Scenarios `examples: optional`), (c) the `applicability: code-shaped features only` directive on `.data-model.md` and `.contracts.md`, (d) the inline `N/A — <reason>` fallback documented in both file templates, (e) the `## Overview` dense-prose section is gone, and (f) the non-overlap clarification (data-model vs. contracts) is stated in the prompt text itself.
- [x] All 898 tests pass (890 pre-existing + 8 new).

## Issue
- Closes #422

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRsRAh3uusHDvNvrsFGZhe)_