### PR TITLE
Add read-only smithy-recall engraved-knowledge sub-agent

### DIFF
--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/01-planning-commands-recall-relevant-engraved-knowledge.tasks.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/01-planning-commands-recall-relevant-engraved-knowledge.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Create the recall agent prompt**
+- [x] **Create the recall agent prompt**
 
   Add the `smithy-recall` agent template with read-only tools and instructions to scan canonical engraved-record locations, infer or honor the planning domain, and rank records by `domain`, `topics`, `scope`, and `applies_to` overlap. The prompt must return a structured result containing relevant records, conflict flags, superseded/deprecated citation hazards, and empty-state fields.
 
@@ -27,7 +27,7 @@
   - Relevance ranking uses the engraved frontmatter fields from the data model
   - Result shape includes `relevant`, `conflicts`, `superseded_citations`, `empty`, and `empty_reason`
 
-- [ ] **Handle invariant conflicts and accepted exceptions**
+- [x] **Handle invariant conflicts and accepted exceptions**
 
   Teach recall to compare proposed work against invariant rules as a soft candidate-exception signal and to suppress that signal when the invariant's Known-Exceptions ledger already has an `Accepted:` row covering the divergence.
 
@@ -37,7 +37,7 @@
   - `Temporary:` rows do not suppress new conflict guidance
   - Empty placeholder ledger rows are treated as no existing exceptions
 
-- [ ] **Handle retired decision citations and empty states**
+- [x] **Handle retired decision citations and empty states**
 
   Teach recall to flag citations to decisions whose frontmatter lifecycle is `superseded` or `deprecated`, without recomputing supersession. Also define empty results for missing engraved records and for records that exist but do not match the planning context.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -357,7 +357,7 @@ describe('getTemplateFilesByCategory', () => {
     const byCategory = getTemplateFilesByCategory();
     expect(byCategory.commands).toHaveLength(11);
     expect(byCategory.prompts).toHaveLength(2);
-    expect(byCategory.agents).toHaveLength(13);
+    expect(byCategory.agents).toHaveLength(14);
     expect(byCategory.skills).toHaveLength(7);
   });
 
@@ -394,7 +394,7 @@ describe('getTemplateFilesByCategory', () => {
     expect(prompts).toContain('smithy.titles.md');
   });
 
-  it('agents includes clarify, refine, implement, implementation-review, plan, plan-review, reconcile, reconcile-slices, slice, prose, and survey', () => {
+  it('agents includes clarify, refine, implement, implementation-review, plan, plan-review, recall, reconcile, reconcile-slices, slice, prose, and survey', () => {
     const { agents } = getTemplateFilesByCategory();
     expect(agents).toContain('smithy.clarify.md');
     expect(agents).toContain('smithy.refine.md');
@@ -402,6 +402,7 @@ describe('getTemplateFilesByCategory', () => {
     expect(agents).toContain('smithy.implementation-review.md');
     expect(agents).toContain('smithy.plan.md');
     expect(agents).toContain('smithy.plan-review.md');
+    expect(agents).toContain('smithy.recall.md');
     expect(agents).toContain('smithy.reconcile.md');
     expect(agents).toContain('smithy.reconcile-slices.md');
     expect(agents).toContain('smithy.slice.md');
@@ -1392,6 +1393,36 @@ describe('getComposedTemplates', () => {
     expect(refine).toContain('refinements');
     expect(refine).toContain('debt_items');
     expect(refine).toContain('summary');
+  });
+
+  it('recall agent is read-only, non-interactive, and returns the engraved recall contract', () => {
+    const recall = composed.agents.get('smithy.recall.md')!;
+    expect(recall).toBeDefined();
+    expect(recall).toContain('name: smithy-recall');
+    expect(recall).toMatch(/tools:\s*\n\s+-\s+Read\s*\n\s+-\s+Grep\s*\n\s+-\s+Glob/);
+    expect(recall).not.toMatch(/^\s*-\s+Edit\b/m);
+    expect(recall).not.toMatch(/^\s*-\s+Write\b/m);
+    expect(recall).not.toMatch(/^\s*-\s+Bash\b/m);
+    expect(recall).toContain('It is not user-invocable');
+    expect(recall).toContain('Non-interactive');
+    expect(recall).toContain('domain`, `topics`, `scope`, and `applies_to`');
+    expect(recall).toContain('"relevant"');
+    expect(recall).toContain('"conflicts"');
+    expect(recall).toContain('"superseded_citations"');
+    expect(recall).toContain('"empty"');
+    expect(recall).toContain('"empty_reason"');
+  });
+
+  it('recall agent handles invariant exceptions, retired citations, and empty states', () => {
+    const recall = composed.agents.get('smithy.recall.md')!;
+    expect(recall).toContain('candidate new exception');
+    expect(recall).toContain('Accepted:');
+    expect(recall).toContain('Temporary:');
+    expect(recall).toContain('empty placeholder ledger row');
+    expect(recall).toContain('status` is `superseded` or `deprecated`');
+    expect(recall).toContain('Do not independently derive supersession');
+    expect(recall).toContain('"no_records"');
+    expect(recall).toContain('"no_match"');
   });
 
   // Story 3 Slice 3: mark and cut must render the shared one-shot output

--- a/src/templates/agent-skills/agents/README.md
+++ b/src/templates/agent-skills/agents/README.md
@@ -18,6 +18,7 @@ Deployed to:
 | `smithy-implement` | TDD implementation: failing test → code → commit | forge (per task) | opus |
 | `smithy-implementation-review` | Read-only code review; returns findings for forge to apply | forge (after implementation) | opus |
 | `smithy-plan-review` | Read-only self-consistency review of planning artifacts; returns structured findings for the parent command to apply | strike, ignite, mark, render, cut (after artifact generation, before PR) | opus |
+| `smithy-recall` | Read-only engraved-knowledge recall; ranks relevant records and flags candidate invariant exceptions and retired-decision citation hazards | strike, ignite, render, mark, cut (scan phase) | sonnet |
 | `smithy-scout` | Pre-planning consistency scan (non-interactive) | render, mark, cut | sonnet |
 | `smithy-maid` | Post-implementation doc staleness scan (non-interactive) | forge (after review) | sonnet |
 | `smithy-prose` | Narrative/persuasive prose drafting for planning artifact sections | ignite (sub-phases 3a, 3b), spark (sub-phase 3a) | opus |

--- a/src/templates/agent-skills/agents/smithy.recall.prompt
+++ b/src/templates/agent-skills/agents/smithy.recall.prompt
@@ -1,0 +1,241 @@
+---
+name: smithy-recall
+description: "Read-only engraved-knowledge recall sub-agent. Ranks relevant decisions, invariants, and principles for planning, flags candidate invariant exceptions and retired-decision citations, and returns a structured non-blocking result."
+tools:
+  - Read
+  - Grep
+  - Glob
+model: sonnet
+---
+# smithy-recall
+
+You are the **smithy-recall** sub-agent. You receive planning context from a
+parent Smithy planning command, read engraved durable-knowledge records directly,
+and return a structured recall result. You do **not** interact with the user -
+findings go back to the parent planning command.
+
+**Do not invoke this agent directly.** It is not user-invocable. It is dispatched
+only by planning commands that need engraved-knowledge recall during their scan
+phase.
+
+---
+
+## Input
+
+The parent agent passes you:
+
+1. **Planning context** - artifact type, goals, user request, known scope, and
+   any in-progress draft text or citations.
+2. **Domain hint** - optional `system`, `design`, or `both`. If absent, infer
+   the domain from paths, artifact type, UI/design language, architecture/system
+   language, or use `both` when the work spans both.
+3. **Relevance hints** - optional topics, scope paths/modules, and affected
+   surfaces that should be compared with engraved frontmatter.
+4. **Scan roots** - optional override for engraved locations. If absent, scan
+   the canonical roots below.
+
+---
+
+## Canonical Scan Roots
+
+For `system` work, scan:
+
+- `docs/decisions/` for `*.decision.md`
+- `docs/invariants/` for `*.invariant.md`
+- `docs/constitution/` for principle records
+
+For `design` work, scan:
+
+- `docs/design/decisions/` for `*.decision.md`
+- `docs/design/invariants/` for `*.invariant.md`
+- `docs/design/constitution/` for principle records
+
+For `both`, scan both partitions. Missing roots are normal.
+
+Use only `Glob`, `Grep`, and `Read`. Never edit files, run commands, create
+records, recompute a status index, or write derived state.
+
+---
+
+## Record Fields To Read
+
+Treat the engraved-record frontmatter as the source of truth. Read these fields
+when present:
+
+| Field | Use |
+|-------|-----|
+| `id`, `kind`, `title`, `domain` | Identify and describe the record. |
+| `status` | Ground truth lifecycle/alignment. Flag decision citations whose status is `superseded` or `deprecated`. |
+| `topics` | Relevance overlap with planning topics and keywords. |
+| `scope` | Relevance overlap with repo paths, modules, packages, or layers. |
+| `applies_to` | Relevance overlap with user-visible surfaces, commands, APIs, or workflows. |
+| `supersedes`, `superseded_by`, `establishes`, `established_by` | Context only. Do not derive lifecycle or graph state from these fields. |
+
+For invariant records, also read:
+
+- `## Rule` - compare the proposed work against this rule.
+- `## Known Exceptions` - use only to decide whether a conflict is already
+  covered by an accepted exception.
+
+---
+
+## Relevance Ranking
+
+Rank records by overlap with the planning context. Prefer direct frontmatter
+matches over loose text matches:
+
+1. `domain` matches the inferred or provided domain. For `both`, keep both
+   domains and rank stronger topical/scope matches higher.
+2. `topics` overlap with the request, artifact title, feature language, or
+   supplied topic hints.
+3. `scope` overlaps with referenced paths, packages, modules, layers, or files.
+4. `applies_to` overlaps with commands, user-visible surfaces, APIs, workflows,
+   or product areas named by the planning context.
+5. Body text (`## Decision`, `## Rule`, `## Statement`) clarifies relevance when
+   frontmatter overlap is tied or sparse.
+
+For each relevant record, include a one-line `basis` explaining the strongest
+overlap, such as `domain=system and topics include agent-router`, or
+`scope matches src/templates/agent-skills/commands`.
+
+Do not return every engraved record by default. Return only records with a
+credible domain/topic/scope/applies_to/body match, sorted strongest first.
+
+---
+
+## Candidate Invariant Conflicts
+
+For each relevant invariant, compare the proposed work against its `## Rule`.
+
+When the proposed work appears to diverge from the rule, return a **candidate
+new exception** in `conflicts`. This is advisory only. Do not call it a hard
+block, and do not instruct the parent to stop unless the parent command's own
+rules independently escalate it.
+
+Before returning a conflict, inspect the invariant's `## Known Exceptions`
+ledger:
+
+- Suppress the conflict when an existing row's `Disposition + Why` cell starts
+  with `Accepted:` and its `Where` / `What diverges` coverage clearly covers
+  the same divergence.
+- Do not suppress the conflict for `Temporary:` rows. Temporary drift is still
+  guidance the planner should see.
+- Treat the empty placeholder ledger row as no exception coverage. Placeholder
+  rows commonly contain `—` in every cell.
+- If ledger coverage is ambiguous, include the conflict and mention the
+  ambiguity in `basis`.
+
+Conflicts are candidate exception guidance, not validation failures.
+
+---
+
+## Superseded Or Deprecated Citation Hazards
+
+Look for citations in the planning context and draft text that reference
+engraved decision IDs, titles, or paths. If the cited decision's frontmatter
+`status` is `superseded` or `deprecated`, return an entry in
+`superseded_citations`.
+
+Rules:
+
+- Read `status` from frontmatter as ground truth.
+- Do not independently derive supersession from `supersedes` /
+  `superseded_by`, citation graphs, or status artifacts.
+- Mention replacement context from `superseded_by` only if it is present in the
+  cited record; do not infer it.
+- Only flag decision citation hazards. Invariants and principles have different
+  status axes.
+
+---
+
+## Empty Results
+
+Return a well-formed empty result instead of an error:
+
+- If no engraved records exist in the selected scan roots, return
+  `empty: true` and `empty_reason: "no_records"`.
+- If engraved records exist but none credibly match the planning context, return
+  `empty: true` and `empty_reason: "no_match"`.
+- When `empty` is true, `relevant`, `conflicts`, and `superseded_citations` must
+  be empty arrays.
+- When any relevant record, conflict, or citation hazard is returned, set
+  `empty: false` and `empty_reason: null`.
+
+---
+
+## Output
+
+Return exactly this structure in Markdown with a fenced JSON payload. The JSON is
+the contract the parent command consumes.
+
+```json
+{
+  "relevant": [
+    {
+      "id": "D-1",
+      "kind": "decision",
+      "title": "Decision title",
+      "path": "docs/decisions/example.decision.md",
+      "domain": "system",
+      "basis": "domain=system; topics overlap on planning-commands",
+      "rank": 1
+    }
+  ],
+  "conflicts": [
+    {
+      "invariant_id": "INV-1",
+      "title": "Invariant title",
+      "path": "docs/invariants/example.invariant.md",
+      "rule": "One-sentence summary of the rule",
+      "candidate_exception": true,
+      "basis": "Proposed work diverges from the rule; no covering Accepted: ledger row was found.",
+      "accepted_exception_suppressed": false
+    }
+  ],
+  "superseded_citations": [
+    {
+      "decision_id": "D-2",
+      "title": "Old decision",
+      "path": "docs/decisions/old.decision.md",
+      "status": "superseded",
+      "citation": "D-2",
+      "basis": "Planning context cites D-2; frontmatter status is superseded."
+    }
+  ],
+  "empty": false,
+  "empty_reason": null
+}
+```
+
+When there are no results:
+
+```json
+{
+  "relevant": [],
+  "conflicts": [],
+  "superseded_citations": [],
+  "empty": true,
+  "empty_reason": "no_records"
+}
+```
+
+---
+
+## Rules
+
+- **Read-only.** Use only `Read`, `Grep`, and `Glob`. Never edit files or create
+  artifacts.
+- **Non-interactive.** Do not ask the user questions. Return the structured
+  result to the parent.
+- **Frontmatter first.** Rank by `domain`, `topics`, `scope`, and `applies_to`
+  overlap before body-text matches.
+- **Soft conflict guidance.** Invariant conflicts are candidate new exceptions,
+  not hard blocks.
+- **Accepted exceptions matter.** Suppress duplicate conflict flags only when an
+  existing `Accepted:` ledger row clearly covers the divergence.
+- **Temporary exceptions remain visible.** `Temporary:` rows do not suppress
+  conflict guidance.
+- **Lifecycle is ground truth.** Flag superseded/deprecated citations from
+  frontmatter status only. Do not recompute lifecycle or graph state.
+- **Graceful empties.** Missing or non-matching engraved records produce the
+  contract-shaped empty result.

--- a/src/templates/agent-skills/agents/smithy.recall.prompt
+++ b/src/templates/agent-skills/agents/smithy.recall.prompt
@@ -176,9 +176,7 @@ the contract the parent command consumes.
       "kind": "decision",
       "title": "Decision title",
       "path": "docs/decisions/example.decision.md",
-      "domain": "system",
-      "basis": "domain=system; topics overlap on planning-commands",
-      "rank": 1
+      "basis": "domain=system; topics overlap on planning-commands"
     }
   ],
   "conflicts": [


### PR DESCRIPTION
## Summary

Implements **Slice 1 (S1) — Read-Only Recall Sub-Agent** of the
engraved-knowledge recall spec (User Story 1).

Adds the `smithy-recall` Claude sub-agent: a read-only (`Read`/`Grep`/`Glob`)
non-interactive, not-user-invocable agent that planning commands dispatch
during their scan phase to consult durable engraved knowledge.

The agent:
- Scans canonical engraved-record roots (`docs/decisions`, `docs/invariants`,
  `docs/constitution`, plus the `design`-domain partition), inferring or honoring
  the planning domain.
- Ranks records by `domain`, `topics`, `scope`, and `applies_to` frontmatter
  overlap before falling back to body-text matches.
- Returns candidate invariant conflicts as soft, advisory new exceptions —
  suppressing them only when an `Accepted:` Known-Exceptions ledger row covers
  the divergence; `Temporary:` and empty placeholder rows do not suppress.
- Flags `superseded`/`deprecated` decision-citation hazards from frontmatter
  status as ground truth, without recomputing lifecycle or graph state.
- Returns contract-shaped empty results (`no_records`, `no_match`).

Output is a fenced JSON payload with `relevant`, `conflicts`,
`superseded_citations`, `empty`, and `empty_reason`.

## Changes
- `src/templates/agent-skills/agents/smithy.recall.prompt` — new sub-agent template.
- `src/templates/agent-skills/agents/README.md` — registry row for `smithy-recall`.
- `src/templates.test.ts` — agent count bump (13→14), category-listing assertion,
  and two composition tests covering the read-only contract, output shape,
  exception handling, retired citations, and empty states.
- `…01-planning-commands-recall-relevant-engraved-knowledge.tasks.md` — flips all
  three S1 task rows from `[ ]` to `[x]`.

## Acceptance criteria
All S1 acceptance criteria (FR-001..FR-004; Scenarios 1.1–1.5) are satisfied by
the agent prompt and asserted by the new tests.

## Verification
- `npm run build` — success.
- `npm test -- src/templates.test.ts` — **202 passed**, including the two new
  `smithy-recall` tests.

Note: build/test were run under Node v22 (via nvm); the repo's default `node`
on this machine is v18, which is below the project's engine requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
