### PR TITLE
feat: screen design-context annotation skill (#407)

### DIFF
--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -539,6 +539,7 @@ export const claudeToolPermissions: string[] = [
   "Skill(smithy.forge *)",
   "Skill(smithy.gh-issue *)",
   "Skill(smithy.helper-docker *)",
+  "Skill(smithy.helper-screen-design *)",
   "Skill(smithy.helper-voice *)",
   "Skill(smithy.ignite *)",
   "Skill(smithy.mark *)",

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { Dotprompt } from 'dotprompt';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import {
   stripFrontmatter,
   parseFrontmatterName,
@@ -353,16 +355,17 @@ describe('getTemplateFilesByCategory', () => {
     expect(byCategory.commands).toHaveLength(10);
     expect(byCategory.prompts).toHaveLength(2);
     expect(byCategory.agents).toHaveLength(13);
-    expect(byCategory.skills).toHaveLength(5);
+    expect(byCategory.skills).toHaveLength(6);
   });
 
-  it('skills includes smithy.pr-review, smithy.status, smithy.gh-issue, smithy.helper-docker, and smithy.helper-voice', () => {
+  it('skills includes smithy.pr-review, smithy.status, smithy.gh-issue, smithy.helper-docker, smithy.helper-voice, and smithy.helper-screen-design', () => {
     const { skills } = getTemplateFilesByCategory();
     expect(skills).toContain('smithy.pr-review');
     expect(skills).toContain('smithy.status');
     expect(skills).toContain('smithy.gh-issue');
     expect(skills).toContain('smithy.helper-docker');
     expect(skills).toContain('smithy.helper-voice');
+    expect(skills).toContain('smithy.helper-screen-design');
   });
 
   it('commands includes expected template files', () => {
@@ -925,6 +928,136 @@ describe('getComposedTemplates', () => {
     // future edit that quietly adds provider-specific syntax has to
     // also remove the assertion.
     expect(body).toMatch(/Provider-neutral/i);
+  });
+
+  // Issue #407 (EPIC #404): smithy.helper-screen-design is a body-only,
+  // lazy-loaded operational skill that owns the authoring contract for
+  // `design/screens/<ScreenId>.design.md`. The skill body is the single
+  // source of truth for the YAML front-matter schema, the rationale-only
+  // body rule, the skeleton template, and the worked Library example, so
+  // downstream commands (`smithy.forge` once #408 wires UI emission and
+  // `smithy.audit` / `flow-lint` once #409 lands) Skill() it instead of
+  // composing a partial. These assertions back-stop the deployment contract
+  // (body-only, frontmatter retained, auto-trigger description) and every
+  // load-bearing piece of the schema so a regression that drops a section,
+  // weakens the no-re-description guard, or relocates the artifact path
+  // fails the suite immediately.
+  it('smithy.helper-screen-design is body-only (no scripts) with frontmatter retained', () => {
+    const skill = composed.skills.get('smithy.helper-screen-design');
+    expect(skill).toBeDefined();
+    expect(skill!.prompt).toMatch(/^---\s*\n/);
+    expect(skill!.prompt).toContain('name: smithy.helper-screen-design');
+    expect(skill!.scripts.size).toBe(0);
+  });
+
+  it('smithy.helper-screen-design description triggers on authoring and auditing UI screens', () => {
+    const skill = composed.skills.get('smithy.helper-screen-design')!;
+    // Auto-trigger description (frontmatter) must name the artifact path,
+    // the two invocation modes (authoring + auditing), and the four
+    // front-matter keys so calling agents recognize when to lazy-load it.
+    expect(skill.prompt).toContain('design/screens/<ScreenId>.design.md');
+    expect(skill.prompt).toMatch(/authoring or auditing/i);
+    expect(skill.prompt).toContain('kind: ui');
+    // The four schema keys are the load-bearing claim of the description.
+    expect(skill.prompt).toMatch(/id\s*\/\s*composable\s*\/\s*design_system\s*\/\s*bundle/);
+  });
+
+  it('smithy.helper-screen-design body documents the four front-matter fields', () => {
+    const skill = composed.skills.get('smithy.helper-screen-design')!;
+    expect(skill.prompt).toContain('## YAML front-matter schema');
+    for (const field of ['`id`', '`composable`', '`design_system`', '`bundle`']) {
+      expect(skill.prompt).toContain(field);
+    }
+    // Explicit YAML labeling — the front-matter is YAML between `---` fences,
+    // not a Smithy-specific format. Guard against a future edit that drops
+    // the YAML labeling and leaves only an implicit convention.
+    expect(skill.prompt).toMatch(/YAML front-matter/);
+    expect(skill.prompt).toMatch(/between `---`[\s\S]*fences/);
+  });
+
+  it('smithy.helper-screen-design body documents the three rationale-only sections', () => {
+    const skill = composed.skills.get('smithy.helper-screen-design')!;
+    expect(skill.prompt).toContain('## Body shape');
+    for (const section of [
+      'Why this screen exists',
+      'Deliberate choices',
+      'Deferred',
+    ]) {
+      expect(skill.prompt).toContain(section);
+    }
+  });
+
+  it('smithy.helper-screen-design enforces the no-re-description rule', () => {
+    const skill = composed.skills.get('smithy.helper-screen-design')!;
+    // The whole point of the annotation is that it is NOT a parallel screen
+    // spec — the composable owns layout/behavior, this file owns intent.
+    // Guard against a future edit that softens the rule.
+    expect(skill.prompt).toMatch(/thin/i);
+    expect(skill.prompt).toMatch(/intent/i);
+    expect(skill.prompt).toMatch(/rationale only/i);
+    // The forbidden-sections list keeps the rule operational rather than
+    // aspirational — the review checklist must call them out by name.
+    expect(skill.prompt).toMatch(/no `## Layout`, `## States`, or `## Flow`/);
+  });
+
+  it('smithy.helper-screen-design ships the skeleton template and the Library example', () => {
+    const skill = composed.skills.get('smithy.helper-screen-design')!;
+    expect(skill.prompt).toContain('## Skeleton template');
+    expect(skill.prompt).toContain('## Worked example — `Library.design.md`');
+    // Library example must be filled out, not a placeholder — at least the
+    // composable path and the rationale sections from the issue.
+    expect(skill.prompt).toContain('id: Library');
+    expect(skill.prompt).toContain('LibraryScreen.kt');
+    expect(skill.prompt).toContain('story-spider-design');
+  });
+
+  it('smithy.helper-screen-design ships a review checklist for the audit/lint surfaces', () => {
+    const skill = composed.skills.get('smithy.helper-screen-design')!;
+    // The checklist is what makes the skill usable by smithy.audit (and
+    // later flow-lint #409) — it converts the prose contract into a
+    // line-by-line list of findings. Guard the items that matter most.
+    expect(skill.prompt).toContain('## Review checklist');
+    expect(skill.prompt).toMatch(/Missing required front-matter key/i);
+    expect(skill.prompt).toMatch(/composable[\s\S]*does not resolve/i);
+    // The forbidden body sections must be named explicitly in the checklist —
+    // a vague "no layout content" wouldn't give the audit a hit-list.
+    for (const heading of [
+      '`## Layout`',
+      '`## States`',
+      '`## Flow`',
+      '`## Steps`',
+      '`## Walkthrough`',
+    ]) {
+      expect(skill.prompt).toContain(heading);
+    }
+  });
+
+  it('agent-skills README points at the smithy.helper-screen-design skill instead of redefining the schema', () => {
+    // The README intentionally does not duplicate the schema (so the two
+    // cannot drift). It must, however, point at the skill so contributors
+    // can find the source of truth.
+    const readmePath = path.join(
+      process.cwd(),
+      'src',
+      'templates',
+      'agent-skills',
+      'README.md',
+    );
+    const readme = fs.readFileSync(readmePath, 'utf8');
+    expect(readme).toContain('## Screen Design-Context Annotations');
+    expect(readme).toContain('smithy.helper-screen-design');
+    expect(readme).toContain('skills/smithy.helper-screen-design/SKILL.prompt');
+    // README must NOT carry the schema body itself anymore. Naming the
+    // worked example by filename is fine ("a worked `Library.design.md`
+    // example lives in the skill") — what must NOT appear is the example
+    // body or screen-specific field semantics. These load-bearing strings
+    // appear only in the SKILL; if a future edit copies them back into the
+    // README, the guard fires.
+    expect(readme).not.toContain('FAB rather than an');
+    expect(readme).not.toContain('Empty state owns the screen');
+    expect(readme).not.toContain('LibraryScreen.kt');
+    expect(readme).not.toContain('owning Compose file');
+    expect(readme).not.toContain('bundle wins on layout');
   });
 
   it('categorizes templates correctly', () => {

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -264,6 +264,23 @@ on `—` (build-ahead-of-backend).
 - **`phase` is feature-level**, not user-story/slice level — the build/wire
   decomposition happens at the feature granularity (two features in the DAG).
 
+## Screen Design-Context Annotations
+
+Each `ScreenId` listed under a UI feature's `screens:` field resolves — in the
+**app repo, not in Smithy** — to a thin durable annotation at
+`design/screens/<ScreenId>.design.md`. The composable is the screen's body; this
+file carries the screen's *intent* (why it exists, deliberate choices, deferred
+bits) colocated with the code so it travels and versions with the composable.
+
+The full authoring contract — YAML front-matter schema (`id`, `composable`,
+`design_system`, `bundle`), the rationale-only body rule, the skeleton template,
+a worked `Library.design.md` example, naming decisions, and a review checklist
+— lives in the body-on-demand skill **`smithy.helper-screen-design`**
+(`skills/smithy.helper-screen-design/SKILL.prompt`). Agents lazy-load it via
+`Skill("smithy.helper-screen-design")` when authoring or auditing a screen
+annotation; this README intentionally does not duplicate the schema so the two
+cannot drift.
+
 ## Sub-Agent Roles
 
 Sub-agents are invoked by parent commands, not directly by users:

--- a/src/templates/agent-skills/skills/smithy.helper-screen-design/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.helper-screen-design/SKILL.prompt
@@ -1,0 +1,203 @@
+---
+name: smithy.helper-screen-design
+description: "Schema and authoring rules for `design/screens/<ScreenId>.design.md` — the thin durable intent annotation that colocates with a UI screen's Jetpack Compose body. Use when authoring or auditing a screen design-context annotation, when emitting a screen as part of a UI feature (kind: ui), or when validating that an existing annotation stays thin. Provides the YAML front-matter field schema (id / composable / design_system / bundle), the rationale-only body rule, a skeleton template, and a worked Library example."
+---
+# smithy.helper-screen-design
+
+Authoring contract for the thin durable annotation that carries a UI screen's
+*intent*. The composable is the screen's body; the `<ScreenId>.design.md` file
+at `design/screens/<ScreenId>.design.md` (in the **app repo**, alongside the
+code) is metadata *about* that body — why the screen exists, what was
+deliberately chosen, what was deferred. Load this skill when:
+
+- Writing a new `<ScreenId>.design.md` for a `kind: ui` feature.
+- Auditing an existing annotation for drift, redundancy, or layout
+  re-description.
+- Emitting a screen annotation as part of `forge`'s UI build phase
+  (EPIC #404 / issue #408).
+- Validating cross-references during `flow-lint` (issue #409).
+
+Do **not** load this skill for backend features or for general voice/audience
+prose work — `smithy.helper-voice` covers the latter, and `kind: backend`
+features have no screen artifact at all.
+
+---
+
+## Why a thin annotation (not a screen spec)
+
+The "third lifetime" question for UI work — *what is durable about a screen?*
+— resolves to: **the composable**. Every spec we could write about layout,
+structure, or steps is either already encoded in the composable or destined
+to drift against it. So the durable artifact is rationale only:
+
+- **The composable owns layout, structure, and behavior** (verified by the
+  bundle when present, the design skill always, and the Maestro flow at
+  `wire`).
+- **The `.design.md` owns intent** — the product reason, the choices, the
+  non-decisions — colocated with the code so neither moves without the
+  other.
+
+If a contributor can rebuild the screen by reading the `.design.md`, the
+file is wrong. If they can explain *why the screen looks the way it does*
+from reading it, the file is right.
+
+---
+
+## YAML front-matter schema
+
+Every `<ScreenId>.design.md` opens with YAML front-matter between `---`
+fences. Four keys, three required:
+
+| Key | Required | Notes |
+|-----|----------|-------|
+| `id` | Yes | Flat, stable `ScreenId`. Matches the `screens:` list of the originating UI feature in `.features.md`; never reused across screens. |
+| `composable` | Yes | Repo-relative path to the owning Compose file (e.g. `app/src/main/kotlin/io/balexda/readercompose/ui/views/library/LibraryScreen.kt`). Paths survive package renames; the path is the contract, not a fully-qualified Kotlin name. |
+| `design_system` | Yes | Reference to the committed design skill (e.g. `story-spider-design`). Source of truth even when a `bundle` is present — bundle wins on layout & visual intent, skill wins on implementation dialect. |
+| `bundle` | No | Repo-relative path to the originating Claude Design export (e.g. `design/bundles/library.zip`). A visual/structural reference, not a drop-in. Omit the key entirely when no bundle exists — do not set it to `null` or an empty string. |
+
+No other keys. In particular, **no `flows:` field here** — flow membership is
+declared on the originating feature in `.features.md`; duplicating it on the
+screen would create two places to update.
+
+---
+
+## Body shape — three rationale-only sections
+
+The body is rationale only, organized under three `##` sections in this
+order:
+
+| Section | What goes here | What does *not* go here |
+|---------|----------------|--------------------------|
+| `## Why this screen exists` | The product reason this screen owns space — one short paragraph. | Anything about how it looks. |
+| `## Deliberate choices` | Decisions a future contributor (or `forge`) would otherwise re-litigate (list vs. grid, FAB vs. app-bar action, empty-state weight). State the choice **and the why**. | Step-by-step descriptions, pixel-level layout, copy text. |
+| `## Deferred` | Things this screen explicitly does *not* do, with enough context that they don't get reinvented. | Backlog grooming for other screens. |
+
+There is **no `## Layout`, `## States`, or `## Flow` section.** The
+composable and the Maestro flow (at `wire`) own those. If you find yourself
+typing "the top of the screen contains…" — stop. That belongs in the
+composable or the bundle, not here. No layout description, no step-by-step
+walkthrough, no copy strings, no state-machine diagrams.
+
+---
+
+## Skeleton template
+
+````markdown
+---
+id: <ScreenId>
+composable: <repo-relative path to the owning Compose file>
+design_system: <committed design skill, e.g. story-spider-design>
+bundle: <repo-relative path to the Claude Design export, or omit the key>
+---
+
+# <ScreenId> — design context
+
+## Why this screen exists
+
+<One short paragraph: the product reason this screen owns space. Not what it
+looks like — why it is here at all.>
+
+## Deliberate choices
+
+- **<choice>.** <Why we picked it over the obvious alternative.>
+- **<choice>.** <Why we picked it over the obvious alternative.>
+
+## Deferred
+
+- **<thing not done>.** <Why we left it out and what would unblock it.>
+````
+
+---
+
+## Worked example — `Library.design.md`
+
+````markdown
+---
+id: Library
+composable: app/src/main/kotlin/io/balexda/readercompose/ui/views/library/LibraryScreen.kt
+design_system: story-spider-design
+bundle: design/bundles/library.zip
+---
+
+# Library — design context
+
+## Why this screen exists
+
+The Library is Story Spider's home base — the first surface a returning
+reader sees, listing every title they have added so far. Anchoring the home
+tab here (rather than a "Now Reading" continuation) keeps the model simple
+while the library is small and keeps the "add a new title" action one tap
+from the launcher.
+
+## Deliberate choices
+
+- **List, not grid.** Titles are URLs with long names; a single-column list
+  shows the full name without truncation. The lower information density is
+  the intended trade.
+- **FAB for "add title."** The primary add action is a FAB rather than an
+  app-bar action because it is the only affordance that drives growth of
+  the library — biasing visual weight toward it is intentional.
+- **Empty state owns the screen.** Before any titles exist, the empty state
+  is the full content area (illustration + one-sentence value prop + the
+  same add-title affordance the FAB triggers), not a footnote under an
+  empty list.
+
+## Deferred
+
+- **Sorting / filtering.** Insertion order only for now; sorting waits
+  until the library is plausibly large enough to need it (and a real user
+  asks).
+- **Per-title artwork.** The bundle shows placeholder thumbnails; real
+  artwork is downstream of the metadata-extraction feature, not this
+  screen.
+- **Multi-select / bulk delete.** Out of scope until we have a story for
+  why someone would remove titles in bulk; single-item swipe-to-delete is
+  sufficient at current scale.
+````
+
+Note what is *not* in the example: no list-row anatomy, no FAB position, no
+copy strings, no state-machine diagram. All of those belong in the
+composable (or, for navigation, the Maestro flow at `wire`).
+
+---
+
+## Naming decisions
+
+- **`id` is flat**, matching the rest of the repo-resident UI graph
+  (`ScreenId`, `FlowId`). The repo is the namespace; no scoping prefix,
+  no path-encoded hierarchy.
+- **`composable` is a path, not a fully-qualified Kotlin name.** Paths
+  survive package renames; fully-qualified names do not, and the file
+  already encodes the package.
+- **`design_system` is the *committed skill*, not the bundle.** A bundle
+  is optional and per-screen; the skill is the foundation and applies
+  even when no bundle exists, so it owns the source-of-truth slot.
+- **No `flows:` field on the screen.** Flow membership is declared on the
+  originating feature; duplicating it here would create two places to
+  update.
+
+---
+
+## Review checklist
+
+When auditing an existing `<ScreenId>.design.md`, flag any of the
+following:
+
+- [ ] Missing required front-matter key (`id`, `composable`, `design_system`).
+- [ ] `composable:` path does not resolve to an existing file in the repo.
+- [ ] `id` does not match the feature's `screens:` list, or is reused
+      across screens.
+- [ ] `design_system:` empty even when a `bundle:` is set (bundle without
+      skill is invalid — skill is source of truth).
+- [ ] Body contains a `## Layout`, `## States`, `## Flow`, `## Steps`, or
+      `## Walkthrough` section.
+- [ ] "Deliberate choices" describes what the screen looks like instead of
+      why the choice was made.
+- [ ] "Deferred" lists items that belong to a different screen or
+      feature.
+- [ ] Bundle path set but file does not exist (or vice versa — bundle file
+      present but key omitted).
+
+Surface each as a finding for the parent command (`smithy.forge` review
+pass, `smithy.audit`, or `flow-lint`) to act on. This skill itself does not
+modify files.


### PR DESCRIPTION
## Summary
- Primary outcome: Defines the **thin durable annotation** that carries a UI screen's *intent* — colocated with the code so it travels and versions with the composable. The composable is the screen's body; this file is metadata about it, not a re-description.
- Notable behaviour changes: Ships as a new `smithy.helper-screen-design` body-only operational skill (matching the `smithy.helper-docker` / `smithy.helper-voice` pattern). Agents `Skill("smithy.helper-screen-design")` to load the schema on demand.
- Follow-up work deferred: Forge UI emission lands with **#408**; cross-file resolution / dangling-reference checks land with **#409 flow-lint**. The symmetric flow-side skill is a sibling change for **#431** (currently the open draft on #406).

## Context
- Implements **#407** ("Screen design-context annotation template"), part of EPIC **#404** ("Screens & flows as first-class Smithy feature kinds").
- Depends on **#405** (feature-map `kind`/`phase` schema), which shipped in PR **#411** and introduced the `screens: [<ScreenId>]` field. Each `ScreenId` resolves — in the **app repo** — to `design/screens/<ScreenId>.design.md`; this PR defines what that file looks like.
- Resolves the "third lifetime" question for screens: spec is transient, the composable is the screen's body, and the durable artifact is **rationale only** (why it exists, deliberate choices, deferred bits).

### Why a skill, not a snippet
The first pass landed the schema as a `snippets/screen-design-annotation.md` Handlebars partial. Snippets only resolve when a `.prompt` file composes them via `{{>partial-name}}`, and none did — there is no consumer in this PR's scope (forge UI emission is #408; audit/flow-lint cross-file checks are #409). The partial was dead weight, and snippets are not deployed standalone, so no agent in a target repo could even read it.

The repo already has the right vertical: `smithy.helper-*` lazy-loaded operational skills. They advertise their `description` to the agent on every load, but the body only materializes on `Skill("name")` invocation. That's exactly the right shape for a body-of-truth that's reachable today, doesn't bloat any command's prompt, and naturally factors into one PR per artifact kind. This PR ships `smithy.helper-screen-design`; the symmetric `smithy.helper-flow-definition` is for #431 to ship.

## Implementation Notes
- **`src/templates/agent-skills/skills/smithy.helper-screen-design/SKILL.prompt`** *(new)* — body-only, no `scripts/`. Frontmatter `name` + `description`; description triggers on "authoring or auditing a screen design-context annotation" and lists the four schema keys so agents recognize when to lazy-load. Body covers: motivation (why thin), **YAML front-matter schema** (`id` / `composable` / `design_system` / `bundle`) explicitly labeled, three rationale-only `##` sections (`Why this screen exists` / `Deliberate choices` / `Deferred`), skeleton template, worked `Library.design.md` example, naming decisions, and a **review checklist** the audit/flow-lint surfaces can drive findings from (including the forbidden-section blacklist: `## Layout`, `## States`, `## Flow`, `## Steps`, `## Walkthrough`).
- **`src/templates/agent-skills/README.md`** — adds a **short pointer paragraph** ("Screen Design-Context Annotations") that names the skill, links the SKILL.prompt path, and explicitly does not duplicate the schema. The single source of truth lives in the skill body.
- **`src/permissions.ts`** — adds `Skill(smithy.helper-screen-design *)` to the Claude allow-list so the skill loads without an approval prompt (matching how `helper-docker` and `helper-voice` are wired).
- **YAML front-matter labeling** is now explicit ("YAML front-matter between `---` fences") in both the schema prose and the skeleton, addressing the implicit-format ambiguity in the first pass.
- **`src/templates.test.ts`** — large rewrite of the new contract:
  - Snippet count reverts 16 → 15; the `screen-design-annotation snippet` describe block is replaced by a `smithy.helper-screen-design` describe block.
  - Skills count 5 → 6; `smithy.helper-screen-design` joins the explicit name list.
  - Eight new assertions lock the skill's contract: body-only / frontmatter retained, description triggers + schema-key list, four front-matter fields documented with explicit YAML labeling, three rationale-only body sections, no-re-description guard, skeleton + filled Library example present, review checklist names every forbidden body heading by ` `` ` literal, and the agent-skills README points at the skill **without** carrying the schema body (guarded by load-bearing strings from the example body and screen-specific field semantics).
  - `node:fs` / `node:path` imports added for the README cross-file assertion.
- **No `.claude/` or manifest regeneration** (per CLAUDE.md — that drift is intentional between releases). The deployed `.claude/skills/smithy.helper-screen-design/` materializes on the next `chore: upgrade Smithy templates to latest` chore PR.

### Files touched

| File | Change |
|------|--------|
| `src/templates/agent-skills/skills/smithy.helper-screen-design/SKILL.prompt` | **new** — body-on-demand operational skill with full schema, skeleton, Library example, naming decisions, and review checklist. |
| `src/templates/agent-skills/README.md` | Short pointer paragraph at the skill; schema body removed. |
| `src/templates/agent-skills/snippets/screen-design-annotation.md` | **deleted** — dead partial with no composer; content moved into the skill. |
| `src/templates/agent-skills/snippets/README.md` | Reverts the snippet-table entry from the first pass. |
| `src/permissions.ts` | Adds `Skill(smithy.helper-screen-design *)` to Claude allow-list. |
| `src/templates.test.ts` | Snippet count 16→15, skills count 5→6, new skill `describe` block (8 assertions), README cross-file guard, `node:fs`/`node:path` imports. |

## Risks & Mitigations
- **Risk:** authors treat the body as a spec and re-describe layout, defeating the whole point. **Mitigation:** the schema explicitly forbids it (skill body calls this out under "Body shape" with a "what does *not* go here" column, and the review checklist names every forbidden section heading by ` `` ` literal); the worked example contains zero layout language; the test suite locks the forbidden-heading list so a softening edit fails CI.
- **Risk:** field names drift once #408 starts emitting these files. **Mitigation:** the skill is the single source; #408 will `Skill("smithy.helper-screen-design")` rather than re-typing the field list. The new tests lock the four field names so a rename fails CI.
- **Risk:** the example `composable:` path bakes in a Story Spider directory convention. **Mitigation:** the example is illustrative (matching the path style from issue #407 itself); the schema describes `composable` as "repo-relative path to the owning Compose file", so other app repos can use their own layout.
- **Risk:** the symmetric flow-side skill (#431) chooses a divergent name or shape. **Mitigation:** PR body and skill description both flag the parallel: `smithy.helper-flow-definition` (or equivalent) should mirror this skill's shape so forge/audit/flow-lint compose them symmetrically.

## Rollback Plan
- Code: revert this commit. Adds one new skill file plus a permissions allow-list entry; deletes one unreferenced snippet; touches the agent-skills README pointer paragraph and the test suite. No runtime CLI behaviour, no manifest, no deployed `.claude/` regeneration. Safe to revert in isolation.
- Data: none.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build` — tsup ⚡️ Build success).
- [x] Type check succeeds (`npm run typecheck` — clean).
- [ ] CLI `init` smoke test (`node dist/cli.js init`) — _N/A; this PR adds a skill + permissions entry + README pointer only and changes no init behaviour._

### Template Generation
- [ ] Gemini Skills: `.gemini/skills/` — _N/A; the deployed `.gemini/skills/smithy.helper-screen-design/SKILL.md` materializes on the next `chore: upgrade Smithy templates to latest` PR per CLAUDE.md._
- [ ] Codex Prompts: `tools/codex/prompts/` — _N/A._
- [ ] Claude Prompts: `.claude/prompts/` — _N/A; ditto for `.claude/skills/`._
- [ ] GitHub Issue Templates: `.github/ISSUE_TEMPLATE/` — _N/A; unchanged._

### Permissions & Configuration
- [x] Claude allow-list: `Skill(smithy.helper-screen-design *)` added; existing `current-form Skill permissions` test passes (every deployed `smithy.*` command and skill has a `Skill(<name> *)` entry).
- [ ] Gemini Config — _N/A; unchanged._
- [ ] Codex Config — _N/A; unchanged._

### Manual Test Cases
- [ ] No init/uninit/update flows changed — Agent/Manual test review not required for this PR.

### Automated coverage added
- [x] `templates.test.ts` — skill is body-only with frontmatter retained, description triggers on authoring/auditing UI screens and lists the four schema keys, body documents the four front-matter fields with explicit YAML labeling, three rationale-only body sections, no-re-description guard (forbidden-section blacklist), skeleton + Library example present, review checklist names every forbidden body heading.
- [x] `templates.test.ts` — agent-skills README points at the skill and does **not** carry the schema body (guarded by load-bearing strings from the example body and screen-specific field semantics).
- [x] Full suite: **915 tests pass** (up from 901; was 913 in the first pass).

## Issue
- Closes #407

https://claude.ai/code/session_01JiCuUnPfN7Hzw4F8NCRx1B