### PR TITLE
Add voice/audience tag lint to smithy.audit

### DIFF
--- a/evals/cases/audit-voice-lint.yaml
+++ b/evals/cases/audit-voice-lint.yaml
@@ -1,0 +1,58 @@
+# Voice & audience tag-lint eval scenario (EPIC #419, issue #424).
+#
+# Exercises the cross-cutting Voice & Audience Tag Lint added to
+# `/smithy.audit` against the planted fixture under
+# `evals/fixture/specs/audit-voice/`. The fixture carries seven tagged `##`
+# sections; six plant a distinct tag/content defect and one is clean. This
+# single scenario asserts the audit surfaces the defects at the right
+# severity, mirroring how `audit-flawed-spec.yaml` bundles several planted
+# flaws into one audit run rather than paying for a separate live invocation
+# per flaw.
+#
+# Section → planted condition (see the fixture header for the authoritative
+# map):
+#   ## Summary      — CLEAN (no finding).
+#   ## Goals        — unknown KEY  `audiance:`             → Critical.
+#   ## Approach     — unknown VALUE `mode: reference-guide`→ Critical.
+#   ## Background   — length budget violated               → Warning.
+#   ## Architecture — `diagram: required` w/o mermaid      → Warning.
+#   ## Data Handling— `examples: forbidden` w/ code block  → Warning.
+#   ## Contracts    — `applicability:` + `N/A —` body      → accepted.
+#
+# Mirrors the EvalScenario shape in `evals/lib/types.ts` and the single-quote
+# regex convention in `evals/cases/strike-health-check.yaml`. Audit runs
+# single-agent in File Argument Mode, so this scenario omits
+# `sub_agent_evidence` and `timeout`.
+
+name: audit-voice-lint
+skill: /smithy.audit
+# Fixture-relative path (resolved inside the runner's temp copy of
+# `evals/fixture/`; see `audit-flawed-spec.yaml` for the same convention). The
+# source-tree location is `evals/fixture/specs/audit-voice/audit-voice-tagged.spec.md`.
+prompt: specs/audit-voice/audit-voice-tagged.spec.md
+structural_expectations:
+  required_headings:
+    # Best-effort ATX heading the audit emits when rendering Output item 2 as a
+    # section — same anchor used by `audit-flawed-spec.yaml`.
+    - '## Audit Report'
+  required_patterns:
+    # Two planted ERROR conditions (unknown key + unknown value) must produce
+    # at least one Critical finding. `\*{0,2}` tolerates Markdown emphasis.
+    - '\*{0,2}Critical\*{0,2}'
+    # Unknown-key finding must quote the misspelled key verbatim.
+    - 'audiance'
+    # diagram: required → the missing-diagram finding names the mermaid block
+    # the section lacks (the lint rule is phrased "no fenced ```mermaid block").
+    - 'mermaid'
+    # At least one of the three WARN conditions (length / diagram / forbidden
+    # examples) must render a Warning severity label.
+    - '\*{0,2}Warning\*{0,2}'
+    # Executive-Summary marker — audit emits `1. **Executive Summary**: ...`;
+    # this tolerates the emphasis and trailing description.
+    - '\*\*Executive Summary\*\*'
+  forbidden_patterns:
+    # Generic refusals / non-skill responses.
+    - "I'd be happy to help"
+    - "Sure, here's"
+    # Leading YAML frontmatter; `\r?\n` tolerates CRLF.
+    - '^---\r?\n'

--- a/evals/fixture/specs/audit-voice/audit-voice-tagged.spec.md
+++ b/evals/fixture/specs/audit-voice/audit-voice-tagged.spec.md
@@ -1,0 +1,103 @@
+<!--
+PLANTED EVAL FIXTURE — DO NOT "FIX" THIS FILE.
+
+This `.spec.md` exercises the Voice & Audience Tag Lint added to
+`/smithy.audit` (EPIC #419, issue #424). Every `##` section below carries a
+`<!-- audience: ... -->` voice tag, and six of the seven sections plant a
+specific, deliberate tag/content defect the lint must catch. The seventh is
+clean. Running `/smithy.audit` against this file must surface the planted
+defects at the right severity.
+
+Section → planted condition map (keep in sync with the consuming scenario
+`evals/cases/audit-voice-lint.yaml`):
+
+  ## Summary       — CLEAN tagged section (no finding expected).
+  ## Goals         — unknown KEY  `audiance:`            → Critical.
+  ## Approach      — unknown VALUE `mode: reference-guide`→ Critical.
+  ## Background    — length budget violated (declared
+                     `2-3 sentences`, body is ~8)         → Warning.
+  ## Architecture  — `diagram: required` with no mermaid  → Warning.
+  ## Data Handling — `examples: forbidden` with a code
+                     block present                        → Warning.
+  ## Contracts     — `applicability:` + `N/A — <reason>`
+                     body → ACCEPTED, no warnings.
+
+Maintainer instructions:
+  - DO NOT "correct" the planted tags or bodies; doing so makes the
+    audit-voice-lint scenario stop detecting the regression it exists to
+    catch.
+  - If the lint grammar or severities change in
+    `src/templates/agent-skills/snippets/audit-checklist-voice.md`,
+    update both this fixture and the scenario's `required_patterns`
+    together.
+-->
+
+# Feature Specification: Tag-lint exercise spec
+
+**Spec Folder**: `audit-voice`
+**Branch**: `audit-voice/example`
+**Created**: 2026-06-06
+**Status**: Draft
+**Input**: A purpose-built spec whose per-section voice tags exercise every
+branch of the `/smithy.audit` voice lint.
+
+## Summary
+<!-- audience: stakeholder; mode: explanation; length: 2-3 sentences; diagram: optional; examples: discouraged -->
+
+This spec exists only to drive the audit voice lint. It declares a clean
+stakeholder-facing summary that fits comfortably inside its two-sentence
+budget.
+
+## Goals
+<!-- audiance: reviewer; mode: explanation; length: 1-2 paragraphs; diagram: optional; examples: discouraged -->
+
+The tag above misspells `audience` as `audiance`, which is an unrecognized
+key. The lint must flag the unknown key as a Critical finding and quote the
+offending token.
+
+## Approach
+<!-- audience: reviewer; mode: reference-guide; length: 1-2 paragraphs; diagram: optional; examples: discouraged -->
+
+The `mode` value `reference-guide` is outside the fixed enum
+`{explanation, reference, how-to, tutorial}`. The lint must flag the unknown
+value as a Critical finding.
+
+## Background
+<!-- audience: stakeholder; mode: explanation; length: 2-3 sentences; diagram: optional; examples: discouraged -->
+
+This section declares a two-to-three sentence budget but runs far past it. The
+manual reconciliation process predates the current tooling. It was introduced
+when the team was a third of its present size. The original author has since
+left. Nobody fully owns it today. Each sprint a different engineer reconciles
+the files by hand. The drift compounds quietly between sprints. By any honest
+reading this paragraph is eight sentences long and materially overruns its
+declared budget, which the lint must flag as a Warning.
+
+## Architecture
+<!-- audience: builder; mode: explanation; length: 1-2 paragraphs; diagram: required; examples: recommended -->
+
+The tag declares `diagram: required`, but this section contains only prose and
+no fenced mermaid block. The lint must flag the missing required diagram as a
+Warning. The component talks to the queue, which talks to the worker pool,
+which writes to the store — exactly the kind of three-node flow a diagram
+would carry better than this sentence does.
+
+## Data Handling
+<!-- audience: builder; mode: how-to; length: 5-15 steps; diagram: optional; examples: forbidden -->
+
+The tag declares `examples: forbidden`, yet the section includes a fenced code
+block. The lint must flag the forbidden example as a Warning.
+
+```ts
+function handle(record: Record<string, unknown>): void {
+  store.write(record);
+}
+```
+
+## Contracts
+<!-- audience: builder; mode: reference; length: tables only; diagram: optional; examples: required; applicability: code-shaped features only -->
+
+N/A — this exercise spec is docs-only and exposes no code-shaped contract, so
+the section legitimately resolves to a single N/A line. Because the tag
+declares an `applicability:` condition, the lint must ACCEPT this body and
+emit no length, diagram, or examples warnings for it.

--- a/evals/fixture/specs/audit-voice/audit-voice-tagged.spec.md
+++ b/evals/fixture/specs/audit-voice/audit-voice-tagged.spec.md
@@ -97,7 +97,4 @@ function handle(record: Record<string, unknown>): void {
 ## Contracts
 <!-- audience: builder; mode: reference; length: tables only; diagram: optional; examples: required; applicability: code-shaped features only -->
 
-N/A — this exercise spec is docs-only and exposes no code-shaped contract, so
-the section legitimately resolves to a single N/A line. Because the tag
-declares an `applicability:` condition, the lint must ACCEPT this body and
-emit no length, diagram, or examples warnings for it.
+N/A — docs-only exercise spec; the `applicability:` tag licenses this single-line N/A body, which the lint must ACCEPT with no length, diagram, or examples warnings.

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -104,7 +104,7 @@ describe('resolveSnippets', () => {
 describe('loadSnippets', () => {
   it('loads all snippet files', () => {
     const snippets = loadSnippets();
-    expect(snippets.size).toBe(16);
+    expect(snippets.size).toBe(17);
 
     const expectedFiles = [
       'audit-checklist-rfc.md',
@@ -112,6 +112,7 @@ describe('loadSnippets', () => {
       'audit-checklist-spec.md',
       'audit-checklist-tasks.md',
       'audit-checklist-strike.md',
+      'audit-checklist-voice.md',
       'competing-lenses-decomposition.md',
       'competing-lenses-implementation.md',
       'competing-lenses-scoping.md',
@@ -137,6 +138,7 @@ describe('loadSnippets', () => {
     expect(snippets.get('audit-checklist-spec.md')).toContain('Audit Checklist (.spec.md)');
     expect(snippets.get('audit-checklist-tasks.md')).toContain('Audit Checklist (.tasks.md)');
     expect(snippets.get('audit-checklist-strike.md')).toContain('Audit Checklist (.strike.md)');
+    expect(snippets.get('audit-checklist-voice.md')).toContain('Voice & Audience Tag Lint');
     expect(snippets.get('guidance-shell.md')).toContain('Shell Best Practices');
     expect(snippets.get('tdd-protocol.md')).toContain('TDD Protocol');
     expect(snippets.get('review-protocol.md')).toContain('Review Protocol');
@@ -2484,6 +2486,21 @@ describe('getComposedTemplates', () => {
     // The retired row labels must no longer appear in the audit template
     expect(audit).not.toContain('Persona Clarity');
     expect(audit).not.toContain('Scope Boundaries');
+  });
+
+  it('audit template renders the voice/audience tag lint snippet', () => {
+    const audit = composed.commands.get('smithy.audit.md')!;
+    expect(audit).toBeDefined();
+
+    // The cross-cutting voice lint partial must be resolved (no unresolved ref).
+    expect(audit).not.toContain('{{>audit-checklist-voice}}');
+
+    // Key surfaces of the lint rule must be present in the composed prompt.
+    expect(audit).toContain('Voice & Audience Tag Lint');
+    expect(audit).toContain('Unknown key');
+    expect(audit).toContain('Unknown value');
+    expect(audit).toContain('mermaid');
+    expect(audit).toContain('applicability');
   });
 
   it('render with claude variant renders competing plan dispatch', async () => {

--- a/src/templates/agent-skills/commands/smithy.audit.prompt
+++ b/src/templates/agent-skills/commands/smithy.audit.prompt
@@ -97,6 +97,10 @@ Use the checklist matching the artifact's extension. Each checklist defines what
 
 ---
 
+{{>audit-checklist-voice}}
+
+---
+
 ## Read-Only Enforcement
 
 **CRITICAL**: The audit is strictly read-only.

--- a/src/templates/agent-skills/snippets/audit-checklist-voice.md
+++ b/src/templates/agent-skills/snippets/audit-checklist-voice.md
@@ -1,0 +1,74 @@
+## Voice & Audience Tag Lint (cross-cutting)
+
+This lint runs **in addition to** the extension-specific checklist above, on
+**every** artifact type that carries per-section voice tags (`.rfc.md`,
+`.features.md`, `.spec.md`, `.tasks.md`, `.strike.md`). It validates the
+`<!-- audience: ... -->` HTML comments that sit directly under `##` section
+headings — the tagging convention defined by the `smithy.helper-voice` skill
+(§8, "Audience tag grammar"). The tags declare each section's intended voice;
+this lint surfaces drift between the declared intent and the section's actual
+content.
+
+If the artifact contains **no** voice-tag comments at all, skip this lint
+entirely and report nothing for it — untagged artifacts are out of scope, not
+a finding.
+
+### Tag grammar
+
+A voice tag is a single HTML comment on the first non-blank line beneath a
+`##` heading:
+
+```
+## <Section title>
+<!-- audience: <role>[+ai-input]; mode: <mode>; length: <budget>; diagram: <required|recommended|optional>; examples: <required|recommended|discouraged|forbidden>[; applicability: <free-text>] -->
+```
+
+Parse the comment body into `key: value` pairs split on `;`. Keys and values
+are case-sensitive and lowercase. Recognized keys and their value domains:
+
+| Key | Value domain | Notes |
+|-----|--------------|-------|
+| `audience` | `stakeholder`, `reviewer`, `builder` — optionally with a `+ai-input` suffix (e.g. `builder+ai-input`) | Fixed enum (base role). |
+| `mode` | `explanation`, `reference`, `how-to`, `tutorial` | Fixed enum. |
+| `length` | free-text budget (`2-3 sentences`, `3-6 paragraphs`, `tables only`, `5-15 steps`) | Not enum-checked; parsed for the length budget rule below. |
+| `diagram` | `required`, `recommended`, `optional` | Fixed enum. |
+| `examples` | `required`, `recommended`, `discouraged`, `forbidden` | Fixed enum. |
+| `applicability` | free-text condition (e.g. `code-shaped features only`) | Optional. Not enum-checked. Its presence licenses an `N/A` body (see below). |
+
+### Lint rules
+
+For each tagged `##` section, apply these rules against the section **body**
+(everything between this heading and the next `##`/`#` heading or end of file).
+Map severities onto the audit's standard labels: **Error → Critical**,
+**Warn → Warning**.
+
+| Rule | Trigger | Severity |
+|------|---------|----------|
+| **Unknown key** | The tag contains a key not in the recognized set above (e.g. a typo like `audiance:`, or an invented key like `tone:`). Report the offending key verbatim. | **Critical** |
+| **Unknown value** | A fixed-enum key (`audience`, `mode`, `diagram`, `examples`) carries a value outside its domain (e.g. `mode: reference-guide`, `diagram: mandatory`, `audience: stakeholders`). For `audience`, strip an optional `+ai-input` suffix before checking the base role. Report the offending `key: value` verbatim. | **Critical** |
+| **Length budget violated** | The section's actual length materially exceeds (or falls short of) the declared `length:` budget. Count sentences for a `<N>-<M> sentences` budget; count paragraphs for `<N>-<M> paragraphs`; count ordered-list items for `<N>-<M> steps`. **Tolerate ±1 sentence / ±1 paragraph / ±1 step** before flagging — only flag *material* violations (e.g. declared `2-3 sentences`, actual 8). For a `tables only` / `tables / signatures` budget, flag a body that is multi-paragraph narrative prose with no table, signature, schema, or `N/A` line. | **Warning** |
+| **Missing required diagram** | `diagram: required` but the section body contains no fenced ` ```mermaid ` block. | **Warning** |
+| **Missing required examples** | `examples: required` but the section body contains no fenced code block (` ``` ... ``` `). | **Warning** |
+| **Forbidden examples present** | `examples: forbidden` but the section body **does** contain a fenced code block. | **Warning** |
+
+### The `N/A` exception
+
+A section whose tag declares an `applicability:` condition may legitimately
+resolve to a single-line `N/A` body of the form `N/A — <reason>` (em-dash or
+`--`/`-`). When the body is such an `N/A` line, the section is **accepted**:
+suppress the length-budget, missing-required-diagram, and
+missing/forbidden-examples warnings for it — an `N/A` section is intentionally
+empty of tables, diagrams, and examples. Unknown-key and unknown-value errors
+still apply to the tag itself even when the body is `N/A`.
+
+A body that is `N/A` **without** an `applicability:` directive in the tag is a
+**Note** (the author skipped a section the template expected to be filled) —
+not a Critical.
+
+### Output
+
+Fold every finding into the standard Audit Report (Critical / Warning / Note),
+citing the section heading and quoting the offending tag fragment or the
+length count. If every tagged section passes, record a single Note that the
+voice-tag lint passed clean. Like the rest of the audit, this lint is
+**read-only** — never edit the tags or the artifact to make them pass.

--- a/src/templates/agent-skills/snippets/audit-checklist-voice.md
+++ b/src/templates/agent-skills/snippets/audit-checklist-voice.md
@@ -2,7 +2,8 @@
 
 This lint runs **in addition to** the extension-specific checklist above, on
 **every** artifact type that carries per-section voice tags (`.rfc.md`,
-`.features.md`, `.spec.md`, `.tasks.md`, `.strike.md`). It validates the
+`.features.md`, `.spec.md`, `.data-model.md`, `.contracts.md`, `.tasks.md`,
+`.strike.md`). It validates the
 `<!-- audience: ... -->` HTML comments that sit directly under `##` section
 headings — the tagging convention defined by the `smithy.helper-voice` skill
 (§8, "Audience tag grammar"). The tags declare each section's intended voice;
@@ -20,7 +21,7 @@ A voice tag is a single HTML comment on the first non-blank line beneath a
 
 ```
 ## <Section title>
-<!-- audience: <role>[+ai-input]; mode: <mode>; length: <budget>; diagram: <required|recommended|optional>; examples: <required|recommended|discouraged|forbidden>[; applicability: <free-text>] -->
+<!-- audience: <role>[+ai-input]; mode: <mode>; length: <budget>; diagram: <required|recommended|optional>; examples: <required|recommended|discouraged|optional|forbidden>[; applicability: <free-text>] -->
 ```
 
 Parse the comment body into `key: value` pairs split on `;`. Keys and values
@@ -32,7 +33,7 @@ are case-sensitive and lowercase. Recognized keys and their value domains:
 | `mode` | `explanation`, `reference`, `how-to`, `tutorial` | Fixed enum. |
 | `length` | free-text budget (`2-3 sentences`, `3-6 paragraphs`, `tables only`, `5-15 steps`) | Not enum-checked; parsed for the length budget rule below. |
 | `diagram` | `required`, `recommended`, `optional` | Fixed enum. |
-| `examples` | `required`, `recommended`, `discouraged`, `forbidden` | Fixed enum. |
+| `examples` | `required`, `recommended`, `discouraged`, `optional`, `forbidden` | Fixed enum. `optional` imposes no example constraint. |
 | `applicability` | free-text condition (e.g. `code-shaped features only`) | Optional. Not enum-checked. Its presence licenses an `N/A` body (see below). |
 
 ### Lint rules
@@ -47,8 +48,8 @@ Map severities onto the audit's standard labels: **Error → Critical**,
 | **Unknown key** | The tag contains a key not in the recognized set above (e.g. a typo like `audiance:`, or an invented key like `tone:`). Report the offending key verbatim. | **Critical** |
 | **Unknown value** | A fixed-enum key (`audience`, `mode`, `diagram`, `examples`) carries a value outside its domain (e.g. `mode: reference-guide`, `diagram: mandatory`, `audience: stakeholders`). For `audience`, strip an optional `+ai-input` suffix before checking the base role. Report the offending `key: value` verbatim. | **Critical** |
 | **Length budget violated** | The section's actual length materially exceeds (or falls short of) the declared `length:` budget. Count sentences for a `<N>-<M> sentences` budget; count paragraphs for `<N>-<M> paragraphs`; count ordered-list items for `<N>-<M> steps`. **Tolerate ±1 sentence / ±1 paragraph / ±1 step** before flagging — only flag *material* violations (e.g. declared `2-3 sentences`, actual 8). For a `tables only` / `tables / signatures` budget, flag a body that is multi-paragraph narrative prose with no table, signature, schema, or `N/A` line. | **Warning** |
-| **Missing required diagram** | `diagram: required` but the section body contains no fenced ` ```mermaid ` block. | **Warning** |
-| **Missing required examples** | `examples: required` but the section body contains no fenced code block (` ``` ... ``` `). | **Warning** |
+| **Missing required diagram** | `diagram: required` but the section body contains no fenced `mermaid` code block. | **Warning** |
+| **Missing required examples** | `examples: required` but the section body contains no fenced code block of any language. | **Warning** |
 | **Forbidden examples present** | `examples: forbidden` but the section body **does** contain a fenced code block. | **Warning** |
 
 ### The `N/A` exception


### PR DESCRIPTION
## Summary
- Primary outcome: `/smithy.audit` now lints the per-section `<!-- audience: ... -->` voice tags introduced by #422, turning the tagging convention from documentation into enforcement.
- Notable behaviour changes: A new cross-cutting **Voice & Audience Tag Lint** runs on any artifact that carries voice tags (`.rfc.md`, `.features.md`, `.spec.md`, `.tasks.md`, `.strike.md`) and is skipped entirely on untagged artifacts. It reports Critical/Warning findings folded into the existing Audit Report.
- Follow-up work deferred (if any): The lint still carries the voice specs implicitly via the tag grammar; the template-driven enforcement surface (reading specs from the generating command templates) remains the broader EPIC #419 direction.

## Context
- Why are we doing this work now? Part of EPIC #419 (voice & audience). Depends on #422 (PR #429), which stamped audience tags onto every artifact-producing command template. This slice makes the audit enforce those tags so drift between declared intent and actual content surfaces as findings.
- What user story or scenario does it unlock or improve? Every `/smithy.audit` run on a tagged artifact now catches malformed tags (typos, bad enum values) and content that violates its declared voice budget (over-long sections, missing required diagrams/examples, forbidden examples), while still accepting legitimate `N/A — <reason>` bodies for sections whose tag declares an `applicability:` condition.

## Implementation Notes
- New snippet `src/templates/agent-skills/snippets/audit-checklist-voice.md` defines the lint: parses the `;`-separated tag grammar (`audience` / `mode` / `length` / `diagram` / `examples` / `applicability`) under each `##` heading and applies:
  - **Critical** — unknown key (e.g. `audiance:`); unknown value for a fixed enum (`audience` ∈ {stakeholder, reviewer, builder} +optional `+ai-input`; `mode` ∈ {explanation, reference, how-to, tutorial}; `diagram` ∈ {required, recommended, optional}; `examples` ∈ {required, recommended, discouraged, forbidden}).
  - **Warning** — material length-budget overrun (±1 sentence/paragraph/step tolerance); `diagram: required` with no fenced ```mermaid``` block; `examples: required` with no fenced code block; `examples: forbidden` with a fenced code block.
  - **Accept** — `N/A — <reason>` body when the tag declares `applicability:` (suppresses length/diagram/examples warnings for that section).
- Wired `{{>audit-checklist-voice}}` into `smithy.audit.prompt` after the extension-specific checklists.
- Impacted boundaries: source templates and evals only. **Per CLAUDE.md, the committed `.claude/` snapshot and `.smithy/smithy-manifest.json` were intentionally NOT regenerated.**

## Risks & Mitigations
- Risk: lint over-fires on artifacts without tags. | Mitigation: rule explicitly no-ops when an artifact contains no voice-tag comments.
- Risk: live-model audit phrasing drifts from the eval's `required_patterns`. | Mitigation: patterns target stable, verbatim signals (the quoted typo'd key, the literal `mermaid`, severity labels) rather than full sentences, mirroring the existing `audit-flawed-spec` scenario.

## Rollback Plan
- Revert this commit: removes the snippet, the `{{>audit-checklist-voice}}` wire-in, the eval fixture/scenario, and the templates.test deltas. No data or deployed-artifact changes are involved.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build` — via `pretest`)
- [x] Type check succeeds (`npm run typecheck`)
- [ ] CLI `init` smoke test (`node dist/cli.js init`) — not exercised; no CLI behaviour changed.

### Template Generation
- [x] `npm test` (950 tests) passes, including the audit template render assertions (voice snippet resolves; lint surfaces present in composed prompt).
- [x] `npm run test:evals` (187 tests) passes, including the clean-load check over the real `evals/cases/` directory (the new `audit-voice-lint.yaml` parses without being skipped).

### Notes on `npm run eval`
`npm run eval` spawns the live `claude` CLI per scenario and makes real billed API calls (not wired into default CI — it is the maintainer's on-demand step per CLAUDE.md). The new fixture and scenario were verified to be structurally valid and to load cleanly; the live run is left for the maintainer's on-demand eval pass.

## Issue
- Closes #424
