### PR TITLE
flow-lint: deterministic UI flow/screen graph check for app CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ npm run test:evals   # Run evals unit tests (structural, parse-stream, runner, f
 node dist/cli.js init    # Test init flow
 node dist/cli.js uninit  # Test uninit flow
 node dist/cli.js update  # Test update flow
+node dist/cli.js flow-lint   # Lint the UI flow/screen graph (see docs/flow-lint.md)
 ```
 
 **Important:** Always use `npm run` / `npm test` scripts for building, typechecking, and testing. Do not use `npx tsx`, `npx vitest`, or similar direct invocations — they require extra approvals and waste time.

--- a/docs/flow-lint.md
+++ b/docs/flow-lint.md
@@ -1,0 +1,110 @@
+# `flow-lint` — keep the UI flow/screen graph honest in CI
+
+`smithy flow-lint` is a deterministic, **Smithy-state-free** check that
+guarantees the UI flow/screen graph committed to your **app repo** resolves. It
+makes **no agent calls**, reads **no Smithy manifest**, and is fast enough to
+run on every push — independent of any `forge` invocation.
+
+It is the CI half of EPIC #404: a screen's body is its composable, a flow's
+body is an executable Maestro test, and the thin annotations that tie them
+together (`design/screens/<ScreenId>.design.md`, `design/flows/<FlowId>.flow.md`)
+are only worth keeping if their cross-references actually resolve. A dangling
+reference means a product path was *severed* — `flow-lint` surfaces it as a
+failure that names the specific broken path, so it reads as signal, not noise.
+
+The authoring contract these checks enforce lives in the
+`smithy.helper-flow-definition` and `smithy.helper-screen-design` skills.
+
+## Repo layout it expects
+
+```
+design/flows/<FlowId>.flow.md        # flow INTENT annotation (id, screens, maestro)
+design/screens/<ScreenId>.design.md  # screen INTENT annotation (id, composable)
+maestro/flows/<FlowId>.yaml          # flow BEHAVIORAL body (the Maestro test)
+app/.../<Screen>.kt                  # the composable a screen annotation points at
+```
+
+`--design-dir` and `--maestro-dir` override the `design` / `maestro/flows`
+defaults when your repo uses different roots.
+
+## What it checks
+
+| Code | Severity | Caught when… |
+|------|----------|--------------|
+| `flow-frontmatter-missing` / `-invalid` | error | a `.flow.md` lacks `id`/`screens`/`maestro` or its front-matter won't parse |
+| `flow-id-mismatch` | error | a flow's `id` ≠ its `<FlowId>.flow.md` filename stem |
+| `flow-id-duplicate` | error | the same `FlowId` is declared by more than one file (flat-namespace uniqueness) |
+| `flow-screen-missing` | error | a `screens:` entry has no resolving `design/screens/<ScreenId>.design.md` |
+| `flow-maestro-missing` | error | a flow's `maestro:` path does not resolve to a real file |
+| `flow-maestro-nonconventional` | warning | the `maestro:` path resolves but is not `maestro/flows/<FlowId>.yaml` |
+| `screen-frontmatter-missing` / `-invalid` | error | a `.design.md` lacks `id`/`composable` or won't parse |
+| `screen-id-mismatch` | error | a screen's `id` ≠ its `<ScreenId>.design.md` filename stem |
+| `screen-id-duplicate` | error | the same `ScreenId` is declared by more than one file |
+| `screen-composable-missing` | warning | a screen's `composable:` path does not exist on disk |
+| `maestro-orphan` | error | a `maestro/flows/*.yaml` is referenced by no `.flow.md` (an orphan test) |
+
+`screen-composable-missing` and `flow-maestro-nonconventional` are **warnings**:
+product code may legitimately lag the annotation, and an explicit non-standard
+test path is allowed. Pass `--strict` to promote every warning to a failure.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | the graph resolves (no errors; no warnings either under `--strict`) |
+| `1` | one or more dangling references / lint errors |
+| `2` | a usage error (e.g. `--root` does not exist, bad `--format`) |
+
+## Output
+
+Default output is a human report with a one-line verdict; `--format json`
+emits the stable `FlowLintResult` shape (`findings[]`, `errorCount`,
+`warningCount`, `ok`, `strict`, and the scan counts) for machine consumers.
+
+```
+$ smithy flow-lint
+✖ error [flow-screen-missing] design/flows/AddTitle.flow.md: `screens` entry `AddTitle` does not resolve → design/screens/AddTitle.design.md not found
+✖ error [maestro-orphan] maestro/flows/Orphan.yaml: orphan Maestro flow — no `.flow.md` references it via `maestro:`
+✖ flow-lint failed — 2 errors — scanned 2 flows, 2 screens, 2 Maestro flows
+```
+
+## CI wiring example (GitHub Actions)
+
+`flow-lint` ships in the `@balexda/smithy` CLI, so the app repo's CI installs
+it with `npx` and runs it from the repo root. No emulator, no build — it reads
+files only.
+
+```yaml
+# .github/workflows/flow-lint.yml
+name: flow-lint
+on:
+  pull_request:
+    paths:
+      - 'design/flows/**'
+      - 'design/screens/**'
+      - 'maestro/flows/**'
+  push:
+    branches: [main]
+
+jobs:
+  flow-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      # Pin the version you adopted; flow-lint reads files only — no emulator.
+      - name: Resolve the UI flow/screen graph
+        run: npx --yes @balexda/smithy@latest flow-lint --no-color
+```
+
+Drop `--strict` in if you want a missing composable or a non-conventional
+Maestro path to block the merge too.
+
+## Fixtures
+
+Two worked trees live at `src/flow-lint/__fixtures__/` — a `passing/` tree
+where every reference resolves and a `dangling/` tree with one of each severed
+reference category (see its `README.md`). They back the unit tests and double
+as copy-paste examples of the layout.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { toolchains, type LanguageToolchain } from './permissions.js';
 import { uninitAction } from './commands/uninit.js';
 import { updateAction, type UpdateOptions } from './commands/update.js';
 import { statusAction, type StatusOptions } from './commands/status.js';
+import { flowLintAction, type FlowLintOptions } from './commands/flow-lint.js';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json') as { version: string };
@@ -104,6 +105,24 @@ program
   .action((opts: Record<string, unknown>) => {
     const statusOpts: StatusOptions = { ...opts } as StatusOptions;
     return statusAction(statusOpts);
+  });
+
+program
+  .command('flow-lint')
+  .description('Deterministic check that the UI flow/screen graph resolves (CI lint)')
+  .option('--root <path>', 'Repo root to lint (defaults to current working directory)')
+  .option('--design-dir <path>', "Directory holding flows/ and screens/ (default 'design')")
+  .option('--maestro-dir <path>', "Directory holding Maestro yaml files (default 'maestro/flows')")
+  .addOption(
+    new Option('--format <format>', 'Output format')
+      .choices(['text', 'json'])
+      .default('text'),
+  )
+  .option('--strict', 'Promote warnings (e.g. missing composable) to failures')
+  .option('--no-color', 'Suppress ANSI color output')
+  .action((opts: Record<string, unknown>) => {
+    const flowLintOpts: FlowLintOptions = { ...opts } as FlowLintOptions;
+    return flowLintAction(flowLintOpts);
   });
 
 program.parse(process.argv);

--- a/src/commands/flow-lint.test.ts
+++ b/src/commands/flow-lint.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { flowLintAction } from './flow-lint.js';
+
+const FIXTURES = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'flow-lint',
+  '__fixtures__',
+);
+
+describe('flowLintAction', () => {
+  let logSpy: MockInstance;
+  let errSpy: MockInstance;
+  let exitCodeBefore: typeof process.exitCode;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitCodeBefore = process.exitCode;
+    process.exitCode = 0;
+  });
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    process.exitCode = exitCodeBefore;
+  });
+
+  const stdout = () => logSpy.mock.calls.map((c) => c[0]).join('\n');
+  const stderr = () => errSpy.mock.calls.map((c) => c[0]).join('\n');
+
+  it('exits 0 and prints a pass on the passing tree', () => {
+    flowLintAction({ root: join(FIXTURES, 'passing'), color: false });
+    expect(process.exitCode).toBe(0);
+    expect(stdout()).toContain('flow-lint passed');
+  });
+
+  it('exits 1 and names severed paths on the dangling tree', () => {
+    flowLintAction({ root: join(FIXTURES, 'dangling'), color: false });
+    expect(process.exitCode).toBe(1);
+    const out = stdout();
+    expect(out).toContain('flow-lint failed');
+    expect(out).toContain('design/screens/AddTitle.design.md');
+    expect(out).toContain('maestro/flows/ReadTitle.yaml');
+    expect(out).toContain('Orphan.yaml');
+  });
+
+  it('emits machine-readable JSON with --format json', () => {
+    flowLintAction({ root: join(FIXTURES, 'dangling'), format: 'json' });
+    expect(process.exitCode).toBe(1);
+    const payload = JSON.parse(stdout());
+    expect(payload.errorCount).toBe(3);
+    expect(payload.warningCount).toBe(1);
+    expect(payload.findings.map((f: { code: string }) => f.code)).toContain('flow-screen-missing');
+  });
+
+  it('passes through --strict to the result verdict', () => {
+    flowLintAction({ root: join(FIXTURES, 'dangling'), strict: true, format: 'json' });
+    const payload = JSON.parse(stdout());
+    expect(payload.strict).toBe(true);
+    expect(payload.ok).toBe(false);
+  });
+
+  it('exits 2 on a non-existent --root', () => {
+    flowLintAction({ root: join(FIXTURES, 'does-not-exist') });
+    expect(process.exitCode).toBe(2);
+    expect(stderr()).toContain('--root path does not exist');
+  });
+
+  it('exits 2 on an invalid --format', () => {
+    flowLintAction({ root: join(FIXTURES, 'passing'), format: 'xml' });
+    expect(process.exitCode).toBe(2);
+    expect(stderr()).toContain('invalid --format');
+  });
+});

--- a/src/commands/flow-lint.ts
+++ b/src/commands/flow-lint.ts
@@ -1,0 +1,86 @@
+/**
+ * `smithy flow-lint` subcommand — thin CLI wiring around the flow-lint engine.
+ *
+ * A deterministic, Smithy-state-free check that guarantees the UI flow/screen
+ * graph in an app repo resolves. No agent calls, no manifest reads — fast
+ * enough to run on every CI push, and runnable outside any forge invocation.
+ *
+ * Exit codes:
+ *   0  the graph resolves (no errors; no warnings either under `--strict`).
+ *   1  one or more dangling references / lint errors were found.
+ *   2  a usage error (e.g. `--root` does not exist, bad `--format`).
+ *
+ * See `docs/flow-lint.md` for the CI wiring example and the
+ * `smithy.helper-flow-definition` skill for the authoring contract enforced.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { lintFlows, renderJson, renderResult } from '../flow-lint/index.js';
+import type { FlowLintOptions as LintOptions } from '../flow-lint/index.js';
+
+export interface FlowLintOptions {
+  root?: string;
+  designDir?: string;
+  maestroDir?: string;
+  format?: string;
+  strict?: boolean;
+  color?: boolean;
+}
+
+const VALID_FORMATS = ['text', 'json'] as const;
+
+export function flowLintAction(opts: FlowLintOptions = {}): void {
+  const format = opts.format ?? 'text';
+  if (!VALID_FORMATS.includes(format as (typeof VALID_FORMATS)[number])) {
+    console.error(
+      `smithy flow-lint: invalid --format value '${format}'. Valid values: ${VALID_FORMATS.join(', ')}`,
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  const rawRoot = opts.root ?? process.cwd();
+  const resolvedRoot = path.resolve(rawRoot);
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(resolvedRoot);
+  } catch (error: unknown) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? (error as { code?: unknown }).code
+        : undefined;
+    const message =
+      code === 'ENOENT'
+        ? `smithy flow-lint: --root path does not exist: ${rawRoot}`
+        : code === 'EACCES' || code === 'EPERM'
+          ? `smithy flow-lint: cannot access --root path: ${rawRoot}`
+          : `smithy flow-lint: failed to inspect --root path: ${rawRoot}`;
+    console.error(message);
+    process.exitCode = 2;
+    return;
+  }
+  if (!stat.isDirectory()) {
+    console.error(`smithy flow-lint: --root path is not a directory: ${rawRoot}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const lintOpts: LintOptions = { root: resolvedRoot, strict: opts.strict ?? false };
+  if (opts.designDir !== undefined) lintOpts.designDir = opts.designDir;
+  if (opts.maestroDir !== undefined) lintOpts.maestroDir = opts.maestroDir;
+  const result = lintFlows(lintOpts);
+
+  if (format === 'json') {
+    console.log(renderJson(result));
+  } else {
+    // `--no-color` (Commander sets `color: false`) and the ambient `NO_COLOR`
+    // env var both suppress ANSI styling.
+    const noColor = opts.color === false || process.env.NO_COLOR !== undefined;
+    console.log(renderResult(result, { noColor }));
+  }
+
+  process.exitCode = result.ok ? 0 : 1;
+}

--- a/src/flow-lint/__fixtures__/README.md
+++ b/src/flow-lint/__fixtures__/README.md
@@ -1,0 +1,35 @@
+# flow-lint fixtures
+
+Two self-contained app-repo trees used by `linter.test.ts` and `flow-lint.test.ts`,
+and doubling as worked examples for `docs/flow-lint.md`. Each tree mirrors the
+EPIC #404 layout:
+
+```
+design/flows/<FlowId>.flow.md       design/screens/<ScreenId>.design.md
+maestro/flows/<FlowId>.yaml         app/.../<Screen>.kt   (composable stubs)
+```
+
+## `passing/` — the graph resolves
+
+Every cross-reference resolves, so `flow-lint` exits `0` with no findings:
+
+- Flows `AddTitle`, `ReadTitle` — each `screens:` entry resolves to a screen,
+  each `maestro:` path resolves to a yaml at the conventional location.
+- Screens `Library`, `AddTitle`, `Player` — each `composable:` path resolves to
+  a (non-compiled) Kotlin stub under `app/`.
+- Maestro flows `AddTitle.yaml`, `ReadTitle.yaml` — each claimed by a flow.
+
+## `dangling/` — planted severed references
+
+Each break is a distinct dangling-reference category. `flow-lint` exits `1`
+(3 errors + 1 warning):
+
+| Code | Where | Severed path |
+|------|-------|--------------|
+| `flow-screen-missing` (error) | `design/flows/AddTitle.flow.md` | `design/screens/AddTitle.design.md` — screen absent |
+| `flow-maestro-missing` (error) | `design/flows/ReadTitle.flow.md` | `maestro/flows/ReadTitle.yaml` — yaml absent |
+| `maestro-orphan` (error) | `maestro/flows/Orphan.yaml` | referenced by no flow |
+| `screen-composable-missing` (warning) | `design/screens/Library.design.md` | `app/.../LibraryScreen.kt` — stub absent |
+
+The warning does not fail CI on its own; `--strict` promotes it so the run
+exits `1` on warnings too.

--- a/src/flow-lint/__fixtures__/dangling/app/src/main/kotlin/com/storyspider/ui/player/PlayerScreen.kt
+++ b/src/flow-lint/__fixtures__/dangling/app/src/main/kotlin/com/storyspider/ui/player/PlayerScreen.kt
@@ -1,0 +1,5 @@
+// Fixture stub — the one composable that *does* resolve in the dangling tree,
+// so the Player screen annotation has no severed reference. Not compiled.
+package com.storyspider.ui.player
+
+// composable: PlayerScreen — testIDs: player-surface

--- a/src/flow-lint/__fixtures__/dangling/design/flows/AddTitle.flow.md
+++ b/src/flow-lint/__fixtures__/dangling/design/flows/AddTitle.flow.md
@@ -1,0 +1,22 @@
+---
+id: AddTitle
+screens: [Library, AddTitle]
+maestro: maestro/flows/AddTitle.yaml
+---
+
+# Flow: AddTitle
+
+## Intent
+
+PLANTED BREAK: `screens:` lists `AddTitle`, but there is no
+`design/screens/AddTitle.design.md` in this tree — the screen reference is
+severed. flow-lint must report `flow-screen-missing` naming that path.
+
+## Guards
+
+- **Confirm is disabled until the URL is valid.**
+
+## Entry / Exit
+
+- **Enter from**: Library screen, tap on `library-fab`.
+- **Exit on**: tap `add-title-confirm-button-enabled` → Library list.

--- a/src/flow-lint/__fixtures__/dangling/design/flows/ReadTitle.flow.md
+++ b/src/flow-lint/__fixtures__/dangling/design/flows/ReadTitle.flow.md
@@ -1,0 +1,22 @@
+---
+id: ReadTitle
+screens: [Library, Player]
+maestro: maestro/flows/ReadTitle.yaml
+---
+
+# Flow: ReadTitle
+
+## Intent
+
+PLANTED BREAK: `maestro:` points at `maestro/flows/ReadTitle.yaml`, but that
+file does not exist in this tree — the test body is severed. flow-lint must
+report `flow-maestro-missing` naming that path.
+
+## Guards
+
+- **A title row routes to the player.**
+
+## Entry / Exit
+
+- **Enter from**: Library screen, tap on `library-row-<title-slug>`.
+- **Exit on**: Player screen visible.

--- a/src/flow-lint/__fixtures__/dangling/design/screens/Library.design.md
+++ b/src/flow-lint/__fixtures__/dangling/design/screens/Library.design.md
@@ -1,0 +1,22 @@
+---
+id: Library
+composable: app/src/main/kotlin/com/storyspider/ui/library/LibraryScreen.kt
+design_system: story-spider-design
+---
+
+# Screen: Library
+
+## Why this screen exists
+
+PLANTED BREAK: the `composable:` path does not exist in this tree (no stub
+`.kt` file). flow-lint must report `screen-composable-missing` as a *warning*
+naming the severed path — a warning, not an error, because product code may
+legitimately lag the annotation (it fails CI only under `--strict`).
+
+## Deliberate choices
+
+- **List over grid.**
+
+## Deferred
+
+- Sorting controls.

--- a/src/flow-lint/__fixtures__/dangling/design/screens/Player.design.md
+++ b/src/flow-lint/__fixtures__/dangling/design/screens/Player.design.md
@@ -1,0 +1,21 @@
+---
+id: Player
+composable: app/src/main/kotlin/com/storyspider/ui/player/PlayerScreen.kt
+design_system: story-spider-design
+---
+
+# Screen: Player
+
+## Why this screen exists
+
+A clean screen: its `id` matches the filename, and its `composable:` path
+resolves to a stub in this tree. Present so the dangling fixture still has at
+least one fully-resolving node.
+
+## Deliberate choices
+
+- **Single-title focus.**
+
+## Deferred
+
+- Inline speed controls.

--- a/src/flow-lint/__fixtures__/dangling/maestro/flows/AddTitle.yaml
+++ b/src/flow-lint/__fixtures__/dangling/maestro/flows/AddTitle.yaml
@@ -1,0 +1,10 @@
+# A valid Maestro flow, claimed by AddTitle.flow.md — present so the tree has
+# at least one resolving flow→yaml link. The breakage is the AddTitle *screen*,
+# not this yaml.
+appId: com.storyspider.app
+---
+- launchApp
+- assertVisible:
+    id: "library-fab"
+- tapOn:
+    id: "library-fab"

--- a/src/flow-lint/__fixtures__/dangling/maestro/flows/Orphan.yaml
+++ b/src/flow-lint/__fixtures__/dangling/maestro/flows/Orphan.yaml
@@ -1,0 +1,9 @@
+# PLANTED BREAK: this Maestro flow is an orphan — no `design/flows/*.flow.md`
+# references `maestro/flows/Orphan.yaml` via its `maestro:` field. flow-lint
+# must report `maestro-orphan` naming this path (a test guarding a product path
+# that the flow graph has forgotten).
+appId: com.storyspider.app
+---
+- launchApp
+- assertVisible:
+    id: "library-list"

--- a/src/flow-lint/__fixtures__/passing/app/src/main/kotlin/com/storyspider/ui/addtitle/AddTitleScreen.kt
+++ b/src/flow-lint/__fixtures__/passing/app/src/main/kotlin/com/storyspider/ui/addtitle/AddTitleScreen.kt
@@ -1,0 +1,6 @@
+// Fixture stub — stands in for the real Jetpack Compose body so flow-lint can
+// resolve the screen's `composable:` annotation path. Not compiled.
+package com.storyspider.ui.addtitle
+
+// composable: AddTitleScreen — testIDs: add-title-title-field,
+// add-title-url-field, add-title-confirm-button-enabled

--- a/src/flow-lint/__fixtures__/passing/app/src/main/kotlin/com/storyspider/ui/library/LibraryScreen.kt
+++ b/src/flow-lint/__fixtures__/passing/app/src/main/kotlin/com/storyspider/ui/library/LibraryScreen.kt
@@ -1,0 +1,5 @@
+// Fixture stub — stands in for the real Jetpack Compose body so flow-lint can
+// resolve the screen's `composable:` annotation path. Not compiled.
+package com.storyspider.ui.library
+
+// composable: LibraryScreen — testIDs: library-fab, library-list, library-row-<slug>

--- a/src/flow-lint/__fixtures__/passing/app/src/main/kotlin/com/storyspider/ui/player/PlayerScreen.kt
+++ b/src/flow-lint/__fixtures__/passing/app/src/main/kotlin/com/storyspider/ui/player/PlayerScreen.kt
@@ -1,0 +1,5 @@
+// Fixture stub — stands in for the real Jetpack Compose body so flow-lint can
+// resolve the screen's `composable:` annotation path. Not compiled.
+package com.storyspider.ui.player
+
+// composable: PlayerScreen — testIDs: player-surface

--- a/src/flow-lint/__fixtures__/passing/design/flows/AddTitle.flow.md
+++ b/src/flow-lint/__fixtures__/passing/design/flows/AddTitle.flow.md
@@ -1,0 +1,24 @@
+---
+id: AddTitle
+screens: [Library, AddTitle]
+maestro: maestro/flows/AddTitle.yaml
+---
+
+# Flow: AddTitle
+
+## Intent
+
+Adding a title is the entry point of the entire product — a library with no way
+to add to it is dead on arrival. This journey is a durable truth we refuse to
+ship a release that breaks.
+
+## Guards
+
+- **Confirm is disabled until the URL is valid.** Prevents half-formed titles
+  from entering the library; the yaml asserts the disabled→enabled transition.
+
+## Entry / Exit
+
+- **Enter from**: Library screen, tap on `library-fab`.
+- **Exit on**: tap `add-title-confirm-button-enabled` with a valid URL → return
+  to Library list, new title visible.

--- a/src/flow-lint/__fixtures__/passing/design/flows/ReadTitle.flow.md
+++ b/src/flow-lint/__fixtures__/passing/design/flows/ReadTitle.flow.md
@@ -1,0 +1,28 @@
+---
+id: ReadTitle
+screens: [Library, Player]
+maestro: maestro/flows/ReadTitle.yaml
+---
+
+# Flow: ReadTitle
+
+## Intent
+
+Opening a saved title into the player is the core read path — the reason the
+library exists at all.
+
+## Guards
+
+- **A title row routes to the player.** Tapping a library row must land on the
+  player with the chosen title loaded; the yaml asserts the player surface.
+
+## Entry / Exit
+
+- **Enter from**: Library screen, tap on `library-row-<title-slug>`.
+- **Exit on**: Player screen visible with the selected title.
+
+## Coverage Caveat
+
+This flow does not observe TTS auto-advance, locked-screen playback, or
+audio-focus handling — those audio-service behaviors live below the UI driver
+and need instrumentation-level tests. A green Maestro run is not TTS coverage.

--- a/src/flow-lint/__fixtures__/passing/design/screens/AddTitle.design.md
+++ b/src/flow-lint/__fixtures__/passing/design/screens/AddTitle.design.md
@@ -1,0 +1,21 @@
+---
+id: AddTitle
+composable: app/src/main/kotlin/com/storyspider/ui/addtitle/AddTitleScreen.kt
+design_system: story-spider-design
+---
+
+# Screen: AddTitle
+
+## Why this screen exists
+
+A focused capture surface for a new title's name and source URL, kept separate
+from the library so the add gesture is deliberate.
+
+## Deliberate choices
+
+- **Confirm gated on a valid URL.** A title without a playable source is
+  useless; the screen refuses to create one.
+
+## Deferred
+
+- Source autodetection from a pasted link — manual entry first.

--- a/src/flow-lint/__fixtures__/passing/design/screens/Library.design.md
+++ b/src/flow-lint/__fixtures__/passing/design/screens/Library.design.md
@@ -1,0 +1,21 @@
+---
+id: Library
+composable: app/src/main/kotlin/com/storyspider/ui/library/LibraryScreen.kt
+design_system: story-spider-design
+---
+
+# Screen: Library
+
+## Why this screen exists
+
+The library is the home surface — the durable list of everything the user has
+saved to read.
+
+## Deliberate choices
+
+- **List over grid.** Titles are text-first; a list keeps long titles readable
+  where a grid would truncate them.
+
+## Deferred
+
+- Sorting and filtering controls — added once the list grows past a screenful.

--- a/src/flow-lint/__fixtures__/passing/design/screens/Player.design.md
+++ b/src/flow-lint/__fixtures__/passing/design/screens/Player.design.md
@@ -1,0 +1,21 @@
+---
+id: Player
+composable: app/src/main/kotlin/com/storyspider/ui/player/PlayerScreen.kt
+design_system: story-spider-design
+---
+
+# Screen: Player
+
+## Why this screen exists
+
+The player is where reading actually happens — the durable playback surface for
+a single title.
+
+## Deliberate choices
+
+- **Single-title focus.** The player shows one title at a time; queue
+  management lives upstream in the library.
+
+## Deferred
+
+- Inline speed and voice controls — surfaced once the core read path is solid.

--- a/src/flow-lint/__fixtures__/passing/maestro/flows/AddTitle.yaml
+++ b/src/flow-lint/__fixtures__/passing/maestro/flows/AddTitle.yaml
@@ -1,0 +1,30 @@
+# Selectors are keyed to testIDs. Never visible text, never layout position.
+appId: com.storyspider.app
+---
+- launchApp
+- assertVisible:
+    id: "library-fab"
+- tapOn:
+    id: "library-fab"
+- assertVisible:
+    id: "add-title-title-field"
+- assertVisible:
+    id: "add-title-url-field"
+# Guard: confirm is disabled until the URL is valid.
+- assertNotVisible:
+    id: "add-title-confirm-button-enabled"
+- tapOn:
+    id: "add-title-title-field"
+- inputText: "The Magic Circle"
+- tapOn:
+    id: "add-title-url-field"
+- inputText: "https://example.com/magic-circle.mp3"
+# Guard: with a valid URL, confirm becomes reachable.
+- assertVisible:
+    id: "add-title-confirm-button-enabled"
+- tapOn:
+    id: "add-title-confirm-button-enabled"
+- assertVisible:
+    id: "library-list"
+- assertVisible:
+    id: "library-row-the-magic-circle"

--- a/src/flow-lint/__fixtures__/passing/maestro/flows/ReadTitle.yaml
+++ b/src/flow-lint/__fixtures__/passing/maestro/flows/ReadTitle.yaml
@@ -1,0 +1,10 @@
+# Selectors are keyed to testIDs. Never visible text, never layout position.
+appId: com.storyspider.app
+---
+- launchApp
+- assertVisible:
+    id: "library-list"
+- tapOn:
+    id: "library-row-the-magic-circle"
+- assertVisible:
+    id: "player-surface"

--- a/src/flow-lint/index.ts
+++ b/src/flow-lint/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Public surface of the `flow-lint` module. The command layer
+ * (`src/commands/flow-lint.ts`) and tests import from here.
+ */
+
+export { lintFlows } from './linter.js';
+export { parseFrontMatter, parseFlowDoc, parseScreenDoc } from './parser.js';
+export { renderResult, renderJson } from './render.js';
+export type { RenderOptions } from './render.js';
+export type {
+  Finding,
+  FindingCode,
+  FlowDoc,
+  FlowLintOptions,
+  FlowLintResult,
+  ScreenDoc,
+  Severity,
+} from './types.js';

--- a/src/flow-lint/linter.test.ts
+++ b/src/flow-lint/linter.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+
+import { lintFlows } from './linter.js';
+import type { FindingCode } from './types.js';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__');
+
+function codes(root: string, strict = false): FindingCode[] {
+  return lintFlows({ root, strict }).findings.map((f) => f.code);
+}
+
+describe('lintFlows — committed fixtures', () => {
+  it('passes cleanly on the passing tree', () => {
+    const result = lintFlows({ root: join(FIXTURES, 'passing') });
+    expect(result.findings).toEqual([]);
+    expect(result.ok).toBe(true);
+    expect(result.errorCount).toBe(0);
+    expect(result.warningCount).toBe(0);
+    expect(result).toMatchObject({ flowsScanned: 2, screensScanned: 3, maestroScanned: 2 });
+  });
+
+  it('reports every planted dangling reference on the dangling tree', () => {
+    const result = lintFlows({ root: join(FIXTURES, 'dangling') });
+    expect(result.ok).toBe(false);
+    expect(result.errorCount).toBe(3);
+    expect(result.warningCount).toBe(1);
+
+    const byCode = new Map(result.findings.map((f) => [f.code, f]));
+    expect(byCode.get('flow-screen-missing')?.ref).toBe('design/screens/AddTitle.design.md');
+    expect(byCode.get('flow-maestro-missing')?.ref).toBe('maestro/flows/ReadTitle.yaml');
+    expect(byCode.get('maestro-orphan')?.path).toBe('maestro/flows/Orphan.yaml');
+    expect(byCode.get('screen-composable-missing')?.severity).toBe('warning');
+  });
+
+  it('names the severed path in the dangling messages', () => {
+    const { findings } = lintFlows({ root: join(FIXTURES, 'dangling') });
+    const screenMiss = findings.find((f) => f.code === 'flow-screen-missing');
+    expect(screenMiss?.message).toContain('design/flows/AddTitle.flow.md');
+    expect(screenMiss?.message).toContain('design/screens/AddTitle.design.md');
+  });
+
+  it('promotes the composable warning to a failure under --strict', () => {
+    const lenient = lintFlows({ root: join(FIXTURES, 'dangling') });
+    const strict = lintFlows({ root: join(FIXTURES, 'dangling'), strict: true });
+    expect(lenient.ok).toBe(false); // already failing on errors
+    expect(strict.ok).toBe(false);
+    expect(strict.strict).toBe(true);
+    // The warning count is unchanged; only the verdict (ok) is affected.
+    expect(strict.warningCount).toBe(1);
+  });
+});
+
+describe('lintFlows — synthetic edge cases', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'flow-lint-'));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function write(rel: string, content: string): void {
+    const abs = join(root, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+
+  function flow(stem: string, fm: string): void {
+    write(`design/flows/${stem}.flow.md`, `---\n${fm}\n---\n# ${stem}\n`);
+  }
+  function screen(stem: string, fm: string): void {
+    write(`design/screens/${stem}.design.md`, `---\n${fm}\n---\n# ${stem}\n`);
+  }
+
+  it('lints an empty repo (no design/maestro dirs) cleanly', () => {
+    const result = lintFlows({ root });
+    expect(result.ok).toBe(true);
+    expect(result.findings).toEqual([]);
+  });
+
+  it('flags a flow id that does not match its filename stem', () => {
+    flow('AddTitle', 'id: AddTitleX\nscreens: []\nmaestro: maestro/flows/AddTitle.yaml');
+    write('maestro/flows/AddTitle.yaml', 'appId: x\n---\n- launchApp\n');
+    expect(codes(root)).toContain('flow-id-mismatch');
+  });
+
+  it('flags missing required flow front-matter keys', () => {
+    write('design/flows/Bare.flow.md', '---\nid: Bare\n---\n# Bare\n');
+    const found = lintFlows({ root }).findings.filter((f) => f.code === 'flow-frontmatter-missing');
+    expect(found.map((f) => f.ref).sort()).toEqual(['maestro', 'screens']);
+  });
+
+  it('flags invalid flow front-matter', () => {
+    write('design/flows/Bad.flow.md', '# no front matter at all\n');
+    expect(codes(root)).toContain('flow-frontmatter-invalid');
+  });
+
+  it('flags duplicate FlowIds across files', () => {
+    flow('AddTitle', 'id: Dup\nscreens: []\nmaestro: maestro/flows/AddTitle.yaml');
+    flow('AddTitle2', 'id: Dup\nscreens: []\nmaestro: maestro/flows/AddTitle2.yaml');
+    write('maestro/flows/AddTitle.yaml', 'appId: x\n---\n- launchApp\n');
+    write('maestro/flows/AddTitle2.yaml', 'appId: x\n---\n- launchApp\n');
+    const dup = lintFlows({ root }).findings.find((f) => f.code === 'flow-id-duplicate');
+    expect(dup?.message).toContain('design/flows/AddTitle.flow.md');
+    expect(dup?.message).toContain('design/flows/AddTitle2.flow.md');
+  });
+
+  it('flags duplicate ScreenIds across files', () => {
+    screen('Library', 'id: Dup\ncomposable: x.kt');
+    screen('Library2', 'id: Dup\ncomposable: y.kt');
+    expect(codes(root)).toContain('screen-id-duplicate');
+  });
+
+  it('warns (does not error) on a non-conventional but resolving maestro path', () => {
+    flow('AddTitle', 'id: AddTitle\nscreens: []\nmaestro: tests/maestro/add.yaml');
+    write('tests/maestro/add.yaml', 'appId: x\n---\n- launchApp\n');
+    const result = lintFlows({ root });
+    const nonconv = result.findings.find((f) => f.code === 'flow-maestro-nonconventional');
+    expect(nonconv?.severity).toBe('warning');
+    expect(result.errorCount).toBe(0);
+    expect(result.ok).toBe(true);
+  });
+
+  it('resolves screens by declared id, not filename guess', () => {
+    flow('AddTitle', 'id: AddTitle\nscreens: [Library]\nmaestro: maestro/flows/AddTitle.yaml');
+    screen('Library', 'id: Library\ncomposable: app/Library.kt');
+    write('app/Library.kt', '// stub\n');
+    write('maestro/flows/AddTitle.yaml', 'appId: x\n---\n- launchApp\n');
+    const result = lintFlows({ root });
+    expect(result.ok).toBe(true);
+  });
+
+  it('honors custom designDir / maestroDir', () => {
+    write('ui/flows/AddTitle.flow.md', '---\nid: AddTitle\nscreens: []\nmaestro: e2e/AddTitle.yaml\n---\n# x\n');
+    write('e2e/AddTitle.yaml', 'appId: x\n---\n- launchApp\n');
+    const result = lintFlows({ root, designDir: 'ui', maestroDir: 'e2e' });
+    expect(result.ok).toBe(true);
+    expect(result.flowsScanned).toBe(1);
+    expect(result.maestroScanned).toBe(1);
+  });
+
+  it('flips a warning-only tree from ok to failing under --strict', () => {
+    // Library's composable path is missing → a lone warning, no errors.
+    flow('AddTitle', 'id: AddTitle\nscreens: [Library]\nmaestro: maestro/flows/AddTitle.yaml');
+    screen('Library', 'id: Library\ncomposable: app/Missing.kt');
+    write('maestro/flows/AddTitle.yaml', 'appId: x\n---\n- launchApp\n');
+
+    const lenient = lintFlows({ root });
+    expect(lenient.errorCount).toBe(0);
+    expect(lenient.warningCount).toBe(1);
+    expect(lenient.ok).toBe(true);
+
+    const strict = lintFlows({ root, strict: true });
+    expect(strict.ok).toBe(false);
+  });
+
+  it('produces stable, sorted finding order', () => {
+    flow('Zeta', 'id: Zeta\nscreens: [Missing]\nmaestro: maestro/flows/Zeta.yaml');
+    flow('Alpha', 'id: Alpha\nscreens: [Missing]\nmaestro: maestro/flows/Alpha.yaml');
+    write('maestro/flows/Zeta.yaml', 'appId: x\n---\n- launchApp\n');
+    write('maestro/flows/Alpha.yaml', 'appId: x\n---\n- launchApp\n');
+    const paths = lintFlows({ root }).findings.map((f) => f.path);
+    expect(paths).toEqual([...paths].sort());
+  });
+});

--- a/src/flow-lint/linter.ts
+++ b/src/flow-lint/linter.ts
@@ -1,0 +1,322 @@
+/**
+ * The `flow-lint` engine: resolve the UI flow/screen graph in an app repo and
+ * surface every dangling reference as a finding that names the severed path.
+ *
+ * Checks (all deterministic, no agent calls):
+ *
+ *   1. Front-matter integrity — required keys present, YAML valid, and `id`
+ *      matching the filename stem, for both `.flow.md` and `.design.md`.
+ *   2. Flat-namespace uniqueness — no `FlowId` and no `ScreenId` declared
+ *      twice across the repo.
+ *   3. Flow → screen resolution — every `screens:` entry resolves to an
+ *      existing `design/screens/<ScreenId>.design.md`.
+ *   4. Flow → Maestro resolution — every flow's `maestro:` path resolves to a
+ *      real file (and warns when it is not the conventional location).
+ *   5. Maestro → flow resolution — no `maestro/flows/*.yaml` is an orphan
+ *      (referenced by no `.flow.md`).
+ *   6. Screen → composable resolution — a screen's `composable:` path exists
+ *      (a warning by default; the product code may legitimately lag the
+ *      annotation, so it does not fail CI unless `--strict`).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { parseFlowDoc, parseScreenDoc } from './parser.js';
+import type {
+  Finding,
+  FlowDoc,
+  FlowLintOptions,
+  FlowLintResult,
+  ScreenDoc,
+} from './types.js';
+
+const FLOW_SUFFIX = '.flow.md';
+const SCREEN_SUFFIX = '.design.md';
+const MAESTRO_SUFFIX = '.yaml';
+
+/** Normalise a path to repo-relative POSIX form for stable finding output. */
+function toPosix(p: string): string {
+  return p.split(path.sep).join('/');
+}
+
+/** List files in `dir` (relative to root) ending in `suffix`, sorted. */
+function listFiles(root: string, dir: string, suffix: string): string[] {
+  const abs = path.join(root, dir);
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(abs, { withFileTypes: true });
+  } catch {
+    return []; // Missing directory is not itself an error — an empty graph lints clean.
+  }
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith(suffix))
+    .map((e) => toPosix(path.join(dir, e.name)))
+    .sort();
+}
+
+/** Filename stem with `suffix` removed (e.g. `AddTitle.flow.md` → `AddTitle`). */
+function stemOf(relPath: string, suffix: string): string {
+  const base = relPath.slice(relPath.lastIndexOf('/') + 1);
+  return base.slice(0, base.length - suffix.length);
+}
+
+function readFlows(root: string, designDir: string): FlowDoc[] {
+  const dir = `${designDir}/flows`;
+  return listFiles(root, dir, FLOW_SUFFIX).map((rel) => {
+    const text = fs.readFileSync(path.join(root, rel), 'utf8');
+    return parseFlowDoc(rel, stemOf(rel, FLOW_SUFFIX), text);
+  });
+}
+
+function readScreens(root: string, designDir: string): ScreenDoc[] {
+  const dir = `${designDir}/screens`;
+  return listFiles(root, dir, SCREEN_SUFFIX).map((rel) => {
+    const text = fs.readFileSync(path.join(root, rel), 'utf8');
+    return parseScreenDoc(rel, stemOf(rel, SCREEN_SUFFIX), text);
+  });
+}
+
+/** Does `relPath` (repo-relative) resolve to a real file on disk? */
+function fileExists(root: string, relPath: string): boolean {
+  try {
+    return fs.statSync(path.join(root, relPath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Collect every duplicate value in `entries`, keyed by id. Only ids that
+ * appear on more than one doc are returned, each with all owning paths sorted.
+ */
+function findDuplicates(entries: Array<{ id: string; path: string }>): Map<string, string[]> {
+  const byId = new Map<string, string[]>();
+  for (const { id, path: p } of entries) {
+    const list = byId.get(id) ?? [];
+    list.push(p);
+    byId.set(id, list);
+  }
+  const dupes = new Map<string, string[]>();
+  for (const [id, paths] of byId) {
+    if (paths.length > 1) dupes.set(id, [...paths].sort());
+  }
+  return dupes;
+}
+
+/**
+ * Run the full lint over the repo rooted at `opts.root`. Pure with respect to
+ * everything except reading the design/maestro trees — it writes no files and
+ * touches no Smithy manifest.
+ */
+export function lintFlows(opts: FlowLintOptions): FlowLintResult {
+  const designDir = (opts.designDir ?? 'design').replace(/\/+$/, '');
+  const maestroDir = (opts.maestroDir ?? 'maestro/flows').replace(/\/+$/, '');
+  const strict = opts.strict ?? false;
+
+  const flows = readFlows(opts.root, designDir);
+  const screens = readScreens(opts.root, designDir);
+  const maestroFiles = listFiles(opts.root, maestroDir, MAESTRO_SUFFIX);
+
+  const findings: Finding[] = [];
+  const add = (f: Finding) => findings.push(f);
+
+  // --- Screen front-matter integrity + the ScreenId resolution index --------
+  // `screensById` maps a declared ScreenId to its design doc so flows can
+  // resolve `screens:` entries by id (not by filename guesswork).
+  const screensById = new Map<string, ScreenDoc>();
+  for (const screen of screens) {
+    if (screen.parseError) {
+      add({
+        severity: 'error',
+        code: 'screen-frontmatter-invalid',
+        path: screen.path,
+        message: `${screen.path}: ${screen.parseError}`,
+      });
+      continue;
+    }
+    if (!screen.id) {
+      add({
+        severity: 'error',
+        code: 'screen-frontmatter-missing',
+        path: screen.path,
+        ref: 'id',
+        message: `${screen.path}: missing required front-matter key \`id\``,
+      });
+      continue;
+    }
+    if (screen.id !== screen.stem) {
+      add({
+        severity: 'error',
+        code: 'screen-id-mismatch',
+        path: screen.path,
+        ref: screen.id,
+        message: `${screen.path}: \`id: ${screen.id}\` does not match filename stem \`${screen.stem}\` (expected ${screen.stem}${SCREEN_SUFFIX})`,
+      });
+    }
+    // Index by id even on a stem mismatch so flow resolution keys off the
+    // declared id; the mismatch is reported separately above.
+    if (!screensById.has(screen.id)) screensById.set(screen.id, screen);
+
+    if (!screen.composable) {
+      add({
+        severity: 'error',
+        code: 'screen-frontmatter-missing',
+        path: screen.path,
+        ref: 'composable',
+        message: `${screen.path}: missing required front-matter key \`composable\``,
+      });
+    } else if (!fileExists(opts.root, screen.composable)) {
+      add({
+        severity: 'warning',
+        code: 'screen-composable-missing',
+        path: screen.path,
+        ref: screen.composable,
+        message: `${screen.path}: \`composable\` path does not exist → ${screen.composable}`,
+      });
+    }
+  }
+
+  // --- ScreenId uniqueness --------------------------------------------------
+  const screenDupes = findDuplicates(
+    screens.filter((s) => s.id).map((s) => ({ id: s.id as string, path: s.path })),
+  );
+  for (const [id, paths] of [...screenDupes].sort(([a], [b]) => a.localeCompare(b))) {
+    add({
+      severity: 'error',
+      code: 'screen-id-duplicate',
+      path: paths[0] as string,
+      ref: id,
+      message: `ScreenId \`${id}\` declared by ${paths.length} files: ${paths.join(', ')}`,
+    });
+  }
+
+  // --- Flow front-matter integrity + the flow→maestro claim set -------------
+  // `claimedMaestro` records which Maestro yaml each flow points at, so the
+  // orphan check can spot any yaml no flow references.
+  const claimedMaestro = new Set<string>();
+  for (const flow of flows) {
+    if (flow.parseError) {
+      add({
+        severity: 'error',
+        code: 'flow-frontmatter-invalid',
+        path: flow.path,
+        message: `${flow.path}: ${flow.parseError}`,
+      });
+      continue;
+    }
+
+    const missing: string[] = [];
+    if (!flow.id) missing.push('id');
+    if (flow.screens === undefined) missing.push('screens');
+    if (!flow.maestro) missing.push('maestro');
+    for (const key of missing) {
+      add({
+        severity: 'error',
+        code: 'flow-frontmatter-missing',
+        path: flow.path,
+        ref: key,
+        message: `${flow.path}: missing required front-matter key \`${key}\``,
+      });
+    }
+
+    if (flow.id && flow.id !== flow.stem) {
+      add({
+        severity: 'error',
+        code: 'flow-id-mismatch',
+        path: flow.path,
+        ref: flow.id,
+        message: `${flow.path}: \`id: ${flow.id}\` does not match filename stem \`${flow.stem}\` (expected ${flow.stem}${FLOW_SUFFIX})`,
+      });
+    }
+
+    // Flow → screen resolution.
+    for (const screenId of flow.screens ?? []) {
+      if (!screensById.has(screenId)) {
+        add({
+          severity: 'error',
+          code: 'flow-screen-missing',
+          path: flow.path,
+          ref: `${designDir}/screens/${screenId}${SCREEN_SUFFIX}`,
+          message: `${flow.path}: \`screens\` entry \`${screenId}\` does not resolve → ${designDir}/screens/${screenId}${SCREEN_SUFFIX} not found`,
+        });
+      }
+    }
+
+    // Flow → Maestro resolution.
+    if (flow.maestro) {
+      const claimed = toPosix(path.normalize(flow.maestro));
+      claimedMaestro.add(claimed);
+      if (!fileExists(opts.root, flow.maestro)) {
+        add({
+          severity: 'error',
+          code: 'flow-maestro-missing',
+          path: flow.path,
+          ref: flow.maestro,
+          message: `${flow.path}: \`maestro\` path does not resolve → ${flow.maestro} not found`,
+        });
+      } else {
+        const conventional = `${maestroDir}/${flow.stem}${MAESTRO_SUFFIX}`;
+        if (claimed !== conventional) {
+          add({
+            severity: 'warning',
+            code: 'flow-maestro-nonconventional',
+            path: flow.path,
+            ref: flow.maestro,
+            message: `${flow.path}: \`maestro\` resolves to ${flow.maestro} but the conventional path is ${conventional}`,
+          });
+        }
+      }
+    }
+  }
+
+  // --- FlowId uniqueness ----------------------------------------------------
+  const flowDupes = findDuplicates(
+    flows.filter((f) => f.id).map((f) => ({ id: f.id as string, path: f.path })),
+  );
+  for (const [id, paths] of [...flowDupes].sort(([a], [b]) => a.localeCompare(b))) {
+    add({
+      severity: 'error',
+      code: 'flow-id-duplicate',
+      path: paths[0] as string,
+      ref: id,
+      message: `FlowId \`${id}\` declared by ${paths.length} files: ${paths.join(', ')}`,
+    });
+  }
+
+  // --- Maestro → flow resolution (orphan tests) -----------------------------
+  for (const yaml of maestroFiles) {
+    if (!claimedMaestro.has(yaml)) {
+      add({
+        severity: 'error',
+        code: 'maestro-orphan',
+        path: yaml,
+        ref: yaml,
+        message: `${yaml}: orphan Maestro flow — no \`.flow.md\` references it via \`maestro:\``,
+      });
+    }
+  }
+
+  // Stable ordering: by source path, then code, then ref.
+  findings.sort(
+    (a, b) =>
+      a.path.localeCompare(b.path) ||
+      a.code.localeCompare(b.code) ||
+      (a.ref ?? '').localeCompare(b.ref ?? ''),
+  );
+
+  const errorCount = findings.filter((f) => f.severity === 'error').length;
+  const warningCount = findings.filter((f) => f.severity === 'warning').length;
+  const ok = errorCount === 0 && (!strict || warningCount === 0);
+
+  return {
+    findings,
+    errorCount,
+    warningCount,
+    ok,
+    strict,
+    flowsScanned: flows.length,
+    screensScanned: screens.length,
+    maestroScanned: maestroFiles.length,
+  };
+}

--- a/src/flow-lint/parser.test.ts
+++ b/src/flow-lint/parser.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseFlowDoc, parseFrontMatter, parseScreenDoc } from './parser.js';
+
+describe('parseFrontMatter', () => {
+  it('parses a fenced YAML mapping', () => {
+    const { data, error } = parseFrontMatter('---\nid: AddTitle\nscreens: [A, B]\n---\nbody\n');
+    expect(error).toBeUndefined();
+    expect(data).toEqual({ id: 'AddTitle', screens: ['A', 'B'] });
+  });
+
+  it('returns null data when there is no front-matter block', () => {
+    expect(parseFrontMatter('# just markdown\n')).toEqual({ data: null });
+  });
+
+  it('tolerates a leading BOM and blank lines before the fence', () => {
+    const { data } = parseFrontMatter('﻿\n\n---\nid: X\n---\n');
+    expect(data).toEqual({ id: 'X' });
+  });
+
+  it('reports an error on malformed YAML', () => {
+    const { data, error } = parseFrontMatter('---\nid: : :\n  - broken\n---\n');
+    expect(data).toBeNull();
+    expect(error).toBeDefined();
+  });
+
+  it('reports an error when the block is a sequence, not a mapping', () => {
+    const { data, error } = parseFrontMatter('---\n- a\n- b\n---\n');
+    expect(data).toBeNull();
+    expect(error).toMatch(/mapping/);
+  });
+});
+
+describe('parseFlowDoc', () => {
+  it('extracts id, screens, and maestro', () => {
+    const doc = parseFlowDoc(
+      'design/flows/AddTitle.flow.md',
+      'AddTitle',
+      '---\nid: AddTitle\nscreens: [Library, AddTitle]\nmaestro: maestro/flows/AddTitle.yaml\n---\n',
+    );
+    expect(doc).toMatchObject({
+      id: 'AddTitle',
+      screens: ['Library', 'AddTitle'],
+      maestro: 'maestro/flows/AddTitle.yaml',
+      stem: 'AddTitle',
+    });
+    expect(doc.parseError).toBeUndefined();
+  });
+
+  it('coerces a single screen scalar into a one-element list', () => {
+    const doc = parseFlowDoc('f.flow.md', 'f', '---\nid: f\nscreens: Library\nmaestro: m.yaml\n---\n');
+    expect(doc.screens).toEqual(['Library']);
+  });
+
+  it('treats an explicitly empty screens list as present-but-empty', () => {
+    const doc = parseFlowDoc('f.flow.md', 'f', '---\nid: f\nscreens: []\nmaestro: m.yaml\n---\n');
+    expect(doc.screens).toEqual([]);
+  });
+
+  it('reports a parseError when there is no front-matter', () => {
+    const doc = parseFlowDoc('f.flow.md', 'f', '# no front matter\n');
+    expect(doc.parseError).toMatch(/front-matter/);
+  });
+});
+
+describe('parseScreenDoc', () => {
+  it('extracts id and composable only', () => {
+    const doc = parseScreenDoc(
+      'design/screens/Library.design.md',
+      'Library',
+      '---\nid: Library\ncomposable: app/Library.kt\ndesign_system: x\n---\n',
+    );
+    expect(doc).toMatchObject({ id: 'Library', composable: 'app/Library.kt', stem: 'Library' });
+  });
+});

--- a/src/flow-lint/parser.ts
+++ b/src/flow-lint/parser.ts
@@ -1,0 +1,112 @@
+/**
+ * Front-matter parsing for `flow-lint`.
+ *
+ * Pure text → structure. No filesystem I/O here (the linter owns that) so the
+ * parser stays trivially unit-testable. Both `.flow.md` and `.design.md` open
+ * with a YAML front-matter block fenced by `---` lines, per the
+ * `smithy.helper-flow-definition` and `smithy.helper-screen-design` skills.
+ */
+
+import { parse as parseYaml } from 'yaml';
+
+import type { FlowDoc, ScreenDoc } from './types.js';
+
+/** Outcome of pulling the YAML front-matter block out of a Markdown file. */
+export interface FrontMatter {
+  /** Parsed mapping, or `null` when there is no front-matter / it is not a map. */
+  data: Record<string, unknown> | null;
+  /** Set when a fenced block exists but failed to parse as YAML. */
+  error?: string;
+}
+
+const FENCE = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
+
+/**
+ * Extract and parse the leading `---`-fenced YAML front-matter from `text`.
+ * Returns `{ data: null }` when no fenced block is present at the top of the
+ * file; returns `{ data: null, error }` when a block is present but invalid.
+ */
+export function parseFrontMatter(text: string): FrontMatter {
+  // Tolerate a UTF-8 BOM and leading blank lines before the opening fence.
+  const stripped = text.replace(/^﻿/, '').replace(/^\s*\n/, '');
+  const match = FENCE.exec(stripped);
+  if (!match) return { data: null };
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(match[1] ?? '');
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : String(err) };
+  }
+
+  if (parsed === null || parsed === undefined) return { data: null };
+  if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { data: null, error: 'front-matter is not a key/value mapping' };
+  }
+  return { data: parsed as Record<string, unknown> };
+}
+
+/** Coerce a YAML scalar into a trimmed string, or `undefined` when absent/empty. */
+function asString(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return undefined;
+}
+
+/**
+ * Coerce a YAML value into a list of strings. Accepts a real YAML sequence
+ * (`[A, B]` or block list) or a single scalar (treated as a one-element list).
+ * Returns `undefined` when the key is absent, the empty array when present but
+ * empty.
+ */
+function asStringList(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (Array.isArray(value)) {
+    return value.map(asString).filter((v): v is string => v !== undefined);
+  }
+  const single = asString(value);
+  return single === undefined ? [] : [single];
+}
+
+/**
+ * Parse a `<FlowId>.flow.md` file into a {@link FlowDoc}. `path` is the
+ * repo-relative POSIX path used for findings; `stem` is its filename stem
+ * (the expected FlowId).
+ */
+export function parseFlowDoc(path: string, stem: string, text: string): FlowDoc {
+  const { data, error } = parseFrontMatter(text);
+  if (error) return { path, stem, parseError: error };
+  if (data === null) return { path, stem, parseError: 'no YAML front-matter block found' };
+
+  // Assign optional keys only when present — `exactOptionalPropertyTypes`
+  // forbids setting them to an explicit `undefined`.
+  const doc: FlowDoc = { path, stem };
+  const id = asString(data.id);
+  if (id !== undefined) doc.id = id;
+  const screens = asStringList(data.screens);
+  if (screens !== undefined) doc.screens = screens;
+  const maestro = asString(data.maestro);
+  if (maestro !== undefined) doc.maestro = maestro;
+  return doc;
+}
+
+/**
+ * Parse a `<ScreenId>.design.md` file into a {@link ScreenDoc}. Only the keys
+ * `flow-lint` resolves (`id`, `composable`) are extracted; the richer screen
+ * schema is the screen-design skill's concern.
+ */
+export function parseScreenDoc(path: string, stem: string, text: string): ScreenDoc {
+  const { data, error } = parseFrontMatter(text);
+  if (error) return { path, stem, parseError: error };
+  if (data === null) return { path, stem, parseError: 'no YAML front-matter block found' };
+
+  const doc: ScreenDoc = { path, stem };
+  const id = asString(data.id);
+  if (id !== undefined) doc.id = id;
+  const composable = asString(data.composable);
+  if (composable !== undefined) doc.composable = composable;
+  return doc;
+}

--- a/src/flow-lint/render.test.ts
+++ b/src/flow-lint/render.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderJson, renderResult } from './render.js';
+import type { FlowLintResult } from './types.js';
+
+function result(overrides: Partial<FlowLintResult> = {}): FlowLintResult {
+  return {
+    findings: [],
+    errorCount: 0,
+    warningCount: 0,
+    ok: true,
+    strict: false,
+    flowsScanned: 2,
+    screensScanned: 3,
+    maestroScanned: 2,
+    ...overrides,
+  };
+}
+
+describe('renderResult', () => {
+  it('renders a passing summary with the scan counts', () => {
+    const out = renderResult(result(), { noColor: true });
+    expect(out).toContain('flow-lint passed');
+    expect(out).toContain('scanned 2 flows, 3 screens, 2 Maestro flows');
+  });
+
+  it('singularizes a one-of count', () => {
+    const out = renderResult(result({ flowsScanned: 1, maestroScanned: 1 }), { noColor: true });
+    expect(out).toContain('1 flow,');
+    expect(out).toContain('1 Maestro flow');
+  });
+
+  it('lists findings with severity tag, code, and message', () => {
+    const out = renderResult(
+      result({
+        ok: false,
+        errorCount: 1,
+        warningCount: 1,
+        findings: [
+          {
+            severity: 'error',
+            code: 'flow-screen-missing',
+            path: 'design/flows/AddTitle.flow.md',
+            ref: 'design/screens/AddTitle.design.md',
+            message: 'design/flows/AddTitle.flow.md: severed → design/screens/AddTitle.design.md',
+          },
+          {
+            severity: 'warning',
+            code: 'screen-composable-missing',
+            path: 'design/screens/Library.design.md',
+            message: 'design/screens/Library.design.md: composable missing',
+          },
+        ],
+      }),
+      { noColor: true },
+    );
+    expect(out).toContain('✖ error [flow-screen-missing]');
+    expect(out).toContain('▲ warning [screen-composable-missing]');
+    expect(out).toContain('flow-lint failed');
+    expect(out).toContain('1 error, 1 warning');
+  });
+
+  it('marks strict in the failure line', () => {
+    const out = renderResult(
+      result({ ok: false, warningCount: 1, strict: true }),
+      { noColor: true },
+    );
+    expect(out).toContain('(--strict)');
+  });
+
+  it('notes non-fatal warnings on a pass', () => {
+    const out = renderResult(result({ warningCount: 1 }), { noColor: true });
+    expect(out).toContain('flow-lint passed');
+    expect(out).toContain('1 warning');
+  });
+});
+
+describe('renderJson', () => {
+  it('serializes the full result shape', () => {
+    const parsed = JSON.parse(renderJson(result({ warningCount: 1 })));
+    expect(parsed).toMatchObject({
+      ok: true,
+      warningCount: 1,
+      flowsScanned: 2,
+      findings: [],
+    });
+  });
+});

--- a/src/flow-lint/render.ts
+++ b/src/flow-lint/render.ts
@@ -1,0 +1,91 @@
+/**
+ * Human-facing rendering for `flow-lint` results. Pure string-building; the
+ * command layer owns printing and exit codes. Colour is opt-out via the
+ * `noColor` flag (and the ambient `NO_COLOR` env var, honoured by the caller).
+ */
+
+import pc from 'picocolors';
+
+import type { FlowLintResult } from './types.js';
+
+export interface RenderOptions {
+  noColor?: boolean;
+}
+
+interface Painter {
+  red: (s: string) => string;
+  yellow: (s: string) => string;
+  green: (s: string) => string;
+  dim: (s: string) => string;
+  bold: (s: string) => string;
+}
+
+function painter(noColor: boolean): Painter {
+  if (noColor) {
+    const id = (s: string) => s;
+    return { red: id, yellow: id, green: id, dim: id, bold: id };
+  }
+  return {
+    red: (s) => pc.red(s),
+    yellow: (s) => pc.yellow(s),
+    green: (s) => pc.green(s),
+    dim: (s) => pc.dim(s),
+    bold: (s) => pc.bold(s),
+  };
+}
+
+function pluralize(n: number, word: string): string {
+  return `${n} ${word}${n === 1 ? '' : 's'}`;
+}
+
+/**
+ * Render a {@link FlowLintResult} as the default human-readable report. The
+ * final line is always a one-line summary so CI logs surface the verdict even
+ * when truncated.
+ */
+export function renderResult(result: FlowLintResult, opts: RenderOptions = {}): string {
+  const noColor = opts.noColor ?? false;
+  const c = painter(noColor);
+  const lines: string[] = [];
+
+  for (const f of result.findings) {
+    const tag =
+      f.severity === 'error' ? c.red('✖ error') : c.yellow('▲ warning');
+    const code = c.dim(`[${f.code}]`);
+    lines.push(`${tag} ${code} ${f.message}`);
+  }
+
+  if (result.findings.length > 0) lines.push('');
+
+  const scanned = c.dim(
+    `scanned ${pluralize(result.flowsScanned, 'flow')}, ` +
+      `${pluralize(result.screensScanned, 'screen')}, ` +
+      `${pluralize(result.maestroScanned, 'Maestro flow')}`,
+  );
+
+  if (result.ok && result.warningCount === 0) {
+    lines.push(`${c.green('✓ flow-lint passed')} — ${scanned}`);
+  } else if (result.ok) {
+    // Warnings present but not fatal (non-strict).
+    lines.push(
+      `${c.green('✓ flow-lint passed')} with ${pluralize(result.warningCount, 'warning')} — ${scanned}`,
+    );
+  } else {
+    const counts =
+      `${pluralize(result.errorCount, 'error')}` +
+      (result.warningCount > 0 ? `, ${pluralize(result.warningCount, 'warning')}` : '') +
+      (result.strict ? ' (--strict)' : '');
+    lines.push(`${c.red(c.bold('✖ flow-lint failed'))} — ${counts} — ${scanned}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Serialize a result as the stable JSON contract for `--format json`. Mirrors
+ * {@link FlowLintResult} verbatim so machine consumers depend on the typed
+ * shape, not the text report.
+ */
+export function renderJson(result: FlowLintResult): string {
+  return JSON.stringify(result, null, 2);
+}

--- a/src/flow-lint/types.ts
+++ b/src/flow-lint/types.ts
@@ -1,0 +1,123 @@
+/**
+ * Shared types for `flow-lint` — the deterministic, Smithy-state-free check
+ * that guarantees the UI flow/screen graph in an app repo resolves.
+ *
+ * The lint operates entirely on files committed to the app repo (EPIC #404
+ * layout):
+ *
+ *   design/flows/<FlowId>.flow.md      — durable flow INTENT annotation
+ *   design/screens/<ScreenId>.design.md — durable screen INTENT annotation
+ *   maestro/flows/<FlowId>.yaml         — durable flow BEHAVIORAL body
+ *
+ * It performs no agent calls and reads no Smithy manifest — the repo is the
+ * single source of truth. See `docs/flow-lint.md` and the
+ * `smithy.helper-flow-definition` skill for the authoring contract these
+ * checks enforce.
+ */
+
+/** Severity of a single lint finding. */
+export type Severity = 'error' | 'warning';
+
+/**
+ * Stable machine-readable finding codes. Kept as a closed union so the JSON
+ * output is a documented contract and tests can assert on codes rather than
+ * brittle message text.
+ */
+export type FindingCode =
+  // A `.flow.md` is missing one of the required front-matter keys.
+  | 'flow-frontmatter-missing'
+  // A `.flow.md` front-matter block failed to parse as YAML.
+  | 'flow-frontmatter-invalid'
+  // A flow's `id` does not match its `<FlowId>.flow.md` filename stem.
+  | 'flow-id-mismatch'
+  // The same `FlowId` is declared by more than one `.flow.md`.
+  | 'flow-id-duplicate'
+  // A flow's `screens:` entry has no resolving `design/screens/<ScreenId>.design.md`.
+  | 'flow-screen-missing'
+  // A flow's `maestro:` path does not resolve to an existing file.
+  | 'flow-maestro-missing'
+  // A flow's `maestro:` path resolves but is not the conventional
+  // `maestro/flows/<FlowId>.yaml` location.
+  | 'flow-maestro-nonconventional'
+  // A `.design.md` is missing one of the required front-matter keys.
+  | 'screen-frontmatter-missing'
+  // A `.design.md` front-matter block failed to parse as YAML.
+  | 'screen-frontmatter-invalid'
+  // A screen's `id` does not match its `<ScreenId>.design.md` filename stem.
+  | 'screen-id-mismatch'
+  // The same `ScreenId` is declared by more than one `.design.md`.
+  | 'screen-id-duplicate'
+  // A screen's `composable:` path does not resolve to an existing file.
+  | 'screen-composable-missing'
+  // A `maestro/flows/*.yaml` is referenced by no `.flow.md` (an orphan test).
+  | 'maestro-orphan';
+
+/**
+ * One lint finding. `path` names the source artifact the finding is about
+ * (repo-relative, POSIX separators); `ref` names the *severed* path or id —
+ * the specific thing that failed to resolve — so a failure points straight at
+ * the broken reference rather than forcing a reader to reconstruct it.
+ */
+export interface Finding {
+  severity: Severity;
+  code: FindingCode;
+  /** Repo-relative path of the artifact the finding concerns. */
+  path: string;
+  /** The severed reference (path or id) when the finding is a dangling ref. */
+  ref?: string;
+  /** Human-readable, single-line description that names the severed path. */
+  message: string;
+}
+
+/** Result of a full lint run. */
+export interface FlowLintResult {
+  findings: Finding[];
+  errorCount: number;
+  warningCount: number;
+  /**
+   * `true` when the run should be treated as a CI pass: no errors, and (when
+   * `strict` is set) no warnings either.
+   */
+  ok: boolean;
+  /** Whether warnings were promoted to failures (`--strict`). */
+  strict: boolean;
+  flowsScanned: number;
+  screensScanned: number;
+  maestroScanned: number;
+}
+
+/** Options controlling a lint run. */
+export interface FlowLintOptions {
+  /** Repo root to lint. Defaults to `process.cwd()` at the command layer. */
+  root: string;
+  /** Directory (relative to root) holding `flows/` and `screens/`. Default `design`. */
+  designDir?: string;
+  /** Directory (relative to root) holding the Maestro yaml files. Default `maestro/flows`. */
+  maestroDir?: string;
+  /** Promote every warning to a failure (affects `ok`, not severity labels). */
+  strict?: boolean;
+}
+
+/** Parsed `<FlowId>.flow.md` front-matter, with the source path attached. */
+export interface FlowDoc {
+  /** Repo-relative POSIX path to the `.flow.md`. */
+  path: string;
+  /** Filename stem (the declared-or-expected FlowId). */
+  stem: string;
+  id?: string;
+  screens?: string[];
+  maestro?: string;
+  /** Set when the front-matter could not be parsed at all. */
+  parseError?: string;
+}
+
+/** Parsed `<ScreenId>.design.md` front-matter, with the source path attached. */
+export interface ScreenDoc {
+  /** Repo-relative POSIX path to the `.design.md`. */
+  path: string;
+  /** Filename stem (the declared-or-expected ScreenId). */
+  stem: string;
+  id?: string;
+  composable?: string;
+  parseError?: string;
+}


### PR DESCRIPTION
## What

Implements **#409** (part of EPIC #404): `flow-lint` — a deterministic,
Smithy-state-free check that runs in the **app's CI** and guarantees the UI
flow/screen graph resolves. No agent calls, no manifest reads; fast enough for
every push and runnable outside any `forge` invocation.

Closes #409.

## Why

A screen's body is its composable and a flow's body is an executable Maestro
test (EPIC #404). The thin annotations tying them together are only worth
keeping if their cross-references resolve. A dangling reference means a product
path was *severed* — `flow-lint` makes that the signal, surfacing each as a
failure that names the specific broken path.

## Checks

| Requirement (#409) | Enforced by |
|---|---|
| `screens:` resolves to a real `design/screens/<ScreenId>.design.md` (composable ideally exists) | `flow-screen-missing` (error); `screen-composable-missing` (warning, `--strict` promotes) |
| Every `flow.md` ↔ `maestro/flows/<FlowId>.yaml`, no orphan tests | `flow-maestro-missing` + `maestro-orphan` (errors) |
| Flat FlowId/ScreenId uniqueness | `flow-id-duplicate` / `screen-id-duplicate` (errors) |
| Dangling refs named, not hidden | every finding carries the severed `ref` path |
| Pure lint, fast, no agent | pure fs read + parse; mirrors the `status` command structure |

Plus front-matter integrity and id↔filename-stem matching for both artifact
kinds.

## Shape

- `src/flow-lint/` — pure logic: `parser` (front-matter), `linter`
  (cross-ref engine), `render` (text + JSON), behind `index.ts`.
- `src/commands/flow-lint.ts` — thin wrapper wired into `cli.ts`. Exit `0`
  pass / `1` lint failure / `2` usage error. `--format json` emits a stable
  `FlowLintResult`; `--strict` fails on warnings; `--design-dir` /
  `--maestro-dir` override roots.
- `src/flow-lint/__fixtures__/{passing,dangling}/` — committed worked trees;
  the dangling tree plants one of each severed-reference category (documented
  in its `README.md`).
- `docs/flow-lint.md` — full reference + a GitHub Actions CI wiring example.

## Testing

- `npm run typecheck` — clean.
- `npm test` — **986 passed** (37 new across parser / linter / render / command).
- CLI smoke: `passing` → exit 0; `dangling` → exit 1 naming each severed path;
  `--strict` and `--format json` verified.

Per CLAUDE.md, `.claude/` and the manifest are **not** regenerated — source
templates only.
