### PR TITLE
Trim smithy.prose to load voice helper in draft mode

### DIFF
--- a/specs/2026-06-06-012-integrate-the-voice-helper-across-smithy-prose-surfaces/01-prose-drafting-surfaces-consult-the-skill-in-draft-mode.tasks.md
+++ b/specs/2026-06-06-012-integrate-the-voice-helper-across-smithy-prose-surfaces/01-prose-drafting-surfaces-consult-the-skill-in-draft-mode.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Replace duplicated prose rules with skill load**
+- [x] **Replace duplicated prose rules with skill load**
 
   Update `src/templates/agent-skills/agents/smithy.prose.prompt` so Step 3 explicitly loads `Skill("smithy.helper-voice")` in draft mode before drafting assigned sections. Remove the inlined shared-principles and anti-pattern taxonomy, but keep the context-gathering flow and prose-agent responsibilities intact for AS 1.1 and AS 1.4.
 
@@ -26,7 +26,7 @@
   - The removed text includes the duplicated shared-principles list and anti-pattern block.
   - No replacement text re-inlines the skill's taxonomy or examples.
 
-- [ ] **Preserve section-specific prose protocol**
+- [x] **Preserve section-specific prose protocol**
 
   Verify and, if needed, adjust `src/templates/agent-skills/agents/smithy.prose.prompt` so the gap-marker rule, no-invented-figures rule, and Summary / Motivation / Personas structure remain available after the trim. The prose-specific rules the helper skill does not carry must remain in the prompt for AS 1.2.
 
@@ -35,7 +35,7 @@
   - The prompt still forbids invented figures when context lacks numbers.
   - Summary, Motivation / Problem Statement, and Personas guidance remains present.
 
-- [ ] **Add prose-trim regression coverage and validate**
+- [x] **Add prose-trim regression coverage and validate**
 
   Add focused coverage in `src/templates.test.ts` (or its existing helpers) asserting that the composed `smithy.prose` template carries a named `Skill("smithy.helper-voice")` reference and no longer contains the removed shared-principles heading or anti-pattern block. Keep assertions structural: check for stable markers — the helper reference and the removed `Prose principles — follow these on every sentence` heading / anti-pattern block — and do **not** assert on long taxonomy paragraphs or sentences whose wording may change. Then run the parse test and the spark/ignite eval scenarios, recording any eval limitation in the PR notes rather than widening this slice beyond FR-001 and FR-016.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -2174,6 +2174,14 @@ describe('getComposedTemplates', () => {
     expect(prose).not.toContain('{{>');
   });
 
+  it('prose agent loads the voice helper without duplicated taxonomy markers', () => {
+    const prose = composed.agents.get('smithy.prose.md')!;
+    expect(prose).toBeDefined();
+    expect(prose).toContain('Skill("smithy.helper-voice")');
+    expect(prose).not.toContain('Prose principles — follow these on every sentence');
+    expect(prose).not.toContain('Anti-pattern to avoid');
+  });
+
   it('strike with claude variant renders competing plan dispatch', async () => {
     const claudeComposed = await getComposedTemplates('claude');
     const strike = claudeComposed.commands.get('smithy.strike.md')!;

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -2180,6 +2180,9 @@ describe('getComposedTemplates', () => {
     expect(prose).toContain('Skill("smithy.helper-voice")');
     expect(prose).not.toContain('Prose principles — follow these on every sentence');
     expect(prose).not.toContain('Anti-pattern to avoid');
+    // Section-specific guidance carries audience tags in the shared grammar so
+    // the sub-agent parameterizes the helper per section (PR #454 review).
+    expect(prose).toContain('<!-- audience: stakeholder; mode: explanation; length: 2-3 sentences;');
   });
 
   it('strike with claude variant renders competing plan dispatch', async () => {

--- a/src/templates/agent-skills/agents/smithy.prose.prompt
+++ b/src/templates/agent-skills/agents/smithy.prose.prompt
@@ -69,15 +69,22 @@ from the provided context, note the gap in `## Gaps / Missing Context`.
 
 ### Step 3: Draft the Sections
 
-Before drafting, load `Skill("smithy.helper-voice")` in draft mode for the
-shared voice taxonomy. Apply that guidance together with the section-specific
-structure below for each assigned section.
+Load `Skill("smithy.helper-voice")` in draft mode for the shared voice
+taxonomy, then **parameterize it per assigned section**: each section under
+**Section-Specific Guidance** below carries an `<!-- audience: ... -->` tag
+naming its Role × Mode pair and length budget (e.g., the Summary is drafted
+as `stakeholder × explanation` to a 2-3 sentence budget). For each assigned
+section, read its tag, apply the helper's rules for that cell, and then layer
+the section-specific structure below on top. Mapping each section to the right
+voice cell — and holding the draft to that budget — is this sub-agent's job;
+the helper supplies the cross-cutting taxonomy, not the per-section choice.
 
 ---
 
 ## Section-Specific Guidance
 
 ### Summary
+<!-- audience: stakeholder; mode: explanation; length: 2-3 sentences; diagram: optional; examples: discouraged -->
 
 - **Length**: 2–3 sentences maximum.
 - **Structure**: (1) What this change does — concrete and specific, not generic.
@@ -88,6 +95,7 @@ structure below for each assigned section.
   benefit]. Without it, [cost that compounds over time]."
 
 ### Motivation / Problem Statement
+<!-- audience: stakeholder; mode: explanation; length: 3-6 paragraphs; diagram: optional; examples: discouraged -->
 
 - **Length**: 3–6 paragraphs. Each paragraph earns its place.
 - **Paragraph 1 — The problem in the wild**: Describe the concrete situation
@@ -107,6 +115,7 @@ structure below for each assigned section.
 - **Close**: One sentence stating the goal — what a solved world looks like.
 
 ### Personas
+<!-- audience: stakeholder; mode: explanation; length: 1 paragraph per persona; diagram: optional; examples: discouraged -->
 
 - **Structure**: One subsection (or paragraph block) per named persona role.
 - **Each persona must include**: (1) Their role and the context in which they

--- a/src/templates/agent-skills/agents/smithy.prose.prompt
+++ b/src/templates/agent-skills/agents/smithy.prose.prompt
@@ -69,52 +69,9 @@ from the provided context, note the gap in `## Gaps / Missing Context`.
 
 ### Step 3: Draft the Sections
 
-Apply the following structure and style to each assigned section.
-
-**Prose principles — follow these on every sentence:**
-
-- Lead with impact, not description. Prefer *"Teams lose `[X hours]` per sprint
-  to manual reconciliation"* over *"Manual reconciliation is slow."*
-- Name real costs: time, cognitive load, deployment risk, coordination overhead.
-  Avoid vague qualifiers like "sometimes", "often", "can be".
-- **All figures must come from the provided context.** If `idea_description`,
-  `clarify_output`, or the RFC file states a concrete number — hours, incidents,
-  team size, frequency — use it. If the context does not supply a figure, write
-  a gap marker instead: `[X hours]`, `[N incidents per sprint]`, `[## engineers]`.
-  The sentence structure and writing style stay the same; only the number
-  becomes a placeholder the author fills in. **Do not invent plausible-sounding
-  magnitudes to fill the structural need.**
-- Establish urgency: explain why the status quo is increasingly untenable, not
-  just inconvenient. Escalating team size, growing complexity, or upcoming
-  milestones all justify a "why now" framing.
-- State stakeholder value in concrete outcomes, not features. Prefer *"developers
-  can ship a feature without a Slack thread to track down the right config"*
-  over *"this improves the developer experience"*.
-- Use connective tissue: each sentence should follow from the previous one.
-  Avoid bullet-enumeration style inside prose sections — that is the anti-pattern.
-
-**Anti-pattern to avoid:**
-> ❌ "The current system has several issues:
-> - Manual reconciliation is slow
-> - Errors occur frequently
-> - Developers are frustrated"
-
-**Preferred pattern — when context supplies figures:**
-> ✓ "Each deployment forces developers to manually reconcile three separate
-> config sources — a process that consumes a full afternoon per sprint and
-> introduces the class of config-drift errors that caused three P1 incidents
-> last quarter. As the team scales from 8 to 20 engineers, this bottleneck
-> compounds: every new engineer inherits the same manual overhead with no
-> systematic way to detect or correct drift before it reaches production."
-
-**Same pattern — when figures are absent from context (use gap markers):**
-> ✓ "Each deployment forces developers to manually reconcile `[N]` separate
-> config sources — a process that consumes `[X hours]` per sprint and
-> introduces the class of config-drift errors that caused `[N]` P1 incidents
-> last quarter. As the team scales from `[current size]` to `[target size]`
-> engineers, this bottleneck compounds: every new engineer inherits the same
-> manual overhead with no systematic way to detect or correct drift before it
-> reaches production."
+Before drafting, load `Skill("smithy.helper-voice")` in draft mode for the
+shared voice taxonomy. Apply that guidance together with the section-specific
+structure below for each assigned section.
 
 ---
 


### PR DESCRIPTION
## Summary

Slice 1 of the voice-helper integration (spec `2026-06-06-012`, User Story 1):
trim `smithy.prose` so it loads the shared voice taxonomy via the helper skill
instead of carrying its own duplicate.

- `smithy.prose` Step 3 now loads `Skill("smithy.helper-voice")` in draft mode
  before drafting, replacing the inlined shared-principles list and anti-pattern
  block (FR-001, FR-003; AS 1.1, AS 1.4).
- Prose-specific rules the helper does not carry are preserved: gap markers
  (`[X hours]`), the no-invented-figures rule, and the Summary /
  Motivation / Personas section guidance (AS 1.2).
- Added a structural regression test in `src/templates.test.ts` asserting the
  composed `smithy.prose` template carries the `Skill("smithy.helper-voice")`
  reference and no longer contains the `Prose principles` heading or the
  `Anti-pattern to avoid` block (FR-016).
- Flipped the three Slice 1 task rows in the tasks file to `[x]`.

## Verification

- `npm run typecheck` — passes.
- `npm test` — 961 tests pass (27 files), including the new prose assertion.
- `.claude/` snapshot and `.smithy/smithy-manifest.json` left unchanged per FR-016.

### Eval limitation

The Tier-3 spark/ignite eval scenarios (SC-001 — demonstrate at least one actual
`Skill("smithy.helper-voice")` invocation at runtime) were **not run**: they are
agent-execution evals requiring live model/API access and are not runnable
deterministically from this implementation step. The structural test above guards
the static contract (helper reference present, duplicated taxonomy removed);
runtime invocation coverage should be confirmed when the eval framework is
exercised. Recorded here per the slice's instruction rather than widening the
slice beyond FR-001 / FR-016.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
