### PR TITLE
Spec: Forge-JVM eval scenario + M1 baseline-set gate (F6)

### DIFF
--- a/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
+++ b/docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md
@@ -109,7 +109,7 @@ Recommended specification sequence:
 | F3 | Feature 1.4: smithy.fix End-to-End Eval Scenario | F1 | specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/ |
 | F4 | Feature 1.5: smithy.forge End-to-End Eval Scenario + Runner git-init (RFC SD-002) | F1 | specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/ |
 | F5 | Feature 1.6: JVM Multi-Language Fixture | — | specs/2026-06-06-011-jvm-multi-language-fixture/ |
-| F6 | Feature 1.7: Forge-JVM Eval Scenario + M1 Baseline-Set Completeness Gate | F1, F4, F5 | — |
+| F6 | Feature 1.7: Forge-JVM Eval Scenario + M1 Baseline-Set Completeness Gate | F1, F4, F5 | specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/ |
 
 Feature 1.1 and Feature 1.2 are referenced-only rows with no implementation work, so they are intentionally omitted from the Dependency Order table. No spec will be authored against them in this milestone because they are inherited substrate / cross-RFC dependency.
 

--- a/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.contracts.md
+++ b/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.contracts.md
@@ -16,17 +16,26 @@ This feature defines the contracts for the JVM forge eval scenario, its committe
 
 ```yaml
 name: forge-tdd-slice-jvm
-skill: smithy.forge
+skill: /smithy.forge
+prompt: <forge task-file invocation, mirroring the F1.5 forge-JS scenario>
 fixture: jvm
 requires_git: true
 ```
+
+The `skill` value uses the slash-command form (`/smithy.forge`), matching every
+committed scenario YAML: the runner invokes non-Codex agents as
+`${scenario.skill} ${scenario.prompt}` (`evals/lib/runner.ts`), so the bare
+`smithy.forge` would be sent as plain text and never trigger the forge skill.
+The `prompt` field is required and must be a non-empty string — the scenario
+loader skips any case missing it (`evals/lib/scenario-loader.ts`).
 
 #### Inputs
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes | Stable JVM scenario identity. |
-| `skill` | string | Yes | Forge skill invocation target. |
+| `skill` | string | Yes | Forge skill invocation target in slash-command form (`/smithy.forge`). |
+| `prompt` | string | Yes | Non-empty forge task-file invocation; loader rejects a missing/empty prompt. |
 | `fixture` | string | Yes | JVM fixture selector from F1.6. |
 | `requires_git` | boolean | Yes | Git-initialization opt-in from F1.5. |
 | `structural_expectations` | object | Yes | Forge completion expectations for this scenario. |

--- a/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.contracts.md
+++ b/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.contracts.md
@@ -76,8 +76,8 @@ The JSON shape follows the token-aware baseline schema established by F1.3a.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | scenario result | EvalResult | Yes | Successful JVM forge result used to generate the baseline. |
-| token totals | object | Yes | Input and output token envelope. |
-| structural envelope | object | Yes | Expected structural result envelope. |
+| measured token totals | object | Yes | Per-run input/output token *counts* from the result, used to derive the committed `token_envelope` (`input`/`output` `{min,max}`) bounds — distinct from the envelope itself. |
+| structural expectations | object | Yes | Expected headings/tables captured as the structural baseline. |
 
 #### Outputs
 

--- a/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.contracts.md
+++ b/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.contracts.md
@@ -1,0 +1,189 @@
+# Contracts: Forge-JVM Eval Scenario + M1 Baseline-Set Completeness Gate
+
+## Overview
+
+This feature defines the contracts for the JVM forge eval scenario, its committed token-aware baseline, and the M1 baseline-set audit. It consumes the token baseline schema from F1.3a, the forge scenario and git setup contracts from F1.5, and the JVM fixture selector from F1.6.
+
+## Interfaces
+
+### 1) Forge-JVM Scenario Declaration
+
+**Purpose**: Declares the JVM forge eval case as a normal scenario in the eval suite.
+**Consumers**: Scenario loader, eval runner, baseline comparison, baseline-set audit.
+**Providers**: Scenario YAML under `evals/cases/`.
+
+#### Signature
+
+```yaml
+name: forge-tdd-slice-jvm
+skill: smithy.forge
+fixture: jvm
+requires_git: true
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Stable JVM scenario identity. |
+| `skill` | string | Yes | Forge skill invocation target. |
+| `fixture` | string | Yes | JVM fixture selector from F1.6. |
+| `requires_git` | boolean | Yes | Git-initialization opt-in from F1.5. |
+| `structural_expectations` | object | Yes | Forge completion expectations for this scenario. |
+| `sub_agent_evidence` | array | Yes | Expected forge helper evidence. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| loaded scenario | EvalScenario | Scenario model with JVM fixture and git requirements. |
+| eval result | EvalResult | Structural, sub-agent, and token result for the JVM forge run. |
+| report row | EvalReport row | User-visible JVM forge status and token totals. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| JVM fixture selector is missing or invalid | Scenario loading or preparation fails clearly. | Prevents accidental JavaScript-fixture fallback. |
+| Git initialization is not enabled | Scenario fails before or during forge repository operations. | Forge requires a working repository. |
+| Structural expectations fail | Eval result fails and reports the missing evidence. | The JVM forge behavior did not meet the scenario contract. |
+
+### 2) Forge-JVM Baseline Contract
+
+**Purpose**: Stores the committed baseline used for JVM forge token deltas.
+**Consumers**: Baseline loader, baseline comparison, eval reports, future PR-description token-delta protocol.
+**Providers**: Baseline JSON under `evals/baselines/`.
+
+#### Signature
+
+```text
+evals/baselines/forge-tdd-slice-jvm.json
+```
+
+The JSON shape follows the token-aware baseline schema established by F1.3a.
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| scenario result | EvalResult | Yes | Successful JVM forge result used to generate the baseline. |
+| token totals | object | Yes | Input and output token envelope. |
+| structural envelope | object | Yes | Expected structural result envelope. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| baseline file | JSON | Stable committed baseline for `forge-tdd-slice-jvm`. |
+| baseline comparison | CheckResult[] | Structural and token-envelope comparison results. |
+| report marker | string | Existing report baseline marker for the JVM case. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Baseline file missing | M1 baseline audit fails. | Required M1 baseline is absent. |
+| Baseline schema malformed | Baseline loading or audit fails with the path and field. | Required M1 baseline cannot support token deltas. |
+| Token envelope absent | Audit fails for the JVM baseline. | F1.7 must close on token-aware baselines, not structural-only baselines. |
+| Runtime exceeds token envelope | Baseline comparison reports token status through the normal report path. | Future cost changes remain visible. |
+
+### 3) M1 Baseline-Set Audit
+
+**Purpose**: Determines whether the Measurement Foundation milestone has the required committed baseline floor.
+**Consumers**: F1.7 tests, maintainers closing M1, downstream M2/M3 contributors.
+**Providers**: Baseline files and optional audit helper/test code.
+
+#### Signature
+
+```text
+required:
+  - strike-health-check
+  - fix-from-issue
+  - forge-tdd-slice
+  - forge-tdd-slice-jvm
+informational:
+  - planning-command baselines from expand-evals, when visible
+```
+
+The implementation may expose this as a unit test, a helper function, or an eval/baseline validation path. The behavior, not the helper name, is contractual.
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| required baseline paths | string[] | Yes | Four required M1 baseline paths. |
+| baseline schema validator | function | Yes | Existing token-aware baseline validation/comparison surface. |
+| planning baseline discovery | function | No | Optional discovery for informational expand-evals baselines. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| audit pass/fail | boolean | Passes only when every required baseline exists and validates. |
+| required statuses | array | Status for each required baseline. |
+| informational statuses | array | Non-gating planning-command baseline statuses. |
+| failure messages | string[] | Missing or malformed required baseline messages. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Required baseline missing | Audit fails and names the missing path. | M1 cannot close. |
+| Required baseline malformed | Audit fails and names the path and validation reason. | M1 cannot close on unusable data. |
+| Informational planning baseline missing | Audit still passes when required baselines are valid. | Planning-command baselines do not gate M1. |
+| Some planning baselines are present | Audit may report them without changing pass/fail. | Keeps cross-RFC status visible. |
+
+### 4) Milestone Ownership Boundary
+
+**Purpose**: Keeps the M1 closer scoped to measurement artifacts and avoids derived snapshot churn.
+**Consumers**: Reviewers, implementation agents, Hatchery manager session.
+**Providers**: F1.7 implementation patch.
+
+#### Signature
+
+```text
+allowed:
+  evals/cases/forge-tdd-slice-jvm.yaml
+  evals/baselines/forge-tdd-slice-jvm.json
+  eval baseline audit/reporting support and tests
+
+disallowed:
+  .claude/
+  .smithy/smithy-manifest.json
+  F1.5 forge-JS scenario redesign
+  F1.6 JVM fixture redesign
+```
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| implementation diff | file set | Yes | Files changed by the F1.7 implementation. |
+| ownership matrix | artifact context | Yes | RFC and feature-map boundaries. |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| reviewable scope | file set | Changes tied to JVM scenario, JVM baseline, and M1 audit. |
+| excluded artifacts | file set | Snapshot or upstream-owned files left untouched. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| Snapshot files change | Remove from F1.7 and defer to M1-close chore. | Derived artifacts are not feature-owned. |
+| Forge-JS contract is redesigned | Move redesign to F1.5 follow-up unless strictly additive compatibility is needed. | Preserves feature ownership. |
+| JVM fixture is redesigned | Move fixture changes to F1.6 follow-up unless strictly necessary to consume the existing contract. | Preserves feature ownership. |
+
+## Events / Hooks
+
+No new runtime event stream is introduced. The JVM scenario participates in the existing eval run, stream parsing, report formatting, and baseline comparison paths.
+
+## Integration Boundaries
+
+- **F1.3a baseline boundary**: F1.7 consumes the token-aware baseline schema and comparison behavior.
+- **F1.5 forge boundary**: F1.7 consumes the forge scenario pattern and `requires_git` behavior without redesigning the JavaScript forge scenario.
+- **F1.6 fixture boundary**: F1.7 consumes `fixture: jvm` and the committed JVM fixture without changing fixture resolution semantics.
+- **Expand-evals boundary**: Planning-command baselines are informational and do not gate M1 closure.
+- **Snapshot boundary**: `.claude/` and `.smithy/` refreshes remain dedicated milestone-close chores, not F1.7 work.

--- a/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.data-model.md
+++ b/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.data-model.md
@@ -1,0 +1,158 @@
+# Data Model: Forge-JVM Eval Scenario + M1 Baseline-Set Completeness Gate
+
+## Overview
+
+This feature adds one JVM forge eval scenario, its committed token-aware baseline, and an audit view of the M1 baseline set. The model is file-backed: scenario YAML, baseline JSON, and audit results derived from committed eval artifacts. No database or external service storage is introduced.
+
+## Entities
+
+### 1) Forge-JVM Scenario (`forge_jvm_scenario`)
+
+Purpose: Represents the JVM variant of the forge end-to-end eval case.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | Canonical value: `forge-tdd-slice-jvm`. |
+| `skill` | string | Yes | Existing forge skill under test. |
+| `fixture` | string | Yes | Uses the F1.6 selector for the JVM fixture. |
+| `requires_git` | boolean | Yes | Uses the F1.5 git-initialization contract. |
+| `structural_expectations` | StructuralExpectations | Yes | Validates forge completion and expected output shape. |
+| `sub_agent_evidence` | SubAgentEvidence[] | Yes | Verifies expected forge helper evidence. |
+| `timeout` | number | No | Scenario-specific timeout if the JVM build path needs more time than default. |
+
+Validation rules:
+
+- The scenario name must be stable because it determines the baseline stem and report identity.
+- `fixture` must resolve to the committed JVM fixture and must not fall back to the default JavaScript fixture.
+- `requires_git` must be enabled for forge repository operations.
+- Structural expectations should remain aligned with the JavaScript forge scenario without copying ownership of F1.5's scenario design.
+
+### 2) Forge-JVM Baseline (`forge_jvm_baseline`)
+
+Purpose: Stores the committed baseline envelope for the JVM forge scenario.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | Matches `forge-tdd-slice-jvm`. |
+| `structural` | object | Yes | Existing structural baseline envelope. |
+| `tokens` | object | Yes | Token-aware envelope established by F1.3a. |
+| `metadata` | object | No | Stable baseline metadata if supported by the schema. |
+
+Validation rules:
+
+- The baseline filename must be `evals/baselines/forge-tdd-slice-jvm.json`.
+- The baseline must compare against the JVM scenario only.
+- The token envelope must be sufficient for future token-delta reporting.
+- Volatile run-local fields must not be committed.
+
+### 3) M1 Required Baseline (`m1_required_baseline`)
+
+Purpose: Defines one baseline that must exist and validate before M1 can close.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | string | Yes | Stable audit identifier. |
+| `scenario_name` | string | Yes | Scenario that owns the baseline. |
+| `baseline_path` | string | Yes | Repo-relative baseline JSON path. |
+| `owner_feature` | string | Yes | F1.3a, F1.4, F1.5, or F1.7. |
+| `required_for_m1` | boolean | Yes | Always `true` for this entity set. |
+| `status` | enum | Yes | `present`, `missing`, or `malformed`. |
+
+Required baseline set:
+
+| ID | Scenario | Owner Feature | Required |
+|----|----------|---------------|----------|
+| `strike` | `strike-health-check` | F1.3a | Yes |
+| `fix` | `fix-from-issue` | F1.4 | Yes |
+| `forge-js` | `forge-tdd-slice` | F1.5 | Yes |
+| `forge-jvm` | `forge-tdd-slice-jvm` | F1.7 | Yes |
+
+Validation rules:
+
+- Every required baseline must exist.
+- Every required baseline must conform to the token-aware baseline schema.
+- Missing or malformed required baselines fail the M1 gate.
+
+### 4) Planning-Command Baseline Status (`planning_command_baseline_status`)
+
+Purpose: Records optional visibility into expand-evals planning-command baselines without gating M1 closure.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `scenario_name` | string | Yes | Planning-command scenario name when known. |
+| `baseline_path` | string | No | Baseline path when present. |
+| `status` | enum | Yes | `present`, `missing`, `not-yet-merged`, or `unknown`. |
+| `required_for_m1` | boolean | Yes | Always `false`. |
+| `source` | string | Yes | Expand-evals dependency context. |
+
+Validation rules:
+
+- Planning-command statuses must never change the M1 gate result.
+- Present planning-command baselines may be listed for downstream context.
+- Missing planning-command baselines must be reported as informational, not failures.
+
+### 5) Baseline-Set Audit Result (`baseline_set_audit_result`)
+
+Purpose: Summarizes the M1 baseline gate.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `required` | M1RequiredBaseline[] | Yes | Required baseline checks. |
+| `informational` | PlanningCommandBaselineStatus[] | No | Non-gating planning-command checks. |
+| `passed` | boolean | Yes | True only when every required baseline is present and valid. |
+| `failures` | string[] | Yes | Human-readable missing or malformed required baseline messages. |
+
+Validation rules:
+
+- `passed` must be `false` if any required baseline is missing or malformed.
+- `failures` must name the baseline path and reason.
+- Informational rows must not populate `failures`.
+
+## Relationships
+
+- `Forge-JVM Scenario` 1:1 `Forge-JVM Baseline` via scenario name `forge-tdd-slice-jvm`.
+- `Forge-JVM Baseline` is one member of the `M1 Required Baseline` set.
+- `Baseline-Set Audit Result` contains four required `M1 Required Baseline` records.
+- `Baseline-Set Audit Result` may contain zero or more `Planning-Command Baseline Status` records.
+- `Planning-Command Baseline Status` records reference the expand-evals dependency but do not create an M1 dependency.
+
+## State Transitions
+
+### Forge-JVM baseline lifecycle
+
+1. `scenario_declared` -> `scenario_run`
+   - Trigger: the JVM forge scenario is loaded and executed.
+   - Effects: a reportable JVM forge result is produced.
+
+2. `scenario_run` -> `baseline_generated`
+   - Trigger: baseline generation captures the stable result envelope.
+   - Effects: the forge-JVM baseline JSON is created locally.
+
+3. `baseline_generated` -> `baseline_committed`
+   - Trigger: the baseline file is reviewed and committed.
+   - Effects: future eval reports can compare JVM forge runs against the baseline.
+
+4. `baseline_committed` -> `baseline_audited`
+   - Trigger: the M1 baseline-set audit runs.
+   - Effects: the forge-JVM baseline contributes to M1 closure.
+
+### M1 baseline gate lifecycle
+
+1. `unchecked` -> `checked`
+   - Trigger: baseline audit inspects required baseline paths.
+   - Effects: required statuses and informational statuses are computed.
+
+2. `checked` -> `passed`
+   - Trigger: every required baseline exists and validates.
+   - Effects: M1 measurement substrate is complete.
+
+3. `checked` -> `failed`
+   - Trigger: at least one required baseline is missing or malformed.
+   - Effects: M1 closure is blocked until the named baseline issue is fixed.
+
+## Identity & Uniqueness
+
+- The JVM scenario identity is the scenario name `forge-tdd-slice-jvm`.
+- The JVM baseline identity is the path `evals/baselines/forge-tdd-slice-jvm.json`.
+- Required baseline IDs are unique within the M1 audit: `strike`, `fix`, `forge-js`, and `forge-jvm`.
+- Planning-command baseline statuses are unique by scenario name when known.

--- a/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.data-model.md
+++ b/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.data-model.md
@@ -32,12 +32,17 @@ Validation rules:
 
 Purpose: Stores the committed baseline envelope for the JVM forge scenario.
 
+This entity reuses the established token-aware baseline shape (the `Baseline`
+interface in `evals/lib/types.ts` extended with `token_envelope` per F1.5
+`forge_baseline`, consuming F1.3a) — it does not introduce a new JSON shape.
+
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
-| `name` | string | Yes | Matches `forge-tdd-slice-jvm`. |
-| `structural` | object | Yes | Existing structural baseline envelope. |
-| `tokens` | object | Yes | Token-aware envelope established by F1.3a. |
-| `metadata` | object | No | Stable baseline metadata if supported by the schema. |
+| `scenario_name` | string | Yes | Matches `forge-tdd-slice-jvm`. |
+| `captured_at` | string | Yes | ISO 8601 capture timestamp. |
+| `headings` | string[] | Yes | Structural heading expectations inherited from the baseline contract. |
+| `tables` | object[] | No | Structural table expectations inherited from the baseline contract. |
+| `token_envelope` | TokenEnvelope | Yes | Accepted token bounds (`input`/`output` `{min,max}`) using the F1.3a token-aware schema. |
 
 Validation rules:
 

--- a/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.data-model.md
+++ b/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.data-model.md
@@ -13,7 +13,8 @@ Purpose: Represents the JVM variant of the forge end-to-end eval case.
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
 | `name` | string | Yes | Canonical value: `forge-tdd-slice-jvm`. |
-| `skill` | string | Yes | Existing forge skill under test. |
+| `skill` | string | Yes | Existing forge skill under test, in slash-command form (`/smithy.forge`). |
+| `prompt` | string | Yes | Non-empty forge task-file invocation; the scenario loader rejects a missing/empty prompt. |
 | `fixture` | string | Yes | Uses the F1.6 selector for the JVM fixture. |
 | `requires_git` | boolean | Yes | Uses the F1.5 git-initialization contract. |
 | `structural_expectations` | StructuralExpectations | Yes | Validates forge completion and expected output shape. |

--- a/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.spec.md
+++ b/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.spec.md
@@ -1,0 +1,177 @@
+# Feature Specification: Forge-JVM Eval Scenario + M1 Baseline-Set Completeness Gate
+
+**Spec Folder**: `2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate`
+**Branch**: `2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate`
+**Created**: 2026-06-06
+**Status**: Draft
+**Input**: `docs/rfcs/2026-001-token-savings/token-savings.rfc.md` - Milestone 1 measurement-foundation feature for the JVM forge eval scenario and baseline-set completion gate.
+**Source Feature Map**: `docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md` - Feature 1.7: Forge-JVM Eval Scenario + M1 Baseline-Set Completeness Gate
+
+## Clarifications
+
+### Session 2026-06-06
+
+- This specification targets the Dependency Order row `F6`, which corresponds to Feature 1.7 in the measurement-foundation feature map. `[Critical Assumption]`
+- The JVM scenario consumes the F1.5 forge scenario contract and the F1.6 `fixture: jvm` substrate; it does not redefine the forge-JS scenario, runner git initialization, fixture resolver, or JVM fixture contents.
+- The JVM coverage is specified as a separate scenario named `forge-tdd-slice-jvm` so the JavaScript and JVM baselines remain independently addressable in reports and PR descriptions.
+- M1 closure is bounded to the strike, smithy.fix, smithy.forge-JS, and smithy.forge-JVM committed baselines. Planning-command baselines from the expand-evals dependency do not gate this feature.
+- The baseline-set audit records planning-command baseline status as informational context only, so late expand-evals scenario merges remain visible without blocking M1 completion.
+- The M1-close `.claude/` and `.smithy/` snapshot refresh remains a separate chore PR and is out of scope for this feature.
+
+## Artifact Hierarchy
+
+RFC -> Milestone -> Feature -> User Story -> Slice -> Tasks
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1: Add the Forge-JVM Eval Scenario (Priority: P1)
+
+As a Smithy maintainer, I want a JVM variant of the forge eval scenario so that forge behavior is measured against the non-JavaScript fixture before downstream cost-reduction work relies on it.
+
+**Why this priority**: The baseline-set gate cannot close until there is a JVM forge scenario capable of producing the fourth required M1 baseline.
+
+**Independent Test**: Load and run only the JVM forge scenario against the committed JVM fixture, verifying that it selects `fixture: jvm`, requires git setup, exercises the forge workflow, and emits the same structural evidence categories as the forge-JS scenario.
+
+**Acceptance Scenarios**:
+
+1. **Given** the F1.6 JVM fixture exists, **When** the JVM forge scenario is loaded, **Then** it declares `fixture: jvm` and is accepted by the scenario loader.
+2. **Given** the JVM forge scenario runs, **When** the runner prepares the temp copy, **Then** it applies the F1.5 git-initialization contract before forge needs repository operations.
+3. **Given** the JVM forge scenario completes, **When** structural validation runs, **Then** it verifies forge slice-completion markers equivalent in intent to the JavaScript forge scenario without re-owning F1.5's structural expectation design.
+4. **Given** the JVM fixture contains its intentional failing test, **When** forge repairs the scenario, **Then** the scenario proves the JVM fixture can drive an end-to-end forge slice.
+
+---
+
+### User Story 2: Commit the Forge-JVM Token Baseline (Priority: P1)
+
+As a contributor, I want a committed forge-JVM baseline so that future prompt and sub-agent changes can compute token deltas without rerunning the entire historical suite.
+
+**Why this priority**: M2 and M3 token-delta reporting depends on committed baselines, and the JVM scenario is the final M1-owned baseline.
+
+**Independent Test**: Generate and compare the forge-JVM baseline for the JVM scenario, then verify `npm run eval -- --case forge-tdd-slice-jvm` reports a passing baseline comparison using the token-aware schema.
+
+**Acceptance Scenarios**:
+
+1. **Given** the JVM forge scenario has a successful run, **When** the baseline is committed, **Then** `evals/baselines/forge-tdd-slice-jvm.json` exists in the token-aware schema established by F1.3a.
+2. **Given** the committed JVM baseline exists, **When** the JVM scenario runs again, **Then** baseline comparison reports structural compatibility and token-envelope status for the JVM case.
+3. **Given** a future prompt edit changes JVM forge token usage, **When** the report compares against the committed baseline, **Then** the token delta can be read from the normal eval report without hand-curating historical values.
+4. **Given** baseline generation produces volatile fields, **When** the baseline is reviewed, **Then** only stable, schema-owned fields are committed.
+
+---
+
+### User Story 3: Audit M1 Baseline-Set Completeness (Priority: P1)
+
+As an M2 or M3 contributor, I want an explicit M1 baseline-set audit so that I know which committed baselines are guaranteed inputs to token-delta reporting.
+
+**Why this priority**: This feature is the M1 completion gate. Without a visible audit, downstream contributors must infer whether the measurement substrate is complete.
+
+**Independent Test**: Run the baseline audit and verify it checks for strike, smithy.fix, forge-JS, and forge-JVM baseline presence and shape, while treating planning-command baselines as informational.
+
+**Acceptance Scenarios**:
+
+1. **Given** the M1 baseline-set audit runs, **When** strike, smithy.fix, forge-JS, or forge-JVM baseline files are missing, **Then** the audit fails and names each missing required baseline.
+2. **Given** all four required baseline files exist, **When** the audit checks their shape, **Then** each file is validated against the token-aware baseline contract.
+3. **Given** planning-command baselines from expand-evals exist, **When** the audit reports baseline status, **Then** they are listed as informational additions and do not affect the pass/fail gate.
+4. **Given** planning-command baselines have not merged yet, **When** the audit runs, **Then** M1 closure still passes if the four required M1 baselines are present and valid.
+
+---
+
+### User Story 4: Preserve Milestone Ownership Boundaries (Priority: P2)
+
+As a reviewer, I want the M1 closer to avoid unrelated source or snapshot changes so that the final measurement patch remains easy to review and does not conflict with dedicated chore work.
+
+**Why this priority**: F1.7 fans in earlier M1 work. It must close the baseline substrate without taking over upstream feature contracts or derived snapshot refreshes.
+
+**Independent Test**: Review the F1.7 diff and verify it limits changes to the JVM scenario, JVM baseline, baseline audit/reporting support needed for the gate, and tests.
+
+**Acceptance Scenarios**:
+
+1. **Given** F1.5 owns the forge-JS scenario shape, **When** F1.7 lands, **Then** the JavaScript scenario remains semantically unchanged except for shared audit compatibility if required.
+2. **Given** F1.6 owns the JVM fixture and fixture selector, **When** F1.7 lands, **Then** the JVM fixture contents and fixture-resolution contract are not reworked.
+3. **Given** `.claude/` and `.smithy/` snapshots are derived artifacts, **When** F1.7 lands, **Then** those snapshots are not regenerated in the feature PR.
+4. **Given** planning-command baselines are owned by expand-evals scenario-merge PRs, **When** F1.7 lands, **Then** they are not required for M1 closure.
+
+### Edge Cases
+
+- The JVM scenario must fail clearly if `fixture: jvm` is unavailable rather than silently falling back to the JavaScript fixture.
+- The JVM scenario must not rely on a live network, live GitHub state, or uncommitted local files.
+- Baseline audit failures must identify the baseline name and the missing or malformed field so M1 closure blockers are actionable.
+- Token-envelope comparison must tolerate expected per-run variation only within the schema's allowed envelope, not by disabling token checks.
+- Planning-command baseline rows must remain informational even if some are present and others are absent.
+- Snapshot-refresh chores must remain separate even though F1.7 closes M1.
+
+## Dependency Order
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| US1 | Add the Forge-JVM Eval Scenario | — | — |
+| US2 | Commit the Forge-JVM Token Baseline | US1 | — |
+| US3 | Audit M1 Baseline-Set Completeness | US2 | — |
+| US4 | Preserve Milestone Ownership Boundaries | US1, US2, US3 | — |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The eval suite MUST include a JVM forge scenario named `forge-tdd-slice-jvm`.
+- **FR-002**: The JVM forge scenario MUST select the JVM fixture using the F1.6 scenario-level fixture contract.
+- **FR-003**: The JVM forge scenario MUST opt into the F1.5 git-initialization behavior required by forge.
+- **FR-004**: The JVM forge scenario MUST exercise an end-to-end smithy.forge slice against the JVM fixture.
+- **FR-005**: The JVM forge scenario MUST validate forge completion with structural expectations equivalent in intent to the JavaScript forge scenario.
+- **FR-006**: The feature MUST commit `evals/baselines/forge-tdd-slice-jvm.json`.
+- **FR-007**: The forge-JVM baseline MUST use the token-aware baseline schema established by F1.3a.
+- **FR-008**: Baseline comparison MUST report structural status and token-envelope status for the JVM forge scenario.
+- **FR-009**: The M1 baseline-set audit MUST require valid committed baselines for strike, smithy.fix, smithy.forge-JS, and smithy.forge-JVM.
+- **FR-010**: The M1 baseline-set audit MUST fail when any required M1 baseline is missing or malformed.
+- **FR-011**: Planning-command baselines from the expand-evals dependency MUST NOT gate M1 closure.
+- **FR-012**: The baseline-set audit SHOULD record planning-command baseline status as informational context when those baselines are present or absent.
+- **FR-013**: F1.7 MUST NOT regenerate `.claude/` or `.smithy/` snapshots.
+- **FR-014**: F1.7 MUST NOT rework the F1.5 forge-JS scenario contract or the F1.6 JVM fixture contract except where shared compatibility tests require additive assertions.
+- **FR-015**: Tests MUST cover JVM scenario loading, JVM scenario execution or deterministic validation, forge-JVM baseline comparison, and the required-vs-informational baseline audit behavior.
+
+### Key Entities
+
+- **Forge-JVM Scenario**: The eval case that runs smithy.forge against the JVM fixture.
+- **Forge-JVM Baseline**: The committed token-aware baseline for the JVM forge scenario.
+- **M1 Required Baseline Set**: The four baseline files required for M1 closure: strike, smithy.fix, forge-JS, and forge-JVM.
+- **Planning-Command Baseline Status**: Informational audit entries for baselines delivered by the expand-evals dependency.
+- **Baseline-Set Audit**: The validation surface that confirms required baseline presence and schema compatibility.
+
+## Assumptions
+
+- F1.3a has landed the token-aware baseline schema and comparison surface.
+- F1.4 has landed the smithy.fix scenario and baseline.
+- F1.5 has landed the forge-JS scenario, baseline, and git-initialization opt-in contract.
+- F1.6 has landed `fixture: jvm` support and the JVM fixture.
+- `forge-tdd-slice-jvm` is the canonical scenario and baseline stem for the JVM forge eval.
+- Planning-command baselines remain owned by their expand-evals scenario-merge PRs.
+
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | The baseline-set audit format is specified functionally but not tied to a specific implementation surface. Implementers may extend an existing eval/baseline test, add a dedicated audit helper, or encode the gate in scenario-level tests, provided missing required baselines fail clearly and planning-command baselines remain informational. | Integration | Medium | Medium | open | — |
+| SD-002 | The feature map allows the JVM forge scenario to be either a second YAML file or a fixture-parameterized run of the existing forge scenario. This spec chooses the separate `forge-tdd-slice-jvm` scenario for independent baseline identity; if implementation discovers the runner already supports parameterized cases more cleanly, preserve the canonical scenario/baseline identity in reports. | Functional Scope | Low | Medium | open | — |
+
+## Out of Scope
+
+- Editing the F1.5 forge-JS scenario's structural expectation design.
+- Editing the F1.6 JVM fixture contents or fixture-selection contract.
+- Changing smithy.forge prompt behavior for M2 cost reductions.
+- Implementing the M3 build-output protocol.
+- Committing or requiring planning-command baselines from expand-evals.
+- Regenerating `.claude/` or `.smithy/` snapshots.
+- Adding non-JVM language fixtures or non-forge JVM scenarios.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `forge-tdd-slice-jvm` loads as a JVM-fixture forge scenario.
+- **SC-002**: The JVM forge scenario can produce a passing structural eval run against the JVM fixture.
+- **SC-003**: `evals/baselines/forge-tdd-slice-jvm.json` is committed in the token-aware schema.
+- **SC-004**: Baseline comparison succeeds for the JVM forge scenario against its committed baseline.
+- **SC-005**: The baseline-set audit requires strike, smithy.fix, forge-JS, and forge-JVM baselines.
+- **SC-006**: Planning-command baselines are reported, if visible, without gating M1 closure.
+- **SC-007**: No `.claude/` or `.smithy/` snapshot refresh is included in the feature implementation.


### PR DESCRIPTION
## Summary

Runs `/smithy.mark` on `docs/rfcs/2026-001-token-savings/01-measurement-foundation.features.md` for **Feature 1.7 (F6): Forge-JVM Eval Scenario + M1 Baseline-Set Completeness Gate**.

Produces the three feature-specification artifacts and wires the parent feature map's Dependency Order row:

- `forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.spec.md`
- `forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.data-model.md`
- `forge-jvm-eval-scenario-m1-baseline-set-completeness-gate.contracts.md`
- `01-measurement-foundation.features.md` — F6 Artifact column flipped from `—` to `specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/`

## Scope

Single Smithy step (`smithy.mark`) only — no chaining into downstream `cut`/`forge`. Docs-only patch; no source code touched.

## Completion signal note

This RFC tree has **no `tasks.md`** (tasks files are children of specs authored in a later step and do not exist yet). For a `smithy.mark` step the durable "this slice is done" signal is the parent feature map's Dependency Order **Artifact** column flip (`—` → spec folder), which is included in this patch. There were no `[ ]` checkbox rows to flip in this RFC's table-format Dependency Order sections.

## Verification

- Spec folder name matches the F6 Artifact path exactly.
- Spec self-declared `Spec Folder` matches the directory name.
- All three artifacts present; spec correctly targets F6 / Feature 1.7 and references upstream F1.3a / F1.4 / F1.5 / F1.6.
- No leftover `NEEDS CLARIFICATION`, placeholders, TODOs, or unchecked-box markers in the spec set.

No verification gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
