### PR TITLE
Trim smithy.prose to delegate shared voice principles to smithy.helper-voice

### DIFF
--- a/src/templates/agent-skills/agents/smithy.prose.prompt
+++ b/src/templates/agent-skills/agents/smithy.prose.prompt
@@ -71,12 +71,14 @@ from the provided context, note the gap in `## Gaps / Missing Context`.
 
 Apply the following structure and style to each assigned section.
 
-**Prose principles — follow these on every sentence:**
+**Prose principles:**
 
-- Lead with impact, not description. Prefer *"Teams lose `[X hours]` per sprint
-  to manual reconciliation"* over *"Manual reconciliation is slow."*
-- Name real costs: time, cognitive load, deployment risk, coordination overhead.
-  Avoid vague qualifiers like "sometimes", "often", "can be".
+- **Shared voice guidance lives in `smithy.helper-voice`.** Load that skill for
+  the audience taxonomy (Role × Diátaxis mode), the Diátaxis-mode voice rules,
+  diagram guidance, and the canonical anti-pattern reference (lead-with-impact,
+  no bullet-enumeration inside prose, no hedging). Apply that voice to every
+  section you draft; the rules below are the figure-handling discipline specific
+  to this sub-agent.
 - **All figures must come from the provided context.** If `idea_description`,
   `clarify_output`, or the RFC file states a concrete number — hours, incidents,
   team size, frequency — use it. If the context does not supply a figure, write
@@ -84,37 +86,6 @@ Apply the following structure and style to each assigned section.
   The sentence structure and writing style stay the same; only the number
   becomes a placeholder the author fills in. **Do not invent plausible-sounding
   magnitudes to fill the structural need.**
-- Establish urgency: explain why the status quo is increasingly untenable, not
-  just inconvenient. Escalating team size, growing complexity, or upcoming
-  milestones all justify a "why now" framing.
-- State stakeholder value in concrete outcomes, not features. Prefer *"developers
-  can ship a feature without a Slack thread to track down the right config"*
-  over *"this improves the developer experience"*.
-- Use connective tissue: each sentence should follow from the previous one.
-  Avoid bullet-enumeration style inside prose sections — that is the anti-pattern.
-
-**Anti-pattern to avoid:**
-> ❌ "The current system has several issues:
-> - Manual reconciliation is slow
-> - Errors occur frequently
-> - Developers are frustrated"
-
-**Preferred pattern — when context supplies figures:**
-> ✓ "Each deployment forces developers to manually reconcile three separate
-> config sources — a process that consumes a full afternoon per sprint and
-> introduces the class of config-drift errors that caused three P1 incidents
-> last quarter. As the team scales from 8 to 20 engineers, this bottleneck
-> compounds: every new engineer inherits the same manual overhead with no
-> systematic way to detect or correct drift before it reaches production."
-
-**Same pattern — when figures are absent from context (use gap markers):**
-> ✓ "Each deployment forces developers to manually reconcile `[N]` separate
-> config sources — a process that consumes `[X hours]` per sprint and
-> introduces the class of config-drift errors that caused `[N]` P1 incidents
-> last quarter. As the team scales from `[current size]` to `[target size]`
-> engineers, this bottleneck compounds: every new engineer inherits the same
-> manual overhead with no systematic way to detect or correct drift before it
-> reaches production."
 
 ---
 


### PR DESCRIPTION
## Summary

Trims the `smithy-prose` sub-agent so it delegates the shared voice/audience/anti-pattern guidance to the `smithy.helper-voice` skill, while preserving the section-specific drafting protocols that are the sub-agent's actual reason to exist.

Part of EPIC #419 (voice & audience). Depends on the tagging convention shipped in #422.

## What changed

`src/templates/agent-skills/agents/smithy.prose.prompt` (net: **8 insertions, 37 deletions**):

- **Removed** the duplicated anti-pattern block (wordy-enumeration vs. concrete-prose before/after) — it now lives in `smithy.helper-voice` (§2, §9), so updates happen in one place.
- **Removed** the shared prose principles (lead-with-impact, name-real-costs, establish-urgency, connective-tissue / no bullet-enumeration) — also owned by the skill now.
- **Added** a single bullet at the top of the "Prose principles" section pointing to `smithy.helper-voice` for the audience taxonomy (Role × Diátaxis mode), Diátaxis-mode voice rules, diagram guidance, and the canonical anti-pattern reference.

## What stayed (the sub-agent's actual job)

- The **no-invented-figures / gap-marker** discipline (`[X hours]`, `[N incidents per sprint]`) — section-specific to this sub-agent.
- The per-section structural rules for **Summary**, **Motivation / Problem Statement**, and **Personas** — unchanged.
- Input contract, output format, and rules — unchanged.

The sub-agent `description` already advertised narrative drafting for assigned sections (not voice-in-general), so no change was needed there.

## Verification

- `npm run typecheck` — passes.
- `npm test` — 949 tests pass (27 files).
- `npm run eval -- --case ignite-from-prd` — the narrative-quality signal **`smithy-prose evidence present` passes**, as does the `## Summary` heading check, confirming no regression in narrative drafting. The two failing checks in that run (`PR creation` URL pattern and `smithy-plan-review` evidence) are orthogonal to this change: PR creation fails in the eval sandbox (no GitHub remote/auth for the fixture), and the plan-review evidence concerns a different sub-agent's dispatch. Neither touches `smithy.prose` content.

Per CLAUDE.md, the committed `.claude/` tree and `.smithy/smithy-manifest.json` were intentionally **not** regenerated — only `src/templates/` is edited.

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
