### PR TITLE
Add candidate strategy measurement harness (US1 S1)

### DIFF
--- a/evals/lib/candidate-measurement.test.ts
+++ b/evals/lib/candidate-measurement.test.ts
@@ -232,4 +232,48 @@ describe('buildMeasurementResults', () => {
       ),
     ).toThrow(/input_tokens must be a non-negative integer/);
   });
+
+  it('rejects duplicate fixture baselines instead of silently overwriting', () => {
+    expect(() =>
+      buildMeasurementResults(
+        [
+          {
+            strategy: 'pre_pasted_excerpts',
+            fixture: 'js',
+            tokens: { input: 100, output: 100 },
+            structural_eval_result: 'pass',
+            sampled_review_result: 'pass',
+          },
+        ],
+        [
+          { fixture: 'js', baseline_total_tokens: 1000 },
+          { fixture: 'js', baseline_total_tokens: 2000 },
+        ],
+      ),
+    ).toThrow(/duplicate baseline for js fixture/);
+  });
+
+  it('rejects duplicate (strategy, fixture) candidate results', () => {
+    expect(() =>
+      buildMeasurementResults(
+        [
+          {
+            strategy: 'per_task_brief',
+            fixture: 'js',
+            tokens: { input: 100, output: 100 },
+            structural_eval_result: 'pass',
+            sampled_review_result: 'pass',
+          },
+          {
+            strategy: 'per_task_brief',
+            fixture: 'js',
+            tokens: { input: 200, output: 200 },
+            structural_eval_result: 'pass',
+            sampled_review_result: 'pass',
+          },
+        ],
+        [{ fixture: 'js', baseline_total_tokens: 1000 }],
+      ),
+    ).toThrow(/duplicate measurement result for per_task_brief\/js/);
+  });
 });

--- a/evals/lib/candidate-measurement.test.ts
+++ b/evals/lib/candidate-measurement.test.ts
@@ -7,6 +7,15 @@ import {
 } from './candidate-measurement.js';
 
 describe('candidate measurement plan', () => {
+  const jsContext = {
+    pre_pasted_excerpts: 'JS pre-pasted acceptance excerpts for the slice.',
+    per_task_brief: 'JS generated per-task brief for the slice.',
+  };
+  const jvmContext = {
+    pre_pasted_excerpts: 'JVM pre-pasted acceptance excerpts for the slice.',
+    per_task_brief: 'JVM generated per-task brief for the slice.',
+  };
+
   it('creates isolated runs for both strategies across JS and JVM fixtures', () => {
     const runs = buildCandidateMeasurementPlan(
       {
@@ -15,8 +24,16 @@ describe('candidate measurement plan', () => {
         slice_number: 1,
       },
       [
-        { fixture: 'js', fixture_dir: 'evals/fixture' },
-        { fixture: 'jvm', fixture_dir: 'evals/fixture/jvm' },
+        {
+          fixture: 'js',
+          fixture_dir: 'evals/fixture',
+          candidate_context: jsContext,
+        },
+        {
+          fixture: 'jvm',
+          fixture_dir: 'evals/fixture/jvm',
+          candidate_context: jvmContext,
+        },
       ],
     );
 
@@ -38,10 +55,62 @@ describe('candidate measurement plan', () => {
     }
   });
 
+  it('embeds the strategy-specific context so the two candidates differ materially', () => {
+    const runs = buildCandidateMeasurementPlan(
+      { tasks_file: 'specs/example/01-story.tasks.md', slice_number: 1 },
+      [
+        {
+          fixture: 'js',
+          fixture_dir: 'evals/fixture',
+          candidate_context: jsContext,
+        },
+      ],
+    );
+
+    const prePasted = runs.find((r) => r.strategy === 'pre_pasted_excerpts')!;
+    const perTaskBrief = runs.find((r) => r.strategy === 'per_task_brief')!;
+
+    // Each run carries — and embeds into its prompt — only its own strategy's
+    // context, so token/quality results are attributable to the applied strategy.
+    expect(prePasted.context).toBe(jsContext.pre_pasted_excerpts);
+    expect(prePasted.prompt).toContain(jsContext.pre_pasted_excerpts);
+    expect(prePasted.prompt).not.toContain(jsContext.per_task_brief);
+
+    expect(perTaskBrief.context).toBe(jsContext.per_task_brief);
+    expect(perTaskBrief.prompt).toContain(jsContext.per_task_brief);
+    expect(perTaskBrief.prompt).not.toContain(jsContext.pre_pasted_excerpts);
+
+    expect(prePasted.prompt).not.toBe(perTaskBrief.prompt);
+  });
+
+  it('blocks a run when a strategy context payload is missing or empty', () => {
+    expect(() =>
+      buildCandidateMeasurementPlan(
+        { tasks_file: 'specs/example/01-story.tasks.md', slice_number: 1 },
+        [
+          {
+            fixture: 'js',
+            fixture_dir: 'evals/fixture',
+            candidate_context: {
+              pre_pasted_excerpts: 'present',
+              per_task_brief: '   ',
+            },
+          },
+        ],
+      ),
+    ).toThrow(/js\/per_task_brief candidate_context must be a non-empty string/);
+  });
+
   it('converts a candidate run to an eval scenario without changing forge command syntax', () => {
     const runs = buildCandidateMeasurementPlan(
       { tasks_file: 'specs/example/01-story.tasks.md', slice_number: 2 },
-      [{ fixture: 'js', fixture_dir: 'evals/fixture' }],
+      [
+        {
+          fixture: 'js',
+          fixture_dir: 'evals/fixture',
+          candidate_context: jsContext,
+        },
+      ],
     );
     const run = runs[0]!;
 

--- a/evals/lib/candidate-measurement.test.ts
+++ b/evals/lib/candidate-measurement.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCandidateMeasurementPlan,
+  buildMeasurementResults,
+  candidateRunToScenario,
+} from './candidate-measurement.js';
+
+describe('candidate measurement plan', () => {
+  it('creates isolated runs for both strategies across JS and JVM fixtures', () => {
+    const runs = buildCandidateMeasurementPlan(
+      {
+        tasks_file:
+          'specs/example/01-select-the-bounded-context-delivery-mechanism.tasks.md',
+        slice_number: 1,
+      },
+      [
+        { fixture: 'js', fixture_dir: 'evals/fixture' },
+        { fixture: 'jvm', fixture_dir: 'evals/fixture/jvm' },
+      ],
+    );
+
+    expect(runs).toHaveLength(4);
+    expect(runs.map((r) => `${r.fixture}:${r.strategy}`).sort()).toEqual([
+      'js:per_task_brief',
+      'js:pre_pasted_excerpts',
+      'jvm:per_task_brief',
+      'jvm:pre_pasted_excerpts',
+    ]);
+    for (const run of runs) {
+      expect(run.skill).toBe('/smithy.forge');
+      expect(run.prompt).toContain(
+        '01-select-the-bounded-context-delivery-mechanism.tasks.md 1',
+      );
+      expect(run.prompt).toContain('Candidate measurement mode:');
+      expect(run.prompt).toContain('build-output');
+      expect(run.measurement_mode).toBe(true);
+    }
+  });
+
+  it('converts a candidate run to an eval scenario without changing forge command syntax', () => {
+    const runs = buildCandidateMeasurementPlan(
+      { tasks_file: 'specs/example/01-story.tasks.md', slice_number: 2 },
+      [{ fixture: 'js', fixture_dir: 'evals/fixture' }],
+    );
+    const run = runs[0]!;
+
+    const scenario = candidateRunToScenario(run);
+
+    expect(scenario.name).toBe('forge-js-pre_pasted_excerpts');
+    expect(scenario.skill).toBe('/smithy.forge');
+    expect(scenario.prompt).toContain('specs/example/01-story.tasks.md 2');
+    expect(scenario.structural_expectations.required_headings).toEqual([
+      '## Summary',
+    ]);
+  });
+});
+
+describe('buildMeasurementResults', () => {
+  it('maps candidate and fixture runs to MeasurementResult records', () => {
+    const results = buildMeasurementResults(
+      [
+        {
+          strategy: 'pre_pasted_excerpts',
+          fixture: 'js',
+          tokens: { input: 700, output: 200 },
+          structural_eval_result: 'pass',
+          sampled_review_result: 'pass',
+        },
+        {
+          strategy: 'per_task_brief',
+          fixture: 'jvm',
+          tokens: { input: 1200, output: 300 },
+          structural_eval_result: 'fail',
+          sampled_review_result: 'not_reviewed',
+        },
+      ],
+      [
+        { fixture: 'js', baseline_total_tokens: 1000 },
+        { fixture: 'jvm', baseline_total_tokens: 2000 },
+      ],
+    );
+
+    expect(results).toEqual([
+      {
+        strategy: 'pre_pasted_excerpts',
+        fixture: 'js',
+        baseline_total_tokens: 1000,
+        candidate_total_tokens: 900,
+        input_tokens: 700,
+        output_tokens: 200,
+        delta_percent: -10,
+        structural_eval_result: 'pass',
+        sampled_review_result: 'pass',
+      },
+      {
+        strategy: 'per_task_brief',
+        fixture: 'jvm',
+        baseline_total_tokens: 2000,
+        candidate_total_tokens: 1500,
+        input_tokens: 1200,
+        output_tokens: 300,
+        delta_percent: -25,
+        structural_eval_result: 'fail',
+        sampled_review_result: 'not_reviewed',
+      },
+    ]);
+  });
+
+  it('computes token deltas from the matching fixture baseline', () => {
+    const results = buildMeasurementResults(
+      [
+        {
+          strategy: 'per_task_brief',
+          fixture: 'jvm',
+          tokens: { input: 1500, output: 500 },
+          structural_eval_result: 'pass',
+          sampled_review_result: 'pass',
+        },
+      ],
+      [
+        { fixture: 'js', baseline_total_tokens: 1000 },
+        { fixture: 'jvm', baseline_total_tokens: 4000 },
+      ],
+    );
+    const result = results[0]!;
+
+    expect(result.baseline_total_tokens).toBe(4000);
+    expect(result.candidate_total_tokens).toBe(2000);
+    expect(result.delta_percent).toBe(-50);
+  });
+
+  it('blocks measurement when a matching fixture baseline is missing', () => {
+    expect(() =>
+      buildMeasurementResults(
+        [
+          {
+            strategy: 'pre_pasted_excerpts',
+            fixture: 'jvm',
+            tokens: { input: 1, output: 1 },
+            structural_eval_result: 'pass',
+            sampled_review_result: 'not_reviewed',
+          },
+        ],
+        [{ fixture: 'js', baseline_total_tokens: 10 }],
+      ),
+    ).toThrow(/missing jvm fixture baseline/);
+  });
+
+  it('blocks incomplete candidate token data instead of producing a comparison', () => {
+    expect(() =>
+      buildMeasurementResults(
+        [
+          {
+            strategy: 'per_task_brief',
+            fixture: 'js',
+            tokens: { input: 10.5, output: 2 },
+            structural_eval_result: 'pass',
+            sampled_review_result: 'pass',
+          },
+        ],
+        [{ fixture: 'js', baseline_total_tokens: 20 }],
+      ),
+    ).toThrow(/input_tokens must be a non-negative integer/);
+  });
+});

--- a/evals/lib/candidate-measurement.ts
+++ b/evals/lib/candidate-measurement.ts
@@ -10,9 +10,25 @@ export interface ForgeSliceShape {
   slice_number: number;
 }
 
+/**
+ * The actual bounded context each strategy delivers for a given fixture.
+ *
+ * This is what makes a measurement valid: `pre_pasted_excerpts` carries the
+ * acceptance excerpts the parent flow pastes ahead of the run, while
+ * `per_task_brief` carries the generated brief. Because forge does not parse
+ * strategy *names*, the harness must embed the strategy's real context into the
+ * run so the two candidates exercise materially different inputs rather than the
+ * same normal forge path under different labels.
+ */
+export interface CandidateContext {
+  pre_pasted_excerpts: string;
+  per_task_brief: string;
+}
+
 export interface FixtureInput {
   fixture: ForgeFixture;
   fixture_dir: string;
+  candidate_context: CandidateContext;
 }
 
 export interface CandidateMeasurementRun {
@@ -22,6 +38,8 @@ export interface CandidateMeasurementRun {
   tasks_file: string;
   slice_number: number;
   skill: '/smithy.forge';
+  /** The strategy-specific context embedded into this run's prompt. */
+  context: string;
   prompt: string;
   measurement_mode: true;
 }
@@ -64,10 +82,14 @@ const STRATEGIES: CandidateStrategy[] = [
 /**
  * Build isolated smithy.forge eval runs for candidate measurement.
  *
- * The returned scenarios all use the same forge slice arguments and only vary
- * the candidate context strategy and fixture. This keeps candidate measurement
- * outside normal forge dispatch while still letting the eval runner execute
- * each strategy independently against JS and JVM fixtures.
+ * The returned scenarios share the same forge slice arguments but embed each
+ * strategy's *actual* bounded context (pre-pasted excerpts vs. generated brief)
+ * into the run prompt. Embedding the real context — rather than just naming the
+ * strategy — is what makes the two candidates exercise materially different
+ * inputs, so their token and quality results are attributable to the strategy
+ * that was actually applied. This keeps candidate measurement outside normal
+ * forge dispatch while still letting the eval runner execute each strategy
+ * independently against JS and JVM fixtures.
  */
 export function buildCandidateMeasurementPlan(
   slice: ForgeSliceShape,
@@ -89,21 +111,39 @@ export function buildCandidateMeasurementPlan(
       throw new Error(`fixture_dir for ${fixture.fixture} must be non-empty`);
     }
 
-    return STRATEGIES.map((strategy) => ({
-      strategy,
-      fixture: fixture.fixture,
-      fixture_dir: fixture.fixture_dir,
-      tasks_file: slice.tasks_file,
-      slice_number: slice.slice_number,
-      skill: '/smithy.forge' as const,
-      prompt: [
-        `${slice.tasks_file} ${slice.slice_number}`,
-        '',
-        `Candidate measurement mode: ${strategy}.`,
-        'Keep normal smithy.forge build-output, test-command, TDD-protocol, and model-assignment behavior unchanged.',
-      ].join('\n'),
-      measurement_mode: true as const,
-    }));
+    return STRATEGIES.map((strategy) => {
+      const context = fixture.candidate_context?.[strategy];
+      if (typeof context !== 'string' || context.trim().length === 0) {
+        throw new Error(
+          `${fixture.fixture}/${strategy} candidate_context must be a non-empty string`,
+        );
+      }
+
+      return {
+        strategy,
+        fixture: fixture.fixture,
+        fixture_dir: fixture.fixture_dir,
+        tasks_file: slice.tasks_file,
+        slice_number: slice.slice_number,
+        skill: '/smithy.forge' as const,
+        context,
+        prompt: [
+          `${slice.tasks_file} ${slice.slice_number}`,
+          '',
+          `Candidate measurement mode: ${strategy}.`,
+          'The parent forge flow supplies the bounded acceptance context below so',
+          'each task uses it instead of re-reading the full planning artifacts.',
+          'Use only this supplied context for task acceptance details.',
+          '',
+          `--- BEGIN ${strategy} CONTEXT ---`,
+          context,
+          `--- END ${strategy} CONTEXT ---`,
+          '',
+          'Keep normal smithy.forge build-output, test-command, TDD-protocol, and model-assignment behavior unchanged.',
+        ].join('\n'),
+        measurement_mode: true as const,
+      };
+    });
   });
 }
 

--- a/evals/lib/candidate-measurement.ts
+++ b/evals/lib/candidate-measurement.ts
@@ -1,0 +1,216 @@
+import type { EvalScenario } from './types.js';
+
+export type CandidateStrategy = 'pre_pasted_excerpts' | 'per_task_brief';
+export type ForgeFixture = 'js' | 'jvm';
+export type StructuralEvalResult = 'pass' | 'fail';
+export type SampledReviewResult = 'pass' | 'fail' | 'not_reviewed';
+
+export interface ForgeSliceShape {
+  tasks_file: string;
+  slice_number: number;
+}
+
+export interface FixtureInput {
+  fixture: ForgeFixture;
+  fixture_dir: string;
+}
+
+export interface CandidateMeasurementRun {
+  strategy: CandidateStrategy;
+  fixture: ForgeFixture;
+  fixture_dir: string;
+  tasks_file: string;
+  slice_number: number;
+  skill: '/smithy.forge';
+  prompt: string;
+  measurement_mode: true;
+}
+
+export interface TokenTotalsInput {
+  input: number;
+  output: number;
+}
+
+export interface CandidateRunResultInput {
+  strategy: CandidateStrategy;
+  fixture: ForgeFixture;
+  tokens: TokenTotalsInput;
+  structural_eval_result: StructuralEvalResult;
+  sampled_review_result: SampledReviewResult;
+}
+
+export interface FixtureBaselineInput {
+  fixture: ForgeFixture;
+  baseline_total_tokens: number;
+}
+
+export interface MeasurementResult {
+  strategy: CandidateStrategy;
+  fixture: ForgeFixture;
+  baseline_total_tokens: number;
+  candidate_total_tokens: number;
+  input_tokens: number;
+  output_tokens: number;
+  delta_percent: number;
+  structural_eval_result: StructuralEvalResult;
+  sampled_review_result: SampledReviewResult;
+}
+
+const STRATEGIES: CandidateStrategy[] = [
+  'pre_pasted_excerpts',
+  'per_task_brief',
+];
+
+/**
+ * Build isolated smithy.forge eval runs for candidate measurement.
+ *
+ * The returned scenarios all use the same forge slice arguments and only vary
+ * the candidate context strategy and fixture. This keeps candidate measurement
+ * outside normal forge dispatch while still letting the eval runner execute
+ * each strategy independently against JS and JVM fixtures.
+ */
+export function buildCandidateMeasurementPlan(
+  slice: ForgeSliceShape,
+  fixtures: FixtureInput[],
+): CandidateMeasurementRun[] {
+  if (!Number.isInteger(slice.slice_number) || slice.slice_number <= 0) {
+    throw new Error('slice_number must be a positive integer');
+  }
+  if (slice.tasks_file.length === 0) {
+    throw new Error('tasks_file must be a non-empty string');
+  }
+  if (fixtures.length === 0) {
+    throw new Error('at least one fixture is required');
+  }
+
+  return fixtures.flatMap((fixture) => {
+    assertFixture(fixture.fixture);
+    if (fixture.fixture_dir.length === 0) {
+      throw new Error(`fixture_dir for ${fixture.fixture} must be non-empty`);
+    }
+
+    return STRATEGIES.map((strategy) => ({
+      strategy,
+      fixture: fixture.fixture,
+      fixture_dir: fixture.fixture_dir,
+      tasks_file: slice.tasks_file,
+      slice_number: slice.slice_number,
+      skill: '/smithy.forge' as const,
+      prompt: [
+        `${slice.tasks_file} ${slice.slice_number}`,
+        '',
+        `Candidate measurement mode: ${strategy}.`,
+        'Keep normal smithy.forge build-output, test-command, TDD-protocol, and model-assignment behavior unchanged.',
+      ].join('\n'),
+      measurement_mode: true as const,
+    }));
+  });
+}
+
+export function candidateRunToScenario(
+  run: CandidateMeasurementRun,
+): EvalScenario {
+  return {
+    name: `forge-${run.fixture}-${run.strategy}`,
+    skill: run.skill,
+    prompt: run.prompt,
+    structural_expectations: {
+      required_headings: ['## Summary'],
+    },
+  };
+}
+
+export function buildMeasurementResults(
+  candidateRuns: CandidateRunResultInput[],
+  baselines: FixtureBaselineInput[],
+): MeasurementResult[] {
+  if (candidateRuns.length === 0) {
+    throw new Error('at least one candidate run result is required');
+  }
+
+  const baselinesByFixture = new Map<ForgeFixture, number>();
+  for (const baseline of baselines) {
+    assertFixture(baseline.fixture);
+    assertNonNegativeInteger(
+      baseline.baseline_total_tokens,
+      `${baseline.fixture} baseline_total_tokens`,
+    );
+    if (baseline.baseline_total_tokens === 0) {
+      throw new Error(
+        `${baseline.fixture} baseline_total_tokens must be greater than zero`,
+      );
+    }
+    baselinesByFixture.set(baseline.fixture, baseline.baseline_total_tokens);
+  }
+
+  return candidateRuns.map((run) => {
+    assertStrategy(run.strategy);
+    assertFixture(run.fixture);
+    assertStructuralResult(run.structural_eval_result);
+    assertSampledReviewResult(run.sampled_review_result);
+    if (run.tokens === undefined || run.tokens === null) {
+      throw new Error(
+        `${run.strategy}/${run.fixture} is missing token totals`,
+      );
+    }
+    assertNonNegativeInteger(
+      run.tokens.input,
+      `${run.strategy}/${run.fixture} input_tokens`,
+    );
+    assertNonNegativeInteger(
+      run.tokens.output,
+      `${run.strategy}/${run.fixture} output_tokens`,
+    );
+
+    const baselineTotal = baselinesByFixture.get(run.fixture);
+    if (baselineTotal === undefined) {
+      throw new Error(`missing ${run.fixture} fixture baseline`);
+    }
+
+    const candidateTotal = run.tokens.input + run.tokens.output;
+    const deltaPercent =
+      ((candidateTotal - baselineTotal) / baselineTotal) * 100;
+
+    return {
+      strategy: run.strategy,
+      fixture: run.fixture,
+      baseline_total_tokens: baselineTotal,
+      candidate_total_tokens: candidateTotal,
+      input_tokens: run.tokens.input,
+      output_tokens: run.tokens.output,
+      delta_percent: deltaPercent,
+      structural_eval_result: run.structural_eval_result,
+      sampled_review_result: run.sampled_review_result,
+    };
+  });
+}
+
+function assertStrategy(strategy: CandidateStrategy): void {
+  if (!STRATEGIES.includes(strategy)) {
+    throw new Error(`unsupported candidate strategy: ${String(strategy)}`);
+  }
+}
+
+function assertFixture(fixture: ForgeFixture): void {
+  if (fixture !== 'js' && fixture !== 'jvm') {
+    throw new Error(`unsupported fixture: ${String(fixture)}`);
+  }
+}
+
+function assertStructuralResult(result: StructuralEvalResult): void {
+  if (result !== 'pass' && result !== 'fail') {
+    throw new Error(`unsupported structural_eval_result: ${String(result)}`);
+  }
+}
+
+function assertSampledReviewResult(result: SampledReviewResult): void {
+  if (result !== 'pass' && result !== 'fail' && result !== 'not_reviewed') {
+    throw new Error(`unsupported sampled_review_result: ${String(result)}`);
+  }
+}
+
+function assertNonNegativeInteger(value: number, label: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+}

--- a/evals/lib/candidate-measurement.ts
+++ b/evals/lib/candidate-measurement.ts
@@ -171,6 +171,13 @@ export function buildMeasurementResults(
   const baselinesByFixture = new Map<ForgeFixture, number>();
   for (const baseline of baselines) {
     assertFixture(baseline.fixture);
+    // Reject duplicate fixture baselines rather than silently overwriting the
+    // earlier entry — conflicting baselines for the same fixture would yield
+    // deltas computed against an arbitrary "last write wins" total with no
+    // signal, defeating the like-for-like comparison this output exists for.
+    if (baselinesByFixture.has(baseline.fixture)) {
+      throw new Error(`duplicate baseline for ${baseline.fixture} fixture`);
+    }
     assertNonNegativeInteger(
       baseline.baseline_total_tokens,
       `${baseline.fixture} baseline_total_tokens`,
@@ -183,9 +190,19 @@ export function buildMeasurementResults(
     baselinesByFixture.set(baseline.fixture, baseline.baseline_total_tokens);
   }
 
+  // A MeasurementResult is uniquely identified by (strategy, fixture) per the
+  // data model. Reject duplicate pairs so downstream selection/aggregation in
+  // Slice 2 cannot silently consume an ambiguous, doubled-up result set.
+  const seenResults = new Set<string>();
+
   return candidateRuns.map((run) => {
     assertStrategy(run.strategy);
     assertFixture(run.fixture);
+    const resultKey = `${run.strategy}/${run.fixture}`;
+    if (seenResults.has(resultKey)) {
+      throw new Error(`duplicate measurement result for ${resultKey}`);
+    }
+    seenResults.add(resultKey);
     assertStructuralResult(run.structural_eval_result);
     assertSampledReviewResult(run.sampled_review_result);
     if (run.tokens === undefined || run.tokens === null) {

--- a/specs/2026-05-15-006-smithy-implement-per-task-spec-re-read-reduction/01-select-the-bounded-context-delivery-mechanism.tasks.md
+++ b/specs/2026-05-15-006-smithy-implement-per-task-spec-re-read-reduction/01-select-the-bounded-context-delivery-mechanism.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Add candidate strategy measurement mode**
+- [x] **Add candidate strategy measurement mode**
 
   Extend the forge eval or measurement support code so a maintainer can run the same multi-task forge slice under the parent pre-pasted excerpts candidate and the generated per-task brief candidate. The mode must be isolated from normal forge behavior and preserve the existing build-output, test-command, TDD-protocol, and model-assignment boundaries.
 
@@ -28,7 +28,7 @@
   - Build-output and test-command handling remain untouched (FR-013)
   - Implementation sub-agent model assignment remains unchanged (FR-014)
 
-- [ ] **Capture per-candidate token and quality results**
+- [x] **Capture per-candidate token and quality results**
 
   Thread the existing eval token-total and structural-quality surfaces through the candidate measurement output. Each candidate/fixture result must map to the `MeasurementResult` entity from the data model so the decision step can compare like-for-like records without re-reading raw captures.
 


### PR DESCRIPTION
## Summary

Implements **Slice 1: Candidate Strategy Measurement Harness** of US1 (Select the bounded context-delivery mechanism) for the per-task spec re-read reduction spec.

Adds an isolated measurement path so a maintainer can run the same `smithy.forge` slice shape under both candidate bounded-context strategies — **pre-pasted excerpts** and **per-task brief** — across the **JS and JVM** forge fixtures, and capture comparable token and structural-quality evidence. This slice only makes the US1 decision evidence observable; it does **not** select or wire the production context mechanism (that's Slice 2 / US2).

**Artifact:** `specs/2026-05-15-006-smithy-implement-per-task-spec-re-read-reduction/01-select-the-bounded-context-delivery-mechanism.tasks.md` (Slice 1)

## Changes

- `evals/lib/candidate-measurement.ts` (new)
  - `buildCandidateMeasurementPlan` — builds isolated per-strategy/per-fixture forge runs from a single slice shape. Same forge slice args; only the candidate strategy and fixture vary. The generated prompt explicitly preserves build-output, test-command, TDD-protocol, and model-assignment behavior (FR-013/FR-014), keeping normal `smithy.forge` dispatch untouched.
  - `candidateRunToScenario` — converts a run into an `EvalScenario` without changing forge command syntax.
  - `buildMeasurementResults` — maps each candidate/fixture run to a `MeasurementResult`: input / output / total / delta-from-baseline tokens, structural-eval outcome, and sampled-review outcome (`pass` / `fail` / `not_reviewed`). Blocks on a missing fixture baseline or incomplete candidate token data rather than producing a misleading comparison.
- `evals/lib/candidate-measurement.test.ts` (new) — 6 unit tests covering both strategies across JS/JVM, scenario conversion, result mapping, baseline-derived deltas, and the blocking guards.
- Flips both Slice 1 task rows from `[ ]` to `[x]` in the tasks file.

## Acceptance criteria

Task 1 — Add candidate strategy measurement mode:
- ✅ Both candidate strategies measurable independently against the same slice shape
- ✅ JS and JVM fixtures both supported (AS 1.1)
- ✅ Normal `smithy.forge` dispatch behavior unchanged outside the measurement path
- ✅ Build-output / test-command handling untouched (FR-013)
- ✅ Implementation sub-agent model assignment unchanged (FR-014)

Task 2 — Capture per-candidate token and quality results:
- ✅ Each result records input, output, total, and delta-from-baseline tokens (AS 1.1)
- ✅ Results distinguish JS and JVM fixtures
- ✅ Structural-eval outcome present for every result
- ✅ Sampled-review outcome recorded for every result
- ✅ Missing baseline / incomplete candidate data blocks the result
- ✅ Unit coverage proves token deltas are computed from the matching fixture baseline

## Verification

- `tsc --noEmit` — clean.
- `vitest run --config evals/vitest.config.ts candidate-measurement` — **6/6 pass**.
- Full evals suite: 191/193 pass. The 2 failures are in `evals/fixture.test.ts` and are **pre-existing/environment-only** — they shell out to a built `dist/cli.js` that isn't present in this worktree (no `npm run build` run). They are unrelated to this pure-library change.

> Note: this environment ships Node 18, but the pinned vitest 4 requires Node 20+; tests were run under Node 22 (nvm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
