### PR TITLE
feat(flows): smithy.helper-flow-definition skill — flow entity pair + testID convention

### DIFF
--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -539,6 +539,7 @@ export const claudeToolPermissions: string[] = [
   "Skill(smithy.forge *)",
   "Skill(smithy.gh-issue *)",
   "Skill(smithy.helper-docker *)",
+  "Skill(smithy.helper-flow-definition *)",
   "Skill(smithy.helper-screen-design *)",
   "Skill(smithy.helper-voice *)",
   "Skill(smithy.ignite *)",

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -356,10 +356,10 @@ describe('getTemplateFilesByCategory', () => {
     expect(byCategory.commands).toHaveLength(10);
     expect(byCategory.prompts).toHaveLength(2);
     expect(byCategory.agents).toHaveLength(13);
-    expect(byCategory.skills).toHaveLength(6);
+    expect(byCategory.skills).toHaveLength(7);
   });
 
-  it('skills includes smithy.pr-review, smithy.status, smithy.gh-issue, smithy.helper-docker, smithy.helper-voice, and smithy.helper-screen-design', () => {
+  it('skills includes smithy.pr-review, smithy.status, smithy.gh-issue, smithy.helper-docker, smithy.helper-voice, smithy.helper-screen-design, and smithy.helper-flow-definition', () => {
     const { skills } = getTemplateFilesByCategory();
     expect(skills).toContain('smithy.pr-review');
     expect(skills).toContain('smithy.status');
@@ -367,6 +367,7 @@ describe('getTemplateFilesByCategory', () => {
     expect(skills).toContain('smithy.helper-docker');
     expect(skills).toContain('smithy.helper-voice');
     expect(skills).toContain('smithy.helper-screen-design');
+    expect(skills).toContain('smithy.helper-flow-definition');
   });
 
   it('commands includes expected template files', () => {
@@ -1059,6 +1060,202 @@ describe('getComposedTemplates', () => {
     expect(readme).not.toContain('LibraryScreen.kt');
     expect(readme).not.toContain('owning Compose file');
     expect(readme).not.toContain('bundle wins on layout');
+  });
+
+  // Issue #406 (EPIC #404): smithy.helper-flow-definition is a body-only,
+  // lazy-loaded operational skill that owns the authoring contract for the
+  // durable Flow entity pair — `design/flows/<FlowId>.flow.md` (intent
+  // annotation) + `maestro/flows/<FlowId>.yaml` (executable behavioral
+  // body), keyed 1:1 by flat FlowId. The skill body is the single source
+  // of truth for the YAML front-matter schema, the rationale-only body
+  // rule, the Maestro selector contract, the testID naming convention,
+  // and the worked AddTitle example, so downstream commands
+  // (`smithy.forge` once #408 wires UI emission, `smithy.audit` /
+  // `flow-lint` once #409 lands, and `flow-scaffold` once #410 lands)
+  // Skill() it instead of composing a partial. These assertions back-stop
+  // the deployment contract (body-only, frontmatter retained, auto-trigger
+  // description) and every load-bearing piece of the schema so a
+  // regression that drops a section, weakens the testID-only rule, or
+  // relocates the artifact path fails the suite immediately.
+  it('smithy.helper-flow-definition is body-only (no scripts) with frontmatter retained', () => {
+    const skill = composed.skills.get('smithy.helper-flow-definition');
+    expect(skill).toBeDefined();
+    expect(skill!.prompt).toMatch(/^---\s*\n/);
+    expect(skill!.prompt).toContain('name: smithy.helper-flow-definition');
+    expect(skill!.scripts.size).toBe(0);
+  });
+
+  it('smithy.helper-flow-definition description triggers on authoring and auditing flows', () => {
+    const skill = composed.skills.get('smithy.helper-flow-definition')!;
+    // Auto-trigger description must name BOTH artifact paths (this is the
+    // load-bearing claim — flows are a 1:1 pair, not a single file), the
+    // two invocation modes (authoring + auditing), the wire-phase context,
+    // and the three front-matter keys so calling agents recognize when to
+    // lazy-load it.
+    expect(skill.prompt).toContain('design/flows/<FlowId>.flow.md');
+    expect(skill.prompt).toContain('maestro/flows/<FlowId>.yaml');
+    expect(skill.prompt).toMatch(/authoring or auditing/i);
+    expect(skill.prompt).toContain('kind: ui');
+    expect(skill.prompt).toMatch(/phase:\s*wire/);
+    // The three flow.md schema keys are the load-bearing key list of the
+    // description.
+    expect(skill.prompt).toMatch(/id\s*\/\s*screens\s*\/\s*maestro/);
+  });
+
+  it('smithy.helper-flow-definition body documents the three front-matter fields', () => {
+    const skill = composed.skills.get('smithy.helper-flow-definition')!;
+    expect(skill.prompt).toContain('## YAML front-matter schema');
+    for (const field of ['`id`', '`screens`', '`maestro`']) {
+      expect(skill.prompt).toContain(field);
+    }
+    // Explicit YAML labeling — the front-matter is YAML between `---`
+    // fences, not a Smithy-specific format. Guard against a future edit
+    // that drops the YAML labeling and leaves only an implicit convention.
+    expect(skill.prompt).toMatch(/YAML front-matter/);
+    expect(skill.prompt).toMatch(/between `---`[\s\S]*fences/);
+  });
+
+  it('smithy.helper-flow-definition body documents the four rationale-only sections', () => {
+    const skill = composed.skills.get('smithy.helper-flow-definition')!;
+    expect(skill.prompt).toContain('## Body shape');
+    for (const section of [
+      '## Intent',
+      '## Guards',
+      '## Entry / Exit',
+      '## Coverage Caveat',
+    ]) {
+      expect(skill.prompt).toContain(section);
+    }
+  });
+
+  it('smithy.helper-flow-definition enforces the no-step-descriptions rule', () => {
+    const skill = composed.skills.get('smithy.helper-flow-definition')!;
+    // The whole point of the pair is that the `.flow.md` body is NOT a
+    // parallel narration of the yaml — the yaml owns the steps, the
+    // `.flow.md` owns intent. Guard against a future edit that softens
+    // the rule.
+    expect(skill.prompt).toMatch(/thin/i);
+    expect(skill.prompt).toMatch(/intent/i);
+    expect(skill.prompt).toMatch(/rationale only/i);
+    // The forbidden-sections list keeps the rule operational rather than
+    // aspirational — the review checklist must call them out by name.
+    expect(skill.prompt).toMatch(
+      /no `## Steps`, `## Walkthrough`, `## Flow`,?\s*or `## Path`/,
+    );
+  });
+
+  it('smithy.helper-flow-definition pins the Maestro selector contract (testIDs, not visible text)', () => {
+    const skill = composed.skills.get('smithy.helper-flow-definition')!;
+    // Issue #406's load-bearing rule: selectors keyed to testIDs /
+    // accessibility IDs / semantic tags — never visible text or layout
+    // position. The yaml side becomes useless if this rule softens.
+    expect(skill.prompt).toMatch(/testID/);
+    expect(skill.prompt).toMatch(/accessibility/i);
+    expect(skill.prompt).toMatch(/never visible text/i);
+    expect(skill.prompt).toMatch(/never[^\n]*layout position/i);
+    // The "asserts traversal AND guards" rule — a flow that only walks
+    // the happy path is a smoke test, not a durable flow.
+    expect(skill.prompt).toMatch(/traversal/i);
+    expect(skill.prompt).toMatch(/guard/i);
+    expect(skill.prompt).toMatch(/cannot reach confirm[^\n]*valid URL/i);
+  });
+
+  it('smithy.helper-flow-definition documents the testID naming convention', () => {
+    const skill = composed.skills.get('smithy.helper-flow-definition')!;
+    // Convention shape: kebab-case, `<scope>-<element>[-<modifier>]`,
+    // never from visible text or layout position.
+    expect(skill.prompt).toMatch(/kebab-case/i);
+    expect(skill.prompt).toContain('<scope>-<element>');
+    // The two testID examples cited verbatim in issue #406.
+    expect(skill.prompt).toContain('library-fab');
+    expect(skill.prompt).toContain('add-title-url-field');
+  });
+
+  it('smithy.helper-flow-definition ships the skeleton template and the AddTitle example', () => {
+    const skill = composed.skills.get('smithy.helper-flow-definition')!;
+    expect(skill.prompt).toContain('## Skeleton template');
+    expect(skill.prompt).toContain('## Worked example');
+    // AddTitle example must be filled out (not a placeholder), with both
+    // halves of the pair: front-matter for `.flow.md` and a testID-keyed
+    // yaml exercising the URL guard.
+    expect(skill.prompt).toContain('design/flows/AddTitle.flow.md');
+    expect(skill.prompt).toContain('maestro/flows/AddTitle.yaml');
+    expect(skill.prompt).toMatch(/id:\s*AddTitle/);
+    expect(skill.prompt).toMatch(/screens:\s*\[Library,\s*AddTitle\]/);
+    expect(skill.prompt).toMatch(/maestro:\s*maestro\/flows\/AddTitle\.yaml/);
+    // The yaml side must include the URL-guard assertion the issue calls
+    // out: confirm is not visible until URL is valid.
+    expect(skill.prompt).toContain('add-title-url-field');
+    expect(skill.prompt).toContain('add-title-confirm-button-enabled');
+    expect(skill.prompt).toMatch(/assertNotVisible/);
+  });
+
+  it('smithy.helper-flow-definition documents the audio-service coverage caveat', () => {
+    const skill = composed.skills.get('smithy.helper-flow-definition')!;
+    // Issue #406 coverage caveat: Maestro covers navigable bookends.
+    // Audio-service behaviors (auto-advance under lock, foreground TTS)
+    // need instrumentation-level tests. A green Maestro run must NOT
+    // imply TTS coverage.
+    expect(skill.prompt).toMatch(/navigable bookends/i);
+    expect(skill.prompt).toMatch(/auto-advance/i);
+    expect(skill.prompt).toMatch(/foreground TTS/i);
+    expect(skill.prompt).toMatch(/instrumentation/i);
+    expect(skill.prompt).toMatch(/must not be read as TTS coverage/i);
+  });
+
+  it('smithy.helper-flow-definition ships a review checklist for the audit/lint surfaces', () => {
+    const skill = composed.skills.get('smithy.helper-flow-definition')!;
+    // The checklist is what makes the skill usable by smithy.audit (and
+    // later flow-lint #409) — it converts the prose contract into a
+    // line-by-line list of findings. Guard the items that matter most.
+    expect(skill.prompt).toContain('## Review checklist');
+    expect(skill.prompt).toMatch(/Missing required front-matter key/i);
+    expect(skill.prompt).toMatch(/maestro[\s\S]*does not resolve/i);
+    // The forbidden body sections must be named explicitly in the
+    // checklist — a vague "no walkthrough content" wouldn't give the
+    // audit a hit-list.
+    for (const heading of [
+      '`## Steps`',
+      '`## Walkthrough`',
+      '`## Flow`',
+      '`## Path`',
+    ]) {
+      expect(skill.prompt).toContain(heading);
+    }
+    // Selector-quality checks: visible text and layout-index selectors
+    // are the failure modes the yaml side guards against.
+    expect(skill.prompt).toMatch(/text:[^\n]*selector|visible-text matcher/i);
+    expect(skill.prompt).toMatch(/layout[- ]index/i);
+  });
+
+  it('agent-skills README points at the smithy.helper-flow-definition skill instead of redefining the schema', () => {
+    // The README intentionally does not duplicate the schema (so the two
+    // cannot drift). It must, however, point at the skill so contributors
+    // can find the source of truth.
+    const readmePath = path.join(
+      process.cwd(),
+      'src',
+      'templates',
+      'agent-skills',
+      'README.md',
+    );
+    const readme = fs.readFileSync(readmePath, 'utf8');
+    expect(readme).toContain('## Flow Definitions');
+    expect(readme).toContain('smithy.helper-flow-definition');
+    expect(readme).toContain(
+      'skills/smithy.helper-flow-definition/SKILL.prompt',
+    );
+    // README must NOT carry the schema body itself anymore. Naming the
+    // worked example by filename is fine ("a worked `AddTitle` example
+    // lives in the skill") — what must NOT appear is the example body,
+    // the AddTitle yaml selectors, or the testID convention table.
+    // These load-bearing strings appear only in the SKILL; if a future
+    // edit copies them back into the README, the guard fires.
+    expect(readme).not.toContain('add-title-url-field');
+    expect(readme).not.toContain('add-title-confirm-button-enabled');
+    expect(readme).not.toContain('library-row-<title-slug>');
+    expect(readme).not.toContain('assertNotVisible');
+    expect(readme).not.toContain('appId: com.storyspider.app');
   });
 
   it('categorizes templates correctly', () => {

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -281,6 +281,28 @@ a worked `Library.design.md` example, naming decisions, and a review checklist
 annotation; this README intentionally does not duplicate the schema so the two
 cannot drift.
 
+## Flow Definitions
+
+Each `FlowId` listed under a UI feature's `flows:` field resolves — in the
+**app repo, not in Smithy** — to a durable **1:1 pair** of files:
+`design/flows/<FlowId>.flow.md` (thin intent annotation) and
+`maestro/flows/<FlowId>.yaml` (executable behavioral body). The yaml owns
+the steps and guard assertions a UI driver replays; the `.flow.md` owns
+*why* — the product truth the flow preserves, why the guards exist,
+deliberate entry / exit, and a coverage caveat for anything below what a UI
+driver can observe.
+
+The full authoring contract — YAML front-matter schema (`id`, `screens`,
+`maestro`), the rationale-only body rule, the Maestro selector contract
+(testID-keyed only, asserts traversal AND guards), the testID naming
+convention, skeleton templates for both halves, a worked `AddTitle` example,
+naming decisions, the audio-service coverage caveat, and a review checklist
+— lives in the body-on-demand skill **`smithy.helper-flow-definition`**
+(`skills/smithy.helper-flow-definition/SKILL.prompt`). Agents lazy-load it
+via `Skill("smithy.helper-flow-definition")` when authoring or auditing a
+flow definition (typically at a UI feature's `wire` phase); this README
+intentionally does not duplicate the schema so the two cannot drift.
+
 ## Sub-Agent Roles
 
 Sub-agents are invoked by parent commands, not directly by users:

--- a/src/templates/agent-skills/skills/smithy.helper-flow-definition/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.helper-flow-definition/SKILL.prompt
@@ -197,9 +197,9 @@ appId: <reverse-domain.app.id>
 # Guard: <invariant from flow.md Guards section>.
 - assertNotVisible:
     id: "<guarded-state-test-id>"
-- inputText:
+- tapOn:
     id: "<field-test-id>"
-    text: "<...>"
+- inputText: "<...>"
 # Guard: <invariant becomes reachable once preconditions hold>.
 - assertVisible:
     id: "<guarded-state-test-id>"
@@ -281,12 +281,12 @@ appId: com.storyspider.app
 # Guard: confirm is disabled until the URL is valid.
 - assertNotVisible:
     id: "add-title-confirm-button-enabled"
-- inputText:
+- tapOn:
     id: "add-title-title-field"
-    text: "The Magic Circle"
-- inputText:
+- inputText: "The Magic Circle"
+- tapOn:
     id: "add-title-url-field"
-    text: "https://example.com/magic-circle.mp3"
+- inputText: "https://example.com/magic-circle.mp3"
 # Guard: with a valid URL, confirm becomes reachable.
 - assertVisible:
     id: "add-title-confirm-button-enabled"

--- a/src/templates/agent-skills/skills/smithy.helper-flow-definition/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.helper-flow-definition/SKILL.prompt
@@ -1,0 +1,378 @@
+---
+name: smithy.helper-flow-definition
+description: "Schema and authoring rules for the durable Flow entity pair — `design/flows/<FlowId>.flow.md` (thin intent annotation) and `maestro/flows/<FlowId>.yaml` (executable behavioral body) — keyed 1:1 by flat FlowId. Use when authoring or auditing a flow definition, when emitting a flow as part of a UI feature's wire phase (kind: ui, phase: wire), or when validating an existing flow stays thin and testID-keyed. Provides the YAML front-matter field schema (id / screens / maestro), the rationale-only body rule, the Maestro yaml selector contract, the testID naming convention, a skeleton template, and a worked AddTitle example."
+---
+# smithy.helper-flow-definition
+
+Authoring contract for the durable representation of a UI **flow** — a path a
+user can take through the app that the team commits to preserving. A flow is
+represented by a **1:1 pair** keyed by a flat `FlowId`:
+
+```
+design/flows/<FlowId>.flow.md      # durable INTENT annotation (why)
+maestro/flows/<FlowId>.yaml        # durable BEHAVIORAL body (what runs)
+```
+
+Both files live in the **app repo**, alongside the code, not in Smithy. Load
+this skill when:
+
+- Writing or updating a `<FlowId>.flow.md` + `<FlowId>.yaml` pair for a
+  `kind: ui` feature at `phase: wire`.
+- Auditing an existing flow for drift, redundancy, fragile selectors, or
+  step-leakage from yaml into prose.
+- Emitting a flow as part of `forge`'s UI wire phase
+  (EPIC #404 / issue #408).
+- Validating cross-references during `flow-lint` (issue #409).
+
+Do **not** load this skill for backend features, for screen-only work
+(`smithy.helper-screen-design` covers screens), or for general prose work
+(`smithy.helper-voice`). `kind: backend` features and `phase: build` UI
+features have no flow artifact at all — flows are only emitted at `wire`.
+
+---
+
+## Why a thin annotation + an executable body (not a single spec)
+
+The "third lifetime" question for flows — *what is durable about a user
+journey?* — resolves to: **the Maestro yaml**. Every spec we could write
+that re-narrates the path in prose is either already encoded in the yaml or
+destined to drift against it. So the pair splits cleanly:
+
+- **The Maestro yaml owns behavior** — the actual taps, asserts, and
+  guards a UI driver replays. It is the executable proof that the journey
+  still works.
+- **The `.flow.md` owns intent** — *why* the flow is a durable truth, *why*
+  the guards exist, where the user comes from and where they end up, and
+  what the yaml cannot cover. Colocated with the design folder so neither
+  half moves without the other.
+
+If a contributor can replay the journey by reading the `.flow.md`, the file
+is wrong (those steps belong in the yaml). If the yaml lists taps but
+asserts no guards, the yaml is wrong (it has regressed to a smoke test).
+The pair stays honest only when each file owns its lane.
+
+---
+
+## YAML front-matter schema
+
+Every `<FlowId>.flow.md` opens with YAML front-matter between `---` fences.
+Three keys, all required:
+
+| Key | Required | Notes |
+|-----|----------|-------|
+| `id` | Yes | Flat, stable `FlowId` (e.g. `AddTitle`). Matches the `.flow.md` and `.yaml` filename stems and the `flows:` list of the originating UI feature in `.features.md`. Never reused across flows. |
+| `screens` | Yes | List of `ScreenId` the flow traverses, in entry order (e.g. `[Library, AddTitle]`). Each entry must appear in some feature's `screens:` field; cross-file resolution is enforced by `flow-lint` (#409). |
+| `maestro` | Yes | Repo-relative path to the paired Maestro yaml (e.g. `maestro/flows/AddTitle.yaml`). The path is the contract; renaming the yaml without updating this field is a `flow-lint` failure. |
+
+No other keys. In particular, **no `feature:` or `kind:` field here** — flow
+membership is declared on the originating feature in `.features.md`;
+duplicating it on the flow would create two places to update.
+
+---
+
+## Body shape — three rationale-only sections plus the coverage caveat
+
+The `.flow.md` body is rationale only, organized under three `##` sections
+in this order, followed by a mandatory coverage caveat:
+
+| Section | What goes here | What does *not* go here |
+|---------|----------------|--------------------------|
+| `## Intent` | The durable product truth this flow preserves — one short paragraph. *Why* this journey is worth a permanent test. | Step descriptions, taps, screen transitions. |
+| `## Guards` | The guarantees that must hold along the path, stated as invariants the yaml asserts (e.g. "Confirm is disabled until the URL is valid"). State the invariant **and the why**. | The yaml lines that check them — those live in the yaml. |
+| `## Entry / Exit` | Where the user enters from (the testID or surface that starts the flow) and where they end up. Two short bullets. | The intermediate steps. |
+| `## Coverage Caveat` | What this Maestro flow does **not** observe (audio-service behaviors, background work, anything below the UI driver). Mandatory whenever the screen touches an audio surface. | Aspirational coverage; coverage lives where the test does. |
+
+There is **no `## Steps`, `## Walkthrough`, `## Flow`, or `## Path` section.**
+The yaml owns the steps. If you find yourself typing "the user taps the
+FAB, then the AddTitle screen appears, then…" — stop. That belongs in the
+yaml, not here. No tap-by-tap walkthroughs, no copy strings, no per-step
+screenshots.
+
+---
+
+## Maestro yaml contract
+
+The yaml is the executable behavioral body. Three load-bearing rules:
+
+1. **1:1 with `FlowId`.** One flow = one Maestro flow. Variants that earn a
+   durable name earn their own `FlowId`; never fold multiple paths
+   ("happy + error path") into one yaml.
+2. **Selectors are keyed to testIDs, accessibility IDs, or semantic tags —
+   never visible text and never layout position.** Flow tests must fail
+   on *path* changes (a tap moved, a guard removed, a screen reordered)
+   and survive *visual* changes (copy edits, palette swaps, spacing
+   tweaks). Visual iteration happens upstream on the design canvas, not
+   here.
+3. **Assert the traversal AND the guards.** A Maestro flow that only walks
+   the happy path provides no durability — the guard assertions
+   (`cannot reach confirm without a valid URL`) are what catch path
+   regressions. Every guard named in the `.flow.md` body must have at
+   least one corresponding `assertVisible` / `assertNotVisible` in the
+   yaml.
+
+---
+
+## testID naming convention
+
+Composables expose stable test IDs so the Maestro yaml can key off them:
+
+- **kebab-case**, ASCII-lowercase, hyphens only. No camelCase, no
+  underscores, no spaces.
+- **`<scope>-<element>[-<modifier>]`** structure:
+  - **`<scope>`** — the screen, flow, or area the element belongs to
+    (`library`, `add-title`, `player`, `settings`).
+  - **`<element>`** — the semantic role of the control (`fab`, `field`,
+    `button`, `confirm`, `back`, `list`, `row`).
+  - **`<modifier>`** — when the element has multiple instances on the
+    same scope, the specific field or state (`title-field`, `url-field`,
+    `confirm-button-enabled`, `row-<title-slug>`).
+- **Stable across rewrites.** A testID is part of the screen's public
+  surface. Renaming a testID is a breaking change to every flow that
+  references it — treat it like an API rename.
+- **Never derived from visible text** (so copy edits don't break flows)
+  and **never derived from layout position** (so reordering doesn't
+  break flows).
+
+| testID | What it identifies |
+|--------|-------------------|
+| `library-fab` | Floating action button on the Library screen. |
+| `add-title-title-field` | Title input field on the AddTitle screen. |
+| `add-title-url-field` | URL input field on the AddTitle screen. |
+| `add-title-confirm-button` | Confirm button on the AddTitle screen. |
+| `add-title-confirm-button-enabled` | Confirm button in its enabled state (used to assert the URL guard). |
+| `library-list` | The list container on the Library screen. |
+| `library-row-<title-slug>` | A specific row in the Library list, keyed by the title slug. |
+
+---
+
+## Skeleton template
+
+**`design/flows/<FlowId>.flow.md`:**
+
+````markdown
+---
+id: <FlowId>
+screens: [<ScreenId>, <ScreenId>]
+maestro: maestro/flows/<FlowId>.yaml
+---
+
+# Flow: <FlowId>
+
+## Intent
+
+<One short paragraph: the durable product truth this flow preserves. Why this
+journey is worth a permanent test — not what the user taps.>
+
+## Guards
+
+- **<invariant>.** <Why it matters; the yaml asserts it.>
+- **<invariant>.** <Why it matters; the yaml asserts it.>
+
+## Entry / Exit
+
+- **Enter from**: <surface and testID, e.g. Library screen, tap on `library-fab`>.
+- **Exit on**: <terminal state and testID, e.g. tap `add-title-confirm-button`
+  with a valid URL → return to Library list, new title visible>.
+
+## Coverage Caveat
+
+<What this flow does NOT observe — required whenever the screen touches an
+audio-service surface. Audio-service behaviors (auto-advance under lock,
+foreground TTS, audio-focus handling) need instrumentation-level tests.>
+````
+
+**`maestro/flows/<FlowId>.yaml`:**
+
+```yaml
+# Selectors are keyed to testIDs. Never visible text, never layout position.
+appId: <reverse-domain.app.id>
+---
+- launchApp
+- assertVisible:
+    id: "<entry-test-id>"
+- tapOn:
+    id: "<entry-test-id>"
+- assertVisible:
+    id: "<arrived-test-id>"
+# Guard: <invariant from flow.md Guards section>.
+- assertNotVisible:
+    id: "<guarded-state-test-id>"
+- inputText:
+    id: "<field-test-id>"
+    text: "<...>"
+# Guard: <invariant becomes reachable once preconditions hold>.
+- assertVisible:
+    id: "<guarded-state-test-id>"
+- tapOn:
+    id: "<confirm-test-id>"
+- assertVisible:
+    id: "<exit-test-id>"
+```
+
+---
+
+## Worked example — `AddTitle.flow.md` and `AddTitle.yaml`
+
+**`design/flows/AddTitle.flow.md`:**
+
+````markdown
+---
+id: AddTitle
+screens: [Library, AddTitle]
+maestro: maestro/flows/AddTitle.yaml
+---
+
+# Flow: AddTitle
+
+## Intent
+
+A user adds a new title to their library by tapping the Library FAB, filling
+the title and URL fields, and confirming. The flow exists to lock in the
+durable truth that adding a title is reachable from the library home in one
+tap and returns the user to a list with their new title visible. If this
+journey ever breaks, the product breaks — there is no library without it.
+
+## Guards
+
+- **Confirm is disabled until the URL is valid.** The URL field is the only
+  required input the store cannot recover from; a permissive Confirm would
+  silently persist garbage.
+- **Submitting a duplicate URL is a no-op.** Duplicate detection lives in the
+  store, but the user-visible contract is "no second row appears" — the
+  flow asserts that surface so a regression that breaks dedup is caught.
+- **The back gesture returns to Library without persisting partial input.**
+  Half-filled rows would corrupt the library; the back-out path must drop
+  the draft.
+
+## Entry / Exit
+
+- **Enter from**: Library screen, tap on `library-fab`.
+- **Exit on**: tap `add-title-confirm-button-enabled` with a valid URL →
+  return to Library list, new title visible at the top of `library-list`.
+
+## Coverage Caveat
+
+This flow asserts navigable bookends only. It does **not** cover:
+
+- Auto-advance to the next title under the lock screen.
+- Foreground TTS service playback.
+- Audio focus handling on incoming calls.
+
+Those behaviors live below what a UI driver can observe and must be covered
+by instrumentation-level tests. **A green Maestro run must not be read as
+TTS coverage.**
+````
+
+**`maestro/flows/AddTitle.yaml`:**
+
+```yaml
+# Selectors are keyed to testIDs. Never visible text, never layout position.
+appId: com.storyspider.app
+---
+- launchApp
+- assertVisible:
+    id: "library-fab"
+- tapOn:
+    id: "library-fab"
+- assertVisible:
+    id: "add-title-title-field"
+- assertVisible:
+    id: "add-title-url-field"
+# Guard: confirm is disabled until the URL is valid.
+- assertNotVisible:
+    id: "add-title-confirm-button-enabled"
+- inputText:
+    id: "add-title-title-field"
+    text: "The Magic Circle"
+- inputText:
+    id: "add-title-url-field"
+    text: "https://example.com/magic-circle.mp3"
+# Guard: with a valid URL, confirm becomes reachable.
+- assertVisible:
+    id: "add-title-confirm-button-enabled"
+- tapOn:
+    id: "add-title-confirm-button-enabled"
+- assertVisible:
+    id: "library-list"
+- assertVisible:
+    id: "library-row-the-magic-circle"
+```
+
+Note what is *not* in the `.flow.md` body: no list of taps, no screen
+transitions, no copy strings, no per-step screenshots. Note what *is* in
+the yaml: not just the happy path, but the `assertNotVisible` →
+`assertVisible` pair around `add-title-confirm-button-enabled` that proves
+the URL guard fires.
+
+---
+
+## Naming decisions
+
+- **`id` is flat**, matching `ScreenId` and the rest of the repo-resident
+  UI graph. The repo is the namespace; no scoping prefix, no
+  path-encoded hierarchy. `FlowId`s are never reused.
+- **`screens` is a list, in entry order.** A flow traverses more than one
+  screen (that's what makes it a flow); listing them in entry order
+  makes the resolution at `flow-lint` time deterministic.
+- **`maestro` is a path, not a derived convention.** Renaming the yaml
+  without updating the field is a `flow-lint` failure — the path is the
+  contract, not a derived guess.
+- **No `feature:` or `kind:` field on the flow.** Feature membership is
+  declared on the originating feature in `.features.md` via
+  `flows: [FlowId]`; duplicating it here would create two places to
+  update.
+
+---
+
+## Coverage caveat — applies to every audio-touching flow
+
+Maestro covers **navigable bookends** — what a UI driver can observe by
+tapping, asserting visibility, and reading testID-keyed views.
+**Audio-service behaviors** (auto-advance under lock, foreground TTS,
+audio-focus handling) sit below that layer; their durable body is
+**instrumentation-level tests**, not the Maestro flow.
+**A green Maestro run must not be read as TTS coverage.** Every `.flow.md`
+that touches an audio-service surface states this caveat explicitly under
+`## Coverage Caveat` so reviewers don't infer coverage that isn't there.
+
+---
+
+## Don't over-apply
+
+Reserve Maestro-as-flow for **long-lived product truths** (Library add,
+read, TTS auto-advance). Marginal paths stay prose until they prove
+load-bearing. The cost of a Maestro flow is the maintenance commitment to
+its `.flow.md` + yaml pair forever — only pay it for journeys you would
+refuse to ship a release that broke.
+
+---
+
+## Review checklist
+
+When auditing an existing flow pair, flag any of the following:
+
+- [ ] Missing required front-matter key in `.flow.md` (`id`, `screens`,
+      `maestro`).
+- [ ] `maestro:` path does not resolve to an existing file in the repo.
+- [ ] `id` does not match the originating feature's `flows:` list, or is
+      reused across flows.
+- [ ] `screens:` references a `ScreenId` that no feature declares.
+- [ ] `.flow.md` body contains a `## Steps`, `## Walkthrough`, `## Flow`,
+      or `## Path` section.
+- [ ] `## Guards` lists invariants the yaml does **not** assert (every
+      guard must have a matching `assertVisible` / `assertNotVisible`).
+- [ ] `## Coverage Caveat` is missing on a flow whose screen touches an
+      audio-service surface.
+- [ ] Maestro yaml uses `text:` selectors, visible-text matchers, or
+      layout-index selectors instead of `id:`-based testIDs / accessibility
+      IDs.
+- [ ] Maestro yaml asserts only the happy path (no `assertNotVisible` or
+      negative-state check anywhere) — guards must be testable, not just
+      narrated.
+- [ ] testID referenced in the yaml does not follow
+      `<scope>-<element>[-<modifier>]` kebab-case naming.
+- [ ] Two yamls share one `FlowId`, or one `FlowId` has no matching yaml.
+
+Surface each as a finding for the parent command (`smithy.forge` review
+pass, `smithy.audit`, or `flow-lint`) to act on. This skill itself does
+not modify files.


### PR DESCRIPTION
## Summary
- Primary outcome: Establish the durable Flow representation — a **1:1 pair** keyed by flat `FlowId`: `design/flows/<FlowId>.flow.md` (thin intent annotation) + `maestro/flows/<FlowId>.yaml` (executable behavioral body). Ships as the body-only operational skill `smithy.helper-flow-definition`, the symmetric flow-side counterpart to PR #430's `smithy.helper-screen-design`. **Anchor issue** for EPIC #404; no upstream deps; downstream consumers are #408 (forge parameterization), #409 (flow-lint), #410 (flow-scaffold).
- Notable behaviour changes: None at runtime — schema/skill only. Agents `Skill("smithy.helper-flow-definition")` to lazy-load the schema on demand.
- Follow-up work deferred (if any): Forge UI emission lands with #408; cross-file resolution / dangling-reference checks land with #409 flow-lint. No `.claude/` snapshot regeneration here (per CLAUDE.md).

## Context
- Why are we doing this work now? EPIC #404 makes UI features first-class. The `feature-kinds` schema landed in #405 already references `flows: [FlowId]`, but nothing in the repo yet defines what a `FlowId` actually resolves to — a `.flow.md` doc, a Maestro yaml, and the testID contract that keeps the yaml durable across visual iteration. #406 closes that gap.
- What user story or scenario does it unlock or improve? A `kind: ui` `wire` feature can now point at the canonical Flow schema; reviewers know exactly what artifacts a wire-phase forge run must emit/update; future `flow-lint` (#409) has a stable contract to check against.

### Why a skill, not a snippet
A first pass landed this as a `snippets/flow-entity-pair.md` Handlebars partial. Snippets only resolve when a `.prompt` file composes them via `{{>partial-name}}`, and none did — there is no consumer in this PR's scope (forge UI emission is #408; audit/flow-lint cross-file checks are #409). The partial was dead weight, and snippets are not deployed standalone, so no agent in a target repo could even read it.

The repo already has the right vertical: `smithy.helper-*` lazy-loaded operational skills. They advertise their `description` to the agent on every load, but the body only materializes on `Skill("name")` invocation. PR #430 made the same call for the screen-side counterpart (`smithy.helper-screen-design`); this PR is the symmetric flow-side change PR #430's body explicitly flagged as belonging to #406.

## Implementation Notes
- **`src/templates/agent-skills/skills/smithy.helper-flow-definition/SKILL.prompt`** *(new)* — body-only, no `scripts/`. Frontmatter `name` + `description`; description triggers on "authoring or auditing a flow definition", names BOTH artifact paths (`design/flows/<FlowId>.flow.md` + `maestro/flows/<FlowId>.yaml`), the `kind: ui` / `phase: wire` context, and the three schema keys (`id` / `screens` / `maestro`). Body covers: why a thin annotation + executable body (not a single spec), explicit **YAML front-matter schema** (`id` / `screens` / `maestro`), body shape table (four rationale-only sections — `## Intent` / `## Guards` / `## Entry / Exit` / `## Coverage Caveat` — with what does *not* go in each), Maestro yaml contract (1:1 with FlowId, testID-keyed selectors, asserts traversal AND guards including the verbatim "cannot reach confirm without a valid URL" guard), testID naming convention with examples table, skeleton templates for both halves, filled `AddTitle` worked example (both `.flow.md` and `.yaml` exercising the URL guard via `assertNotVisible` → fill → `assertVisible`), naming decisions, the audio-service coverage caveat ("a green Maestro run must not be read as TTS coverage"), a "don't over-apply" rule, and a **review checklist** the audit / flow-lint surfaces drive findings from (including the forbidden-section blacklist: `## Steps`, `## Walkthrough`, `## Flow`, `## Path`, and selector-quality checks for visible-text / layout-index selectors).
- **`src/templates/agent-skills/README.md`** — adds a short pointer paragraph ("Flow Definitions") that names the skill, links the SKILL.prompt path, and explicitly does not duplicate the schema. The single source of truth lives in the skill body so the README and the skill can't drift. Mirrors how PR #430 handles the screen-side counterpart.
- **`src/permissions.ts`** — adds `Skill(smithy.helper-flow-definition *)` to the Claude allow-list so the skill loads without an approval prompt (matching how `helper-docker`, `helper-voice`, and `helper-screen-design` are wired). The existing `current-form Skill permissions` test iterates over `getTemplateFilesByCategory().skills` and exercises this entry automatically.
- **`src/templates.test.ts`** — large additions for the new contract:
  - Snippet count stays at 15 (no snippet); skills count 6 → 7; `smithy.helper-flow-definition` joins the explicit name list.
  - Ten new assertions lock the skill's contract: body-only / frontmatter retained; description triggers on authoring/auditing flows and names BOTH artifact paths + `kind: ui` + `phase: wire` + the three schema keys; body documents the three front-matter fields with explicit YAML labeling; four rationale-only body sections present; no-step-descriptions rule with forbidden-section blacklist (`## Steps` / `## Walkthrough` / `## Flow` / `## Path`); Maestro selector contract (testIDs, never visible text, never layout position, asserts traversal AND guards including the verbatim URL guard); testID naming convention with the two issue examples (`library-fab`, `add-title-url-field`); skeleton + filled AddTitle example with both halves, AddTitle front-matter, URL-guard `assertNotVisible`; audio-service coverage caveat with every load-bearing phrase; review checklist names every forbidden body heading by `` ` `` literal and flags visible-text / layout-index selectors.
  - One new README cross-file guard: README points at the skill, names the `SKILL.prompt` path, and does **not** carry the schema body itself (forbidden strings: testID examples, AddTitle yaml selectors, the app's `appId`).
- **No `.claude/` or manifest regeneration** (per CLAUDE.md — that drift is intentional between releases). The deployed `.claude/skills/smithy.helper-flow-definition/` materializes on the next `chore: upgrade Smithy templates to latest` chore PR.

### Files touched

| File | Change |
|------|--------|
| `src/templates/agent-skills/skills/smithy.helper-flow-definition/SKILL.prompt` | **new** — body-on-demand operational skill with full schema, Maestro contract, testID convention, skeleton templates, filled AddTitle example (both halves), audio-service coverage caveat, and review checklist. |
| `src/templates/agent-skills/README.md` | Short "Flow Definitions" pointer paragraph at the skill; no schema body. |
| `src/permissions.ts` | Adds `Skill(smithy.helper-flow-definition *)` to Claude allow-list. |
| `src/templates.test.ts` | Skills count 6 → 7, new skill `describe` block (10 assertions), README cross-file guard. |

## Risks & Mitigations
- **Risk:** authors treat the `.flow.md` body as a parallel narration of the yaml, re-describing taps and transitions — defeats the whole point. **Mitigation:** the schema explicitly forbids it (skill body's "Body shape" table calls this out with a "what does *not* go here" column, and the review checklist names every forbidden body heading by `` ` `` literal); the worked example contains zero step-narration; the test suite locks the forbidden-heading list so a softening edit fails CI.
- **Risk:** yaml side regresses to text-based selectors over time, breaking on copy edits. **Mitigation:** the Maestro contract calls out "testIDs / accessibility IDs / semantic tags — never visible text and never layout position" verbatim, and the review checklist's selector-quality bullet flags `text:` selectors and layout-index selectors as findings. The contract test guards both rules.
- **Risk:** field names drift once #408 starts emitting these files. **Mitigation:** the skill is the single source; #408 will `Skill("smithy.helper-flow-definition")` rather than re-typing the field list. The new tests lock the three field names (`id`, `screens`, `maestro`) so a rename fails CI.
- **Risk:** asymmetry with the screen-side skill (PR #430). **Mitigation:** this PR follows PR #430's structure section-by-section (same describe block shape, same "why a skill" rationale, same forbidden-sections + review-checklist pattern), so forge / audit / flow-lint compose them symmetrically.

## Rollback Plan
- Code: revert this commit. Adds one new skill file plus a permissions allow-list entry; touches the agent-skills README pointer paragraph and the test suite. No runtime CLI behaviour, no manifest, no deployed `.claude/` regeneration. Safe to revert in isolation.
- Data: none.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build` — tsup ⚡️ Build success).
- [x] Type check succeeds (`npm run typecheck` — clean).
- [ ] CLI `init` smoke test (`node dist/cli.js init`) — _N/A; this PR adds a skill + permissions entry + README pointer only and changes no init behaviour._

### Template Generation
- [ ] Gemini Skills: `.gemini/skills/` — _N/A; the deployed `.gemini/skills/smithy.helper-flow-definition/SKILL.md` materializes on the next `chore: upgrade Smithy templates to latest` PR per CLAUDE.md._
- [ ] Codex Prompts: `tools/codex/prompts/` — _N/A._
- [ ] Claude Prompts: `.claude/prompts/` — _N/A; ditto for `.claude/skills/`._
- [ ] GitHub Issue Templates: `.github/ISSUE_TEMPLATE/` — _N/A; unchanged._

### Permissions & Configuration
- [x] Claude allow-list: `Skill(smithy.helper-flow-definition *)` added; existing `current-form Skill permissions` test passes (every deployed `smithy.*` command and skill has a `Skill( *)` entry).
- [ ] Gemini Config — _N/A; unchanged._
- [ ] Codex Config — _N/A; unchanged._

### Manual Test Cases
- [ ] No init/uninit/update flows changed — Agent/Manual test review not required for this PR.

### Automated coverage added
- [x] `templates.test.ts` — skill is body-only with frontmatter retained, description triggers on authoring/auditing flows and names both artifact paths + `kind: ui` + `phase: wire` + the three schema keys, body documents the three front-matter fields with explicit YAML labeling, four rationale-only body sections, no-step-descriptions rule (forbidden-section blacklist), Maestro selector contract (testIDs, never visible text, never layout position, traversal-and-guards), testID naming convention with both issue examples, skeleton + AddTitle worked example with both halves and the URL-guard `assertNotVisible`, audio-service coverage caveat, review checklist names every forbidden heading by `` ` `` literal and flags visible-text / layout-index selectors.
- [x] `templates.test.ts` — agent-skills README points at the skill and does **not** carry the schema body (guarded by AddTitle testID strings, AddTitle yaml selectors, and the app's `appId`).
- [x] Full suite: **941 tests pass** (up from 915 on master).

## Issue
- Closes #406

https://claude.ai/code/session_017YjQcJhzmP1fWCuq8n8w7L