### PR TITLE
Spec: Engraved Knowledge Recall and Reference

### DIFF
--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.contracts.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.contracts.md
@@ -2,19 +2,16 @@
 
 ## Overview
 
-This feature introduces contracts at two layers that share one frozen input — the
-engraved-record frontmatter schema (owned by `smithy.engrave.prompt`):
+This feature introduces prompt-layer and template contracts that share one frozen
+input — the engraved-record frontmatter schema (owned by `smithy.engrave.prompt`):
 
-- **Prompt-layer** templates: the `smithy-recall` sub-agent, the
-  `consult-engraved-knowledge` snippet, the `smithy.engrave` projection step, and the
-  `audit-checklist-engraved` snippet.
-- **TS-layer** code: the status type surface, parser, graph edges, stale-ref check,
-  and orders templates.
+- the `smithy-recall` sub-agent and the `consult-engraved-knowledge` snippet (recall),
+- the `smithy.engrave` projection-pointer step,
+- the orders templates and the `audit-checklist-engraved` snippet.
 
-The governing boundary: **the TS status subsystem is the deterministic authority**
-for lifecycle, edges, and stale references; **recall is the authority only for
-semantic relevance and conflict-with-proposed-work**, treating lifecycle as read-only
-ground truth.
+There is no status-subsystem contract here — graph edges, stale-ref detection, and
+status surfacing (#416/#417) are out of scope. Engraved record lifecycle is read by
+recall as read-only ground truth from frontmatter.
 
 ## Interfaces
 
@@ -23,7 +20,8 @@ ground truth.
 **Purpose**: surface engraved records relevant to a planning context and flag
 conflicts and superseded citations.
 **Consumers**: the scan phase of `strike`, `ignite`, `render`, `mark`, `cut` (via the
-`consult-engraved-knowledge` snippet); also invocable ad-hoc.
+`consult-engraved-knowledge` snippet). **Not user-invocable** — dispatched only by
+those planning commands.
 **Providers**: a new read-only sub-agent at
 `src/templates/agent-skills/agents/smithy.recall.prompt` (frontmatter `name: smithy-recall`, `tools: [Read, Grep, Glob]`, `model: sonnet`), modeled on `smithy.scout.prompt`. Deployed to `.claude/agents/` only (Claude sub-agents).
 
@@ -43,14 +41,15 @@ conflicts and superseded citations.
 | `relevant` | RelevantRecord[] | Ranked records with id, kind, title, path, one-line relevance basis. |
 | `conflicts` | ConflictFlag[] | Proposed work vs. an invariant rule — a candidate new exception (soft). |
 | `superseded_citations` | SupersededCitation[] | Citations to superseded/deprecated records. |
-| `empty` | boolean | True when no records exist or none match. |
+| `empty` | boolean | True when there is nothing to return. |
+| `empty_reason` | `no_records \| no_match \| null` | Why the result is empty (`null` when `empty` is false). |
 
 #### Error Conditions
 
 | Condition | Response | Description |
 |-----------|----------|-------------|
-| No engraved records in repo | `empty: true`, no error | Common in fresh repos; caller proceeds normally. |
-| Records exist, none match | `empty: true` (records-exist note) | Distinct from no-records; still non-blocking. |
+| No engraved records in repo | `empty: true, empty_reason: "no_records"` | Common in fresh repos; caller proceeds normally. |
+| Records exist, none match | `empty: true, empty_reason: "no_match"` | Non-blocking. |
 | Divergence already `Accepted:` | omit from `conflicts` | Suppress conflict flags already covered by an accepted ledger row. |
 
 ### `consult-engraved-knowledge` Snippet
@@ -74,10 +73,10 @@ clarification.
 | Gemini / Codex (no sub-agents) | Degraded inline path: `Read`/`Grep` the engraved scan roots directly and apply the same relevance/conflict/superseded reasoning inline. |
 | Handling | Conflicts → fold into clarification (candidate exceptions); superseded citations → flag; clean/empty → proceed. |
 
-### `smithy.engrave` Projection Step
+### `smithy.engrave` Projection-Pointer Step
 
-**Purpose**: refresh a managed engraved-knowledge block in agent-context files after
-an engrave/supersede.
+**Purpose**: maintain a managed pointer block in agent-context files after an
+engrave/supersede.
 **Consumers**: arbitrary agents reading CLAUDE.md / AGENTS.md.
 **Providers**: a new phase appended to `smithy.engrave.prompt`.
 
@@ -85,49 +84,32 @@ an engrave/supersede.
 
 ```
 <!-- smithy:engraved:begin -->
-<generated, deterministic list of live records — id, kind, title, status — sorted by id>
+This repository maintains engraved durable knowledge (decisions, invariants,
+principles). Read the records under these locations and judge their applicability
+before planning or making changes:
+- docs/decisions/
+- docs/invariants/
+- docs/constitution/
 <!-- smithy:engraved:end -->
 ```
+
+The location list reflects the directories actually present in the repo (design-domain
+variants appended when present). The block is a **pointer**, not a record copy.
 
 #### Rules
 
 | Rule | Behavior |
 |------|----------|
-| Idempotent | No-change re-run yields a byte-identical file. |
+| Pointer-only | Content is the location list + applicability note; no record bodies or per-record list. |
+| Present-locations | List reflects the engraved-knowledge directories actually present in the repo. |
+| Idempotent | No-change re-run yields a byte-identical file (deterministic location ordering). |
 | Replace-in-place | Only content between the markers is regenerated. |
 | Prose-safe | Content outside the markers is never modified. |
-| First run | Append a fresh block at a defined anchor when no markers exist. |
+| First run | Add a fresh block at a defined anchor when no markers exist. |
 | Existing-only | Manage agent-context files that already exist; never create missing ones. |
 | Malformed markers | Abort projection for that file with a warning; the engrave op still succeeds. |
-| Content | Live records only (`accepted` decisions, `aligned`/`drifting` invariants, `active` principles); exclude `superseded`/`deprecated`. |
 
-### Status Graph Edges & Stale-Ref Check (TS, deterministic authority)
-
-**Purpose**: model engraved relationships and catch stale references.
-**Providers**: `src/status/graph.ts`, surfaced via `tree.ts` and `suggester.ts`.
-
-#### Edge Types
-
-| Edge | From → To | Source |
-|------|-----------|--------|
-| `citation` | spec / RFC / decision → invariant / principle | frontmatter citations |
-| `supersedes` | decision → decision | `supersedes` / `superseded_by` |
-| `establishes` | decision → invariant | `establishes` / `established_by` |
-
-#### Stale-Reference Predicate
-
-| Condition | Output |
-|-----------|--------|
-| Artifact cites a decision with `lifecycle: superseded` | Stale reference (review/update). |
-| Artifact cites an invariant that is `deprecated` | Stale reference (review/update) — pending SD-007 (invariants have no `deprecated` state in the frozen schema). |
-
-The citation source for these predicates (how spec/RFC artifacts declare a citation) is unresolved — see SD-006.
-
-The render adds a "Decisions & Invariants" group (alignment + lifecycle); the
-suggester emits next-actions (drifting invariant → review exceptions; cites-superseded
-→ review citation).
-
-### Orders Templates (TS)
+### Orders Templates
 
 **Purpose**: scaffold GitHub issue bodies for engraved records.
 **Providers**: `src/orders-templates.ts` (`ORDERS_DEFAULT_TEMPLATES`,
@@ -135,12 +117,12 @@ suggester emits next-actions (drifting invariant → review exceptions; cites-su
 
 | Contract element | Requirement |
 |------------------|-------------|
-| New types | `decision`, `invariant` (optionally `principle` — SD-004). |
+| New types | `decision`, `invariant` (optionally `principle` — SD-003). |
 | Lockstep | Template strings added to both the TS map and the prompt heredoc. |
 | Parity | `src/templates.test.ts` parity assertion extended to the new types. |
-| Auto-detect | `smithy.orders` detects `.decision.md`/`.invariant.md` by suffix; principles lack a suffix (SD-004). |
+| Auto-detect | `smithy.orders` detects `.decision.md`/`.invariant.md` by suffix; principles lack a suffix (SD-003). |
 
-### Audit Checklist (prompt)
+### Audit Checklist
 
 **Purpose**: validate engraved record quality.
 **Providers**: `src/templates/agent-skills/snippets/audit-checklist-engraved.md` +
@@ -157,21 +139,20 @@ suggester emits next-actions (drifting invariant → review exceptions; cites-su
 ## Events / Hooks
 
 - **Engrave/supersede → projection refresh**: completing an engrave or supersede
-  operation triggers the projection step (US3) against all existing target files.
+  operation triggers the projection-pointer step (US2) against all existing target files.
 - **Planning scan → recall dispatch**: entering a planning command's scan phase
-  triggers `consult-engraved-knowledge` (US2).
+  triggers `consult-engraved-knowledge` (US1).
 
 ## Integration Boundaries
 
-- **Recall ↔ status subsystem**: recall reads engraved files directly and does not
-  call the status scanner; whether it consumes deterministic stale-ref output via
-  `smithy status --format json` is unresolved (SD-005).
-- **Projection ↔ recall**: independent. Projection is an author-time write into
-  agent-context files; recall is a plan-time read. The engraved record files remain
-  the single source of truth; neither reads the other's output.
+- **Recall ↔ engraved records**: recall reads engraved files directly (Grep/Glob) and
+  treats frontmatter as ground truth. There is no status-index dependency.
+- **Projection ↔ recall**: independent. Projection is an author-time write of a pointer
+  into agent-context files; recall is a plan-time read of the records. The engraved
+  record files remain the single source of truth.
 - **Cross-agent deployment**: the `smithy-recall` sub-agent reaches Claude only; the
   `consult-engraved-knowledge` snippet reaches all three agents at deploy time and
   must carry the degraded inline path for Gemini/Codex.
 - **Agent-context files**: projection targets are existing CLAUDE.md / AGENTS.md (and
   possibly `.github/copilot-instructions.md`) — the exact default set is unresolved
-  (SD-002).
+  (SD-001).

--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.contracts.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.contracts.md
@@ -1,0 +1,177 @@
+# Contracts: Engraved Knowledge Recall and Reference
+
+## Overview
+
+This feature introduces contracts at two layers that share one frozen input — the
+engraved-record frontmatter schema (owned by `smithy.engrave.prompt`):
+
+- **Prompt-layer** templates: the `smithy-recall` sub-agent, the
+  `consult-engraved-knowledge` snippet, the `smithy.engrave` projection step, and the
+  `audit-checklist-engraved` snippet.
+- **TS-layer** code: the status type surface, parser, graph edges, stale-ref check,
+  and orders templates.
+
+The governing boundary: **the TS status subsystem is the deterministic authority**
+for lifecycle, edges, and stale references; **recall is the authority only for
+semantic relevance and conflict-with-proposed-work**, treating lifecycle as read-only
+ground truth.
+
+## Interfaces
+
+### `smithy-recall` Sub-Agent
+
+**Purpose**: surface engraved records relevant to a planning context and flag
+conflicts and superseded citations.
+**Consumers**: the scan phase of `strike`, `ignite`, `render`, `mark`, `cut` (via the
+`consult-engraved-knowledge` snippet); also invocable ad-hoc.
+**Providers**: a new read-only sub-agent at
+`src/templates/agent-skills/agents/smithy.recall.prompt` (frontmatter `name: smithy-recall`, `tools: [Read, Grep, Glob]`, `model: sonnet`), modeled on `smithy.scout.prompt`. Deployed to `.claude/agents/` only (Claude sub-agents).
+
+#### Inputs
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `planning_context` | text | Yes | Artifact type, goals, and the in-progress draft/feature description. |
+| `domain_hint` | `system \| design \| both` | No | Which domain partition(s) to query; inferred when absent. |
+| `topics`/`scope`/`applies_to` hints | string[] | No | Extracted from the work to seed relevance matching. |
+| `scan_roots` | string[] | No | Engraved directories to read (defaults to canonical locations). |
+
+#### Outputs
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `relevant` | RelevantRecord[] | Ranked records with id, kind, title, path, one-line relevance basis. |
+| `conflicts` | ConflictFlag[] | Proposed work vs. an invariant rule — a candidate new exception (soft). |
+| `superseded_citations` | SupersededCitation[] | Citations to superseded/deprecated records. |
+| `empty` | boolean | True when no records exist or none match. |
+
+#### Error Conditions
+
+| Condition | Response | Description |
+|-----------|----------|-------------|
+| No engraved records in repo | `empty: true`, no error | Common in fresh repos; caller proceeds normally. |
+| Records exist, none match | `empty: true` (records-exist note) | Distinct from no-records; still non-blocking. |
+| Divergence already `Accepted:` | omit from `conflicts` | Suppress conflict flags already covered by an accepted ledger row. |
+
+### `consult-engraved-knowledge` Snippet
+
+**Purpose**: a parameter-free, self-contained partial included at each planning
+command's scan phase that consults engraved knowledge and folds findings into
+clarification.
+**Consumers**: `strike`, `ignite`, `render`, `mark` (Phase 1.5), `cut` (Phase 2.5).
+**Providers**: `src/templates/agent-skills/snippets/consult-engraved-knowledge.md`
+(registered in `snippets/README.md`).
+
+#### Signature
+
+`{{>consult-engraved-knowledge}}` — inlined at deploy time into all three agents.
+
+#### Behavior
+
+| Path | Behavior |
+|------|----------|
+| Claude | Dispatch the `smithy-recall` sub-agent with the planning context. |
+| Gemini / Codex (no sub-agents) | Degraded inline path: `Read`/`Grep` the engraved scan roots directly and apply the same relevance/conflict/superseded reasoning inline. |
+| Handling | Conflicts → fold into clarification (candidate exceptions); superseded citations → flag; clean/empty → proceed. |
+
+### `smithy.engrave` Projection Step
+
+**Purpose**: refresh a managed engraved-knowledge block in agent-context files after
+an engrave/supersede.
+**Consumers**: arbitrary agents reading CLAUDE.md / AGENTS.md.
+**Providers**: a new phase appended to `smithy.engrave.prompt`.
+
+#### Managed-Block Grammar
+
+```
+<!-- smithy:engraved:begin -->
+<generated, deterministic list of live records — id, kind, title, status — sorted by id>
+<!-- smithy:engraved:end -->
+```
+
+#### Rules
+
+| Rule | Behavior |
+|------|----------|
+| Idempotent | No-change re-run yields a byte-identical file. |
+| Replace-in-place | Only content between the markers is regenerated. |
+| Prose-safe | Content outside the markers is never modified. |
+| First run | Append a fresh block at a defined anchor when no markers exist. |
+| Existing-only | Manage agent-context files that already exist; never create missing ones. |
+| Malformed markers | Abort projection for that file with a warning; the engrave op still succeeds. |
+| Content | Live records only (`accepted` decisions, `aligned`/`drifting` invariants, `active` principles); exclude `superseded`/`deprecated`. |
+
+### Status Graph Edges & Stale-Ref Check (TS, deterministic authority)
+
+**Purpose**: model engraved relationships and catch stale references.
+**Providers**: `src/status/graph.ts`, surfaced via `tree.ts` and `suggester.ts`.
+
+#### Edge Types
+
+| Edge | From → To | Source |
+|------|-----------|--------|
+| `citation` | spec / RFC / decision → invariant / principle | frontmatter citations |
+| `supersedes` | decision → decision | `supersedes` / `superseded_by` |
+| `establishes` | decision → invariant | `establishes` / `established_by` |
+
+#### Stale-Reference Predicate
+
+| Condition | Output |
+|-----------|--------|
+| Artifact cites a decision with `lifecycle: superseded` | Stale reference (review/update). |
+| Artifact cites an invariant that is `deprecated` | Stale reference (review/update) — pending SD-007 (invariants have no `deprecated` state in the frozen schema). |
+
+The citation source for these predicates (how spec/RFC artifacts declare a citation) is unresolved — see SD-006.
+
+The render adds a "Decisions & Invariants" group (alignment + lifecycle); the
+suggester emits next-actions (drifting invariant → review exceptions; cites-superseded
+→ review citation).
+
+### Orders Templates (TS)
+
+**Purpose**: scaffold GitHub issue bodies for engraved records.
+**Providers**: `src/orders-templates.ts` (`ORDERS_DEFAULT_TEMPLATES`,
+`ORDERS_TEMPLATE_TYPES`) + the `smithy.orders.prompt` heredoc.
+
+| Contract element | Requirement |
+|------------------|-------------|
+| New types | `decision`, `invariant` (optionally `principle` — SD-004). |
+| Lockstep | Template strings added to both the TS map and the prompt heredoc. |
+| Parity | `src/templates.test.ts` parity assertion extended to the new types. |
+| Auto-detect | `smithy.orders` detects `.decision.md`/`.invariant.md` by suffix; principles lack a suffix (SD-004). |
+
+### Audit Checklist (prompt)
+
+**Purpose**: validate engraved record quality.
+**Providers**: `src/templates/agent-skills/snippets/audit-checklist-engraved.md` +
+`smithy.audit` type-selection wiring.
+
+| Check | Question |
+|-------|----------|
+| Desired invariant | Does each decision state its desired invariant where applicable? |
+| Citations + ledger | Does each invariant cite its establishing decisions and keep a Known-Exceptions ledger? |
+| No stale citation | Does any citation point at a superseded decision? |
+| Pivot-level | Is the record genuinely pivot-level (inclusion test)? |
+| Structure | Are section order and ledger column order load-bearing-correct? |
+
+## Events / Hooks
+
+- **Engrave/supersede → projection refresh**: completing an engrave or supersede
+  operation triggers the projection step (US3) against all existing target files.
+- **Planning scan → recall dispatch**: entering a planning command's scan phase
+  triggers `consult-engraved-knowledge` (US2).
+
+## Integration Boundaries
+
+- **Recall ↔ status subsystem**: recall reads engraved files directly and does not
+  call the status scanner; whether it consumes deterministic stale-ref output via
+  `smithy status --format json` is unresolved (SD-005).
+- **Projection ↔ recall**: independent. Projection is an author-time write into
+  agent-context files; recall is a plan-time read. The engraved record files remain
+  the single source of truth; neither reads the other's output.
+- **Cross-agent deployment**: the `smithy-recall` sub-agent reaches Claude only; the
+  `consult-engraved-knowledge` snippet reaches all three agents at deploy time and
+  must carry the degraded inline path for Gemini/Codex.
+- **Agent-context files**: projection targets are existing CLAUDE.md / AGENTS.md (and
+  possibly `.github/copilot-instructions.md`) — the exact default set is unresolved
+  (SD-002).

--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.contracts.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.contracts.md
@@ -125,7 +125,7 @@ via the `smithy.gh-issue` skill's `create-issue` script.
 | `Temporary:` exception added | Create a drift-tracking issue (title from the divergence; body = invariant id/title + divergence + establishing decision(s)); write the returned `#NNN` into the row's `Tracking Issue` column. |
 | `Accepted:` exception added | No issue; `Tracking Issue` stays `—`. |
 | Issue creation fails | Write the ledger row with `Tracking Issue` `—`, surface the failure, do not roll back. |
-| `Temporary:` exception resolved | Linked-issue handling per SD-003 (auto-close / leave / comment). |
+| `Temporary:` exception resolved | Leave the linked issue **open**; a human closes it. Engrave never auto-closes or comments (mutates GitHub only on creation). |
 
 ### Audit Checklist
 

--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.contracts.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.contracts.md
@@ -7,7 +7,8 @@ input — the engraved-record frontmatter schema (owned by `smithy.engrave.promp
 
 - the `smithy-recall` sub-agent and the `consult-engraved-knowledge` snippet (recall),
 - the `smithy.engrave` projection-pointer step,
-- the orders templates and the `audit-checklist-engraved` snippet.
+- the `smithy.engrave` drift-tracking-issue step (for `Temporary:` exceptions),
+- the `audit-checklist-engraved` snippet.
 
 There is no status-subsystem contract here — graph edges, stale-ref detection, and
 status surfacing (#416/#417) are out of scope. Engraved record lifecycle is read by
@@ -109,18 +110,22 @@ variants appended when present). The block is a **pointer**, not a record copy.
 | Existing-only | Manage agent-context files that already exist; never create missing ones. |
 | Malformed markers | Abort projection for that file with a warning; the engrave op still succeeds. |
 
-### Orders Templates
+### Engrave Exception → Drift-Tracking Issue
 
-**Purpose**: scaffold GitHub issue bodies for engraved records.
-**Providers**: `src/orders-templates.ts` (`ORDERS_DEFAULT_TEMPLATES`,
-`ORDERS_TEMPLATE_TYPES`) + the `smithy.orders.prompt` heredoc.
+**Purpose**: when a `Temporary:` exception is added to an invariant, scaffold a GitHub
+issue for closing the drift and record its number in the ledger. This reinterprets
+the #418 orders half — engraved records do **not** become `smithy.orders` artifact
+types (no `ORDERS_TEMPLATE_TYPES` entries, no parity-test change).
+**Consumers**: developers tracking drift; the invariant's ledger.
+**Providers**: a step added to `smithy.engrave`'s exception phase, creating the issue
+via the `smithy.gh-issue` skill's `create-issue` script.
 
-| Contract element | Requirement |
-|------------------|-------------|
-| New types | `decision`, `invariant` (optionally `principle` — SD-003). |
-| Lockstep | Template strings added to both the TS map and the prompt heredoc. |
-| Parity | `src/templates.test.ts` parity assertion extended to the new types. |
-| Auto-detect | `smithy.orders` detects `.decision.md`/`.invariant.md` by suffix; principles lack a suffix (SD-003). |
+| Trigger | Behavior |
+|---------|----------|
+| `Temporary:` exception added | Create a drift-tracking issue (title from the divergence; body = invariant id/title + divergence + establishing decision(s)); write the returned `#NNN` into the row's `Tracking Issue` column. |
+| `Accepted:` exception added | No issue; `Tracking Issue` stays `—`. |
+| Issue creation fails | Write the ledger row with `Tracking Issue` `—`, surface the failure, do not roll back. |
+| `Temporary:` exception resolved | Linked-issue handling per SD-003 (auto-close / leave / comment). |
 
 ### Audit Checklist
 
@@ -140,6 +145,8 @@ variants appended when present). The block is a **pointer**, not a record copy.
 
 - **Engrave/supersede → projection refresh**: completing an engrave or supersede
   operation triggers the projection-pointer step (US2) against all existing target files.
+- **Temporary exception added → drift-tracking issue**: adding a `Temporary:` ledger
+  row triggers the drift-tracking-issue step (US3) and writes the `#NNN` back.
 - **Planning scan → recall dispatch**: entering a planning command's scan phase
   triggers `consult-engraved-knowledge` (US1).
 

--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.data-model.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.data-model.md
@@ -2,73 +2,56 @@
 
 ## Overview
 
-This model describes how engraved records (decisions, invariants, principles) are
-represented **in the status subsystem's memory** once discovered, plus the
-transient shapes used by recall and projection. The authoritative **on-disk**
-frontmatter schema is owned by
+This feature **reads** engraved records and **points** agents at them; it adds no
+persisted data structures and does not change the engraved schema. The authoritative
+**on-disk** frontmatter schema is owned by
 [`src/templates/agent-skills/commands/smithy.engrave.prompt`](../../src/templates/agent-skills/commands/smithy.engrave.prompt)
-and is **frozen** — this model references it as the source of truth and only adds
-the consuming representations. Fields below mirror that schema; they are not a
-redefinition.
+and is **frozen**. The entities below are (1) a read-only reference to the fields this
+feature consumes and (2) the transient shapes recall and projection produce. There is
+**no** status-subsystem representation here — status integration (#416/#417) is out of
+scope.
 
 ## Entities
 
-### 1) Engraved Record (`engraved`)
+### 1) Engraved Record (reference only — not persisted by this feature)
 
-Purpose: the in-memory representation of a durable-knowledge file, added as a new
-`ArtifactType` member so the scanner/classifier/graph treat it as first-class.
-Unlike planning artifacts, an engraved record has **no** dependency-order table and
-**no** completion rollup.
+Purpose: the fields recall (ranking, conflict, superseded-citation) and the orders/audit
+tooling read from an engraved file. Documented here for traceability; **owned** by the
+engrave schema, not redefined.
 
-| Field | Type | Required | Notes |
-|-------|------|----------|-------|
-| `type` | `'engraved'` | Yes | New member of the `ArtifactType` union. |
-| `kind` | `EngravedKind` = `'decision' \| 'invariant' \| 'principle'` | Yes | Discriminator. |
-| `id` | string | Yes | `D-<N>` / `INV-<N>` / `P-<N>` from frontmatter. |
-| `domain` | `'system' \| 'design'` | Yes | Ownership/recall partition; defaults to `system`. |
-| `title` | string | Yes | From frontmatter / H1. |
-| `path` | string | Yes | Repo-relative file path. |
-| `lifecycle` | `DecisionLifecycle` = `'proposed' \| 'accepted' \| 'superseded' \| 'deprecated'` | decisions | Decision status axis. |
-| `alignment` | `Alignment` = `'aligned' \| 'drifting'` | invariants | Derived from the ledger. |
-| `principleStatus` | `'active'` | principles | Principles have a single status. |
-| `supersedes` | string[] | decisions | Decision IDs this record replaces (`[]` if none). |
-| `superseded_by` | string[] | decisions | Decision IDs that replaced this one. |
-| `establishes` | string[] | decisions | Invariant IDs this decision establishes. |
-| `established_by` | string[] | invariants | Decision IDs that established this invariant (≥1). |
-| `exceptions` | `KnownException[]` | invariants | Parsed ledger rows; empty for the em-dash placeholder. |
-| `topics` | string[] | Yes | Recall/filter metadata (not graph edges). |
-| `scope` | string[] | Yes | Recall/filter metadata. |
-| `applies_to` | string[] | Yes | Recall/filter metadata. |
+| Field | Type | Used by | Notes |
+|-------|------|---------|-------|
+| `id` | string | recall, orders, audit | `D-<N>` / `INV-<N>` / `P-<N>`. |
+| `kind` | `decision \| invariant \| principle` | all | Discriminator. |
+| `domain` | `system \| design` | recall, projection | Recall partition; projection pointer lists present domains. |
+| `title` | string | recall, orders | From frontmatter / H1. |
+| `status` | decision lifecycle (`proposed`/`accepted`/`superseded`/`deprecated`) · invariant alignment (`aligned`/`drifting`) · principle (`active`) | recall, audit | Read as ground truth; recall flags citations to `superseded`/`deprecated`. |
+| `topics` / `scope` / `applies_to` | string[] | recall | Relevance-match metadata. |
+| `supersedes` / `superseded_by` | string[] | recall, audit | Decision supersession edges. |
+| `establishes` / `established_by` | string[] | audit | Decision↔invariant reciprocity. |
+| Known-Exceptions ledger | `KnownException[]` | recall | Recall consults to suppress already-`Accepted:` conflicts. |
 
-Validation rules:
-- An engraved record never carries a `dependency_order` table; the parser must not
-  emit a `format: 'missing'` / `unknown` classification for it.
-- Decisions use `lifecycle`; invariants use `alignment`; principles use
-  `principleStatus`. The three are distinct axes — none is the planning `Status`.
-- `topics`/`scope`/`applies_to` are opaque carried strings for recall/filtering, not
-  promoted into the status graph type surface.
+This feature MUST NOT add frontmatter fields, alter suffixes, or change the ledger
+column order — all are frozen by the engrave schema.
 
 ### 2) Known Exception (`KnownException`)
 
-Purpose: one row of an invariant's Known-Exceptions ledger; the unit that drives
-alignment.
+Purpose: one row of an invariant's Known-Exceptions ledger; recall reads it to decide
+whether a candidate conflict is already an accepted carve-out.
 
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
 | `where` | string | Yes | Repo-relative path, module, or surface. |
 | `what` | string | Yes | What reality does vs. what the rule says. |
-| `disposition` | `'Accepted' \| 'Temporary'` | Yes | Canonical capitalized token from the ledger. |
+| `disposition` | `Accepted \| Temporary` | Yes | Canonical capitalized token from the ledger. |
 | `why` | string | Yes | Reason text following the disposition token. |
 | `tracking_issue` | string \| null | Yes | `#NNN` for `Temporary` rows; `—`/null for `Accepted`. |
-| `severity` | `'low' \| 'medium' \| 'high'` | Yes | High rows may block compounding planning artifacts. |
+| `severity` | `low \| medium \| high` | Yes | Severity of the divergence. |
 
-Validation rules:
-- The single em-dash placeholder row (`—` in every column) parses to **zero**
-  exceptions.
-- Alignment derivation: `drifting` iff ≥1 `Temporary:` row is present; `Accepted:`
-  rows alone never flip to `drifting`.
-- Column order is load-bearing and fixed by the engrave schema:
-  `Where | What diverges | Disposition + Why | Tracking Issue | Severity`.
+Read rules (for recall):
+- A divergence covered by an `Accepted:` row MUST NOT be re-flagged as a candidate
+  new exception (FR-002).
+- The single em-dash placeholder row represents an empty ledger (no exceptions).
 
 ### 3) Recall Result (transient, prompt-layer — not persisted)
 
@@ -78,73 +61,52 @@ Purpose: the structured return of the `smithy-recall` sub-agent.
 |-------|------|----------|-------|
 | `relevant` | RelevantRecord[] | Yes | Ranked; each has id, kind, title, path, one-line relevance basis. |
 | `conflicts` | ConflictFlag[] | Yes | Proposed work vs. an invariant rule (candidate new exception). |
-| `superseded_citations` | SupersededCitation[] | Yes | Citations to superseded/deprecated records (read-only ground truth). |
-| `empty` | boolean | Yes | True when no records exist or none match. |
+| `superseded_citations` | SupersededCitation[] | Yes | Citations to superseded/deprecated records found in the planning context. |
+| `empty` | boolean | Yes | True when there is nothing to return. |
+| `empty_reason` | `no_records \| no_match \| null` | Yes | Discriminates "no engraved records exist" from "records exist, none matched"; `null` when `empty` is false. |
 
-Validation rules:
+Behavior rules:
 - Recall never writes files and never recomputes the supersession/establishes graph;
-  lifecycle is read-only ground truth.
-- A `conflict` is suppressed when an `Accepted:` ledger row already covers the
-  divergence.
+  lifecycle is read-only ground truth from frontmatter.
 
-### 4) Projection Block (transient, prompt-layer — written into agent-context files)
+### 4) Projection Pointer Block (transient, prompt-layer — written into agent-context files)
 
-Purpose: the managed, marker-delimited region maintained by `smithy.engrave`.
+Purpose: the managed, marker-delimited region maintained by `smithy.engrave`. It is a
+**pointer**, not a record copy.
 
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
-| `beginMarker` | `'<!-- smithy:engraved:begin -->'` | Yes | Opening delimiter. |
-| `endMarker` | `'<!-- smithy:engraved:end -->'` | Yes | Closing delimiter. |
-| `entries` | ProjectionEntry[] | Yes | Live records (id, kind, title, status), sorted by `id`. |
+| `beginMarker` | `<!-- smithy:engraved:begin -->` | Yes | Opening delimiter. |
+| `endMarker` | `<!-- smithy:engraved:end -->` | Yes | Closing delimiter. |
+| `locations` | string[] | Yes | Engraved-knowledge directories present in the repo (e.g. `docs/decisions/`, `docs/invariants/`, `docs/constitution/`, design variants when present). |
+| `note` | string | Yes | Short instruction: agents should read those records and judge applicability to the work at hand. |
 
 Validation rules:
-- Includes only live records (`accepted` decisions, `aligned`/`drifting` invariants,
-  `active` principles); excludes `superseded`/`deprecated` decisions.
-- Deterministic sort by `id` so a no-change re-run is byte-identical.
+- The block lists locations only — no record bodies, no per-record list.
+- Content is derived deterministically from the present directories so a no-change
+  re-run is byte-identical (FR-009).
 - Only content between markers is regenerated; content outside is never touched.
 
 ## Relationships
 
-- Decision 1:N Invariant via `establishes` / `established_by` (an invariant traces
-  back to ≥1 establishing decision).
-- Decision 1:N Decision via `supersedes` / `superseded_by` (supersession chain).
-- Artifact (spec/RFC/decision) N:M Invariant/Principle via `citation` edges.
+These relationships exist in the engraved records (authored by `smithy.engrave`); this
+feature only reads them:
+
+- Decision 1:N Invariant via `establishes` / `established_by`.
+- Decision 1:N Decision via `supersedes` / `superseded_by`.
 - Invariant 1:N Known Exception via the ledger.
 
 ## State Transitions
 
-### Decision lifecycle
-
-1. `proposed` → `accepted` — decision is ratified; body becomes append-only.
-2. `accepted` → `superseded` — a new decision with `supersedes: [<id>]` replaces it; `superseded_by` is appended. Never a rewrite.
-3. `accepted` → `deprecated` — retired without replacement.
-
-### Invariant alignment
-
-1. `aligned` → `drifting` — a `Temporary:` exception row is added to the ledger.
-2. `drifting` → `aligned` — all `Temporary:` rows are resolved or converted to `Accepted:`.
-
-These transitions are authored by `smithy.engrave`; the status subsystem only
-*derives and reports* the current state. The classifier computes `alignment` from
-the parsed ledger; it does not mutate records.
+This feature introduces no state transitions. Engraved-record lifecycle
+(`proposed → accepted → superseded | deprecated`) and invariant alignment
+(`aligned ↔ drifting`) are authored by `smithy.engrave`; recall and audit only read
+the current state.
 
 ## Identity & Uniqueness
 
-- Records are identified by frontmatter `id` (`D-`/`INV-`/`P-` prefixes), unique and
-  never reused, stable across renames.
-- Discovery is by suffix (`.decision.md`, `.invariant.md`) plus directory walk of the
-  constitution directory for principles (which have no suffix).
-- Engraved IDs are independent of the planning `M<N>`/`F<N>`/`US<N>`/`S<N>` namespace
-  and never collide with it.
-
-## Type-Surface Audit (consumers of `ArtifactType`)
-
-Adding `'engraved'` to `ArtifactType` requires auditing every exhaustive consumer so
-none silently mishandles the new member. Known sites to verify (US1, FR-001):
-
-- `ScanSummary.counts: Record<ArtifactType, Record<Status, number>>` (`src/status/types.ts`) — decide engraved's counting surface (recommended: a separate alignment/lifecycle count surface, not folded into the status rollup).
-- Suffix/type detection and any `idPrefixForType`-style switch (`src/status/scanner.ts`).
-- The classifier's type/rollup handling (`src/status/classifier.ts`).
-- Graph/tree/suggester type switches (`src/status/{graph,tree,suggester}.ts`).
-- `ORDERS_TEMPLATE_TYPES` and `OrdersTemplateType` (`src/orders-templates.ts`).
-- Test enumerations that assume exactly four artifact types.
+- Records are identified by frontmatter `id` (`D-`/`INV-`/`P-` prefixes).
+- Recall and the projection pointer locate records by the canonical directories
+  (`docs/decisions`, `docs/invariants`, `docs/constitution`, and design variants),
+  and by suffix (`.decision.md`, `.invariant.md`) for decisions/invariants; principles
+  are found by the constitution directory (no suffix).

--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.data-model.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.data-model.md
@@ -1,0 +1,150 @@
+# Data Model: Engraved Knowledge Recall and Reference
+
+## Overview
+
+This model describes how engraved records (decisions, invariants, principles) are
+represented **in the status subsystem's memory** once discovered, plus the
+transient shapes used by recall and projection. The authoritative **on-disk**
+frontmatter schema is owned by
+[`src/templates/agent-skills/commands/smithy.engrave.prompt`](../../src/templates/agent-skills/commands/smithy.engrave.prompt)
+and is **frozen** — this model references it as the source of truth and only adds
+the consuming representations. Fields below mirror that schema; they are not a
+redefinition.
+
+## Entities
+
+### 1) Engraved Record (`engraved`)
+
+Purpose: the in-memory representation of a durable-knowledge file, added as a new
+`ArtifactType` member so the scanner/classifier/graph treat it as first-class.
+Unlike planning artifacts, an engraved record has **no** dependency-order table and
+**no** completion rollup.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `type` | `'engraved'` | Yes | New member of the `ArtifactType` union. |
+| `kind` | `EngravedKind` = `'decision' \| 'invariant' \| 'principle'` | Yes | Discriminator. |
+| `id` | string | Yes | `D-<N>` / `INV-<N>` / `P-<N>` from frontmatter. |
+| `domain` | `'system' \| 'design'` | Yes | Ownership/recall partition; defaults to `system`. |
+| `title` | string | Yes | From frontmatter / H1. |
+| `path` | string | Yes | Repo-relative file path. |
+| `lifecycle` | `DecisionLifecycle` = `'proposed' \| 'accepted' \| 'superseded' \| 'deprecated'` | decisions | Decision status axis. |
+| `alignment` | `Alignment` = `'aligned' \| 'drifting'` | invariants | Derived from the ledger. |
+| `principleStatus` | `'active'` | principles | Principles have a single status. |
+| `supersedes` | string[] | decisions | Decision IDs this record replaces (`[]` if none). |
+| `superseded_by` | string[] | decisions | Decision IDs that replaced this one. |
+| `establishes` | string[] | decisions | Invariant IDs this decision establishes. |
+| `established_by` | string[] | invariants | Decision IDs that established this invariant (≥1). |
+| `exceptions` | `KnownException[]` | invariants | Parsed ledger rows; empty for the em-dash placeholder. |
+| `topics` | string[] | Yes | Recall/filter metadata (not graph edges). |
+| `scope` | string[] | Yes | Recall/filter metadata. |
+| `applies_to` | string[] | Yes | Recall/filter metadata. |
+
+Validation rules:
+- An engraved record never carries a `dependency_order` table; the parser must not
+  emit a `format: 'missing'` / `unknown` classification for it.
+- Decisions use `lifecycle`; invariants use `alignment`; principles use
+  `principleStatus`. The three are distinct axes — none is the planning `Status`.
+- `topics`/`scope`/`applies_to` are opaque carried strings for recall/filtering, not
+  promoted into the status graph type surface.
+
+### 2) Known Exception (`KnownException`)
+
+Purpose: one row of an invariant's Known-Exceptions ledger; the unit that drives
+alignment.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `where` | string | Yes | Repo-relative path, module, or surface. |
+| `what` | string | Yes | What reality does vs. what the rule says. |
+| `disposition` | `'Accepted' \| 'Temporary'` | Yes | Canonical capitalized token from the ledger. |
+| `why` | string | Yes | Reason text following the disposition token. |
+| `tracking_issue` | string \| null | Yes | `#NNN` for `Temporary` rows; `—`/null for `Accepted`. |
+| `severity` | `'low' \| 'medium' \| 'high'` | Yes | High rows may block compounding planning artifacts. |
+
+Validation rules:
+- The single em-dash placeholder row (`—` in every column) parses to **zero**
+  exceptions.
+- Alignment derivation: `drifting` iff ≥1 `Temporary:` row is present; `Accepted:`
+  rows alone never flip to `drifting`.
+- Column order is load-bearing and fixed by the engrave schema:
+  `Where | What diverges | Disposition + Why | Tracking Issue | Severity`.
+
+### 3) Recall Result (transient, prompt-layer — not persisted)
+
+Purpose: the structured return of the `smithy-recall` sub-agent.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `relevant` | RelevantRecord[] | Yes | Ranked; each has id, kind, title, path, one-line relevance basis. |
+| `conflicts` | ConflictFlag[] | Yes | Proposed work vs. an invariant rule (candidate new exception). |
+| `superseded_citations` | SupersededCitation[] | Yes | Citations to superseded/deprecated records (read-only ground truth). |
+| `empty` | boolean | Yes | True when no records exist or none match. |
+
+Validation rules:
+- Recall never writes files and never recomputes the supersession/establishes graph;
+  lifecycle is read-only ground truth.
+- A `conflict` is suppressed when an `Accepted:` ledger row already covers the
+  divergence.
+
+### 4) Projection Block (transient, prompt-layer — written into agent-context files)
+
+Purpose: the managed, marker-delimited region maintained by `smithy.engrave`.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `beginMarker` | `'<!-- smithy:engraved:begin -->'` | Yes | Opening delimiter. |
+| `endMarker` | `'<!-- smithy:engraved:end -->'` | Yes | Closing delimiter. |
+| `entries` | ProjectionEntry[] | Yes | Live records (id, kind, title, status), sorted by `id`. |
+
+Validation rules:
+- Includes only live records (`accepted` decisions, `aligned`/`drifting` invariants,
+  `active` principles); excludes `superseded`/`deprecated` decisions.
+- Deterministic sort by `id` so a no-change re-run is byte-identical.
+- Only content between markers is regenerated; content outside is never touched.
+
+## Relationships
+
+- Decision 1:N Invariant via `establishes` / `established_by` (an invariant traces
+  back to ≥1 establishing decision).
+- Decision 1:N Decision via `supersedes` / `superseded_by` (supersession chain).
+- Artifact (spec/RFC/decision) N:M Invariant/Principle via `citation` edges.
+- Invariant 1:N Known Exception via the ledger.
+
+## State Transitions
+
+### Decision lifecycle
+
+1. `proposed` → `accepted` — decision is ratified; body becomes append-only.
+2. `accepted` → `superseded` — a new decision with `supersedes: [<id>]` replaces it; `superseded_by` is appended. Never a rewrite.
+3. `accepted` → `deprecated` — retired without replacement.
+
+### Invariant alignment
+
+1. `aligned` → `drifting` — a `Temporary:` exception row is added to the ledger.
+2. `drifting` → `aligned` — all `Temporary:` rows are resolved or converted to `Accepted:`.
+
+These transitions are authored by `smithy.engrave`; the status subsystem only
+*derives and reports* the current state. The classifier computes `alignment` from
+the parsed ledger; it does not mutate records.
+
+## Identity & Uniqueness
+
+- Records are identified by frontmatter `id` (`D-`/`INV-`/`P-` prefixes), unique and
+  never reused, stable across renames.
+- Discovery is by suffix (`.decision.md`, `.invariant.md`) plus directory walk of the
+  constitution directory for principles (which have no suffix).
+- Engraved IDs are independent of the planning `M<N>`/`F<N>`/`US<N>`/`S<N>` namespace
+  and never collide with it.
+
+## Type-Surface Audit (consumers of `ArtifactType`)
+
+Adding `'engraved'` to `ArtifactType` requires auditing every exhaustive consumer so
+none silently mishandles the new member. Known sites to verify (US1, FR-001):
+
+- `ScanSummary.counts: Record<ArtifactType, Record<Status, number>>` (`src/status/types.ts`) — decide engraved's counting surface (recommended: a separate alignment/lifecycle count surface, not folded into the status rollup).
+- Suffix/type detection and any `idPrefixForType`-style switch (`src/status/scanner.ts`).
+- The classifier's type/rollup handling (`src/status/classifier.ts`).
+- Graph/tree/suggester type switches (`src/status/{graph,tree,suggester}.ts`).
+- `ORDERS_TEMPLATE_TYPES` and `OrdersTemplateType` (`src/orders-templates.ts`).
+- Test enumerations that assume exactly four artifact types.

--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.data-model.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.data-model.md
@@ -53,6 +53,24 @@ Read rules (for recall):
   new exception (FR-002).
 - The single em-dash placeholder row represents an empty ledger (no exceptions).
 
+Write rule (for the drift-tracking step, US3): when a `Temporary:` row is added,
+`tracking_issue` is populated with the number of a scaffolded drift-tracking issue
+(FR-011); `Accepted:` rows keep `tracking_issue` = `—`.
+
+### 2a) Drift-Tracking Issue (external — GitHub)
+
+Purpose: the GitHub issue created to close a `Temporary:` exception. Not a persisted
+entity in this repo; its identity is the `#NNN` recorded in the ledger row.
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `number` | GitHub (create-issue) | Written back into the `Temporary:` row's `Tracking Issue` cell. |
+| `title` | the divergence | Derived from the exception's `what diverges`. |
+| `body` | invariant + decision | Invariant id/title, the divergence, and the establishing decision(s). |
+
+Created via the `smithy.gh-issue` skill (the same tooling `smithy.orders` uses).
+Engraved records do **not** become `smithy.orders` artifact types.
+
 ### 3) Recall Result (transient, prompt-layer — not persisted)
 
 Purpose: the structured return of the `smithy-recall` sub-agent.

--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.spec.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.spec.md
@@ -14,6 +14,7 @@
 - _Recall is a planning-time **sub-agent** (`smithy-recall`) dispatched only by planning commands — it is **not** user-invocable and exposes no ad-hoc command surface._
 - _Recall reads engraved record files directly (Grep/Glob/Read, modeled on `smithy-scout`); with status integration out of scope, it always reads record frontmatter as the source of truth (no dependency on a status index)._ `[Critical Assumption]`
 - _The Agents.md/Claude.md reference capability is a new **projection step on `smithy.engrave`** that maintains a managed, regenerable block containing a **pointer** to the engraved-knowledge locations plus a short applicability note — not a copy of the records. The reading agent decides how much to load._ `[Critical Assumption]`
+- _The #418 "orders" half is reinterpreted: engraved records are durable knowledge, not a fan-out work hierarchy, so they do **not** become `smithy.orders` artifact types. The only engraved↔issue seam is a **drift-tracking issue** scaffolded at the engrave exception step when a `Temporary:` exception is added, filling the schema's existing `Tracking Issue` ledger column. (User-confirmed.)_
 - _The engraved-knowledge frontmatter schema (kinds, fields, suffixes, ledger column order) is **frozen** and owned by `src/templates/agent-skills/commands/smithy.engrave.prompt`. This spec references it as the source of truth and does not redefine it._
 
 ## Artifact Hierarchy
@@ -61,19 +62,20 @@ As a developer who just engraved or superseded a record, I want `smithy.engrave`
 
 ---
 
-### User Story 3: Orders Scaffolds Tickets for Engraved Records (Priority: P2)
+### User Story 3: Engrave Scaffolds a Drift-Tracking Issue for Temporary Exceptions (Priority: P2)
 
-As a developer using `smithy.orders`, I want to scaffold GitHub issues for decisions and invariants from their files so that engraved work can be tracked with the same issue-creation flow as planning artifacts.
+As a developer adding a `Temporary:` exception to an invariant, I want `smithy.engrave` to open a GitHub issue for closing that drift and record its number in the ledger so that every known divergence from a durable rule is tracked as real, actionable work with a clear done-condition.
 
-**Why this priority**: Additive, low-risk, independent of the other stories; maps to the orders half of #418. Useful polish, not core capability.
+**Why this priority**: This is the one genuine "engraved → work" seam — a `Temporary:` exception is, by definition, drift the team intends to fix. It reinterprets the orders half of #418: rather than treating a decision/invariant as a new `smithy.orders` artifact type (engraved records have no sub-elements, no `## Dependency Order` table, and are durable commitments rather than work to be done — the same reason status integration was dropped), the capability lives at the engrave exception step and fills the schema's existing `Tracking Issue` ledger column.
 
-**Independent Test**: Run `smithy.orders` against a `*.decision.md` and a `*.invariant.md` and confirm structured issue bodies are produced, and the orders-template parity test passes.
+**Independent Test**: Add a `Temporary:` exception to an invariant via `smithy.engrave <invariant> exception`; confirm a GitHub issue is created describing the drift and citing the invariant, and the new ledger row's `Tracking Issue` cell holds the returned `#NNN`.
 
 **Acceptance Scenarios**:
 
-1. **Given** a `*.decision.md` or `*.invariant.md` file, **When** `smithy.orders` auto-detects its type by suffix, **Then** it scaffolds a ticket body from the corresponding engraved orders template.
-2. **Given** new `decision`/`invariant` entries added to `ORDERS_DEFAULT_TEMPLATES`/`ORDERS_TEMPLATE_TYPES`, **When** the `smithy.orders.prompt` heredoc parity test runs, **Then** both surfaces match and the parity assertion in `src/templates.test.ts` passes (extended to cover the new types).
-3. **Given** a principle file (no suffix), **When** orders runs, **Then** behavior follows the resolution of SD-003 (principle template included, or principles excluded from orders auto-detection with a documented note).
+1. **Given** `smithy.engrave <invariant-path> exception` adds a `Temporary:` row, **When** the row is written, **Then** a GitHub issue is scaffolded (via the `smithy.gh-issue` skill) titled from the divergence and bodied with the invariant id/title, the divergence, and the establishing decision(s), and its `#NNN` is written into that row's `Tracking Issue` column.
+2. **Given** an `Accepted:` exception is added (a permanent carve-out, not drift), **When** the row is written, **Then** no issue is created and the row's `Tracking Issue` cell stays `—`.
+3. **Given** issue creation fails (auth/network), **When** the exception is added, **Then** the ledger row is still written (with `Tracking Issue` left `—`) and the failure is surfaced — the engrave operation does not roll back.
+4. **Given** a `Temporary:` exception is later resolved (drift closed, or converted to `Accepted:`), **When** the ledger is updated, **Then** the linked issue is handled per the resolution of SD-003.
 
 ---
 
@@ -109,7 +111,7 @@ Recommended implementation sequence:
 |----|-------|-----------|----------|
 | US1 | Planning Commands Recall Relevant Engraved Knowledge | — | — |
 | US2 | Engrave Projects an Engraved-Knowledge Pointer into Agent-Context Files | — | — |
-| US3 | Orders Scaffolds Tickets for Engraved Records | — | — |
+| US3 | Engrave Scaffolds a Drift-Tracking Issue for Temporary Exceptions | — | — |
 | US4 | Audit Validates Engraved Record Quality | — | — |
 
 All four user stories are independent — four parallel entry points with no cross-story prerequisites. They share only the frozen engraved-record frontmatter schema as a read-only input.
@@ -134,13 +136,15 @@ All four user stories are independent — four parallel entry points with no cro
 - **FR-009**: Projection MUST be idempotent (a no-change re-run produces a byte-identical file), MUST replace only content between the markers, MUST never modify content outside the markers, and MUST add a fresh block at a defined anchor when no markers exist.
 - **FR-010**: Projection MUST manage only agent-context files that already exist (never create missing ones) and MUST abort projection for a file whose markers are malformed/duplicated, with a warning, without failing the underlying engrave operation.
 
-**Orders (US3, #418)**
+**Drift-tracking issue (US3, reinterprets #418 orders half)**
 
-- **FR-011**: `smithy.orders` MUST support `decision` and `invariant` (and optionally `principle`, per SD-003) by adding entries to `ORDERS_DEFAULT_TEMPLATES`/`ORDERS_TEMPLATE_TYPES` and the `smithy.orders.prompt` heredoc in lockstep, with the `src/templates.test.ts` parity assertion extended to cover them.
+- **FR-011**: When `smithy.engrave` adds a `Temporary:` exception to an invariant's Known-Exceptions ledger, it MUST scaffold a GitHub issue for closing the drift (via the `smithy.gh-issue` skill's create-issue script — the same tooling `smithy.orders` uses) and write the returned issue number into that ledger row's `Tracking Issue` column. `Accepted:` exceptions MUST NOT create an issue (their `Tracking Issue` stays `—`).
+- **FR-012**: The drift-issue body MUST identify the invariant (id, title), state the divergence, and cite the establishing decision(s). The body template lives with the engrave exception phase; engraved records MUST NOT add entries to `ORDERS_TEMPLATE_TYPES` / `ORDERS_DEFAULT_TEMPLATES` (they are not a fan-out work hierarchy).
+- **FR-013**: If issue creation fails, engrave MUST still write the ledger row (with `Tracking Issue` left `—`), surface the failure, and not roll back the exception edit.
 
-**Audit (US4, #418)**
+**Audit (US4, #418 audit half)**
 
-- **FR-012**: The system MUST provide an `audit-checklist-engraved` snippet wired into `smithy.audit`'s type-selection mechanism, checking: decision states its desired invariant; invariant cites its decisions and keeps a ledger with the load-bearing column order; no citation to a superseded decision; record is genuinely pivot-level.
+- **FR-014**: The system MUST provide an `audit-checklist-engraved` snippet wired into `smithy.audit`'s type-selection mechanism, checking: decision states its desired invariant; invariant cites its decisions and keeps a ledger with the load-bearing column order; no citation to a superseded decision; record is genuinely pivot-level.
 
 ### Key Entities *(include if feature involves data)*
 
@@ -148,6 +152,7 @@ All four user stories are independent — four parallel entry points with no cro
 - **Known Exception**: a row in an invariant's ledger (`where`, `what diverges`, disposition `Accepted`/`Temporary`, tracking issue, severity) that recall uses to decide whether a conflict is already covered.
 - **Recall Result**: the transient, prompt-layer ranked relevance + conflict/superseded findings returned by `smithy-recall` (not persisted).
 - **Projection Pointer Block**: the managed, marker-delimited region written into agent-context files — a pointer to the engraved-knowledge locations, not a record copy.
+- **Drift-Tracking Issue**: a GitHub issue created to close a `Temporary:` exception; its number is recorded in the ledger row's `Tracking Issue` column.
 
 ## Assumptions
 
@@ -156,6 +161,7 @@ All four user stories are independent — four parallel entry points with no cro
 - The projection block is a pointer + applicability note, not a record index, so the reading agent controls how much it loads. `[Critical Assumption]`
 - The `consult-engraved-knowledge` snippet is self-sufficient with a Claude sub-agent fast-path and an inline degraded path for Gemini/Codex. `[Critical Assumption]`
 - Recall is a sub-agent dispatched only by planning commands; it is not user-invocable.
+- `smithy.orders` gains no engraved artifact types; the only engraved↔issue interaction is the drift-tracking issue created at the engrave exception step for a `Temporary:` exception, which fills the schema's existing `Tracking Issue` ledger column.
 - The engraved frontmatter schema is frozen and owned by `smithy.engrave.prompt`; this spec references it rather than redefining it.
 
 ## Specification Debt
@@ -164,12 +170,13 @@ All four user stories are independent — four parallel entry points with no cro
 |----|-------------|-----------------|--------|------------|--------|------------|
 | SD-001 | Which agent-context files projection manages by default (CLAUDE.md only, also AGENTS.md, also `.github/copilot-instructions.md`) and whether the target set is configurable. | Integration | Medium | Medium | open | — |
 | SD-002 | Whether the optional `design`-domain locations (`docs/design/{decisions,invariants,constitution}`) are in scope for recall and the projection pointer now, or deferred. | Functional Scope | Low | Medium | open | — |
-| SD-003 | Whether `principle` gets an orders template, given principles have no suffix for `smithy.orders` auto-detection (#418 says "optionally"). | Domain & Data Model | Low | Medium | open | — |
+| SD-003 | When a `Temporary:` exception is later resolved (removed or converted to `Accepted:`), whether engrave should auto-close the linked drift-tracking issue, leave it open, or comment-and-leave. | Integration | Low | Medium | open | — |
 
 ## Out of Scope
 
 - **Status-subsystem integration (#416 scanner/parser/classifier, #417 graph edges/surface/stale-ref)** — making engraved records a first-class type in `smithy status` and the build rollup. Deferred and reconsidered separately; engraved knowledge "is durable commitment, not work to be done," so it is surfaced via recall and the projection pointer rather than the status rollup.
-- Re-specifying or modifying the engraved-knowledge frontmatter schema or the `smithy.engrave` authoring phases (shipped in #413/#414).
+- Adding engraved artifact types (`decision`/`invariant`/`principle`) to `smithy.orders` / `ORDERS_TEMPLATE_TYPES`. Engraved records are not a fan-out work hierarchy; the only engraved↔issue interaction is the drift-tracking issue at the engrave exception step (US3).
+- Re-specifying or modifying the engraved-knowledge frontmatter schema or the existing `smithy.engrave` authoring phases (shipped in #413/#414). US3 *adds* a step to the exception phase but does not change the ledger schema.
 - A user-facing standalone `smithy.recall` (or `smithy.engraved`) command and any ad-hoc catalog-lookup surface — recall is a sub-agent only.
 - The UI design pipeline (screens/flows, Claude Design, forge-builds-UI) — tracked under EPIC #404.
 
@@ -180,4 +187,4 @@ All four user stories are independent — four parallel entry points with no cro
 - **SC-001**: Each of the five wired planning commands (`strike`, `ignite`, `render`, `mark`, `cut`) consults engraved knowledge in its scan phase under all three agents (Claude via sub-agent; Gemini/Codex via the degraded inline path).
 - **SC-002**: Recall returns relevant records and correctly flags ≥1 invariant conflict and ≥1 superseded citation in a seeded test scenario, with zero conflict flags for divergences already covered by an `Accepted:` ledger row.
 - **SC-003**: Engraving a record ensures the pointer block in every existing target agent-context file; a no-change re-run leaves those files byte-identical; hand-written prose is never altered.
-- **SC-004**: `smithy.orders` scaffolds tickets for decision and invariant files and the templates parity test passes; `smithy.audit` applies the engraved checklist to an engraved record.
+- **SC-004**: Adding a `Temporary:` exception via `smithy.engrave` creates a drift-tracking GitHub issue and writes its `#NNN` into the ledger row; an `Accepted:` exception creates none; `smithy.audit` applies the engraved checklist to an engraved record.

--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.spec.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.spec.md
@@ -4,51 +4,31 @@
 **Branch**: `feature/epic-412-engraving-decisions` *(pre-staged linked worktree on the epic branch; preserved per the branch-selection policy rather than auto-named)*
 **Created**: 2026-06-06
 **Status**: Draft
-**Input**: User feature description + GitHub EPIC #412 ("Engraved durable knowledge — decisions/invariants/principles") and its open sub-issues #415, #416, #417, #418. The authoring half (#413 schema, #414 `smithy.engrave`) is already shipped. This spec covers the entire *remaining* epic — making engraved knowledge discoverable, recallable during planning, referenced in agent-context files, and audited.
+**Input**: User feature description + GitHub EPIC #412 ("Engraved durable knowledge — decisions/invariants/principles"). The authoring half (#413 schema, #414 `smithy.engrave`) is already shipped. This spec covers the **reference** half — surfacing engraved knowledge during planning (recall, #415), pointing arbitrary agents at it (projection, new), and tooling it for orders/audit (#418). Status-subsystem integration (#416/#417) was scoped **out** during PR review (see Out of Scope).
 
 ## Clarifications
 
 ### Session 2026-06-06
 
-- _Scope: this single spec covers the entire remaining epic — #415 (recall), #416 (status discovery), #417 (graph/surface/stale-ref), #418 (orders/audit) — plus a new engrave→agent-context projection capability not tracked by any sub-issue._ `[Critical Assumption]`
-- _Recall is a planning-time **sub-agent** (`smithy-recall`), not a user-invocable command. Ad-hoc catalog lookup is exposed as a mode/flag on `smithy.engrave`. (User-confirmed; the `smithy.engrave` flag vs. a separate `smithy.engraved` command is unresolved — see SD-001.)_
-- _The Agents.md/Claude.md reference capability is a new **projection step on `smithy.engrave`** that refreshes a managed, regenerable block when a record is engraved or superseded. (User-confirmed.)_
-- _Recall reads engraved record files directly (Grep/Glob/Read, modeled on `smithy-scout`); it does **not** consume the status scanner's output, so recall does not depend on #416._ `[Critical Assumption]`
-- _The deterministic TS status subsystem is the sole authority for lifecycle, citation/supersedes/establishes edges, and stale-reference detection. The recall sub-agent owns only semantic relevance ranking and conflict-with-proposed-work judgment; it treats record lifecycle as read-only ground truth and never recomputes the graph._ `[Critical Assumption]`
-- _Engraved records sit on a separate **alignment** axis (`aligned` / `drifting`) plus decision lifecycle (`proposed`/`accepted`/`superseded`/`deprecated`) and principle `active`; they are excluded from the build/status completion rollup and never appear as `## Dependency Order` rows._
+- _Scope (post PR-review): this spec covers recall (#415), a new engrave→agent-context projection pointer, and orders/audit tooling (#418). Status-subsystem integration (#416 scanner/parser/classifier, #417 graph/surface/stale-ref) is **deferred** — engraved knowledge does not belong in the build-status rollup ("status is about work to be done"). It is surfaced via recall and the projection pointer instead._ `[Critical Assumption]`
+- _Recall is a planning-time **sub-agent** (`smithy-recall`) dispatched only by planning commands — it is **not** user-invocable and exposes no ad-hoc command surface._
+- _Recall reads engraved record files directly (Grep/Glob/Read, modeled on `smithy-scout`); with status integration out of scope, it always reads record frontmatter as the source of truth (no dependency on a status index)._ `[Critical Assumption]`
+- _The Agents.md/Claude.md reference capability is a new **projection step on `smithy.engrave`** that maintains a managed, regenerable block containing a **pointer** to the engraved-knowledge locations plus a short applicability note — not a copy of the records. The reading agent decides how much to load._ `[Critical Assumption]`
 - _The engraved-knowledge frontmatter schema (kinds, fields, suffixes, ledger column order) is **frozen** and owned by `src/templates/agent-skills/commands/smithy.engrave.prompt`. This spec references it as the source of truth and does not redefine it._
 
 ## Artifact Hierarchy
 
 RFC → Milestone → Feature → User Story → Slice → Tasks
 
-This feature is the recall/reference half of EPIC #412. The engraved records it operates on are **roots** in the planning graph — they participate via citation / supersedes / establishes edges, never as Dependency Order rows.
+Engraved records (decisions, invariants, principles) are **roots** — they participate via citation / supersedes / establishes edges declared in frontmatter, never as `## Dependency Order` rows. This feature only **reads and points at** those records; it does not change the engraved schema.
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1: Status Recognizes Engraved Records as a First-Class Type (Priority: P1)
-
-As a developer running `smithy status`, I want decisions, invariants, and principles discovered and reported as a first-class artifact family so that durable commitments are visible alongside planning artifacts instead of being invisible to tooling.
-
-**Why this priority**: This is the foundation #417 (US4) builds on, and it is the smallest increment that makes engraved records exist in tooling. Maps to sub-issue #416, the status-side anchor of the remaining epic.
-
-**Independent Test**: Place sample `*.decision.md`, `*.invariant.md`, and a constitution principle file in the canonical directories, run `smithy status --format json`, and confirm each record appears with `type: "engraved"`, its `kind`, and its alignment/lifecycle — without any planning-artifact dependency-order error.
-
-**Acceptance Scenarios**:
-
-1. **Given** a repo containing `docs/decisions/x.decision.md`, `docs/invariants/y.invariant.md`, and `docs/constitution/z.md`, **When** the scanner runs, **Then** all three are discovered as `type: 'engraved'` records carrying `kind` (`decision`/`invariant`/`principle`), and none is reported as a malformed dependency-order artifact.
-2. **Given** an invariant whose Known-Exceptions ledger contains at least one `Temporary:` row, **When** the record is classified, **Then** its alignment is `drifting`; **Given** a ledger with only `Accepted:` rows or the single em-dash placeholder row, **Then** its alignment is `aligned`.
-3. **Given** a decision with `status: accepted` / `superseded` / `deprecated`, **When** classified, **Then** the decision lifecycle is reported and the record is **excluded** from the build/completion rollup (it does not affect any parent's `completed/total`).
-4. **Given** `ArtifactType` now includes `'engraved'`, **When** the project type-checks and tests run, **Then** every exhaustive `switch (type)` and every `Record<ArtifactType, …>` (notably `ScanSummary.counts`) compiles and behaves correctly, and existing 4-type enumeration tests are updated to account for the new member.
-5. **Given** an invariant with the canonical empty ledger (one row of `—` in every column), **When** parsed, **Then** it yields zero exceptions (no phantom exception) and alignment `aligned`.
-
----
-
-### User Story 2: Planning Commands Recall Relevant Engraved Knowledge (Priority: P1)
+### User Story 1: Planning Commands Recall Relevant Engraved Knowledge (Priority: P1)
 
 As a developer (or arbitrary agent) running a smithy planning command, I want the command to surface the decisions, invariants, and principles relevant to the work at hand — and to flag when my new work conflicts with an invariant or cites a superseded decision — so that durable commitments actively steer new plans instead of being silently ignored.
 
-**Why this priority**: This is the headline value of the epic and the user's primary ask ("update the various smithy skills to reference these engraved pieces of information"). Maps to sub-issue #415.
+**Why this priority**: The headline value of the epic and the user's primary ask ("update the various smithy skills to reference these engraved pieces of information"). Maps to sub-issue #415.
 
 **Independent Test**: With a few engraved records present, invoke a planning command's scan phase against a feature description whose topics overlap one invariant and cite a superseded decision; confirm the command receives a ranked list of relevant records plus a conflict flag and a superseded-citation flag, and folds them into clarification.
 
@@ -56,53 +36,36 @@ As a developer (or arbitrary agent) running a smithy planning command, I want th
 
 1. **Given** engraved records exist and a planning context with topic/scope hints, **When** the `smithy-recall` sub-agent is dispatched, **Then** it returns decisions/invariants/principles ranked by relevance computed from `domain`/`topics`/`scope`/`applies_to` overlap, each with a one-line relevance basis.
 2. **Given** the proposed work would contradict an invariant's `## Rule`, **When** recall runs, **Then** it returns that invariant as a **candidate new exception** (a soft flag, not a hard block) — unless an existing `Accepted:` ledger row already covers that divergence, in which case it is not re-flagged.
-3. **Given** the planning artifact or proposed work cites a decision whose `status` is `superseded` or `deprecated`, **When** recall runs, **Then** it reports a superseded/deprecated-citation hazard, reading lifecycle from the record frontmatter (or the deterministic status output) as ground truth — it does not independently re-derive supersession.
+3. **Given** the planning artifact or proposed work cites a decision whose `status` is `superseded` or `deprecated`, **When** recall runs, **Then** it reports a superseded/deprecated-citation hazard, reading lifecycle from the record frontmatter as ground truth — it does not independently re-derive supersession.
 4. **Given** a feature that spans both `system` and `design` work, **When** recall runs, **Then** it queries both domain partitions; **Given** single-domain work, **Then** it filters to that domain.
-5. **Given** no engraved records exist in the repo, **When** recall runs, **Then** it returns a well-formed empty result ("no engraved knowledge in repo") and the planning command proceeds normally — it does not error.
+5. **Given** no engraved records exist in the repo, **When** recall runs, **Then** it returns a well-formed empty result (`empty: true` with an `empty_reason`) and the planning command proceeds normally — it does not error.
 6. **Given** the `{{>consult-engraved-knowledge}}` snippet is wired into the scan phase of `strike`, `ignite`, `render`, `mark`, and `cut`, **When** any of those commands runs under Claude, **Then** it dispatches `smithy-recall`; **When** run under Gemini or Codex (which have no sub-agents), **Then** the inlined snippet's degraded path reads the engraved scan roots directly so engraved knowledge is still consulted.
 
 ---
 
-### User Story 3: Engrave Projects Engraved Knowledge into Agent-Context Files (Priority: P1)
+### User Story 2: Engrave Projects an Engraved-Knowledge Pointer into Agent-Context Files (Priority: P1)
 
-As a developer who just engraved or superseded a record, I want `smithy.engrave` to refresh a managed, regenerable block in the repo's agent-context files (CLAUDE.md / AGENTS.md) listing the current durable commitments so that arbitrary agents — not just smithy commands — see the engraved knowledge without any extra tooling.
+As a developer who just engraved or superseded a record, I want `smithy.engrave` to maintain a managed block in the repo's agent-context files (CLAUDE.md / AGENTS.md) that **points** arbitrary agents at the engraved-knowledge locations and tells them to check those for applicability — so that any agent, not just smithy commands, knows durable knowledge exists without the records being copied into the context file.
 
-**Why this priority**: The user's explicit second ask ("ask it to update some Agents.md/Claude.md file to reference said decisions"). New capability with no sub-issue; additive scope flagged as such.
+**Why this priority**: The user's explicit second ask ("ask it to update some Agents.md/Claude.md file to reference said decisions"). New capability with no sub-issue. Deliberately a pointer, not a copy, so the reading agent controls how much it loads into context.
 
-**Independent Test**: Engrave a decision in a repo whose CLAUDE.md has hand-written prose but no markers; confirm a marked block is appended listing the live records, the hand-written prose is untouched, and re-running with no record change leaves the file byte-identical.
+**Independent Test**: Engrave a decision in a repo whose CLAUDE.md has hand-written prose but no markers; confirm a marked pointer block is added referencing the engraved-knowledge directories, the hand-written prose is untouched, and re-running with no record change leaves the file byte-identical.
 
 **Acceptance Scenarios**:
 
-1. **Given** an agent-context file with no managed markers, **When** a record is engraved/superseded, **Then** a fresh block delimited by `<!-- smithy:engraved:begin -->` / `<!-- smithy:engraved:end -->` is appended at a defined anchor, and no content outside the markers is modified.
-2. **Given** a file that already contains the marker pair, **When** projection runs, **Then** only the content between the markers is replaced; **Given** no record has changed since the last run, **Then** the file is byte-identical (idempotent; records sorted deterministically by `id`).
-3. **Given** the set of live records, **When** the block is generated, **Then** it lists `accepted` decisions, `aligned`/`drifting` invariants, and `active` principles (each with id, kind, title, status) and **excludes** `superseded`/`deprecated` decisions so agents see only live commitments.
+1. **Given** an agent-context file with no managed markers, **When** a record is engraved/superseded, **Then** a block delimited by `<!-- smithy:engraved:begin -->` / `<!-- smithy:engraved:end -->` is added at a defined anchor, and no content outside the markers is modified.
+2. **Given** the block, **When** it is generated, **Then** its content is a **pointer**: the engraved-knowledge locations present in the repo (e.g. `docs/decisions/`, `docs/invariants/`, `docs/constitution/`, plus design-domain variants when present) and a short note instructing agents to read those records and judge their applicability to the work at hand. It does **not** inline record bodies or a per-record list.
+3. **Given** the file already contains the marker pair, **When** projection runs, **Then** only the content between the markers is replaced; **Given** the present engraved-knowledge locations are unchanged, **Then** the file is byte-identical (idempotent).
 4. **Given** a configured agent-context target file that does not exist on disk, **When** projection runs, **Then** that target is skipped (projection manages existing files only and never creates new ones); present targets are each updated.
 5. **Given** a file whose markers are malformed or duplicated, **When** projection runs, **Then** it aborts the projection for that file with a warning rather than guessing where the block belongs, and the engrave operation itself still succeeds.
 
 ---
 
-### User Story 4: Status Surfaces Engraved Graph Edges and Stale References (Priority: P2)
-
-As a developer reviewing repository health, I want `smithy status` to show the citation/supersedes/establishes relationships for engraved records, group them under a "Decisions & Invariants" heading, and warn when an artifact cites a superseded decision or deprecated invariant so that drift and stale references are caught deterministically.
-
-**Why this priority**: Builds directly on US1's type surface and completes the status-side story (#417). Valuable but secondary to discovery (US1) and recall (US2).
-
-**Independent Test**: With a spec that cites a superseded decision and a drifting invariant present, run `smithy status` and confirm the engraved group renders with alignment/lifecycle, a stale-ref warning is emitted, and a next-action is suggested.
-
-**Acceptance Scenarios**:
-
-1. **Given** engraved records and artifacts that reference them, **When** the graph is built, **Then** it contains `citation` edges (spec/RFC/decision → invariant/principle), `supersedes` edges (decision → decision), and `establishes` edges (decision → invariant).
-2. **Given** an artifact citing a decision whose `status` is `superseded`, **When** the stale-ref check runs, **Then** that reference is flagged as a stale reference extending the existing dangling-reference machinery. (A deprecated-invariant stale-ref class is pending SD-007.)
-3. **Given** engraved records exist, **When** the tree renders, **Then** a "Decisions & Invariants" group appears showing each record's alignment (`aligned`/`drifting`) and decision lifecycle.
-4. **Given** a `drifting` invariant, **When** next-actions are computed, **Then** the suggester recommends reviewing the exceptions ledger; **Given** an artifact citing a superseded decision, **Then** it recommends reviewing/updating the citation.
-
----
-
-### User Story 5: Orders Scaffolds Tickets for Engraved Records (Priority: P2)
+### User Story 3: Orders Scaffolds Tickets for Engraved Records (Priority: P2)
 
 As a developer using `smithy.orders`, I want to scaffold GitHub issues for decisions and invariants from their files so that engraved work can be tracked with the same issue-creation flow as planning artifacts.
 
-**Why this priority**: Additive, low-risk, independent of all other stories; maps to the orders half of #418. Useful polish, not core capability.
+**Why this priority**: Additive, low-risk, independent of the other stories; maps to the orders half of #418. Useful polish, not core capability.
 
 **Independent Test**: Run `smithy.orders` against a `*.decision.md` and a `*.invariant.md` and confirm structured issue bodies are produced, and the orders-template parity test passes.
 
@@ -110,11 +73,11 @@ As a developer using `smithy.orders`, I want to scaffold GitHub issues for decis
 
 1. **Given** a `*.decision.md` or `*.invariant.md` file, **When** `smithy.orders` auto-detects its type by suffix, **Then** it scaffolds a ticket body from the corresponding engraved orders template.
 2. **Given** new `decision`/`invariant` entries added to `ORDERS_DEFAULT_TEMPLATES`/`ORDERS_TEMPLATE_TYPES`, **When** the `smithy.orders.prompt` heredoc parity test runs, **Then** both surfaces match and the parity assertion in `src/templates.test.ts` passes (extended to cover the new types).
-3. **Given** a principle file (no suffix), **When** orders runs, **Then** behavior follows the resolution of SD-004 (principle template included, or principles excluded from orders auto-detection with a documented note).
+3. **Given** a principle file (no suffix), **When** orders runs, **Then** behavior follows the resolution of SD-003 (principle template included, or principles excluded from orders auto-detection with a documented note).
 
 ---
 
-### User Story 6: Audit Validates Engraved Record Quality (Priority: P3)
+### User Story 4: Audit Validates Engraved Record Quality (Priority: P3)
 
 As a developer auditing a durable-knowledge record, I want `smithy.audit` to check engraved records against a dedicated checklist so that decisions, invariants, and principles stay well-formed as they proliferate.
 
@@ -129,31 +92,14 @@ As a developer auditing a durable-knowledge record, I want `smithy.audit` to che
 3. **Given** an invariant, **When** audited, **Then** the checklist verifies it cites its establishing decisions, keeps a Known-Exceptions ledger with the load-bearing column order, and exposes no silent divergence.
 4. **Given** any engraved record, **When** audited, **Then** the checklist applies the inclusion test (is the record genuinely pivot-level?).
 
----
-
-### User Story 7: Ad-Hoc Engraved Catalog Lookup (Priority: P3)
-
-As a developer, I want to list and filter existing engraved records on demand so that I can browse durable commitments without running a full planning command.
-
-**Why this priority**: Convenience over a capability already covered indirectly by recall; the exact surface is unresolved (SD-001). Deferrable.
-
-**Independent Test**: Invoke the engrave catalog mode with a topic/domain filter and confirm it lists matching records with id, kind, title, and status.
-
-**Acceptance Scenarios**:
-
-1. **Given** engraved records exist, **When** the catalog lookup mode is invoked (e.g. `smithy.engrave --list` with optional `--domain`/`--topic` filters), **Then** it returns matching records with id, kind, title, status, and path.
-2. **Given** no records match the filter, **When** the mode runs, **Then** it returns an explicit empty result rather than an error.
-
 ### Edge Cases
 
-- **Recall vs. deterministic authority overlap**: recall must not emit a cites-superseded finding that contradicts the TS stale-ref check; lifecycle is read-only ground truth for recall (see SD-005 for whether recall consumes status JSON or reads frontmatter directly).
 - **Already-accepted exceptions**: recall must suppress a conflict flag when an `Accepted:` ledger row already covers the divergence.
-- **`deprecated` vs `superseded` decisions**: retired-without-replacement vs replaced-by-new-decision drive different next-action guidance.
-- **Scan-root expansion side effects**: adding engraved roots to `SCAN_ROOTS` must not change the canonical-layout fast-path/fallback detection for repos that have only planning artifacts.
-- **Principle discovery without a suffix**: principles are found by directory walk of the constitution dir, not by a `SUFFIX_TYPES` entry — a distinct discovery code path.
-- **Projection coexisting with hand-written prose**: the root CLAUDE.md already has a hand-written "Engraved Knowledge" section with no markers; projection must add its managed block as a distinct region and never overwrite that prose.
-- **Cross-domain `design` roots**: `docs/design/{decisions,invariants,constitution}` discovery is optional per #416 (see SD-003).
-- **Empty repo / zero matches**: recall, projection, catalog lookup, and status all behave gracefully when no engraved records exist.
+- **`deprecated` vs `superseded` decisions**: retired-without-replacement vs replaced-by-new-decision drive different recall guidance.
+- **Projection coexisting with hand-written prose**: the root CLAUDE.md already has a hand-written "Engraved Knowledge" section with no markers; the projection pointer block must be a distinct region and never overwrite that prose.
+- **No engraved-knowledge directories present**: projection on first engrave creates the directories' pointer based on what exists; recall and projection both behave gracefully when no records/directories exist.
+- **Cross-domain `design` locations**: `docs/design/{decisions,invariants,constitution}` handling for recall and the projection pointer is optional (see SD-002).
+- **Principle discovery without a suffix**: recall and the projection pointer locate principles by the constitution directory, not by a suffix.
 
 ## Dependency Order
 
@@ -161,106 +107,77 @@ Recommended implementation sequence:
 
 | ID | Title | Depends On | Artifact |
 |----|-------|-----------|----------|
-| US1 | Status Recognizes Engraved Records as a First-Class Type | — | — |
-| US2 | Planning Commands Recall Relevant Engraved Knowledge | — | — |
-| US3 | Engrave Projects Engraved Knowledge into Agent-Context Files | — | — |
-| US4 | Status Surfaces Engraved Graph Edges and Stale References | US1 | — |
-| US5 | Orders Scaffolds Tickets for Engraved Records | — | — |
-| US6 | Audit Validates Engraved Record Quality | — | — |
-| US7 | Ad-Hoc Engraved Catalog Lookup | — | — |
+| US1 | Planning Commands Recall Relevant Engraved Knowledge | — | — |
+| US2 | Engrave Projects an Engraved-Knowledge Pointer into Agent-Context Files | — | — |
+| US3 | Orders Scaffolds Tickets for Engraved Records | — | — |
+| US4 | Audit Validates Engraved Record Quality | — | — |
 
-US1, US2, US3, US5, US6, and US7 have no upstream dependency on one another — six independent entry points enabling parallel start. Only US4 (graph/surface/stale-ref) has a true data-flow prerequisite on US1's type surface. Recall (US2) deliberately reads engraved files directly and therefore does **not** depend on the status work (US1/US4).
+All four user stories are independent — four parallel entry points with no cross-story prerequisites. They share only the frozen engraved-record frontmatter schema as a read-only input.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-**Status discovery & classification (US1, #416)**
+**Recall (US1, #415)**
 
-- **FR-001**: The system MUST add `'engraved'` to the `ArtifactType` union and audit every exhaustive `switch (type)` and `Record<ArtifactType, …>` site (including `ScanSummary.counts`) so the new member is handled.
-- **FR-002**: The scanner MUST discover engraved records by suffix (`.decision.md`, `.invariant.md`) and by directory walk of the constitution directory (principles have no suffix), adding `docs/decisions`, `docs/invariants`, and `docs/constitution` to the scan roots.
-- **FR-003**: The system MUST parse engraved frontmatter (`kind`, `domain`, `status`, `topics`, `scope`, `applies_to`, `supersedes`, `superseded_by`, `establishes`, `established_by`) and the Known-Exceptions ledger into a structured record, using a parser that bypasses the `## Dependency Order` grammar.
-- **FR-004**: The system MUST classify invariants on an alignment axis: `drifting` when the ledger has ≥1 `Temporary:` row, otherwise `aligned`; the canonical empty (em-dash) ledger row MUST yield zero exceptions and `aligned`.
-- **FR-005**: Engraved records MUST be excluded from the build/completion rollup and MUST NOT be assigned `M<N>`/`F<N>`/`US<N>`/`S<N>` IDs or appear as Dependency Order rows.
-- **FR-006**: Engraved records MUST appear in `smithy status --format json` with their type, kind, lifecycle/alignment, and citation/supersedes/establishes fields.
+- **FR-001**: The system MUST provide a read-only `smithy-recall` sub-agent (tools `Read`, `Grep`, `Glob`; non-interactive; modeled on `smithy-scout`; not user-invocable) that reads engraved record files directly and returns records ranked by relevance computed from `domain`/`topics`/`scope`/`applies_to` overlap with the planning context.
+- **FR-002**: Recall MUST flag proposed work that conflicts with an invariant `## Rule` as a candidate new exception (soft flag), suppressing the flag when an existing `Accepted:` ledger row already covers the divergence.
+- **FR-003**: Recall MUST flag citations (in the planning context or draft artifact) to `superseded` or `deprecated` records, reading record lifecycle from frontmatter as read-only ground truth; it MUST NOT independently recompute the supersession/establishes graph.
+- **FR-004**: Recall MUST be domain-aware: it queries `system`, `design`, or both partitions according to the planning context's domain, and MUST return a well-formed empty result (`empty: true` with an `empty_reason` distinguishing "no records exist" from "records exist, none matched") when nothing applies.
+- **FR-005**: The system MUST provide a `consult-engraved-knowledge` snippet wired into the scan phase of `strike`, `ignite`, `render`, `mark`, and `cut`. The snippet MUST be self-sufficient: a Claude fast-path that dispatches `smithy-recall`, plus an inline degraded path (read the scan roots directly) for Gemini/Codex, which have no sub-agents. It MUST be registered in `snippets/README.md`.
+- **FR-006**: Planning commands MUST fold recall's conflict and superseded-citation findings into their clarification/debt handling.
 
-**Recall (US2, #415)**
+**Projection (US2, new)**
 
-- **FR-007**: The system MUST provide a read-only `smithy-recall` sub-agent (tools `Read`, `Grep`, `Glob`; non-interactive; modeled on `smithy-scout`) that reads engraved record files directly and returns records ranked by relevance computed from `domain`/`topics`/`scope`/`applies_to` overlap with the planning context.
-- **FR-008**: Recall MUST flag proposed work that conflicts with an invariant `## Rule` as a candidate new exception (soft flag), suppressing the flag when an existing `Accepted:` ledger row already covers the divergence.
-- **FR-009**: Recall MUST flag citations to `superseded` or `deprecated` records, treating record lifecycle as read-only ground truth and never independently recomputing the supersession/establishes graph.
-- **FR-010**: Recall MUST be domain-aware: it queries `system`, `design`, or both partitions according to the planning context's domain, and MUST return a well-formed empty result when no records exist or none match.
-- **FR-011**: The system MUST provide a `consult-engraved-knowledge` snippet wired into the scan phase of `strike`, `ignite`, `render`, `mark`, and `cut`. The snippet MUST be self-sufficient: a Claude fast-path that dispatches `smithy-recall`, plus an inline degraded path (read the scan roots directly) for Gemini/Codex, which have no sub-agents. It MUST be registered in `snippets/README.md`.
-- **FR-012**: Planning commands MUST fold recall's conflict and superseded-citation findings into their clarification/debt handling.
+- **FR-007**: `smithy.engrave` MUST, after engraving or superseding a record, ensure a managed block delimited by `<!-- smithy:engraved:begin -->` / `<!-- smithy:engraved:end -->` exists in the repo's agent-context files, whose content is a **pointer** to the engraved-knowledge locations plus a short note instructing agents to read those records and judge applicability. The block MUST NOT inline record bodies or a per-record list.
+- **FR-008**: The pointer MUST reflect the engraved-knowledge directories actually present in the repo (e.g. `docs/decisions/`, `docs/invariants/`, `docs/constitution/`, and design-domain variants when present).
+- **FR-009**: Projection MUST be idempotent (a no-change re-run produces a byte-identical file), MUST replace only content between the markers, MUST never modify content outside the markers, and MUST add a fresh block at a defined anchor when no markers exist.
+- **FR-010**: Projection MUST manage only agent-context files that already exist (never create missing ones) and MUST abort projection for a file whose markers are malformed/duplicated, with a warning, without failing the underlying engrave operation.
 
-**Projection (US3, new)**
+**Orders (US3, #418)**
 
-- **FR-013**: `smithy.engrave` MUST, after engraving or superseding a record, refresh a managed block delimited by `<!-- smithy:engraved:begin -->` / `<!-- smithy:engraved:end -->` in the repo's agent-context files.
-- **FR-014**: The managed block MUST list live records only — `accepted` decisions, `aligned`/`drifting` invariants, and `active` principles — each with id, kind, title, and status, sorted deterministically by `id`, excluding `superseded`/`deprecated` decisions.
-- **FR-015**: Projection MUST be idempotent (a no-change re-run produces a byte-identical file), MUST replace only content between the markers, MUST never modify content outside the markers, and MUST append a fresh block at a defined anchor when no markers exist.
-- **FR-016**: Projection MUST manage only agent-context files that already exist (never create missing ones) and MUST abort projection for a file whose markers are malformed/duplicated, with a warning, without failing the underlying engrave operation.
+- **FR-011**: `smithy.orders` MUST support `decision` and `invariant` (and optionally `principle`, per SD-003) by adding entries to `ORDERS_DEFAULT_TEMPLATES`/`ORDERS_TEMPLATE_TYPES` and the `smithy.orders.prompt` heredoc in lockstep, with the `src/templates.test.ts` parity assertion extended to cover them.
 
-**Graph, surface & stale-ref (US4, #417)**
+**Audit (US4, #418)**
 
-- **FR-017**: The graph MUST add `citation` (spec/RFC/decision → invariant/principle), `supersedes` (decision → decision), and `establishes` (decision → invariant) edges derived from engraved frontmatter.
-- **FR-018**: The stale-ref check MUST flag any artifact that cites a `superseded` decision, extending the existing dangling-reference machinery. (Whether invariants can themselves be `deprecated` — and thus produce a second stale-ref class — is unresolved against the frozen schema; see SD-007.)
-- **FR-019**: The status render MUST present a "Decisions & Invariants" group showing alignment and decision lifecycle, and the suggester MUST emit next-actions for drifting invariants (review exceptions) and superseded citations (review/update).
-
-**Orders & audit (US5/US6, #418)**
-
-- **FR-020**: `smithy.orders` MUST support `decision` and `invariant` (and optionally `principle`, per SD-004) by adding entries to `ORDERS_DEFAULT_TEMPLATES`/`ORDERS_TEMPLATE_TYPES` and the `smithy.orders.prompt` heredoc in lockstep, with the `src/templates.test.ts` parity assertion extended to cover them.
-- **FR-021**: The system MUST provide an `audit-checklist-engraved` snippet wired into `smithy.audit`'s type-selection mechanism, checking: decision states its desired invariant; invariant cites its decisions and keeps a ledger; no citation to a superseded decision; record is genuinely pivot-level.
-
-**Catalog lookup (US7, #415 standalone)**
-
-- **FR-022**: The system MUST provide an ad-hoc engraved catalog lookup mode (surface unresolved — SD-001) that lists records filtered by domain/topic and returns id, kind, title, status, and path, with an explicit empty result when nothing matches.
+- **FR-012**: The system MUST provide an `audit-checklist-engraved` snippet wired into `smithy.audit`'s type-selection mechanism, checking: decision states its desired invariant; invariant cites its decisions and keeps a ledger with the load-bearing column order; no citation to a superseded decision; record is genuinely pivot-level.
 
 ### Key Entities *(include if feature involves data)*
 
-- **Engraved Record**: a decision, invariant, or principle file. On-disk schema is owned by `smithy.engrave.prompt`; this feature adds its in-memory representation to the status subsystem. See `engraved-knowledge-recall-and-reference.data-model.md`.
-- **Known Exception**: a row in an invariant's ledger (`where`, `what diverges`, disposition `Accepted`/`Temporary`, tracking issue, severity) that drives alignment.
-- **Graph Edge**: `citation` / `supersedes` / `establishes` relationships among records and artifacts.
-- **Stale Reference**: an artifact citing a superseded decision or deprecated invariant.
+- **Engraved Record** *(reference only)*: a decision, invariant, or principle file. The on-disk schema is **frozen** and owned by `smithy.engrave.prompt`; this feature reads it but does not extend or persist it. See `engraved-knowledge-recall-and-reference.data-model.md`.
+- **Known Exception**: a row in an invariant's ledger (`where`, `what diverges`, disposition `Accepted`/`Temporary`, tracking issue, severity) that recall uses to decide whether a conflict is already covered.
 - **Recall Result**: the transient, prompt-layer ranked relevance + conflict/superseded findings returned by `smithy-recall` (not persisted).
-- **Projection Block**: the managed, marker-delimited region written into agent-context files.
+- **Projection Pointer Block**: the managed, marker-delimited region written into agent-context files — a pointer to the engraved-knowledge locations, not a record copy.
 
 ## Assumptions
 
-- This single spec covers the entire remaining epic plus the new projection capability. `[Critical Assumption]`
-- Recall reads engraved files directly (Grep/Glob), so #415 does not depend on #416 and the two can be built in parallel. `[Critical Assumption]`
-- The deterministic TS subsystem owns lifecycle/edges/stale-refs; recall owns only semantic relevance and conflict-with-draft, treating lifecycle as ground truth. `[Critical Assumption]`
+- Status-subsystem integration (#416/#417) is out of scope for this spec; engraved knowledge is surfaced via recall and the projection pointer, not `smithy status`. `[Critical Assumption]`
+- Recall reads engraved files directly (Grep/Glob) and treats frontmatter as ground truth, so it has no dependency on a status index. `[Critical Assumption]`
+- The projection block is a pointer + applicability note, not a record index, so the reading agent controls how much it loads. `[Critical Assumption]`
 - The `consult-engraved-knowledge` snippet is self-sufficient with a Claude sub-agent fast-path and an inline degraded path for Gemini/Codex. `[Critical Assumption]`
-- `Alignment` is modeled as a separate axis from the existing `Status` union; engraved records are excluded from the completion rollup.
-- The projection block lists a deterministic full live index sorted by `id` (not an LLM-curated subset), so idempotency holds.
-- Projection manages only existing agent-context files and never creates missing ones; the exact default target set (CLAUDE.md, AGENTS.md, possibly `.github/copilot-instructions.md`) is unresolved — see SD-002.
+- Recall is a sub-agent dispatched only by planning commands; it is not user-invocable.
 - The engraved frontmatter schema is frozen and owned by `smithy.engrave.prompt`; this spec references it rather than redefining it.
 
 ## Specification Debt
 
 | ID | Description | Source Category | Impact | Confidence | Status | Resolution |
 |----|-------------|-----------------|--------|------------|--------|------------|
-| SD-001 | Unresolved choice for the ad-hoc catalog-lookup surface: a `--list`/query flag on `smithy.engrave` vs. a separate `smithy.engraved` command (the latter expands the deploy surface across all three agents). | Functional Scope | Medium | Medium | open | — |
-| SD-002 | Which agent-context files projection manages by default (CLAUDE.md only, also AGENTS.md, also `.github/copilot-instructions.md`) and whether the target set is configurable. | Integration | Medium | Medium | open | — |
-| SD-003 | Whether the optional `design`-domain scan roots (`docs/design/{decisions,invariants,constitution}`) are in scope for this spec or deferred (#416 marks them optional). | Functional Scope | Low | Medium | open | — |
-| SD-004 | Whether `principle` gets an orders template, given principles have no suffix for `smithy.orders` auto-detection (#418 says "optionally"). | Domain & Data Model | Low | Medium | open | — |
-| SD-005 | Whether recall consumes the deterministic stale-ref output via `smithy status --format json` (a physically enforced ownership boundary) or reads record frontmatter directly (looser coupling, lighter dependency). | Integration | Medium | Medium | open | — |
-| SD-006 | How spec/RFC artifacts declare citations to engraved records — the `citation` edge (FR-017) and stale-ref predicate (FR-018) both depend on a citation source that the frozen frontmatter schema does not define (engraved records carry outbound edges, but the planning-artifact side has no defined citation field/syntax). | plan-review:Logical gap | Important | Low | open | — |
-| SD-007 | Whether invariants can be `deprecated` (and thus form a second stale-ref class): #417 wants "deprecated invariant" citations flagged, but the frozen engrave schema gives invariants only the `aligned`/`drifting` alignment axis with no lifecycle/deprecated state. | plan-review:Internal contradiction | Minor | Low | open | — |
+| SD-001 | Which agent-context files projection manages by default (CLAUDE.md only, also AGENTS.md, also `.github/copilot-instructions.md`) and whether the target set is configurable. | Integration | Medium | Medium | open | — |
+| SD-002 | Whether the optional `design`-domain locations (`docs/design/{decisions,invariants,constitution}`) are in scope for recall and the projection pointer now, or deferred. | Functional Scope | Low | Medium | open | — |
+| SD-003 | Whether `principle` gets an orders template, given principles have no suffix for `smithy.orders` auto-detection (#418 says "optionally"). | Domain & Data Model | Low | Medium | open | — |
 
 ## Out of Scope
 
+- **Status-subsystem integration (#416 scanner/parser/classifier, #417 graph edges/surface/stale-ref)** — making engraved records a first-class type in `smithy status` and the build rollup. Deferred and reconsidered separately; engraved knowledge "is durable commitment, not work to be done," so it is surfaced via recall and the projection pointer rather than the status rollup.
 - Re-specifying or modifying the engraved-knowledge frontmatter schema or the `smithy.engrave` authoring phases (shipped in #413/#414).
+- A user-facing standalone `smithy.recall` (or `smithy.engraved`) command and any ad-hoc catalog-lookup surface — recall is a sub-agent only.
 - The UI design pipeline (screens/flows, Claude Design, forge-builds-UI) — tracked under EPIC #404.
-- A persisted generated engraved-index artifact (e.g. `engraved.index.json`) shared by recall/status/projection — noted as a possible future optimization, not built here.
-- Any user-facing standalone `smithy.recall` command (recall is a sub-agent only).
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
 
-- **SC-001**: `smithy status --format json` reports every `*.decision.md`, `*.invariant.md`, and constitution principle in the canonical directories as a first-class `engraved` record with correct kind and alignment/lifecycle.
-- **SC-002**: Each of the five wired planning commands (`strike`, `ignite`, `render`, `mark`, `cut`) consults engraved knowledge in its scan phase under all three agents (Claude via sub-agent; Gemini/Codex via the degraded inline path).
-- **SC-003**: Recall returns relevant records and correctly flags ≥1 invariant conflict and ≥1 superseded citation in a seeded test scenario, with zero conflict flags for divergences already covered by an `Accepted:` ledger row.
-- **SC-004**: Engraving a record updates the managed block in every existing target agent-context file; a no-change re-run leaves those files byte-identical; hand-written prose is never altered.
-- **SC-005**: `smithy status` shows a "Decisions & Invariants" group and emits a stale-ref warning for an artifact citing a superseded decision, plus a next-action for a drifting invariant.
-- **SC-006**: `smithy.orders` scaffolds tickets for decision and invariant files and the templates parity test passes; `smithy.audit` applies the engraved checklist to an engraved record.
+- **SC-001**: Each of the five wired planning commands (`strike`, `ignite`, `render`, `mark`, `cut`) consults engraved knowledge in its scan phase under all three agents (Claude via sub-agent; Gemini/Codex via the degraded inline path).
+- **SC-002**: Recall returns relevant records and correctly flags ≥1 invariant conflict and ≥1 superseded citation in a seeded test scenario, with zero conflict flags for divergences already covered by an `Accepted:` ledger row.
+- **SC-003**: Engraving a record ensures the pointer block in every existing target agent-context file; a no-change re-run leaves those files byte-identical; hand-written prose is never altered.
+- **SC-004**: `smithy.orders` scaffolds tickets for decision and invariant files and the templates parity test passes; `smithy.audit` applies the engraved checklist to an engraved record.

--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.spec.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.spec.md
@@ -75,7 +75,7 @@ As a developer adding a `Temporary:` exception to an invariant, I want `smithy.e
 1. **Given** `smithy.engrave <invariant-path> exception` adds a `Temporary:` row, **When** the row is written, **Then** a GitHub issue is scaffolded (via the `smithy.gh-issue` skill) titled from the divergence and bodied with the invariant id/title, the divergence, and the establishing decision(s), and its `#NNN` is written into that row's `Tracking Issue` column.
 2. **Given** an `Accepted:` exception is added (a permanent carve-out, not drift), **When** the row is written, **Then** no issue is created and the row's `Tracking Issue` cell stays `—`.
 3. **Given** issue creation fails (auth/network), **When** the exception is added, **Then** the ledger row is still written (with `Tracking Issue` left `—`) and the failure is surfaced — the engrave operation does not roll back.
-4. **Given** a `Temporary:` exception is later resolved (drift closed, or converted to `Accepted:`), **When** the ledger is updated, **Then** the linked issue is handled per the resolution of SD-003.
+4. **Given** a `Temporary:` exception is later resolved (drift closed, or converted to `Accepted:`), **When** the ledger is updated, **Then** engrave leaves the linked drift-tracking issue **open** for a human to close — it does not auto-close or comment on the issue (engrave mutates GitHub only on exception creation).
 
 ---
 
@@ -170,7 +170,7 @@ All four user stories are independent — four parallel entry points with no cro
 |----|-------------|-----------------|--------|------------|--------|------------|
 | SD-001 | Which agent-context files projection manages by default (CLAUDE.md only, also AGENTS.md, also `.github/copilot-instructions.md`) and whether the target set is configurable. | Integration | Medium | Medium | open | — |
 | SD-002 | Whether the optional `design`-domain locations (`docs/design/{decisions,invariants,constitution}`) are in scope for recall and the projection pointer now, or deferred. | Functional Scope | Low | Medium | open | — |
-| SD-003 | When a `Temporary:` exception is later resolved (removed or converted to `Accepted:`), whether engrave should auto-close the linked drift-tracking issue, leave it open, or comment-and-leave. | Integration | Low | Medium | open | — |
+| SD-003 | When a `Temporary:` exception is later resolved (removed or converted to `Accepted:`), whether engrave should auto-close the linked drift-tracking issue, leave it open, or comment-and-leave. | Integration | Low | Medium | resolved | Resolved 2026-06-06 — engrave leaves the linked issue **open** for a human to close. Engrave mutates GitHub only when a `Temporary:` exception is created, never on resolve. |
 
 ## Out of Scope
 

--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.spec.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.spec.md
@@ -1,0 +1,266 @@
+# Feature Specification: Engraved Knowledge Recall and Reference
+
+**Spec Folder**: `2026-06-06-012-engraved-knowledge-recall-and-reference`
+**Branch**: `feature/epic-412-engraving-decisions` *(pre-staged linked worktree on the epic branch; preserved per the branch-selection policy rather than auto-named)*
+**Created**: 2026-06-06
+**Status**: Draft
+**Input**: User feature description + GitHub EPIC #412 ("Engraved durable knowledge — decisions/invariants/principles") and its open sub-issues #415, #416, #417, #418. The authoring half (#413 schema, #414 `smithy.engrave`) is already shipped. This spec covers the entire *remaining* epic — making engraved knowledge discoverable, recallable during planning, referenced in agent-context files, and audited.
+
+## Clarifications
+
+### Session 2026-06-06
+
+- _Scope: this single spec covers the entire remaining epic — #415 (recall), #416 (status discovery), #417 (graph/surface/stale-ref), #418 (orders/audit) — plus a new engrave→agent-context projection capability not tracked by any sub-issue._ `[Critical Assumption]`
+- _Recall is a planning-time **sub-agent** (`smithy-recall`), not a user-invocable command. Ad-hoc catalog lookup is exposed as a mode/flag on `smithy.engrave`. (User-confirmed; the `smithy.engrave` flag vs. a separate `smithy.engraved` command is unresolved — see SD-001.)_
+- _The Agents.md/Claude.md reference capability is a new **projection step on `smithy.engrave`** that refreshes a managed, regenerable block when a record is engraved or superseded. (User-confirmed.)_
+- _Recall reads engraved record files directly (Grep/Glob/Read, modeled on `smithy-scout`); it does **not** consume the status scanner's output, so recall does not depend on #416._ `[Critical Assumption]`
+- _The deterministic TS status subsystem is the sole authority for lifecycle, citation/supersedes/establishes edges, and stale-reference detection. The recall sub-agent owns only semantic relevance ranking and conflict-with-proposed-work judgment; it treats record lifecycle as read-only ground truth and never recomputes the graph._ `[Critical Assumption]`
+- _Engraved records sit on a separate **alignment** axis (`aligned` / `drifting`) plus decision lifecycle (`proposed`/`accepted`/`superseded`/`deprecated`) and principle `active`; they are excluded from the build/status completion rollup and never appear as `## Dependency Order` rows._
+- _The engraved-knowledge frontmatter schema (kinds, fields, suffixes, ledger column order) is **frozen** and owned by `src/templates/agent-skills/commands/smithy.engrave.prompt`. This spec references it as the source of truth and does not redefine it._
+
+## Artifact Hierarchy
+
+RFC → Milestone → Feature → User Story → Slice → Tasks
+
+This feature is the recall/reference half of EPIC #412. The engraved records it operates on are **roots** in the planning graph — they participate via citation / supersedes / establishes edges, never as Dependency Order rows.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1: Status Recognizes Engraved Records as a First-Class Type (Priority: P1)
+
+As a developer running `smithy status`, I want decisions, invariants, and principles discovered and reported as a first-class artifact family so that durable commitments are visible alongside planning artifacts instead of being invisible to tooling.
+
+**Why this priority**: This is the foundation #417 (US4) builds on, and it is the smallest increment that makes engraved records exist in tooling. Maps to sub-issue #416, the status-side anchor of the remaining epic.
+
+**Independent Test**: Place sample `*.decision.md`, `*.invariant.md`, and a constitution principle file in the canonical directories, run `smithy status --format json`, and confirm each record appears with `type: "engraved"`, its `kind`, and its alignment/lifecycle — without any planning-artifact dependency-order error.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repo containing `docs/decisions/x.decision.md`, `docs/invariants/y.invariant.md`, and `docs/constitution/z.md`, **When** the scanner runs, **Then** all three are discovered as `type: 'engraved'` records carrying `kind` (`decision`/`invariant`/`principle`), and none is reported as a malformed dependency-order artifact.
+2. **Given** an invariant whose Known-Exceptions ledger contains at least one `Temporary:` row, **When** the record is classified, **Then** its alignment is `drifting`; **Given** a ledger with only `Accepted:` rows or the single em-dash placeholder row, **Then** its alignment is `aligned`.
+3. **Given** a decision with `status: accepted` / `superseded` / `deprecated`, **When** classified, **Then** the decision lifecycle is reported and the record is **excluded** from the build/completion rollup (it does not affect any parent's `completed/total`).
+4. **Given** `ArtifactType` now includes `'engraved'`, **When** the project type-checks and tests run, **Then** every exhaustive `switch (type)` and every `Record<ArtifactType, …>` (notably `ScanSummary.counts`) compiles and behaves correctly, and existing 4-type enumeration tests are updated to account for the new member.
+5. **Given** an invariant with the canonical empty ledger (one row of `—` in every column), **When** parsed, **Then** it yields zero exceptions (no phantom exception) and alignment `aligned`.
+
+---
+
+### User Story 2: Planning Commands Recall Relevant Engraved Knowledge (Priority: P1)
+
+As a developer (or arbitrary agent) running a smithy planning command, I want the command to surface the decisions, invariants, and principles relevant to the work at hand — and to flag when my new work conflicts with an invariant or cites a superseded decision — so that durable commitments actively steer new plans instead of being silently ignored.
+
+**Why this priority**: This is the headline value of the epic and the user's primary ask ("update the various smithy skills to reference these engraved pieces of information"). Maps to sub-issue #415.
+
+**Independent Test**: With a few engraved records present, invoke a planning command's scan phase against a feature description whose topics overlap one invariant and cite a superseded decision; confirm the command receives a ranked list of relevant records plus a conflict flag and a superseded-citation flag, and folds them into clarification.
+
+**Acceptance Scenarios**:
+
+1. **Given** engraved records exist and a planning context with topic/scope hints, **When** the `smithy-recall` sub-agent is dispatched, **Then** it returns decisions/invariants/principles ranked by relevance computed from `domain`/`topics`/`scope`/`applies_to` overlap, each with a one-line relevance basis.
+2. **Given** the proposed work would contradict an invariant's `## Rule`, **When** recall runs, **Then** it returns that invariant as a **candidate new exception** (a soft flag, not a hard block) — unless an existing `Accepted:` ledger row already covers that divergence, in which case it is not re-flagged.
+3. **Given** the planning artifact or proposed work cites a decision whose `status` is `superseded` or `deprecated`, **When** recall runs, **Then** it reports a superseded/deprecated-citation hazard, reading lifecycle from the record frontmatter (or the deterministic status output) as ground truth — it does not independently re-derive supersession.
+4. **Given** a feature that spans both `system` and `design` work, **When** recall runs, **Then** it queries both domain partitions; **Given** single-domain work, **Then** it filters to that domain.
+5. **Given** no engraved records exist in the repo, **When** recall runs, **Then** it returns a well-formed empty result ("no engraved knowledge in repo") and the planning command proceeds normally — it does not error.
+6. **Given** the `{{>consult-engraved-knowledge}}` snippet is wired into the scan phase of `strike`, `ignite`, `render`, `mark`, and `cut`, **When** any of those commands runs under Claude, **Then** it dispatches `smithy-recall`; **When** run under Gemini or Codex (which have no sub-agents), **Then** the inlined snippet's degraded path reads the engraved scan roots directly so engraved knowledge is still consulted.
+
+---
+
+### User Story 3: Engrave Projects Engraved Knowledge into Agent-Context Files (Priority: P1)
+
+As a developer who just engraved or superseded a record, I want `smithy.engrave` to refresh a managed, regenerable block in the repo's agent-context files (CLAUDE.md / AGENTS.md) listing the current durable commitments so that arbitrary agents — not just smithy commands — see the engraved knowledge without any extra tooling.
+
+**Why this priority**: The user's explicit second ask ("ask it to update some Agents.md/Claude.md file to reference said decisions"). New capability with no sub-issue; additive scope flagged as such.
+
+**Independent Test**: Engrave a decision in a repo whose CLAUDE.md has hand-written prose but no markers; confirm a marked block is appended listing the live records, the hand-written prose is untouched, and re-running with no record change leaves the file byte-identical.
+
+**Acceptance Scenarios**:
+
+1. **Given** an agent-context file with no managed markers, **When** a record is engraved/superseded, **Then** a fresh block delimited by `<!-- smithy:engraved:begin -->` / `<!-- smithy:engraved:end -->` is appended at a defined anchor, and no content outside the markers is modified.
+2. **Given** a file that already contains the marker pair, **When** projection runs, **Then** only the content between the markers is replaced; **Given** no record has changed since the last run, **Then** the file is byte-identical (idempotent; records sorted deterministically by `id`).
+3. **Given** the set of live records, **When** the block is generated, **Then** it lists `accepted` decisions, `aligned`/`drifting` invariants, and `active` principles (each with id, kind, title, status) and **excludes** `superseded`/`deprecated` decisions so agents see only live commitments.
+4. **Given** a configured agent-context target file that does not exist on disk, **When** projection runs, **Then** that target is skipped (projection manages existing files only and never creates new ones); present targets are each updated.
+5. **Given** a file whose markers are malformed or duplicated, **When** projection runs, **Then** it aborts the projection for that file with a warning rather than guessing where the block belongs, and the engrave operation itself still succeeds.
+
+---
+
+### User Story 4: Status Surfaces Engraved Graph Edges and Stale References (Priority: P2)
+
+As a developer reviewing repository health, I want `smithy status` to show the citation/supersedes/establishes relationships for engraved records, group them under a "Decisions & Invariants" heading, and warn when an artifact cites a superseded decision or deprecated invariant so that drift and stale references are caught deterministically.
+
+**Why this priority**: Builds directly on US1's type surface and completes the status-side story (#417). Valuable but secondary to discovery (US1) and recall (US2).
+
+**Independent Test**: With a spec that cites a superseded decision and a drifting invariant present, run `smithy status` and confirm the engraved group renders with alignment/lifecycle, a stale-ref warning is emitted, and a next-action is suggested.
+
+**Acceptance Scenarios**:
+
+1. **Given** engraved records and artifacts that reference them, **When** the graph is built, **Then** it contains `citation` edges (spec/RFC/decision → invariant/principle), `supersedes` edges (decision → decision), and `establishes` edges (decision → invariant).
+2. **Given** an artifact citing a decision whose `status` is `superseded`, **When** the stale-ref check runs, **Then** that reference is flagged as a stale reference extending the existing dangling-reference machinery. (A deprecated-invariant stale-ref class is pending SD-007.)
+3. **Given** engraved records exist, **When** the tree renders, **Then** a "Decisions & Invariants" group appears showing each record's alignment (`aligned`/`drifting`) and decision lifecycle.
+4. **Given** a `drifting` invariant, **When** next-actions are computed, **Then** the suggester recommends reviewing the exceptions ledger; **Given** an artifact citing a superseded decision, **Then** it recommends reviewing/updating the citation.
+
+---
+
+### User Story 5: Orders Scaffolds Tickets for Engraved Records (Priority: P2)
+
+As a developer using `smithy.orders`, I want to scaffold GitHub issues for decisions and invariants from their files so that engraved work can be tracked with the same issue-creation flow as planning artifacts.
+
+**Why this priority**: Additive, low-risk, independent of all other stories; maps to the orders half of #418. Useful polish, not core capability.
+
+**Independent Test**: Run `smithy.orders` against a `*.decision.md` and a `*.invariant.md` and confirm structured issue bodies are produced, and the orders-template parity test passes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `*.decision.md` or `*.invariant.md` file, **When** `smithy.orders` auto-detects its type by suffix, **Then** it scaffolds a ticket body from the corresponding engraved orders template.
+2. **Given** new `decision`/`invariant` entries added to `ORDERS_DEFAULT_TEMPLATES`/`ORDERS_TEMPLATE_TYPES`, **When** the `smithy.orders.prompt` heredoc parity test runs, **Then** both surfaces match and the parity assertion in `src/templates.test.ts` passes (extended to cover the new types).
+3. **Given** a principle file (no suffix), **When** orders runs, **Then** behavior follows the resolution of SD-004 (principle template included, or principles excluded from orders auto-detection with a documented note).
+
+---
+
+### User Story 6: Audit Validates Engraved Record Quality (Priority: P3)
+
+As a developer auditing a durable-knowledge record, I want `smithy.audit` to check engraved records against a dedicated checklist so that decisions, invariants, and principles stay well-formed as they proliferate.
+
+**Why this priority**: A safety net rather than core capability; deferrable. Maps to the audit half of #418.
+
+**Independent Test**: Run `smithy.audit` against an invariant missing its citations and confirm the engraved checklist flags it.
+
+**Acceptance Scenarios**:
+
+1. **Given** an engraved record path, **When** `smithy.audit` selects a checklist by artifact type, **Then** it uses the new `audit-checklist-engraved` snippet (the audit type-selection mechanism is extended to recognize engraved records).
+2. **Given** a decision, **When** audited, **Then** the checklist verifies it states a desired invariant where applicable, that `establishes`/`established_by` reciprocity holds, and that no citation points at a superseded decision.
+3. **Given** an invariant, **When** audited, **Then** the checklist verifies it cites its establishing decisions, keeps a Known-Exceptions ledger with the load-bearing column order, and exposes no silent divergence.
+4. **Given** any engraved record, **When** audited, **Then** the checklist applies the inclusion test (is the record genuinely pivot-level?).
+
+---
+
+### User Story 7: Ad-Hoc Engraved Catalog Lookup (Priority: P3)
+
+As a developer, I want to list and filter existing engraved records on demand so that I can browse durable commitments without running a full planning command.
+
+**Why this priority**: Convenience over a capability already covered indirectly by recall; the exact surface is unresolved (SD-001). Deferrable.
+
+**Independent Test**: Invoke the engrave catalog mode with a topic/domain filter and confirm it lists matching records with id, kind, title, and status.
+
+**Acceptance Scenarios**:
+
+1. **Given** engraved records exist, **When** the catalog lookup mode is invoked (e.g. `smithy.engrave --list` with optional `--domain`/`--topic` filters), **Then** it returns matching records with id, kind, title, status, and path.
+2. **Given** no records match the filter, **When** the mode runs, **Then** it returns an explicit empty result rather than an error.
+
+### Edge Cases
+
+- **Recall vs. deterministic authority overlap**: recall must not emit a cites-superseded finding that contradicts the TS stale-ref check; lifecycle is read-only ground truth for recall (see SD-005 for whether recall consumes status JSON or reads frontmatter directly).
+- **Already-accepted exceptions**: recall must suppress a conflict flag when an `Accepted:` ledger row already covers the divergence.
+- **`deprecated` vs `superseded` decisions**: retired-without-replacement vs replaced-by-new-decision drive different next-action guidance.
+- **Scan-root expansion side effects**: adding engraved roots to `SCAN_ROOTS` must not change the canonical-layout fast-path/fallback detection for repos that have only planning artifacts.
+- **Principle discovery without a suffix**: principles are found by directory walk of the constitution dir, not by a `SUFFIX_TYPES` entry — a distinct discovery code path.
+- **Projection coexisting with hand-written prose**: the root CLAUDE.md already has a hand-written "Engraved Knowledge" section with no markers; projection must add its managed block as a distinct region and never overwrite that prose.
+- **Cross-domain `design` roots**: `docs/design/{decisions,invariants,constitution}` discovery is optional per #416 (see SD-003).
+- **Empty repo / zero matches**: recall, projection, catalog lookup, and status all behave gracefully when no engraved records exist.
+
+## Dependency Order
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|-----------|----------|
+| US1 | Status Recognizes Engraved Records as a First-Class Type | — | — |
+| US2 | Planning Commands Recall Relevant Engraved Knowledge | — | — |
+| US3 | Engrave Projects Engraved Knowledge into Agent-Context Files | — | — |
+| US4 | Status Surfaces Engraved Graph Edges and Stale References | US1 | — |
+| US5 | Orders Scaffolds Tickets for Engraved Records | — | — |
+| US6 | Audit Validates Engraved Record Quality | — | — |
+| US7 | Ad-Hoc Engraved Catalog Lookup | — | — |
+
+US1, US2, US3, US5, US6, and US7 have no upstream dependency on one another — six independent entry points enabling parallel start. Only US4 (graph/surface/stale-ref) has a true data-flow prerequisite on US1's type surface. Recall (US2) deliberately reads engraved files directly and therefore does **not** depend on the status work (US1/US4).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Status discovery & classification (US1, #416)**
+
+- **FR-001**: The system MUST add `'engraved'` to the `ArtifactType` union and audit every exhaustive `switch (type)` and `Record<ArtifactType, …>` site (including `ScanSummary.counts`) so the new member is handled.
+- **FR-002**: The scanner MUST discover engraved records by suffix (`.decision.md`, `.invariant.md`) and by directory walk of the constitution directory (principles have no suffix), adding `docs/decisions`, `docs/invariants`, and `docs/constitution` to the scan roots.
+- **FR-003**: The system MUST parse engraved frontmatter (`kind`, `domain`, `status`, `topics`, `scope`, `applies_to`, `supersedes`, `superseded_by`, `establishes`, `established_by`) and the Known-Exceptions ledger into a structured record, using a parser that bypasses the `## Dependency Order` grammar.
+- **FR-004**: The system MUST classify invariants on an alignment axis: `drifting` when the ledger has ≥1 `Temporary:` row, otherwise `aligned`; the canonical empty (em-dash) ledger row MUST yield zero exceptions and `aligned`.
+- **FR-005**: Engraved records MUST be excluded from the build/completion rollup and MUST NOT be assigned `M<N>`/`F<N>`/`US<N>`/`S<N>` IDs or appear as Dependency Order rows.
+- **FR-006**: Engraved records MUST appear in `smithy status --format json` with their type, kind, lifecycle/alignment, and citation/supersedes/establishes fields.
+
+**Recall (US2, #415)**
+
+- **FR-007**: The system MUST provide a read-only `smithy-recall` sub-agent (tools `Read`, `Grep`, `Glob`; non-interactive; modeled on `smithy-scout`) that reads engraved record files directly and returns records ranked by relevance computed from `domain`/`topics`/`scope`/`applies_to` overlap with the planning context.
+- **FR-008**: Recall MUST flag proposed work that conflicts with an invariant `## Rule` as a candidate new exception (soft flag), suppressing the flag when an existing `Accepted:` ledger row already covers the divergence.
+- **FR-009**: Recall MUST flag citations to `superseded` or `deprecated` records, treating record lifecycle as read-only ground truth and never independently recomputing the supersession/establishes graph.
+- **FR-010**: Recall MUST be domain-aware: it queries `system`, `design`, or both partitions according to the planning context's domain, and MUST return a well-formed empty result when no records exist or none match.
+- **FR-011**: The system MUST provide a `consult-engraved-knowledge` snippet wired into the scan phase of `strike`, `ignite`, `render`, `mark`, and `cut`. The snippet MUST be self-sufficient: a Claude fast-path that dispatches `smithy-recall`, plus an inline degraded path (read the scan roots directly) for Gemini/Codex, which have no sub-agents. It MUST be registered in `snippets/README.md`.
+- **FR-012**: Planning commands MUST fold recall's conflict and superseded-citation findings into their clarification/debt handling.
+
+**Projection (US3, new)**
+
+- **FR-013**: `smithy.engrave` MUST, after engraving or superseding a record, refresh a managed block delimited by `<!-- smithy:engraved:begin -->` / `<!-- smithy:engraved:end -->` in the repo's agent-context files.
+- **FR-014**: The managed block MUST list live records only — `accepted` decisions, `aligned`/`drifting` invariants, and `active` principles — each with id, kind, title, and status, sorted deterministically by `id`, excluding `superseded`/`deprecated` decisions.
+- **FR-015**: Projection MUST be idempotent (a no-change re-run produces a byte-identical file), MUST replace only content between the markers, MUST never modify content outside the markers, and MUST append a fresh block at a defined anchor when no markers exist.
+- **FR-016**: Projection MUST manage only agent-context files that already exist (never create missing ones) and MUST abort projection for a file whose markers are malformed/duplicated, with a warning, without failing the underlying engrave operation.
+
+**Graph, surface & stale-ref (US4, #417)**
+
+- **FR-017**: The graph MUST add `citation` (spec/RFC/decision → invariant/principle), `supersedes` (decision → decision), and `establishes` (decision → invariant) edges derived from engraved frontmatter.
+- **FR-018**: The stale-ref check MUST flag any artifact that cites a `superseded` decision, extending the existing dangling-reference machinery. (Whether invariants can themselves be `deprecated` — and thus produce a second stale-ref class — is unresolved against the frozen schema; see SD-007.)
+- **FR-019**: The status render MUST present a "Decisions & Invariants" group showing alignment and decision lifecycle, and the suggester MUST emit next-actions for drifting invariants (review exceptions) and superseded citations (review/update).
+
+**Orders & audit (US5/US6, #418)**
+
+- **FR-020**: `smithy.orders` MUST support `decision` and `invariant` (and optionally `principle`, per SD-004) by adding entries to `ORDERS_DEFAULT_TEMPLATES`/`ORDERS_TEMPLATE_TYPES` and the `smithy.orders.prompt` heredoc in lockstep, with the `src/templates.test.ts` parity assertion extended to cover them.
+- **FR-021**: The system MUST provide an `audit-checklist-engraved` snippet wired into `smithy.audit`'s type-selection mechanism, checking: decision states its desired invariant; invariant cites its decisions and keeps a ledger; no citation to a superseded decision; record is genuinely pivot-level.
+
+**Catalog lookup (US7, #415 standalone)**
+
+- **FR-022**: The system MUST provide an ad-hoc engraved catalog lookup mode (surface unresolved — SD-001) that lists records filtered by domain/topic and returns id, kind, title, status, and path, with an explicit empty result when nothing matches.
+
+### Key Entities *(include if feature involves data)*
+
+- **Engraved Record**: a decision, invariant, or principle file. On-disk schema is owned by `smithy.engrave.prompt`; this feature adds its in-memory representation to the status subsystem. See `engraved-knowledge-recall-and-reference.data-model.md`.
+- **Known Exception**: a row in an invariant's ledger (`where`, `what diverges`, disposition `Accepted`/`Temporary`, tracking issue, severity) that drives alignment.
+- **Graph Edge**: `citation` / `supersedes` / `establishes` relationships among records and artifacts.
+- **Stale Reference**: an artifact citing a superseded decision or deprecated invariant.
+- **Recall Result**: the transient, prompt-layer ranked relevance + conflict/superseded findings returned by `smithy-recall` (not persisted).
+- **Projection Block**: the managed, marker-delimited region written into agent-context files.
+
+## Assumptions
+
+- This single spec covers the entire remaining epic plus the new projection capability. `[Critical Assumption]`
+- Recall reads engraved files directly (Grep/Glob), so #415 does not depend on #416 and the two can be built in parallel. `[Critical Assumption]`
+- The deterministic TS subsystem owns lifecycle/edges/stale-refs; recall owns only semantic relevance and conflict-with-draft, treating lifecycle as ground truth. `[Critical Assumption]`
+- The `consult-engraved-knowledge` snippet is self-sufficient with a Claude sub-agent fast-path and an inline degraded path for Gemini/Codex. `[Critical Assumption]`
+- `Alignment` is modeled as a separate axis from the existing `Status` union; engraved records are excluded from the completion rollup.
+- The projection block lists a deterministic full live index sorted by `id` (not an LLM-curated subset), so idempotency holds.
+- Projection manages only existing agent-context files and never creates missing ones; the exact default target set (CLAUDE.md, AGENTS.md, possibly `.github/copilot-instructions.md`) is unresolved — see SD-002.
+- The engraved frontmatter schema is frozen and owned by `smithy.engrave.prompt`; this spec references it rather than redefining it.
+
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | Unresolved choice for the ad-hoc catalog-lookup surface: a `--list`/query flag on `smithy.engrave` vs. a separate `smithy.engraved` command (the latter expands the deploy surface across all three agents). | Functional Scope | Medium | Medium | open | — |
+| SD-002 | Which agent-context files projection manages by default (CLAUDE.md only, also AGENTS.md, also `.github/copilot-instructions.md`) and whether the target set is configurable. | Integration | Medium | Medium | open | — |
+| SD-003 | Whether the optional `design`-domain scan roots (`docs/design/{decisions,invariants,constitution}`) are in scope for this spec or deferred (#416 marks them optional). | Functional Scope | Low | Medium | open | — |
+| SD-004 | Whether `principle` gets an orders template, given principles have no suffix for `smithy.orders` auto-detection (#418 says "optionally"). | Domain & Data Model | Low | Medium | open | — |
+| SD-005 | Whether recall consumes the deterministic stale-ref output via `smithy status --format json` (a physically enforced ownership boundary) or reads record frontmatter directly (looser coupling, lighter dependency). | Integration | Medium | Medium | open | — |
+| SD-006 | How spec/RFC artifacts declare citations to engraved records — the `citation` edge (FR-017) and stale-ref predicate (FR-018) both depend on a citation source that the frozen frontmatter schema does not define (engraved records carry outbound edges, but the planning-artifact side has no defined citation field/syntax). | plan-review:Logical gap | Important | Low | open | — |
+| SD-007 | Whether invariants can be `deprecated` (and thus form a second stale-ref class): #417 wants "deprecated invariant" citations flagged, but the frozen engrave schema gives invariants only the `aligned`/`drifting` alignment axis with no lifecycle/deprecated state. | plan-review:Internal contradiction | Minor | Low | open | — |
+
+## Out of Scope
+
+- Re-specifying or modifying the engraved-knowledge frontmatter schema or the `smithy.engrave` authoring phases (shipped in #413/#414).
+- The UI design pipeline (screens/flows, Claude Design, forge-builds-UI) — tracked under EPIC #404.
+- A persisted generated engraved-index artifact (e.g. `engraved.index.json`) shared by recall/status/projection — noted as a possible future optimization, not built here.
+- Any user-facing standalone `smithy.recall` command (recall is a sub-agent only).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `smithy status --format json` reports every `*.decision.md`, `*.invariant.md`, and constitution principle in the canonical directories as a first-class `engraved` record with correct kind and alignment/lifecycle.
+- **SC-002**: Each of the five wired planning commands (`strike`, `ignite`, `render`, `mark`, `cut`) consults engraved knowledge in its scan phase under all three agents (Claude via sub-agent; Gemini/Codex via the degraded inline path).
+- **SC-003**: Recall returns relevant records and correctly flags ≥1 invariant conflict and ≥1 superseded citation in a seeded test scenario, with zero conflict flags for divergences already covered by an `Accepted:` ledger row.
+- **SC-004**: Engraving a record updates the managed block in every existing target agent-context file; a no-change re-run leaves those files byte-identical; hand-written prose is never altered.
+- **SC-005**: `smithy status` shows a "Decisions & Invariants" group and emits a stale-ref warning for an artifact citing a superseded decision, plus a next-action for a drifting invariant.
+- **SC-006**: `smithy.orders` scaffolds tickets for decision and invariant files and the templates parity test passes; `smithy.audit` applies the engraved checklist to an engraved record.


### PR DESCRIPTION
## Summary

Feature specification for the **remaining half of EPIC #412** — making engraved durable knowledge (decisions/invariants/principles) discoverable, recallable during planning, referenced in agent-context files, and audited. The authoring half (#413 schema, #414 `smithy.engrave`) already shipped; this spec covers the open sub-issues plus a user-requested projection capability.

- **Spec folder**: `specs/2026-06-06-012-engraved-knowledge-recall-and-reference/`
- **Artifacts**: `…spec.md`, `…data-model.md`, `…contracts.md`
- Maps to: **#415** (recall), **#416** (status discovery), **#417** (graph + stale-ref), **#418** (orders + audit), plus a **new** engrave→agent-context projection step.

## User stories (7)

| ID | Title | Priority | Maps to |
|----|-------|----------|---------|
| US1 | Status recognizes engraved records as a first-class type | P1 | #416 |
| US2 | Planning commands recall relevant engraved knowledge | P1 | #415 |
| US3 | Engrave projects engraved knowledge into agent-context files | P1 | new |
| US4 | Status surfaces engraved graph edges and stale references | P2 | #417 |
| US5 | Orders scaffolds tickets for engraved records | P2 | #418 |
| US6 | Audit validates engraved record quality | P3 | #418 |
| US7 | Ad-hoc engraved catalog lookup | P3 | #415 |

22 functional requirements; 6 key entities. Only US4 depends on another story (US1); the other six are independent entry points — recall (US2) deliberately reads engraved files directly so #415 does not depend on #416.

## Key design decisions (from 4-lens competing-plan reconciliation)

- **Recall is a Claude-only sub-agent** modeled on `smithy-scout`; the `consult-engraved-knowledge` snippet inlines into all three agents and carries a degraded inline path for Gemini/Codex.
- **Deterministic/semantic ownership seam**: the TS status subsystem owns lifecycle/edges/stale-refs; recall owns only relevance + conflict-with-draft and treats lifecycle as read-only ground truth (no duplicated supersession logic).
- **`Alignment` is a separate axis** from `Status`; engraved records are excluded from the build rollup and bypass the Dependency Order grammar.
- **Projection** writes a deterministic, idempotent managed block (`<!-- smithy:engraved:begin/end -->`) into existing agent-context files only; hand-written prose untouched.

## Plan-review pass (applied)

- **Fixed (High)**: invariant vocabulary corrected to `aligned`/`drifting` (was mislabeled `active`, which is the principle status) across FR-014, US3, data-model, contracts.
- **Routed to debt**: SD-006 (undefined citation source for spec/RFC→engraved edges), SD-007 (frozen schema gives invariants no `deprecated` state, contra #417). Stale-ref language softened to reference these.

## Specification Debt (7 open items)

SD-001 catalog-lookup surface (engrave flag vs `smithy.engraved`); SD-002 default projection target files; SD-003 optional design-domain scan roots; SD-004 principle orders template; SD-005 recall reads frontmatter vs consumes status JSON; SD-006 citation source mechanism; SD-007 invariant deprecation.

Next step: task decomposition with `smithy.cut`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)