### PR TITLE
spec: JVM multi-language fixture + per-scenario fixture select (M1 F5)

### DIFF
--- a/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
+++ b/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
@@ -108,7 +108,7 @@ Recommended specification sequence:
 | F2 | Feature 1.3b: Per-Sub-Agent Token Attribution | F1 | specs/2026-05-20-008-per-sub-agent-token-attribution/ |
 | F3 | Feature 1.4: smithy.fix End-to-End Eval Scenario | F1 | specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/ |
 | F4 | Feature 1.5: smithy.forge End-to-End Eval Scenario + Runner git-init (RFC SD-002) | F1 | specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/ |
-| F5 | Feature 1.6: JVM Multi-Language Fixture | — | — |
+| F5 | Feature 1.6: JVM Multi-Language Fixture | — | specs/2026-06-06-011-jvm-multi-language-fixture/ |
 | F6 | Feature 1.7: Forge-JVM Eval Scenario + M1 Baseline-Set Completeness Gate | F1, F4, F5 | — |
 
 Feature 1.1 and Feature 1.2 are referenced-only rows with no implementation work, so they are intentionally omitted from the Dependency Order table. No spec will be authored against them in this milestone because they are inherited substrate / cross-RFC dependency.

--- a/specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.contracts.md
+++ b/specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.contracts.md
@@ -1,0 +1,176 @@
+# Contracts: JVM Multi-Language Fixture
+
+## Overview
+
+This feature defines the additive contracts needed for multiple eval fixtures: a scenario YAML field, loader validation, runner fixture resolution, and the committed JVM fixture layout. Existing scenarios that omit the new field keep their current behavior.
+
+## Interfaces
+
+### 1) Scenario Fixture Declaration
+
+**Purpose**: Allows a scenario YAML file to select a fixture under `evals/fixture/`.
+**Consumers**: Scenario loader, eval runner, scenario tests.
+**Providers**: Scenario YAML files under `evals/cases/`.
+
+#### Signature
+
+```yaml
+fixture: jvm
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `fixture` | string | No | Relative path under `evals/fixture/`. Omitted keeps default fixture behavior. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `EvalScenario.fixture` | string | Loaded fixture selector when supplied. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Field is absent | Load scenario normally and use the global or default fixture path. | Existing scenarios remain compatible. |
+| Field is empty | Reject or skip the scenario with a validation error naming `fixture`. | Empty selectors have no stable meaning. |
+| Field is non-string | Reject or skip the scenario with a validation error naming `fixture`. | Keeps scenario metadata typed. |
+| Field is absolute | Reject or skip the scenario with a validation error naming `fixture`. | Scenario YAML cannot select arbitrary machine paths. |
+| Field contains `..` | Reject or skip the scenario with a validation error naming `fixture`. | Prevents escaping `evals/fixture/`. |
+
+### 2) Fixture Resolution
+
+**Purpose**: Computes the source fixture directory copied for a single scenario run.
+**Consumers**: Eval runner and runner tests.
+**Providers**: Scenario metadata, CLI `--fixture` option, repository fixture root.
+
+#### Signature
+
+```ts
+resolveFixtureDir(
+  scenario: EvalScenario,
+  globalFixtureDir: string,
+  repoFixtureRoot: string,
+): string
+```
+
+The implementation may choose a different helper name, but the behavior must be separately unit-testable from agent spawning.
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scenario.fixture` | string | No | Scenario selector relative to `evals/fixture/`. |
+| `globalFixtureDir` | string | Yes | Existing runner fixture argument, defaulting to repository `evals/fixture/`. |
+| `repoFixtureRoot` | string | Yes | Repository fixture root for scenario selectors. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| effective fixture path | string | Absolute directory path to copy into the temp execution directory. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Scenario selector exists and target directory is missing | Fail before agent spawn with scenario name and resolved path. | The scenario is misconfigured. |
+| Scenario selector exists and target is not a directory | Fail before agent spawn with scenario name and resolved path. | The runner cannot copy a fixture file as a project root. |
+| Scenario selector escapes fixture root after normalization | Fail before agent spawn. | Defense in depth beyond loader validation. |
+| Global fixture is missing and scenario omits `fixture` | Preserve existing global-fixture failure behavior, but include the path in the error. | Compatibility with `--fixture` remains explicit. |
+
+### 3) Runner Copy Contract
+
+**Purpose**: Ensures the selected fixture, not always the default fixture, is copied and checksummed.
+**Consumers**: `runScenario`, fixture checksum code, tests.
+**Providers**: Fixture resolver.
+
+#### Signature
+
+```ts
+runScenario(
+  scenario: EvalScenario,
+  fixtureDir: string,
+  agent?: EvalAgent,
+): Promise<RunOutput>
+```
+
+`fixtureDir` remains the effective fixture directory passed to the runner. Orchestrator-level code is responsible for resolving per-scenario fixture overrides before calling `runScenario`, unless implementation extracts resolution into `runScenario` itself with equivalent tests.
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| effective fixture directory | string | Yes | Directory copied to a temp execution directory. |
+| `scenario.name` | string | Yes | Used in fixture resolution errors and test diagnostics. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| temp copy | filesystem state | Copy of the effective fixture directory. |
+| source checksum | string | Hash computed against the same effective fixture directory before and after execution. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Source fixture changes during execution | Fail with checksum mismatch for the selected fixture. | Existing mutation guard applies to every fixture. |
+| Selected fixture contains generated build output | Unit tests or repository status should expose unwanted committed files. | Keeps fixtures stable and small. |
+| F1.5 git initialization is present | Preserve it after fixture copy resolution. | Fixture selection and git setup are separate runner responsibilities. |
+
+### 4) JVM Fixture Layout
+
+**Purpose**: Defines the committed file shape future JVM scenarios can rely on.
+**Consumers**: F1.7 JVM forge scenario, M3 build-output protocol work, maintainers.
+**Providers**: Files under `evals/fixture/jvm/`.
+
+#### Signature
+
+```text
+evals/fixture/jvm/
+├── README.md
+├── settings.gradle(.kts)
+├── build.gradle(.kts)
+└── src/
+    ├── main/java/...
+    └── test/java/...
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| JDK | tool | Yes | Java toolchain needed to compile and test the fixture. |
+| Gradle or wrapper | tool/files | Yes | Build tool path documented by the fixture README. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| JVM project | files | Minimal Gradle project committed under `evals/fixture/jvm/`. |
+| failing test | test result | Deterministic failure that a future forge task can repair. |
+| README | documentation | Commands, intentional failure, and maintenance boundaries. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| JDK unavailable | README documents the prerequisite; local validation can skip with a clear tooling note. | The fixture is not executed by default unit tests unless tooling exists. |
+| Gradle unavailable and no wrapper committed | README documents the prerequisite. | Avoids hidden assumptions. |
+| Generated `build/` directory appears | Remove it or ignore it before commit. | Generated output is not fixture source. |
+| Test unexpectedly passes before F1.7 | Treat as fixture drift. | The failing test is the future forge repair target. |
+
+## Events / Hooks
+
+No runtime event stream is introduced. Fixture selection happens before existing temp-copy setup, skill deployment, agent spawning, parsing, structural validation, and report generation.
+
+## Integration Boundaries
+
+- **Scenario YAML boundary**: adds optional `fixture` metadata without changing existing required fields.
+- **Loader boundary**: validates the new field and leaves omitted values compatible.
+- **Runner boundary**: resolves and copies the effective fixture directory before existing git initialization and skill deployment.
+- **Fixture filesystem boundary**: adds `evals/fixture/jvm/` without moving or changing the existing JavaScript fixture root.
+- **Future scenario boundary**: F1.7 consumes `fixture: jvm` when it authors the JVM forge scenario and baseline.

--- a/specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.contracts.md
+++ b/specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.contracts.md
@@ -35,10 +35,10 @@ fixture: jvm
 | Condition | Response | Description |
 |-----------|----------|-------------|
 | Field is absent | Load scenario normally and use the global or default fixture path. | Existing scenarios remain compatible. |
-| Field is empty | Reject or skip the scenario with a validation error naming `fixture`. | Empty selectors have no stable meaning. |
-| Field is non-string | Reject or skip the scenario with a validation error naming `fixture`. | Keeps scenario metadata typed. |
-| Field is absolute | Reject or skip the scenario with a validation error naming `fixture`. | Scenario YAML cannot select arbitrary machine paths. |
-| Field contains `..` | Reject or skip the scenario with a validation error naming `fixture`. | Prevents escaping `evals/fixture/`. |
+| Field is empty | Skipped by `loadScenarios` (single stderr line naming `fixture`); thrown by `loadScenarioFromFile`. No new failure mode. | Empty selectors have no stable meaning. |
+| Field is non-string | Skipped by `loadScenarios` (single stderr line naming `fixture`); thrown by `loadScenarioFromFile`. No new failure mode. | Keeps scenario metadata typed. |
+| Field is absolute | Skipped by `loadScenarios` (single stderr line naming `fixture`); thrown by `loadScenarioFromFile`. No new failure mode. | Scenario YAML cannot select arbitrary machine paths. |
+| Field contains `..` | Skipped by `loadScenarios` (single stderr line naming `fixture`); thrown by `loadScenarioFromFile`. No new failure mode. | Prevents escaping `evals/fixture/`. |
 
 ### 2) Fixture Resolution
 

--- a/specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.data-model.md
+++ b/specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.data-model.md
@@ -1,0 +1,150 @@
+# Data Model: JVM Multi-Language Fixture
+
+## Overview
+
+This feature extends eval scenario metadata with an optional fixture selector and adds a second fixture rooted at `evals/fixture/jvm/`. The data model is filesystem-backed only: no database or external storage is introduced. The existing JavaScript fixture remains the default when a scenario does not select a fixture.
+
+## Entities
+
+### 1) Fixture Selector (`fixture_selector`)
+
+Purpose: Declares which fixture a scenario should run against.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `fixture` | string | No | Relative path under `evals/fixture/`. Omitted means use the default fixture path chosen by the runner invocation. |
+
+Validation rules:
+
+- Must be a non-empty string when present.
+- Must be relative, not absolute.
+- Must not contain `..` path segments.
+- Must resolve under `evals/fixture/`.
+- `fixture: jvm` resolves to `evals/fixture/jvm/`.
+
+### 2) Eval Scenario (`eval_scenario`)
+
+Purpose: Existing YAML-loaded scenario shape with additive fixture metadata.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | Existing scenario identifier. |
+| `skill` | string | Yes | Existing Smithy command under test. |
+| `prompt` | string | Yes | Existing prompt or argument string. |
+| `fixture` | string | No | Optional fixture selector. |
+| `model` | string | No | Existing optional model field. |
+| `timeout` | number | No | Existing optional timeout in seconds. |
+| `structural_expectations` | StructuralExpectations | Yes | Existing validation contract. |
+| `sub_agent_evidence` | SubAgentEvidence[] | No | Existing helper evidence contract. |
+
+Validation rules:
+
+- Existing field validation remains unchanged.
+- Fixture validation failure skips or rejects only the offending scenario.
+- Omitted fixture metadata must not change the loaded shape of current scenarios except for the absence of the new optional field.
+
+### 3) Effective Fixture Directory (`effective_fixture_directory`)
+
+Purpose: Concrete source directory copied into a temp run for one scenario.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `scenario_name` | string | Yes | Scenario being prepared. |
+| `source` | enum | Yes | `scenario`, `global`, or `default`. |
+| `path` | string | Yes | Absolute path to the source fixture directory. |
+| `selector` | string | Conditional | Scenario fixture selector when `source` is `scenario`. |
+
+Resolution precedence:
+
+1. Scenario `fixture` value, resolved under repository `evals/fixture/`.
+2. Global `--fixture` directory passed to `npm run eval`.
+3. Default `evals/fixture/` directory.
+
+Validation rules:
+
+- The effective path must exist.
+- The effective path must be a directory.
+- Scenario-level selectors must not escape the repository fixture root.
+- Failure happens before skill deployment or agent spawn.
+
+### 4) JVM Fixture (`jvm_fixture`)
+
+Purpose: Minimal non-JavaScript project used by future forge and build-output scenarios.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `root` | string | Yes | `evals/fixture/jvm/`. |
+| `settings` | file | Yes | `settings.gradle` or `settings.gradle.kts`. |
+| `build_config` | file | Yes | `build.gradle` or `build.gradle.kts`. |
+| `source_tree` | directory | Yes | Java source under `src/main/java/...`. |
+| `test_tree` | directory | Yes | Test source under `src/test/java/...`. |
+| `readme` | file | Yes | Fixture usage and maintenance notes. |
+| `wrapper` | files | Optional | Gradle wrapper files if implementation chooses wrapper-based reproducibility. |
+
+Validation rules:
+
+- The project must be small enough for eval agents to inspect quickly.
+- The fixture must contain at least one deterministic failing test for a future forge slice.
+- Generated build outputs must not be committed.
+- README instructions must match the actual build tooling committed.
+
+### 5) Fixture Resolver (`fixture_resolver`)
+
+Purpose: Runner logic that computes the effective fixture directory.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `scenario_fixture` | string | No | Scenario metadata value. |
+| `global_fixture` | string | No | Existing CLI `--fixture` value. |
+| `repo_fixture_root` | string | Yes | Repository `evals/fixture/` root used for scenario selectors. |
+| `effective_fixture` | string | Yes | Directory copied into the temp run. |
+
+Validation rules:
+
+- Scenario selector wins over global fixture.
+- Global fixture wins over repository default only when the scenario omits `fixture`.
+- The resolver must be testable without spawning an agent.
+
+## Relationships
+
+- `Eval Scenario` 0..1 `Fixture Selector`.
+- `Fixture Selector` 1:1 `Effective Fixture Directory` when present.
+- `Effective Fixture Directory` 1:1 copied temp run per scenario execution.
+- `JVM Fixture` is selected by `fixture: jvm`.
+- `Fixture Resolver` consumes scenario metadata plus the global fixture argument to produce the effective directory.
+
+## State Transitions
+
+### Scenario fixture lifecycle
+
+1. `declared` -> `loaded`
+   - Trigger: `loadScenarios` validates YAML.
+   - Effects: optional `fixture` metadata is attached to the scenario.
+
+2. `loaded` -> `resolved`
+   - Trigger: runner prepares a scenario.
+   - Effects: precedence rules select an effective fixture directory.
+
+3. `resolved` -> `copied`
+   - Trigger: runner copies the effective fixture into a temp directory.
+   - Effects: scenario execution is isolated from the source fixture.
+
+4. `copied` -> `checked`
+   - Trigger: checksum is computed before and after scenario execution.
+   - Effects: source fixture mutation is detected for the selected fixture.
+
+### JVM fixture lifecycle
+
+1. `authored` -> `documented`
+   - Trigger: README and build instructions are committed alongside source.
+   - Effects: maintainers can run and inspect the fixture.
+
+2. `documented` -> `consumed`
+   - Trigger: F1.7 adds a JVM forge scenario using `fixture: jvm`.
+   - Effects: the fixture becomes part of the measured eval suite.
+
+## Identity & Uniqueness
+
+- Fixture selectors are unique within a scenario by the single optional `fixture` field.
+- The JVM fixture is identified by `fixture: jvm` and path `evals/fixture/jvm/`.
+- Effective fixture directories are unique per scenario run by their temp-copy path, not by the source path.

--- a/specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.data-model.md
+++ b/specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.data-model.md
@@ -40,7 +40,7 @@ Purpose: Existing YAML-loaded scenario shape with additive fixture metadata.
 Validation rules:
 
 - Existing field validation remains unchanged.
-- Fixture validation failure skips or rejects only the offending scenario.
+- Fixture validation failure skips only the offending file in `loadScenarios` (single stderr line), and throws in `loadScenarioFromFile`; other scenarios are unaffected.
 - Omitted fixture metadata must not change the loaded shape of current scenarios except for the absence of the new optional field.
 
 ### 3) Effective Fixture Directory (`effective_fixture_directory`)
@@ -95,7 +95,7 @@ Purpose: Runner logic that computes the effective fixture directory.
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
 | `scenario_fixture` | string | No | Scenario metadata value. |
-| `global_fixture` | string | No | Existing CLI `--fixture` value. |
+| `global_fixture` | string | Yes | Existing CLI `--fixture` value. Always set: `run-evals.ts` defaults the `--fixture` option to `evals/fixture`, so the resolver always receives a string. Matches the required `globalFixtureDir` parameter in `contracts.md`. |
 | `repo_fixture_root` | string | Yes | Repository `evals/fixture/` root used for scenario selectors. |
 | `effective_fixture` | string | Yes | Directory copied into the temp run. |
 

--- a/specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.spec.md
+++ b/specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.spec.md
@@ -1,0 +1,172 @@
+# Feature Specification: JVM Multi-Language Fixture
+
+**Spec Folder**: `2026-06-06-011-jvm-multi-language-fixture`
+**Branch**: `2026-06-06-011-jvm-multi-language-fixture`
+**Created**: 2026-06-06
+**Status**: Draft
+**Input**: `docs/rfcs/2026-001-token-savings/token-savings.rfc.md` - Milestone 1 measurement-foundation feature for a JVM fixture and per-scenario fixture selection.
+**Source Feature Map**: `docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md` - Feature 1.6: JVM Multi-Language Fixture
+
+## Clarifications
+
+### Session 2026-06-06
+
+- This specification targets the Dependency Order row `F5`, which corresponds to Feature 1.6 in the measurement-foundation feature map. `[Critical Assumption]`
+- The existing eval fixture at `evals/fixture/` remains the default JavaScript fixture. This feature adds an additional JVM fixture and a scenario-level selection mechanism rather than replacing the current fixture.
+- The scenario YAML field is specified as `fixture:`. Values are relative paths under `evals/fixture/`; omitted values continue to use the existing JavaScript fixture root.
+- A scenario-level `fixture:` value overrides the global `--fixture` CLI argument for that scenario. The global flag remains the default when a scenario omits `fixture:`.
+- F1.5 owns git initialization around fixture copy and process spawn. This feature owns fixture path resolution and the JVM fixture contents; second-to-land changes in `evals/lib/runner.ts` must rebase without rewriting F1.5 git behavior.
+- This feature creates substrate only. The JVM forge eval scenario and JVM baseline are owned by F1.7.
+
+## Artifact Hierarchy
+
+RFC -> Milestone -> Feature -> User Story -> Slice -> Tasks
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1: Declare Per-Scenario Fixture Selection (Priority: P1)
+
+As a Smithy maintainer, I want eval scenarios to declare which fixture they run against so that the runner can exercise non-JavaScript toolchains without a separate orchestrator path per scenario.
+
+**Why this priority**: The JVM fixture is unusable by future scenarios until scenario metadata can select it deterministically.
+
+**Independent Test**: Load scenarios with omitted, valid, and malformed `fixture` values and verify the loaded scenario model preserves valid fixture selection while rejecting invalid metadata.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scenario YAML omits `fixture`, **When** `loadScenarios` parses it, **Then** the loaded scenario remains valid and uses the existing default fixture behavior.
+2. **Given** a scenario YAML includes `fixture: jvm`, **When** `loadScenarios` parses it, **Then** the loaded scenario exposes the fixture selector to the runner.
+3. **Given** a scenario YAML includes an empty, absolute, parent-traversing, or non-string `fixture` value, **When** scenario validation runs, **Then** the scenario is rejected or skipped with a field-specific validation error.
+
+---
+
+### User Story 2: Resolve Fixture Paths in the Runner (Priority: P1)
+
+As a Smithy contributor, I want the eval runner to resolve a scenario's fixture path consistently so that JS and JVM scenarios can coexist in one eval suite and still honor the existing `--fixture` override.
+
+**Why this priority**: F1.7 must run a forge scenario against the JVM fixture without changing the global runner invocation for every other case.
+
+**Independent Test**: Run mocked scenarios through the runner path resolver and verify default, global-override, and scenario-level fixture cases resolve to the expected directories.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scenario omits `fixture` and the user does not pass `--fixture`, **When** the runner prepares the scenario, **Then** it copies the existing `evals/fixture/` directory.
+2. **Given** a scenario omits `fixture` and the user passes `--fixture /tmp/custom-fixture`, **When** the runner prepares the scenario, **Then** it copies `/tmp/custom-fixture`.
+3. **Given** a scenario declares `fixture: jvm`, **When** the runner prepares the scenario, **Then** it resolves and copies `evals/fixture/jvm/` regardless of the global `--fixture` value.
+4. **Given** a scenario declares a fixture path that does not exist or is not a directory, **When** the runner prepares the scenario, **Then** it fails before spawning the agent with an error naming the scenario and fixture path.
+
+---
+
+### User Story 3: Provide a Minimal JVM Gradle Fixture (Priority: P1)
+
+As a Smithy maintainer, I want a minimal realistic Gradle-based JVM fixture so that forge and build-output protocol work can be evaluated against a non-JavaScript toolchain.
+
+**Why this priority**: M3's build-output protocol makes Gradle-specific claims, and M2 forge reductions need validation beyond the JavaScript fixture.
+
+**Independent Test**: Inspect and build the JVM fixture locally, then run its intentionally failing test to confirm it presents a deterministic forge-ready failure.
+
+**Acceptance Scenarios**:
+
+1. **Given** `evals/fixture/jvm/` exists, **When** a maintainer lists its contents, **Then** it contains a minimal Gradle project with settings, build configuration, source, and test files.
+2. **Given** the JVM fixture is built, **When** Gradle runs with the documented command, **Then** the project compiles without requiring network access beyond any documented first-time dependency resolution.
+3. **Given** the fixture test suite runs, **When** the planted failing test executes, **Then** the failure is deterministic and suitable for a smithy.forge slice to repair.
+4. **Given** the fixture is read by eval agents, **When** they inspect its README, **Then** the intended failing behavior and maintenance boundaries are documented.
+
+---
+
+### User Story 4: Preserve Existing Fixture Behavior (Priority: P1)
+
+As a Smithy contributor, I want the existing JavaScript fixture and planning-command scenarios to keep working so that adding JVM support does not destabilize the current eval suite.
+
+**Why this priority**: The JVM fixture is additive measurement substrate. Regressing existing scenarios would weaken the quality net that downstream cost work depends on.
+
+**Independent Test**: Run the eval unit tests for scenario loading, runner fixture copy behavior, fixture checksum behavior, and existing fixture deployment after adding JVM fixture support.
+
+**Acceptance Scenarios**:
+
+1. **Given** existing scenario YAML files do not declare `fixture`, **When** the full scenario list is loaded, **Then** their loaded shapes and default fixture selection remain unchanged.
+2. **Given** the runner executes a default-fixture scenario, **When** checksum validation runs, **Then** it still hashes the source fixture selected for that scenario and fails on source mutation.
+3. **Given** `evals/fixture/README.md` documents existing planted JS fixture artifacts, **When** this feature lands, **Then** those plants are not moved, renamed, or cleaned up.
+4. **Given** the new JVM fixture contains Gradle output or build directories after manual testing, **When** fixture checksum and repository status are inspected, **Then** generated directories are ignored or absent from the committed fixture.
+
+### Edge Cases
+
+- `fixture:` must not accept absolute paths, `..` segments, symlink escapes, or empty strings.
+- Scenario-level fixture selection must not alter scenario sorting, duplicate-name detection, structural expectations, sub-agent evidence, `timeout`, or `model` loading.
+- The default fixture path must remain compatible with the current `npm run eval -- --fixture <path>` behavior.
+- JVM fixture dependency resolution may need network on a developer's first run; the committed fixture must document whether a Gradle wrapper is included or whether system Gradle/JDK are required.
+- F1.7 may add the first scenario that consumes `fixture: jvm`; this feature still must unit test the loader and resolver before that scenario exists.
+
+## Dependency Order
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| US1 | Declare Per-Scenario Fixture Selection | — | — |
+| US2 | Resolve Fixture Paths in the Runner | US1 | — |
+| US3 | Provide a Minimal JVM Gradle Fixture | — | — |
+| US4 | Preserve Existing Fixture Behavior | US1, US2, US3 | — |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The `EvalScenario` type MUST support an optional `fixture` string.
+- **FR-002**: `loadScenarios` MUST preserve omitted `fixture` values as the existing default fixture behavior.
+- **FR-003**: `loadScenarios` MUST reject malformed `fixture` values with an error that names the `fixture` field.
+- **FR-004**: Valid `fixture` values MUST be relative paths under `evals/fixture/`.
+- **FR-005**: Valid `fixture` values MUST reject absolute paths, empty strings, parent traversal, and path forms that escape `evals/fixture/`.
+- **FR-006**: The runner MUST resolve the effective fixture directory per scenario using this precedence: scenario `fixture` value, then global `--fixture`, then default `evals/fixture/`.
+- **FR-007**: A scenario-level `fixture` value MUST override the global `--fixture` argument for that scenario.
+- **FR-008**: Missing or non-directory effective fixtures MUST fail before agent spawn with a clear scenario-specific error.
+- **FR-009**: The JVM fixture MUST live under `evals/fixture/jvm/`.
+- **FR-010**: The JVM fixture MUST contain a minimal Gradle project with settings, build configuration, Java source, and at least one test.
+- **FR-011**: The JVM fixture MUST include a deterministic failing test suitable for a future smithy.forge slice.
+- **FR-012**: The JVM fixture README MUST document how to run the fixture, which failure is intentional, and which files are fixture-owned.
+- **FR-013**: Existing JavaScript fixture files and existing scenario YAML files MUST NOT be moved, renamed, or semantically changed by this feature.
+- **FR-014**: Unit tests MUST cover loader validation, fixture precedence, missing fixture failure, default fixture preservation, and JVM fixture presence.
+
+### Key Entities
+
+- **Fixture Selector**: Optional scenario metadata naming a fixture subdirectory under `evals/fixture/`.
+- **Effective Fixture Directory**: The concrete directory copied into the temp run for a scenario after applying precedence rules.
+- **JVM Fixture**: The committed Gradle project under `evals/fixture/jvm/`.
+- **Fixture Resolver**: Runner logic that turns scenario metadata and CLI defaults into the effective fixture directory.
+- **Fixture Maintenance Notes**: Documentation in the JVM fixture that explains intentional failures and generated-file boundaries.
+
+## Assumptions
+
+- The existing `evals/fixture/` root remains the JavaScript default fixture for all current scenarios.
+- `fixture: jvm` is the canonical selector for the new JVM fixture.
+- Gradle is the JVM build tool for this program because M3 F3.1's build-output protocol specifically needs Gradle clauses.
+- A small Java project is sufficient; Kotlin, Spring, Android, and multi-module Gradle are out of scope.
+- F1.7 owns the first JVM forge scenario and baseline, so this feature does not need to author scenario YAML that consumes the new fixture.
+
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | The fixture selector is specified as `fixture:` with relative paths under `evals/fixture/`, resolving feature-map SD-002 for F1.6. If implementation discovers a current CLI flag path assumption that makes this precedence hard to preserve, update this debt row with the exact compatibility tradeoff before changing the contract. | Integration Points | Medium | High | open | — |
+| SD-002 | The Gradle wrapper choice is left to implementation. Including a wrapper improves reproducibility but adds binary/script files; requiring system Gradle keeps the fixture smaller but depends on developer tooling. The fixture README must document whichever option is chosen. | Non-Functional Quality | Medium | Medium | open | — |
+| SD-003 | F1.5 and F1.6 both touch `evals/lib/runner.ts`. F1.5 owns git setup around temp-copy initialization; F1.6 owns fixture path resolution before the copy. Second-to-land implementation must rebase and keep both contracts intact. | Integration | Medium | High | open | — |
+
+## Out of Scope
+
+- Authoring `evals/cases/forge-tdd-slice-jvm.yaml` or any other JVM scenario.
+- Committing `evals/baselines/forge-tdd-slice-jvm.json`.
+- Changing F1.5's forge-JS scenario or git initialization contract.
+- Implementing the M3 build-output protocol.
+- Adding Cargo, Go, Python, Kotlin, Android, Spring, or multi-module fixtures.
+- Regenerating `.claude/` or `.smithy/` snapshots.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Scenario loading supports optional `fixture` metadata with validation coverage.
+- **SC-002**: Runner fixture resolution supports default fixture, global `--fixture`, and scenario-level override behavior.
+- **SC-003**: `evals/fixture/jvm/` contains a documented minimal Gradle project with deterministic source and test files.
+- **SC-004**: Existing eval scenarios that omit `fixture` continue to load and run against the JavaScript fixture by default.
+- **SC-005**: Missing or invalid fixture selections fail before agent spawn with clear errors.
+- **SC-006**: Unit tests cover the loader, resolver, default compatibility, and JVM fixture shape.

--- a/specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.spec.md
+++ b/specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.spec.md
@@ -13,7 +13,7 @@
 
 - This specification targets the Dependency Order row `F5`, which corresponds to Feature 1.6 in the measurement-foundation feature map. `[Critical Assumption]`
 - The existing eval fixture at `evals/fixture/` remains the default JavaScript fixture. This feature adds an additional JVM fixture and a scenario-level selection mechanism rather than replacing the current fixture.
-- The scenario YAML field is specified as `fixture:`. Values are relative paths under `evals/fixture/`; omitted values continue to use the existing JavaScript fixture root.
+- The scenario YAML field is specified as `fixture:`. Values are relative paths under `evals/fixture/`; an omitted value preserves the existing defaulting behavior — the global `--fixture` argument when set, otherwise the `evals/fixture/` JavaScript fixture root.
 - A scenario-level `fixture:` value overrides the global `--fixture` CLI argument for that scenario. The global flag remains the default when a scenario omits `fixture:`.
 - F1.5 owns git initialization around fixture copy and process spawn. This feature owns fixture path resolution and the JVM fixture contents; second-to-land changes in `evals/lib/runner.ts` must rebase without rewriting F1.5 git behavior.
 - This feature creates substrate only. The JVM forge eval scenario and JVM baseline are owned by F1.7.
@@ -30,13 +30,13 @@ As a Smithy maintainer, I want eval scenarios to declare which fixture they run 
 
 **Why this priority**: The JVM fixture is unusable by future scenarios until scenario metadata can select it deterministically.
 
-**Independent Test**: Load scenarios with omitted, valid, and malformed `fixture` values and verify the loaded scenario model preserves valid fixture selection while rejecting invalid metadata.
+**Independent Test**: Load scenarios with omitted, valid, and malformed `fixture` values and verify the loaded scenario model preserves valid fixture selection while `loadScenarios` skips files with invalid metadata.
 
 **Acceptance Scenarios**:
 
 1. **Given** a scenario YAML omits `fixture`, **When** `loadScenarios` parses it, **Then** the loaded scenario remains valid and uses the existing default fixture behavior.
 2. **Given** a scenario YAML includes `fixture: jvm`, **When** `loadScenarios` parses it, **Then** the loaded scenario exposes the fixture selector to the runner.
-3. **Given** a scenario YAML includes an empty, absolute, parent-traversing, or non-string `fixture` value, **When** scenario validation runs, **Then** the scenario is rejected or skipped with a field-specific validation error.
+3. **Given** a scenario YAML includes an empty, absolute, parent-traversing, or non-string `fixture` value, **When** `loadScenarios` parses it, **Then** the offending file is skipped (not the whole run) with a single stderr line naming the `fixture` field — matching the existing loader policy where `loadScenarios` skips invalid files and `loadScenarioFromFile` throws. This feature adds no new failure-handling mode.
 
 ---
 
@@ -114,7 +114,7 @@ Recommended implementation sequence:
 
 - **FR-001**: The `EvalScenario` type MUST support an optional `fixture` string.
 - **FR-002**: `loadScenarios` MUST preserve omitted `fixture` values as the existing default fixture behavior.
-- **FR-003**: `loadScenarios` MUST reject malformed `fixture` values with an error that names the `fixture` field.
+- **FR-003**: `loadScenarios` MUST skip files with malformed `fixture` values, emitting a single stderr line that names the `fixture` field (consistent with its existing skip-and-continue policy); `loadScenarioFromFile` MUST throw on the same input.
 - **FR-004**: Valid `fixture` values MUST be relative paths under `evals/fixture/`.
 - **FR-005**: Valid `fixture` values MUST reject absolute paths, empty strings, parent traversal, and path forms that escape `evals/fixture/`.
 - **FR-006**: The runner MUST resolve the effective fixture directory per scenario using this precedence: scenario `fixture` value, then global `--fixture`, then default `evals/fixture/`.
@@ -130,10 +130,10 @@ Recommended implementation sequence:
 ### Key Entities
 
 - **Fixture Selector**: Optional scenario metadata naming a fixture subdirectory under `evals/fixture/`.
+- **Eval Scenario**: The existing YAML-loaded scenario shape, extended with the additive optional `fixture` selector.
 - **Effective Fixture Directory**: The concrete directory copied into the temp run for a scenario after applying precedence rules.
-- **JVM Fixture**: The committed Gradle project under `evals/fixture/jvm/`.
+- **JVM Fixture**: The committed Gradle project under `evals/fixture/jvm/`, including its README maintenance notes that document intentional failures and generated-file boundaries.
 - **Fixture Resolver**: Runner logic that turns scenario metadata and CLI defaults into the effective fixture directory.
-- **Fixture Maintenance Notes**: Documentation in the JVM fixture that explains intentional failures and generated-file boundaries.
 
 ## Assumptions
 


### PR DESCRIPTION
## Summary

`smithy.mark` step for **Feature 1.6 (F5)** of the token-savings RFC measurement-foundation feature map (`docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md`, arg `5`).

Specifies a committed **JVM (Gradle) eval fixture** under `evals/fixture/jvm/` plus an additive, per-scenario **`fixture:` selector** on the scenario YAML schema, so a single forge scenario can target the existing JS fixture or the new JVM fixture without an orchestrator change per scenario. This is substrate only — F1.7 owns the first JVM forge scenario and baseline.

## Changes

- New spec folder `specs/2026-06-06-011-jvm-multi-language-fixture/`:
  - `*.spec.md` — 4 user stories (US1–US4), FR-001…FR-014, success criteria SC-001…SC-006, 3 spec-debt rows, out-of-scope.
  - `*.data-model.md` — fixture-selector / eval-scenario / effective-fixture-directory / jvm-fixture / fixture-resolver entities, resolution precedence, lifecycles.
  - `*.contracts.md` — scenario fixture declaration, fixture resolution, runner copy contract, JVM fixture layout, integration boundaries.
- Links the spec folder in the **F5 Dependency Order** row of the feature map (Artifact column `—` → spec folder path).

## Resolved feature-map debt

- **SD-002** (fixture field shape): settled as `fixture:`, optional, relative path under `evals/fixture/`, defaulting to the JS fixture when omitted, per-scenario value overriding the global `--fixture` flag (spec SD-001).
- **SD-007** (F1.5/F1.6 both touch `evals/lib/runner.ts`): F1.5 owns git setup around temp-copy init; F1.6 owns fixture-path resolution before the copy; second-to-land rebases (spec SD-003).

## Completion signal

This is a `smithy.mark` (feature-spec) step, not an implementation step. There is no `tasks.md` at the feature-map level — per the repo's artifact rules the **Artifact column** in the Dependency Order table is the started/not-started signal, and it is flipped from `—` to the new spec folder in this patch.

## Verification

Markdown-only artifact change; no source code touched, so build/test suites are not meaningfully exercised by this diff. Verified: all three artifacts have correct headers and well-formed tables, the F5 row links the spec folder, and the spec's out-of-scope/debt sections stay within F1.6's ownership boundary (no F1.5/F1.7 encroachment). No verification gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
