### PR TITLE
Add UI kind branching to smithy.mark routing (US1 S1)

### DIFF
--- a/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/01-mark-authors-a-ui-spec-with-a-typed-ordering-ledger-durable-artifacts.tasks.md
+++ b/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/01-mark-authors-a-ui-spec-with-a-typed-ordering-ledger-durable-artifacts.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Branch mark on feature kind**
+- [x] **Branch mark on feature kind**
 
   Update `src/templates/agent-skills/commands/smithy.mark.prompt` so `.features.md` routing carries the selected feature's `kind` metadata into Phase 1 and explicitly selects the backend or UI authoring path. Preserve the current backend spec-triad behavior for `kind: backend` and absent kind input, satisfying AS 1.4.
 
@@ -27,7 +27,7 @@
   - The selected feature's UI metadata is available to later mark phases
   - Existing feature-number and auto-selection routing semantics remain unchanged
 
-- [ ] **Document UI mark routing**
+- [x] **Document UI mark routing**
 
   Update the relevant template documentation in `src/templates/agent-skills/README.md` or adjacent command/template docs so maintainers can see that `mark` owns UI ledger and durable artifact authoring. Keep the documentation scoped to routing and ownership; AS 1.1-1.3 details remain in the later ledger and artifact slices.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1508,6 +1508,17 @@ describe('getComposedTemplates', () => {
     expect(mark).not.toMatch(/STOP after/i);
   });
 
+  it('mark template routes selected feature metadata by kind', () => {
+    const mark = composed.commands.get('smithy.mark.md')!;
+    expect(mark).toContain('### Feature Kind Path');
+    expect(mark).toContain('Backend spec-triad path');
+    expect(mark).toContain('UI authoring path');
+    expect(mark).toContain('No `kind` field');
+    expect(mark).toContain("selected feature's fenced `yaml` metadata block");
+    expect(mark).toContain('feature-number validation');
+    expect(mark).toContain('auto-selection semantics');
+  });
+
   it('cut template resolves the one-shot-output partial', () => {
     const cut = composed.commands.get('smithy.cut.md')!;
     expect(cut).toBeDefined();
@@ -2889,6 +2900,23 @@ describe('getComposedTemplates', () => {
     expect(render).toMatch(/build\/wire/i);
     expect(render).not.toContain('{{>feature-kinds}}');
     expect(render).not.toContain('{{>');
+  });
+
+  it('feature-kind docs point UI routing and durable design truth at mark', () => {
+    const readmePath = path.join(
+      process.cwd(),
+      'src',
+      'templates',
+      'agent-skills',
+      'README.md',
+    );
+    const readme = fs.readFileSync(readmePath, 'utf8');
+    expect(readme).toContain("branches on the selected\nfeature's `kind`");
+    expect(readme).toContain('absent-kind legacy features');
+    expect(readme).toContain('owns the durable design truth');
+    expect(readme).toContain('Selects the `smithy.mark` authoring path');
+    expect(readme).toContain('the `.flow.md` design truth is authored by `mark`');
+    expect(readme).not.toContain('Selects the downstream `forge` profile');
   });
 
   it('audit features checklist composes the feature-kind/seam categories', () => {

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -2911,7 +2911,7 @@ describe('getComposedTemplates', () => {
       'README.md',
     );
     const readme = fs.readFileSync(readmePath, 'utf8');
-    expect(readme).toContain("branches on the selected\nfeature's `kind`");
+    expect(readme).toMatch(/branches on the selected\s+feature's `kind`/);
     expect(readme).toContain('absent-kind legacy features');
     expect(readme).toContain('owns the durable design truth');
     expect(readme).toContain('Selects the `smithy.mark` authoring path');

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -199,12 +199,18 @@ UI work, its design and phase fields. This README is the source of truth for the
 schema; the same field set is captured once in the `feature-kinds` snippet
 (`snippets/feature-kinds.md`) and pulled into `smithy.render` (authoring) and
 `smithy.audit` (validation) via `{{>feature-kinds}}` so the surfaces never drift.
+When `smithy.mark` consumes a `.features.md` file, it branches on the selected
+feature's `kind`: `backend` and absent-kind legacy features use the existing
+spec-triad path, while `ui` features enter the UI authoring path. That UI path
+owns the durable design truth: the UI spec ledger plus the mark-authored
+`design/screens/<ScreenId>.design.md` and `design/flows/<FlowId>.flow.md`
+artifacts that downstream commands consume.
 
 ### Field schema
 
 | Key | Kind | Required | Notes |
 |-----|------|----------|-------|
-| `kind` | both | Yes | `backend` or `ui`. Selects the downstream `forge` profile. |
+| `kind` | both | Yes | `backend` or `ui`. Selects the `smithy.mark` authoring path. |
 | `phase` | ui | Yes | `build` or `wire` — a **feature-level** attribute. |
 | `design_system` | ui | Yes | Reference to the committed design skill (for example `story-spider-design`); source of truth even when a bundle is present. |
 | `bundle` | ui | No | Repo-relative path to a Claude Design export — a visual/structural reference, not a drop-in. Bundle wins on layout & visual intent; the design skill wins on implementation dialect. |
@@ -220,7 +226,7 @@ spec (prose delta).
 | `phase` | Means | Done when |
 |---------|-------|-----------|
 | `build` | Implement the screen component against a mock, behind `flag`. No real data. | Screen renders every brief state using only design-system tokens/components, gated by the flag. |
-| `wire` | Connect the screen to real data/actions and flip the flag. | Real data wired **and** the executable test body + `flow.md` emitted/updated for every flow in `flows` using the project's UI driver. |
+| `wire` | Connect the screen to real data/actions and flip the flag. | Real data wired and the executable test body emitted/updated for every flow in `flows` using the project's UI driver; the `.flow.md` design truth is authored by `mark`. |
 
 ### The seam = two features sharing one flag
 
@@ -241,6 +247,9 @@ F3 wire-add-title   (kind: ui, phase: wire, flag: add_title_v1, Depends On: F1, 
 ordered before an unbuilt backend feature (`F1` above) because the flag keeps it
 on mock data; only the `wire` feature lists the backend in `Depends On`. The
 shared `flag` — not a naming convention — is the contract of record.
+`smithy.mark` later turns the selected UI feature metadata into the UI spec
+ledger and durable screen/flow artifacts; `forge` consumes those files while
+building the implementation.
 
 ### Worked example
 
@@ -284,8 +293,8 @@ flows: [AddTitle]
 
 **Description**: Connect AddTitle to `LibraryStore` and flip `add_title_v1`. Confirm
 persists a real `Title`; done includes emitting the executable test body
-(`maestro/flows/AddTitle.yaml` in this Maestro example) and
-`design/flows/AddTitle.flow.md`.
+(`maestro/flows/AddTitle.yaml` in this Maestro example), while
+`design/flows/AddTitle.flow.md` remains mark-authored design truth.
 ````
 
 with a `## Dependency Order` table where `F3` depends on `F1, F2` and `F2` depends
@@ -304,10 +313,11 @@ on `—` (build-ahead-of-backend).
 
 Each `ScreenId` listed under a UI feature's `screens:` field resolves — in the
 **app repo, not in Smithy** — to a thin durable annotation at
-`design/screens/<ScreenId>.design.md`. The screen's component file is the body;
-this file carries the screen's *intent* (why it exists, deliberate choices,
-deferred bits) colocated with the code so it travels and versions with the
-component.
+`design/screens/<ScreenId>.design.md`, authored by `smithy.mark` as durable
+design truth for downstream build and audit steps. The screen's component file is
+the body; this file carries the screen's *intent* (why it exists, deliberate
+choices, deferred bits) colocated with the code so it travels and versions with
+the component.
 
 The full authoring contract — YAML front-matter schema (`id`, `component-path`,
 `design_system`, `bundle`), the rationale-only body rule, the skeleton template,
@@ -324,7 +334,9 @@ Each `FlowId` listed under a UI feature's `flows:` field resolves — in the
 **app repo, not in Smithy** — to a durable **1:1 pair** of files:
 `design/flows/<FlowId>.flow.md` (thin intent annotation) and
 an executable test body in the project's UI driver (for example
-`maestro/flows/<FlowId>.yaml`). The test body owns the steps and guard
+`maestro/flows/<FlowId>.yaml`). `smithy.mark` authors the `.flow.md` design
+truth; downstream build steps consume it and write or update the executable
+body. The test body owns the steps and guard
 assertions a UI driver replays; the `.flow.md` owns *why* — the product truth
 the flow preserves, why the guards exist, deliberate entry / exit, and a
 coverage caveat for anything below what a UI driver can observe.

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -210,7 +210,7 @@ artifacts that downstream commands consume.
 
 | Key | Kind | Required | Notes |
 |-----|------|----------|-------|
-| `kind` | both | Yes | `backend` or `ui`. Selects the `smithy.mark` authoring path. |
+| `kind` | both | Yes (new) | `backend` or `ui`. Selects the `smithy.mark` authoring path. A missing `kind` on legacy feature maps defaults to `backend`. |
 | `phase` | ui | Yes | `build` or `wire` — a **feature-level** attribute. |
 | `design_system` | ui | Yes | Reference to the committed design skill (for example `story-spider-design`); source of truth even when a bundle is present. |
 | `bundle` | ui | No | Repo-relative path to a Claude Design export — a visual/structural reference, not a drop-in. Bundle wins on layout & visual intent; the design skill wins on implementation dialect. |

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -70,6 +70,10 @@ When entering Phase 1 from a `.features.md`, carry forward:
   UI fields such as `phase`, `design_system`, `bundle`, `flag`, `screens`, and
   `flows`. Keep this metadata attached to the planning context so later mark
   phases can author the correct child artifacts without reparsing the feature map.
+  This block is optional: legacy feature maps authored before typed kinds will
+  not have it. When it is absent, carry no UI metadata forward and treat the
+  feature as `kind: backend` per the **Feature Kind Path** table below — never
+  abort or prompt for the missing block.
 - The **Source RFC** path from the `.features.md` header (if present; if missing,
   look for a co-located `.rfc.md` in the same directory).
 - The **feature map path** and **feature number** for traceability.

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -66,9 +66,29 @@ Before starting, determine the mode:
 When entering Phase 1 from a `.features.md`, carry forward:
 - The selected feature's **Title**, **Description**, **User-Facing Value**, and
   **Scope Boundaries** as the starting context.
+- The selected feature's fenced `yaml` metadata block, including `kind` and any
+  UI fields such as `phase`, `design_system`, `bundle`, `flag`, `screens`, and
+  `flows`. Keep this metadata attached to the planning context so later mark
+  phases can author the correct child artifacts without reparsing the feature map.
 - The **Source RFC** path from the `.features.md` header (if present; if missing,
   look for a co-located `.rfc.md` in the same directory).
 - The **feature map path** and **feature number** for traceability.
+
+### Feature Kind Path
+
+When Phase 1 starts from a `.features.md` feature, classify the selected
+feature before drafting artifacts:
+
+| Selected feature metadata | Mark authoring path |
+|---------------------------|---------------------|
+| `kind: backend` | **Backend spec-triad path** — preserve the existing `.spec.md` + `.data-model.md` + `.contracts.md` behavior. |
+| No `kind` field | **Backend spec-triad path** — legacy feature maps continue through the existing flow unchanged. |
+| `kind: ui` | **UI authoring path** — carry the UI metadata forward for the UI spec ledger and mark-owned durable design artifacts. |
+
+Do not change feature-number validation, already-specced detection, or
+auto-selection semantics when applying this branch. Those decisions still happen
+solely from the parsed `### Feature N` headings and the `.features.md`
+`## Dependency Order` table above.
 
 ---
 
@@ -90,8 +110,9 @@ When entering Phase 1 from a `.features.md`, carry forward:
    - **Feature description**: Treat as the starting context.
    - **Feature map** (from Routing): Use the selected feature's Title,
      Description, User-Facing Value, and Scope Boundaries as the starting
-     context. Also read the Source RFC (resolved during Routing) for additional
-     goals and constraints.
+     context, plus the selected metadata and mark authoring path from Routing.
+     Also read the Source RFC (resolved during Routing) for additional goals
+     and constraints.
 2. Explore the codebase to understand current architecture, relevant modules,
    and existing patterns that inform the specification.
 3. Determine the spec folder name:

--- a/src/templates/agent-skills/snippets/feature-kinds.md
+++ b/src/templates/agent-skills/snippets/feature-kinds.md
@@ -3,12 +3,16 @@
 Every feature in a `.features.md` map is **typed**. Each `### Feature N:` carries a
 fenced `yaml` metadata block — placed right after the heading, before the prose —
 declaring its kind and, for UI work, its design and phase fields. The kind selects
-the downstream `forge` profile.
+the `smithy.mark` authoring path: `backend` keeps the existing spec-triad flow,
+while `ui` enters the UI authoring path for the typed ledger and durable design
+truth.
 
 - **`backend`** — server/library functionality; the prose body is a behavioral delta.
-- **`ui`** — screen/flow work; renders a framework-appropriate screen
-  component from a committed design skill and, in the `wire` phase,
-  emits/updates the durable flow artifacts for any flow the screen joins.
+- **`ui`** — screen/flow work; `mark` authors the UI spec ledger and durable
+  screen/flow design artifacts, then downstream build steps render a
+  framework-appropriate screen component from a committed design skill and, in
+  the `wire` phase, emit/update the executable flow body for any flow the screen
+  joins.
 
 | Key | Kind | Required | Notes |
 |-----|------|----------|-------|
@@ -38,9 +42,10 @@ flows: [AddTitle]
 
 **Phase semantics.** `build` implements the screen component against a mock behind
 `flag` (rendering every brief state with design-system tokens only); `wire`
-connects real data, flips the flag, and emits/updates the executable test body +
-`flow.md` for every flow in `flows` using the project's UI driver. Compose,
-Maestro, and `story-spider-design` are examples, not required stacks.
+connects real data, flips the flag, and emits/updates the executable test body for
+every flow in `flows` using the project's UI driver; the `.flow.md` design truth is
+authored by `mark`. Compose, Maestro, and `story-spider-design` are examples, not
+required stacks.
 
 **The build/wire seam.** Flag-gated UI is two features sharing one `flag`: a `build`
 feature and a `wire` feature that lists the build feature in its `Depends On` cell.

--- a/src/templates/agent-skills/snippets/feature-kinds.md
+++ b/src/templates/agent-skills/snippets/feature-kinds.md
@@ -16,7 +16,7 @@ truth.
 
 | Key | Kind | Required | Notes |
 |-----|------|----------|-------|
-| `kind` | both | Yes | `backend` or `ui`. |
+| `kind` | both | Yes (new) | `backend` or `ui`. Missing on legacy maps → `backend`. |
 | `phase` | ui | Yes | `build` or `wire` (feature-level). |
 | `design_system` | ui | Yes | Committed design-skill ref (for example `story-spider-design`); source of truth even when a bundle is present. |
 | `bundle` | ui | No | Path to a Claude Design export — a visual/structural reference, not a drop-in. Bundle wins on layout/visual intent; the skill wins on implementation dialect. |


### PR DESCRIPTION
## Summary

Slice 1 (S1) of User Story 1 — *Mark Authors a UI Spec With a Typed Ordering Ledger + Durable Artifacts* (spec `2026-06-06-012-screens-and-flows-as-ui-feature-kinds`).

Adds the additive UI branch point to `smithy.mark`. When mark consumes a `.features.md`, it now classifies the selected feature by `kind` and routes it through a named UI authoring path, preserving the existing backend spec-triad behavior. No ledger or durable-artifact emission yet — those are Slices 2 and 3.

**Addresses:** FR-001; AS 1.4

## Changes

- **`commands/smithy.mark.prompt`** — Phase 1 routing carries the selected feature's fenced `yaml` metadata block (`kind` plus UI fields) forward; new **Feature Kind Path** table selects the backend spec-triad path for `kind: backend`/absent-kind and the UI authoring path for `kind: ui`. Explicit note keeps feature-number validation and auto-selection semantics unchanged.
- **`README.md`** + **`snippets/feature-kinds.md`** — document that `mark` branches on feature kind and owns the durable UI design truth (`.design.md` / `.flow.md`); removed `forge`-as-author language.
- **`templates.test.ts`** — two tests asserting the mark routing table and the doc ownership corrections.
- **tasks.md** — flipped both Slice 1 rows from `[ ]` to `[x]`.

## Acceptance criteria

Task 1 — Branch mark on feature kind:
- [x] `kind: backend` and absent-kind inputs keep the spec-triad flow
- [x] `kind: ui` inputs enter a named UI authoring path
- [x] Selected UI metadata available to later mark phases
- [x] Feature-number and auto-selection routing semantics unchanged

Task 2 — Document UI mark routing:
- [x] Docs state mark branches on feature kind
- [x] Docs state mark authors UI durable design truth
- [x] Docs no longer describe `forge` as author of `.design.md`/`.flow.md`
- [x] Backend feature documentation remains accurate

## Verification

- `npm run typecheck` — clean (run under Node 22; repo requires Node ≥20)
- `npx vitest run src/templates.test.ts` — 202 passed, including the two new tests

No verification gaps. `.claude/` / `.smithy/` snapshots intentionally not regenerated, per repo guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
