### PR TITLE
Parameterize forge by feature kind/phase for UI build/wire

### DIFF
--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -865,6 +865,14 @@ describe('getComposedTemplates', () => {
       expect(section).toContain('phase');
       expect(section).toContain('design_system');
       expect(section).toContain('bundle');
+      // The resolve instruction must explicitly include `flag` — downstream
+      // steps gate the mock build, flip at wire, and pass it into sub-agents,
+      // so forge must resolve it alongside the other UI fields (PR #434 review).
+      const resolveLine = section
+        .split('\n')
+        .find((l) => /Determine `kind`/.test(l));
+      expect(resolveLine).toBeDefined();
+      expect(resolveLine!).toContain('`flag`');
       // Default-to-backend keeps pre-#404 tasks/strike files on the old path.
       expect(section).toMatch(/default.*backend/i);
     });
@@ -912,7 +920,7 @@ describe('getComposedTemplates', () => {
       const section = routingSection(forge);
       const wireRow = section
         .split('\n')
-        .find((l) => l.includes('`wire`'));
+        .find((l) => l.trimStart().startsWith('|') && l.includes('`wire`'));
       expect(wireRow).toBeDefined();
       expect(wireRow!).toMatch(/maestro flow/i);
       expect(wireRow!).toContain('flow.md');

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -834,6 +834,146 @@ describe('getComposedTemplates', () => {
     expect(forge).toContain('smithy.helper-docker');
   });
 
+  // Issue #408 (EPIC #404): smithy.forge is parameterized by feature `kind`
+  // and `phase` WITHOUT forking the pipeline. The four UI paths are:
+  //   build × no-bundle, build × bundle, wire × (flow emission), plus the
+  //   ui reviewer profile. The backend path must stay unchanged. These tests
+  //   are structural — they isolate the routing section and assert each path's
+  //   distinguishing instruction is present without pinning exact wording.
+  describe('smithy.forge kind/phase routing (#408)', () => {
+    // Helper: slice out the Feature Kind Routing section so assertions don't
+    // accidentally match unrelated prose elsewhere in the prompt.
+    const routingSection = (forge: string): string => {
+      const start = forge.indexOf('## Feature Kind Routing');
+      expect(start).toBeGreaterThan(-1);
+      const end = forge.indexOf('\n## ', start + 1);
+      expect(end).toBeGreaterThan(start);
+      return forge.slice(start, end);
+    };
+
+    it('advertises the two UI helper skills in the operational skills table', () => {
+      const forge = composed.commands.get('smithy.forge.md')!;
+      expect(forge).toContain('smithy.helper-screen-design');
+      expect(forge).toContain('smithy.helper-flow-definition');
+    });
+
+    it('has a Feature Kind Routing section that resolves kind from the feature map and defaults to backend', () => {
+      const section = routingSection(composed.commands.get('smithy.forge.md')!);
+      // Reads kind/phase/design_system/bundle from the feature (#405 schema).
+      expect(section).toContain('Source Feature Map');
+      expect(section).toContain('kind');
+      expect(section).toContain('phase');
+      expect(section).toContain('design_system');
+      expect(section).toContain('bundle');
+      // Default-to-backend keeps pre-#404 tasks/strike files on the old path.
+      expect(section).toMatch(/default.*backend/i);
+    });
+
+    it('keeps the backend path explicitly unchanged', () => {
+      const section = routingSection(composed.commands.get('smithy.forge.md')!);
+      const backendRow = section
+        .split('\n')
+        .find((l) => l.includes('`backend`') && /unchanged/i.test(l));
+      expect(backendRow).toBeDefined();
+    });
+
+    // Path 1 — UI build, no bundle: Compose from prose + committed skill.
+    it('routes UI build with no bundle to Compose from prose + the committed design skill', () => {
+      const section = routingSection(composed.commands.get('smithy.forge.md')!);
+      const buildNoBundle = section
+        .split('\n')
+        .find((l) => l.includes('`build`') && /absent/i.test(l));
+      expect(buildNoBundle).toBeDefined();
+      expect(buildNoBundle!).toMatch(/compose/i);
+      expect(buildNoBundle!).toMatch(/prose/i);
+      expect(buildNoBundle!).toContain('design_system');
+    });
+
+    // Path 2 — UI build, with bundle: translate to Compose under conflict rule.
+    it('routes UI build with a bundle to a Compose translation under the bundle-vs-skill conflict rule', () => {
+      const section = routingSection(composed.commands.get('smithy.forge.md')!);
+      const buildBundle = section
+        .split('\n')
+        .find((l) => l.includes('`build`') && /present/i.test(l));
+      expect(buildBundle).toBeDefined();
+      // Conflict rule: bundle wins on layout/visual intent; skill wins on dialect.
+      expect(buildBundle!).toMatch(/bundle wins on layout/i);
+      expect(buildBundle!).toMatch(/skill wins on implementation dialect/i);
+    });
+
+    it('preloads the design_system skill as implementer context for every UI profile', () => {
+      const section = routingSection(composed.commands.get('smithy.forge.md')!);
+      expect(section).toMatch(/preload the `design_system` skill/i);
+    });
+
+    // Path 3 — UI wire: definition-of-done emits/updates the Maestro flow + flow.md.
+    it('routes UI wire so the definition-of-done emits/updates the Maestro flow + flow.md for participating flows', () => {
+      const forge = composed.commands.get('smithy.forge.md')!;
+      const section = routingSection(forge);
+      const wireRow = section
+        .split('\n')
+        .find((l) => l.includes('`wire`'));
+      expect(wireRow).toBeDefined();
+      expect(wireRow!).toMatch(/maestro flow/i);
+      expect(wireRow!).toContain('flow.md');
+      // The wire gate is a real STOP gate, not a note.
+      const gateStart = forge.indexOf('## Wire Definition-of-Done');
+      expect(gateStart).toBeGreaterThan(-1);
+      const gate = forge.slice(gateStart, forge.indexOf('\n## ', gateStart + 1));
+      expect(gate).toContain('design/flows/<FlowId>.flow.md');
+      expect(gate).toContain('maestro/flows/<FlowId>.yaml');
+      expect(gate).toMatch(/testID-keyed/i);
+      expect(gate).toMatch(/STOP gate/);
+    });
+
+    // Path 4 — reviewer profile selection for kind: ui.
+    it('selects a structural-conformance reviewer profile for kind: ui that does not judge visual fidelity', () => {
+      const forge = composed.commands.get('smithy.forge.md')!;
+      const start = forge.indexOf('### Review profile selection');
+      expect(start).toBeGreaterThan(-1);
+      const profile = forge.slice(start, forge.indexOf('\n{{#ifAgent}}', start));
+      // Structural conformance checks from the issue.
+      expect(profile).toMatch(/tokens-only/i);
+      expect(profile).toMatch(/no hardcoded hex|raw color literal/i);
+      expect(profile).toMatch(/component reuse/i);
+      expect(profile).toMatch(/M2 convention|Material-2/i);
+      expect(profile).toMatch(/every brief state|brief state present/i);
+      expect(profile).toMatch(/touch-target/i);
+      expect(profile).toMatch(/contrast/i);
+      // Explicitly does NOT judge visual fidelity, and stays read-only.
+      expect(profile).toMatch(/does not judge visual fidelity/i);
+      expect(profile).toMatch(/read-only|no-write/i);
+    });
+
+    it('carries the routing and reviewer-profile selection into the Codex (non-agent) variant too', () => {
+      // Routing is agent-independent: it changes inputs + review profile, not
+      // orchestration, so the Codex inline path must see it as well.
+      const forge = codexComposed.commands.get('smithy.forge.md')!;
+      expect(forge).toContain('## Feature Kind Routing');
+      expect(forge).toContain('### Review profile selection');
+      expect(forge).toMatch(/does not judge visual fidelity/i);
+    });
+  });
+
+  it('smithy-implementation-review carries a ui structural-conformance profile that excludes visual fidelity', () => {
+    const review = composed.agents.get('smithy.implementation-review.md')!;
+    expect(review).toBeDefined();
+    // Profile selection input + the two profiles.
+    expect(review).toContain('Review profile');
+    expect(review).toMatch(/`backend` profile/);
+    expect(review).toMatch(/`ui` profile/);
+    // ui profile = structural conformance only, no visual fidelity.
+    expect(review).toMatch(/structural conformance only/i);
+    expect(review).toMatch(/do not judge visual fidelity/i);
+    // ui category vocabulary covers the issue's structural checks.
+    expect(review).toMatch(/Hardcoded design value/i);
+    expect(review).toMatch(/Component reuse/i);
+    expect(review).toMatch(/M2 convention/i);
+    expect(review).toMatch(/Missing brief state/i);
+    expect(review).toMatch(/Accessibility role/i);
+    expect(review).toMatch(/Flow conformance/i);
+  });
+
   // Issue #420: smithy.helper-voice is a new body-only operational skill
   // that distributes the voice & audience taxonomy (EPIC #419). These
   // assertions back-stop the deployment contract (body-only, frontmatter

--- a/src/templates/agent-skills/agents/smithy.implementation-review.prompt
+++ b/src/templates/agent-skills/agents/smithy.implementation-review.prompt
@@ -32,6 +32,9 @@ The parent agent passes you:
    - Contracts (`.contracts.md`) — interfaces and API surface
 5. **Changed files** — list of files modified between BASE_SHA and HEAD.
 6. **Raw diff** — the full `git diff BASE_SHA HEAD` output.
+7. **Review profile** — `backend` (default) or `ui`. For `ui`, the parent also
+   passes the `phase` (`build` | `wire`), the `design_system` skill reference,
+   and the `screens` / `flows` lists.
 
 Read the reference files and changed files to understand both the requirements
 and the implementation. You have only read-only tools (Read, Grep, Glob) —
@@ -43,10 +46,51 @@ you cannot modify files or run commands that mutate state.
 
 ---
 
+## Review profiles
+
+The **Review profile** input selects which categories apply. Use exactly one
+profile per run.
+
+### `backend` profile (default)
+
+Use the six categories under "Categories" below. This is the unchanged code
+review profile.
+
+### `ui` profile (`kind: ui` features)
+
+Review **structural conformance only**. **Do not judge visual fidelity** —
+pixel matching, exact spacing, palette taste, and overall look-and-feel are a
+human glance upstream on the design canvas, never a finding here. A screen that
+conforms structurally but "looks off" is **not** a review finding. Load
+`smithy.helper-screen-design` (and, at `phase: wire`,
+`smithy.helper-flow-definition`) for the authoring contracts you are checking
+against. Classify each `ui`-profile finding's `category` as one of:
+
+- **Hardcoded design value** — a raw color literal (hex, `Color(0x…)`), raw
+  dimension, or other token-able value used instead of a `design_system` token.
+- **Component reuse** — a bespoke widget hand-rolled where a design-system
+  component exists, or a design-system component used against its contract.
+- **M2 convention violation** — diverges from the design dialect (teal-only
+  palette, 4dp corners, no second hue, Material-2 conventions from the
+  `design_system` skill).
+- **Missing brief state** — a state the brief requires (empty, valid,
+  error/invalid, loading/submitting) that the screen does not render.
+- **Accessibility role** — a touch target below the minimum size or a
+  contrast/accessibility role that is not satisfied.
+- **Flow conformance** (`phase: wire` only) — a flow in `flows` whose
+  `flow.md` + Maestro yaml pair is missing, uses visible-text/layout-index
+  selectors instead of testIDs, or asserts a guard in `flow.md` that has no
+  matching `assertVisible` / `assertNotVisible` in the yaml.
+
+Severity × confidence and the `Finding` structure are identical across profiles
+— only the category vocabulary changes.
+
+---
+
 ## Categories
 
-When reviewing an implementation diff, classify each finding's `category`
-as one of:
+These are the **`backend`-profile** categories. When reviewing a backend
+implementation diff, classify each finding's `category` as one of:
 
 - **Missing tests** — behavior introduced without corresponding test coverage,
   or a contract surface that is exercised only in the happy path.
@@ -77,8 +121,9 @@ Return a single `ReviewResult` to smithy-forge. The result has two fields:
 - **`findings`** — a list of `Finding` entries in the structure documented
   in the shared review protocol (`category`, `severity`, `confidence`,
   `description`, `artifact_path`, `proposed_fix`). Emit one finding per
-  distinct issue. Use the six categories listed above for the `category`
-  field.
+  distinct issue. Use the category vocabulary for the **selected review
+  profile** (`backend` six categories, or `ui` structural-conformance
+  categories) for the `category` field.
 - **`summary`** — a short, human-readable summary of what was reviewed and
   the overall assessment (e.g., counts per severity, whether any Critical
   items are present, whether the implementation appears to satisfy the

--- a/src/templates/agent-skills/agents/smithy.implementation-review.prompt
+++ b/src/templates/agent-skills/agents/smithy.implementation-review.prompt
@@ -61,10 +61,15 @@ review profile.
 Review **structural conformance only**. **Do not judge visual fidelity** —
 pixel matching, exact spacing, palette taste, and overall look-and-feel are a
 human glance upstream on the design canvas, never a finding here. A screen that
-conforms structurally but "looks off" is **not** a review finding. Load
-`smithy.helper-screen-design` (and, at `phase: wire`,
-`smithy.helper-flow-definition`) for the authoring contracts you are checking
-against. Classify each `ui`-profile finding's `category` as one of:
+conforms structurally but "looks off" is **not** a review finding. Your tools
+are `Read`/`Grep`/`Glob` only — you do **not** invoke the Skill mechanism. The
+parent (`smithy.forge`) inlines the relevant authoring checklist into your
+dispatch — the `smithy.helper-screen-design` checklist for every UI review, plus
+the `smithy.helper-flow-definition` checklist at `phase: wire` — so you enforce
+the screen and flow-pair contracts from the passed context (if a deployed skill
+file is reachable in the repo you may `Read` it directly, but the category list
+below is self-contained). Classify each `ui`-profile finding's `category` as one
+of:
 
 - **Hardcoded design value** — a raw color literal (hex, `Color(0x…)`), raw
   dimension, or other token-able value used instead of a `design_system` token.

--- a/src/templates/agent-skills/commands/smithy.forge.prompt
+++ b/src/templates/agent-skills/commands/smithy.forge.prompt
@@ -24,6 +24,8 @@ the canonical set of fallbacks for problems that recur across forge runs.
 | Skill | Load when |
 |-------|-----------|
 | `smithy.helper-docker` | A docker command appears stuck (>60s without progress), a container exits unexpectedly, or validation fails with docker-related errors. |
+| `smithy.helper-screen-design` | Implementing or reviewing a `kind: ui` feature — for the screen design-context annotation schema and the bundle-vs-skill conflict rule. |
+| `smithy.helper-flow-definition` | Implementing or reviewing a `kind: ui` feature at `phase: wire` — for the `flow.md` + Maestro yaml entity pair, the testID convention, and the wire definition-of-done. |
 
 ---
 
@@ -84,6 +86,52 @@ This may be:
    - **Goal** — from the `## Goal` section
    - **Tasks** — the ordered checklist under `### Tasks` within `## Single Slice`
    - **Context** — read inline sections (Summary, Requirements, Data Model, Contracts, etc.) instead of external spec files. There are no FR/AS cross-references to extract.
+
+---
+
+## Feature Kind Routing
+
+Smithy features are **typed** — `kind: backend | ui` — as documented in the
+"Feature Kinds and the Build/Wire Seam" section of the agent-skills README. The
+kind and, for UI work, the phase/design fields select the forge **profile**: the
+*same* implementer → tester → reviewer → PR pipeline runs in every case, with
+different inputs and a different review profile. **Routing changes inputs and the
+review profile, not the orchestration.** Resolve the profile once here and carry
+it through Implementation and Review.
+
+### Resolve the feature kind
+
+Determine `kind`, and for UI also `phase`, `design_system`, `bundle`, `screens`,
+and `flows`:
+
+1. **`.tasks.md` mode** — read the spec's `**Source Feature Map**` header
+   (`<path-to-.features.md> — Feature <N>`). Open that `.features.md`, find the
+   `### Feature <N>` heading, and read its fenced ` ```yaml ` metadata block
+   (placed right after the heading, before the prose). If the spec carries no
+   `**Source Feature Map**` header, or the feature has no yaml block, treat the
+   feature as `kind: backend`.
+2. **`.strike.md` mode** — read a `kind:`/`phase:` block from the strike header
+   if one is present; otherwise treat the slice as `kind: backend`.
+3. **No metadata found** — default to `kind: backend`. This keeps every
+   pre-#404 tasks/strike file on the unchanged backend path.
+
+### Profiles
+
+| Kind | Phase | Bundle | Forge profile |
+|------|-------|--------|---------------|
+| `backend` | — | — | **Backend (unchanged).** Tests are behavioral; review is the structural code review below. Everything behaves exactly as it did before this routing existed. |
+| `ui` | `build` | absent | **UI build from prose.** Generate Jetpack Compose for the screen from the screen prose + the committed `design_system` skill. Render *every* brief state (empty, valid, error/invalid, loading/submitting), behind the feature `flag`, against a mock — no real data. |
+| `ui` | `build` | present | **UI build from bundle.** Translate the web bundle (HTML/React/Tailwind) into Compose — it is a visual+structural *reference*, not a drop-in. **Conflict rule: the bundle wins on layout & visual intent; the `design_system` skill wins on implementation dialect** (Compose tokens, teal-only palette, 4dp corners, no second hue). Same flag-gated, mock-data, all-states requirement as the no-bundle build. |
+| `ui` | `wire` | either | **UI wire.** Connect the screen to real data/actions and flip the `flag`. **Definition-of-done includes emitting/updating the Maestro flow + `flow.md` for every flow in `flows`** (per the flow entity pair, #406) — the flow test is a build output, not optional follow-up. See the Wire Definition-of-Done gate below. |
+
+For any `kind: ui` profile, **preload the `design_system` skill as implementer
+context** — it is the source of truth for the design dialect even when a bundle
+is present. Load `smithy.helper-screen-design` (screen annotation schema +
+conflict rule) for build, and additionally `smithy.helper-flow-definition` (flow
+pair + testID convention) for wire.
+
+A `kind: backend` slice skips every UI step in this command; its path is exactly
+as before. The remainder of this prompt notes where the UI profiles diverge.
 
 ---
 
@@ -152,6 +200,29 @@ Store this value for later.
 
 Execute each task from the slice's checklist **in order**:
 
+### UI profile inputs (`kind: ui` only)
+
+When the resolved profile is `kind: ui`, every task is "implement a screen from a
+spec" — the same TDD flow, with extra context the implementer must apply:
+
+- **Preload the `design_system` skill** (e.g. `story-spider-design`) as implementer
+  context — it owns the Compose dialect (tokens, teal-only palette, 4dp corners,
+  no second hue) and is the source of truth even when a bundle is present.
+- **`build` profile** — render the screen against a mock behind the feature
+  `flag`, covering *every* brief state (empty, valid, error/invalid,
+  loading/submitting). No real data. Use **only** design-system tokens and
+  components — no hardcoded hex, no bespoke widgets where a design-system
+  component exists. With a `bundle`, translate it to Compose under the conflict
+  rule (bundle wins on layout/visual intent; skill wins on implementation
+  dialect). Emit/update the screen's `design/screens/<ScreenId>.design.md`
+  annotation per `smithy.helper-screen-design` (intent only — never re-describe
+  layout).
+- **`wire` profile** — connect the screen to real data/actions and flip the
+  `flag`. Additionally, the slice is **not done** until the Maestro flow +
+  `flow.md` are emitted/updated for every flow in `flows`, per
+  `smithy.helper-flow-definition` (testID-keyed selectors; asserts traversal
+  **and** guards). See the Wire Definition-of-Done gate.
+
 {{#ifAgent}}
 Dispatch a sub-agent for each task.
 
@@ -162,6 +233,10 @@ For each task, use the **smithy-implement** sub-agent. Pass it:
 - **Slice goal**: The slice's stated goal
 - **File paths**: The spec, contracts, data-model, and tasks/strike file paths
 - **Branch**: The current branch name
+- **Feature profile** (UI only): `kind`, `phase`, `design_system`, `bundle`,
+  `screens`, `flows`, and the flag — so the sub-agent loads the design skill,
+  applies the conflict rule, and (at `wire`) knows the flow-emission
+  definition-of-done.
 
 After the sub-agent returns:
 
@@ -190,6 +265,33 @@ guidance.
 
 After all tasks are complete:
 
+### Review profile selection
+
+The reviewer profile is selected by the resolved feature kind. **The reviewer
+stays read-only / plan-and-no-write in every profile** — it returns findings;
+forge owns every on-disk change.
+
+- **`kind: backend`** — the default structural code-review profile (categories
+  below / shared review protocol). Unchanged.
+- **`kind: ui`** — the **structural-conformance** profile. The reviewer checks
+  *only* structural conformance and **does not judge visual fidelity** (pixel
+  matching, exact spacing, taste — that is a human glance upstream on the design
+  canvas, never a forge gate). Specifically it checks:
+  - **Tokens-only** — no hardcoded hex / raw color literals; colors and
+    dimensions come from design-system tokens.
+  - **Component reuse** — design-system components are reused, not re-implemented
+    bespoke where a component exists.
+  - **M2 conventions** — Material-2 conventions hold (teal-only palette, 4dp
+    corners, no second hue, the design dialect from the `design_system` skill).
+  - **Every brief state present** — empty, valid, error/invalid, and
+    loading/submitting states are all rendered.
+  - **Touch-target / contrast roles** — minimum touch-target sizes and
+    contrast/accessibility roles are satisfied.
+  - **At `phase: wire`** — additionally, the Maestro flow + `flow.md` pair exists
+    for every flow in `flows`, is testID-keyed (no visible-text or layout-index
+    selectors), and asserts both traversal and guards (per
+    `smithy.helper-flow-definition`).
+
 {{#ifAgent}}
 Compute the diff and changed file list:
 
@@ -207,6 +309,11 @@ Use the **smithy-implementation-review** sub-agent. Pass it:
 - **File paths**: Spec, contracts, data-model files
 - **Changed files**: The list of files changed between BASE_SHA and HEAD
 - **Raw diff**: The full diff output
+- **Review profile**: `backend` (default) or `ui` — and for `ui`, the `phase`,
+  `design_system`, `screens`, and `flows`. The sub-agent applies the
+  structural-conformance profile (tokens-only, component reuse, M2 conventions,
+  every brief state present, touch-target/contrast roles; flow-pair conformance
+  at `wire`) and **does not judge visual fidelity**.
 
 `smithy-implementation-review` is **read-only**. It returns a `ReviewResult`
 containing a list of `Finding` entries (`category`, `severity`, `confidence`,
@@ -333,6 +440,34 @@ ready to ship.
 
 Only after every task in the target slice reads `- [x]` at HEAD may you
 proceed to the Pull Request step.
+
+---
+
+## Wire Definition-of-Done (`kind: ui`, `phase: wire` only)
+
+This gate applies **only** when the resolved profile is `kind: ui` at
+`phase: wire`. Backend slices and `build`-phase UI slices skip it entirely.
+
+For a `wire` slice, the Maestro flow + `flow.md` pair is a **build output**, not
+optional follow-up. Before opening the PR, verify that **for every `FlowId` in
+the feature's `flows`** both of these exist at HEAD and were produced/updated by
+this slice:
+
+- `design/flows/<FlowId>.flow.md` — thin intent annotation (front-matter `id` /
+  `screens` / `maestro`; rationale-only body).
+- `maestro/flows/<FlowId>.yaml` — executable body, **testID-keyed** (no
+  visible-text or layout-index selectors), asserting both the traversal **and**
+  the guards named in the `.flow.md`.
+
+Validate the pair against the `smithy.helper-flow-definition` review checklist.
+
+**STOP gate.** If any flow in `flows` is missing its pair, the pair uses
+text/position selectors, or a guard named in `flow.md` has no matching
+`assertVisible` / `assertNotVisible` in the yaml, the wire slice is **not** done.
+Either emit/fix the flow pair in this slice or, if the work is genuinely out of
+scope, stop and report — do **not** open the PR with the flow emission missing.
+A green PR that omits the flow pair silently drops the durable behavioral test
+the wire phase exists to produce.
 
 ---
 

--- a/src/templates/agent-skills/commands/smithy.forge.prompt
+++ b/src/templates/agent-skills/commands/smithy.forge.prompt
@@ -101,8 +101,10 @@ it through Implementation and Review.
 
 ### Resolve the feature kind
 
-Determine `kind`, and for UI also `phase`, `design_system`, `bundle`, `screens`,
-and `flows`:
+Determine `kind`, and for UI also `phase`, `design_system`, `bundle`, `flag`,
+`screens`, and `flows`. The `flag` is load-bearing downstream — it gates the
+mock build, is flipped at `wire`, and is passed into the implementer and
+reviewer sub-agents — so resolve it here alongside the other UI fields:
 
 1. **`.tasks.md` mode** — read the spec's `**Source Feature Map**` header
    (`<path-to-.features.md> — Feature <N>`). Open that `.features.md`, find the
@@ -314,6 +316,13 @@ Use the **smithy-implementation-review** sub-agent. Pass it:
   structural-conformance profile (tokens-only, component reuse, M2 conventions,
   every brief state present, touch-target/contrast roles; flow-pair conformance
   at `wire`) and **does not judge visual fidelity**.
+- **Helper checklist context** (`ui` only): the reviewer's tools are
+  `Read`/`Grep`/`Glob` — it cannot invoke the Skill mechanism — so **inline the
+  relevant helper-skill review checklist** in this dispatch rather than naming a
+  skill for it to load: the `smithy.helper-screen-design` review checklist for
+  every UI review, plus the `smithy.helper-flow-definition` review checklist at
+  `phase: wire`. This is what lets the reviewer enforce the flow-pair contract
+  (testID-keyed selectors, guard assertions) without loading a skill.
 
 `smithy-implementation-review` is **read-only**. It returns a `ReviewResult`
 containing a list of `Finding` entries (`category`, `severity`, `confidence`,


### PR DESCRIPTION
## What

Parameterizes `smithy.forge` by feature **`kind`** and **`phase`** so a `kind: ui`
feature flows through the *same* implementer → tester → reviewer → PR pipeline as
backend work — different inputs and review profile, **not** a forked pipeline
(EPIC #404).

Closes #408.

## How it routes

Forge resolves `kind` / `phase` / `design_system` / `bundle` / `screens` /
`flows` from the originating `.features.md` feature (via the spec's
`**Source Feature Map**` header, per #405). No metadata → `kind: backend`, so
every pre-#404 tasks/strike file stays on the unchanged path.

| Kind | Phase | Bundle | Profile |
|------|-------|--------|---------|
| `backend` | — | — | Unchanged. |
| `ui` | `build` | absent | Compose from prose + the committed `design_system` skill. |
| `ui` | `build` | present | Translate the web bundle to Compose — **bundle wins on layout/visual intent, skill wins on implementation dialect.** |
| `ui` | `wire` | either | Wire real data + flip the flag; **definition-of-done emits/updates the Maestro flow + `flow.md`** for every participating flow (per #406). |

The `design_system` skill is preloaded as implementer context for every UI
profile. `wire` adds a **STOP gate**: the `design/flows/<FlowId>.flow.md` +
`maestro/flows/<FlowId>.yaml` pair must exist, be testID-keyed, and assert
traversal + guards before the PR opens.

## Reviewer profile

`kind: ui` selects a **structural-conformance-only** reviewer profile (tokens-only
/ no hardcoded hex, component reuse, M2 conventions, every brief state present,
touch-target/contrast roles, flow-pair conformance at `wire`). It **does not
judge visual fidelity** and stays read-only / plan-no-write. `smithy-implementation-review`
gains the matching `ui` category vocabulary, selected by a new `Review profile`
input.

## Tests

`src/templates.test.ts` covers the four UI paths (build±bundle, wire emission,
ui reviewer profile), backend-unchanged, helper-skill advertising, Codex-variant
parity, and the agent's ui profile. Full suite: 959 passing.

## Scope note

Per CLAUDE.md, only `src/templates/agent-skills/` is touched — `.claude/` and the
manifest are intentionally **not** regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
