### PR TITLE
Cut: US2 tasks for engrave projection pointer

### DIFF
--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/02-engrave-projects-an-engraved-knowledge-pointer-into-agent-context-files.tasks.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/02-engrave-projects-an-engraved-knowledge-pointer-into-agent-context-files.tasks.md
@@ -1,0 +1,85 @@
+# Tasks: Engrave Projects an Engraved-Knowledge Pointer into Agent-Context Files
+
+**Source**: `specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.spec.md` — User Story 2
+**Data Model**: `specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.data-model.md`
+**Contracts**: `specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.contracts.md`
+**Story Number**: 02
+
+---
+
+## Slice 1: Engrave Projection Pointer
+
+**Goal**: Extend `smithy.engrave` so every successful engrave or supersede operation refreshes a managed pointer block in existing agent-context files without copying engraved record bodies.
+
+**Justification**: The projection behavior is prompt-layer work with one coherent user-visible outcome: after engrave changes durable knowledge, arbitrary agents can discover where that knowledge lives. Splitting marker handling, directory discovery, and coverage into separate PRs would leave intermediate states that either modify context files unsafely or ship behavior without regression protection.
+
+**Addresses**: FR-007, FR-008, FR-009, FR-010; Acceptance Scenarios 2.1, 2.2, 2.3, 2.4, 2.5
+
+### Tasks
+
+- [ ] **Add the projection phase to engrave**
+
+  Update `src/templates/agent-skills/commands/smithy.engrave.prompt` so create, update, and supersede flows run a final projection step after the engraved record edit succeeds and before the terminal summary. The step must target only existing agent-context files, use the managed marker pair from AS 2.1, and treat projection warnings as non-fatal to the underlying engrave operation.
+
+  _Acceptance criteria:_
+  - `smithy.engrave` describes a projection step after engraving or superseding a record
+  - Projection uses `<!-- smithy:engraved:begin -->` and `<!-- smithy:engraved:end -->`
+  - Missing target files are skipped rather than created
+  - Projection failure for one target does not roll back or fail the record edit
+
+- [ ] **Generate a pointer-only managed block**
+
+  Teach the projection step to discover engraved-knowledge directories present in the repo and render a deterministic pointer block listing those locations plus an applicability note for future agents. The block must list system and design-domain directories when present, and must not inline record bodies or enumerate individual records.
+
+  _Acceptance criteria:_
+  - Pointer content lists present engraved-knowledge directories
+  - `docs/decisions/`, `docs/invariants/`, and `docs/constitution/` are included when present
+  - Design-domain variants are included when present
+  - The block contains no record body text and no per-record index
+  - Location ordering is deterministic
+
+- [ ] **Preserve context files safely**
+
+  Define marker handling in `smithy.engrave.prompt` so files with no markers receive a fresh block at a defined anchor, files with exactly one marker pair replace only content between markers, and malformed or duplicated markers produce a warning with no edit to that file. The behavior must be idempotent: unchanged directory inputs produce byte-identical context files on a second run.
+
+  _Acceptance criteria:_
+  - Files with no markers receive one managed block without altering existing prose
+  - Files with one marker pair replace only the marked region
+  - Malformed or duplicated markers cause a warning and leave that file unchanged
+  - A no-change projection re-run is byte-identical
+
+- [ ] **Assert projection behavior in template tests**
+
+  Extend `src/templates.test.ts` coverage for the composed `smithy.engrave` command so projection requirements fail early if the prompt loses the marker pair, pointer-only constraint, existing-files-only rule, malformed-marker warning, or idempotence rule. Keep the assertions structural and tied to the composed template rather than to deployed `.claude/` snapshots.
+
+  _Acceptance criteria:_
+  - Tests assert the composed engrave prompt contains both managed markers
+  - Tests assert the prompt lists canonical engraved-knowledge directory roots
+  - Tests assert the prompt says missing target files are skipped
+  - Tests assert malformed or duplicated markers warn without guessing
+  - Tests assert projection is pointer-only and idempotent
+
+**PR Outcome**: Running `smithy.engrave` after a record create, update, or supersession keeps existing agent-context files pointed at the repo's engraved-knowledge directories through a safe, deterministic managed block.
+
+---
+
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | inherited from spec: Which agent-context files projection manages by default (CLAUDE.md only, also AGENTS.md, also `.github/copilot-instructions.md`) and whether the target set is configurable. | Integration | Medium | Medium | inherited | — |
+| SD-002 | inherited from spec: Whether the optional `design`-domain locations (`docs/design/{decisions,invariants,constitution}`) are in scope for recall and the projection pointer now, or deferred. | Functional Scope | Low | Medium | inherited | — |
+
+---
+
+## Dependency Order
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| S1 | Engrave Projection Pointer | — | — |
+
+### Cross-Story Dependencies
+
+None — this story is self-contained.

--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.spec.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.spec.md
@@ -110,7 +110,7 @@ Recommended implementation sequence:
 | ID | Title | Depends On | Artifact |
 |----|-------|-----------|----------|
 | US1 | Planning Commands Recall Relevant Engraved Knowledge | — | specs/2026-06-06-012-engraved-knowledge-recall-and-reference/01-planning-commands-recall-relevant-engraved-knowledge.tasks.md |
-| US2 | Engrave Projects an Engraved-Knowledge Pointer into Agent-Context Files | — | — |
+| US2 | Engrave Projects an Engraved-Knowledge Pointer into Agent-Context Files | — | specs/2026-06-06-012-engraved-knowledge-recall-and-reference/02-engrave-projects-an-engraved-knowledge-pointer-into-agent-context-files.tasks.md |
 | US3 | Engrave Scaffolds a Drift-Tracking Issue for Temporary Exceptions | — | — |
 | US4 | Audit Validates Engraved Record Quality | — | — |
 


### PR DESCRIPTION
## Summary

`/smithy.cut` for **User Story 2 — Engrave Projects an Engraved-Knowledge Pointer into Agent-Context Files** of the engraved-knowledge-recall-and-reference spec.

Decomposes US2 into a single coherent PR-sized slice, **Engrave Projection Pointer**, with four tasks covering the projection phase, pointer-only block generation, safe/idempotent marker handling, and template-test assertions.

## Coverage

- **Requirements**: FR-007, FR-008, FR-009, FR-010
- **Acceptance Scenarios**: 2.1, 2.2, 2.3, 2.4, 2.5
- Specification Debt SD-001 / SD-002 inherited from the spec.

## Changes

- **New** `specs/2026-06-06-012-engraved-knowledge-recall-and-reference/02-engrave-projects-an-engraved-knowledge-pointer-into-agent-context-files.tasks.md`
- **Edit** spec `## Dependency Order`: US2 `Artifact` column flipped from `-` to the new tasks file.

## Completion signal

This is a cut step, so the durable "story is cut" signal is the spec's Dependency Order `Artifact` column flip (`-` -> tasks path), per the repo's checkbox->Artifact-column convention -- done in this patch. The task checkboxes inside the new tasks file remain `[ ]` intentionally; they track forge implementation progress, not cut completion.

## Verification

Spec-markdown only -- no source or template code touched, so no unit test applies. Verified structural consistency against the US1 sibling tasks file and confirmed referenced data-model/contracts files exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
