### PR TITLE
Load voice helper in narrative command prompts (US1 S3)

### DIFF
--- a/specs/2026-06-06-012-integrate-the-voice-helper-across-smithy-prose-surfaces/01-prose-drafting-surfaces-consult-the-skill-in-draft-mode.tasks.md
+++ b/specs/2026-06-06-012-integrate-the-voice-helper-across-smithy-prose-surfaces/01-prose-drafting-surfaces-consult-the-skill-in-draft-mode.tasks.md
@@ -109,7 +109,7 @@
 
 ### Tasks
 
-- [ ] **Add voice load to spark direct prose**
+- [x] **Add voice load to spark direct prose**
 
   Update `src/templates/agent-skills/commands/smithy.spark.prompt` so directly authored PRD prose invokes `Skill("smithy.helper-voice")` in draft mode, while narrative sections already delegated to `smithy.prose` continue through that sub-agent. The command should not duplicate taxonomy text or route every section through `smithy.prose` for AS 1.3.
 
@@ -118,7 +118,7 @@
   - Existing `smithy.prose` delegation remains the path for sections it already drafts.
   - The PRD template remains parseable and does not inline helper taxonomy.
 
-- [ ] **Add voice load to ignite direct prose**
+- [x] **Add voice load to ignite direct prose**
 
   Update `src/templates/agent-skills/commands/smithy.ignite.prompt` so direct RFC prose authoring invokes `Skill("smithy.helper-voice")` in draft mode, while Summary / Motivation / Personas delegation continues through `smithy.prose`. Preserve the one-shot output contract and RFC template structure for AS 1.3.
 
@@ -127,7 +127,7 @@
   - Summary / Motivation / Personas remain delegated to `smithy.prose` where applicable.
   - The RFC template and one-shot output block still parse.
 
-- [ ] **Add voice load to strike authoring**
+- [x] **Add voice load to strike authoring**
 
   Update `src/templates/agent-skills/commands/smithy.strike.prompt` so strike-document prose drafting invokes `Skill("smithy.helper-voice")` in draft mode for Explanation sections and concise task guidance. Keep the existing one-shot behavior and artifact template shape intact for AS 1.3.
 
@@ -136,7 +136,7 @@
   - Reference and How-to sections remain concise and structured.
   - No helper taxonomy text is pasted into the strike prompt.
 
-- [ ] **Add voice load to engrave authoring**
+- [x] **Add voice load to engrave authoring**
 
   Update `src/templates/agent-skills/commands/smithy.engrave.prompt` so decision, invariant, and principle prose authoring invokes `Skill("smithy.helper-voice")` in draft mode at the record-writing points. Preserve the durable-knowledge schema and append-only lifecycle rules for AS 1.3.
 
@@ -145,7 +145,7 @@
   - Decision, invariant, and principle schemas remain unchanged.
   - No helper taxonomy text is pasted into the engrave prompt.
 
-- [ ] **Add narrative-command regression coverage and validate**
+- [x] **Add narrative-command regression coverage and validate**
 
   Add focused coverage in `src/templates.test.ts` (or its helpers) asserting that the composed `smithy.spark`, `smithy.ignite`, `smithy.strike`, and `smithy.engrave` templates each carry a named `Skill("smithy.helper-voice")` reference and parse cleanly. Keep assertions structural — check for the named helper reference, not exact taxonomy wording. Then run the parse tests and the relevant eval scenarios after editing spark, ignite, strike, and engrave; keep the `.claude/` snapshot unchanged per FR-016.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -936,6 +936,40 @@ describe('getComposedTemplates', () => {
     expect(body).toMatch(/Provider-neutral/i);
   });
 
+  it('narrative commands load smithy.helper-voice for direct prose authoring', () => {
+    const commandNames = [
+      'smithy.spark.md',
+      'smithy.ignite.md',
+      'smithy.strike.md',
+      'smithy.engrave.md',
+    ];
+
+    for (const commandName of commandNames) {
+      const command = composed.commands.get(commandName);
+      expect(command, `${commandName} should be composed`).toBeDefined();
+      expect(command!, `${commandName} should name the helper skill`).toContain(
+        'Skill("smithy.helper-voice")',
+      );
+      expect(command!, `${commandName} should load the helper in draft mode`).toMatch(
+        /draft mode/i,
+      );
+    }
+
+    const spark = composed.commands.get('smithy.spark.md')!;
+    expect(spark).toContain('Keep the Problem Statement path delegated to `smithy-prose`');
+
+    const ignite = composed.commands.get('smithy.ignite.md')!;
+    expect(ignite).toContain('Keep Summary, Motivation / Problem Statement, and Personas delegated');
+
+    const strike = composed.commands.get('smithy.strike.md')!;
+    expect(strike).toContain('Reference and How-to sections as');
+
+    const engrave = composed.commands.get('smithy.engrave.md')!;
+    expect(engrave).toContain('preserving the decision schema');
+    expect(engrave).toContain('preserving the invariant schema');
+    expect(engrave).toContain('preserving the principle schema');
+  });
+
   // Issue #407 (EPIC #404): smithy.helper-screen-design is a body-only,
   // lazy-loaded operational skill that owns the authoring contract for
   // `design/screens/<ScreenId>.design.md`. The skill body is the single

--- a/src/templates/agent-skills/commands/smithy.engrave.prompt
+++ b/src/templates/agent-skills/commands/smithy.engrave.prompt
@@ -193,6 +193,11 @@ If no prior records exist, start at `D-1` / `INV-1` / `P-1`.
 
 ## Phase 3a: Create a decision
 
+Before authoring decision body prose, load `Skill("smithy.helper-voice")` in
+draft mode. Use it for the Context, Decision, Consequences, Establishes, and
+Citations prose while preserving the decision schema exactly as defined above.
+Do not inline the helper's taxonomy in this prompt.
+
 1. Search the repo for existing decisions whose `topics` / `applies_to`
    overlap with the new topic. If any look like they would be superseded
    by what the user is proposing, surface them and ask whether the new
@@ -253,6 +258,11 @@ If no prior records exist, start at `D-1` / `INV-1` / `P-1`.
 
 ## Phase 3b: Create an invariant
 
+Before authoring invariant body prose, load `Skill("smithy.helper-voice")` in
+draft mode. Use it for the Rule, Rationale, and Citations prose while
+preserving the invariant schema and Known-Exceptions ledger shape exactly as
+defined above.
+
 1. Confirm the **establishing decision**: invariants always cite at least
    one decision in `established_by`. If the caller did not pass one,
    either reference an existing decision (closest match by topic) or
@@ -300,6 +310,10 @@ If no prior records exist, start at `D-1` / `INV-1` / `P-1`.
 ---
 
 ## Phase 3c: Create a principle
+
+Before authoring principle body prose, load `Skill("smithy.helper-voice")` in
+draft mode. Use it for the Statement, apex rationale, and citation guidance
+while preserving the principle schema exactly as defined above.
 
 Principles are apex commitments — the project constitution. Authoring a
 new principle is rare. Before scaffolding, confirm with the user:

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -402,6 +402,13 @@ sessions on this RFC can deduplicate against them:
 canonical title formats and check for repo-level overrides in the project's
 CLAUDE.md. Apply those conventions to all headings in this artifact.
 
+Before drafting orchestrator-inline RFC prose in this phase, load
+`Skill("smithy.helper-voice")` in draft mode. Use it as the shared voice
+source for directly authored RFC sections such as Decisions and coherence
+repairs. Keep Summary, Motivation / Problem Statement, and Personas delegated
+to `smithy-prose` where those sub-phases already own the narrative drafting,
+and do not inline the helper's taxonomy here.
+
 {{#ifAgent}}
 ### RFC File Creation
 

--- a/src/templates/agent-skills/commands/smithy.spark.prompt
+++ b/src/templates/agent-skills/commands/smithy.spark.prompt
@@ -173,6 +173,14 @@ canonical title formats and check for repo-level overrides in the project's
 CLAUDE.md. Apply those conventions to all headings in this artifact. The PRD
 H1 follows the pattern `# PRD: <Title>`.
 
+Before drafting orchestrator-inline PRD prose in this phase, load
+`Skill("smithy.helper-voice")` in draft mode. Use it as the shared voice
+source for directly authored PRD sections such as Proposed Solution, Target
+Users, Success Signals, Assumptions, Specification Debt framing, and Open
+Questions. Keep the Problem Statement path delegated to `smithy-prose`; do not
+route every PRD section through that sub-agent, and do not inline the helper's
+taxonomy here.
+
 ### PRD File Creation
 
 1. Create the `{{artifactsRoot}}docs/prds/` directory if it does not already exist. Phase 1

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -114,6 +114,12 @@ strike document is written and no PR is created.
 canonical title formats and check for repo-level overrides in the project's
 CLAUDE.md. Apply those conventions to all headings in this artifact.
 
+Before writing prose-bearing strike sections, load
+`Skill("smithy.helper-voice")` in draft mode. Use it for Explanation sections
+and concise task guidance while preserving Reference and How-to sections as
+structured artifact content. Do not inline the helper's taxonomy in this
+prompt.
+
 Write a single strike document to `{{artifactsRoot}}specs/strikes/YYYY-MM-DD-<slug>.strike.md`
 with this format:
 


### PR DESCRIPTION
## Summary

Implements **Slice 3** of User Story 1 ("Prose-Drafting Surfaces Consult the Skill in Draft Mode") for spec `2026-06-06-012-integrate-the-voice-helper-across-smithy-prose-surfaces`.

Wires the narrative and durable-knowledge command prompts to load `Skill("smithy.helper-voice")` in draft mode at their direct prose-authoring points, while preserving existing `smithy-prose` delegation and artifact schemas.

## Changes

- **`smithy.spark`** — draft-mode helper load for directly authored PRD prose (Proposed Solution, Target Users, Success Signals, etc.); Problem Statement stays delegated to `smithy-prose`.
- **`smithy.ignite`** — draft-mode helper load for orchestrator-inline RFC prose; Summary / Motivation / Problem Statement / Personas stay delegated to `smithy-prose`. One-shot output contract and RFC template untouched.
- **`smithy.strike`** — draft-mode helper load before writing prose-bearing strike sections; Reference/How-to sections remain structured. One-shot behavior intact.
- **`smithy.engrave`** — draft-mode helper load at the decision (3a), invariant (3b), and principle (3c) record-writing points; durable-knowledge schemas and append-only lifecycle preserved.
- **`src/templates.test.ts`** — structural regression test asserting spark, ignite, strike, and engrave each compose with a named `Skill("smithy.helper-voice")` draft-mode reference and retain their delegation/schema markers.

No helper taxonomy text is inlined into any prompt. `.claude/` snapshot and `.smithy/smithy-manifest.json` left unchanged per FR-016.

## Acceptance criteria

Addresses FR-002, FR-003, FR-016; AS 1.3, AS 1.4. All five Slice 3 task rows flipped `[ ]` to `[x]` in the tasks.md.

## Verification

- `npm run typecheck` — passes.
- `npm test -- src/templates.test.ts` — 203 passed, including the new narrative-command test.

### Verification gap

- **Eval scenarios not run.** The slice's validation AC asks for the spark/ignite/strike/engrave eval scenarios to complete (or be noted). Those require live LLM-agent runs (`npm run eval`) outside this verification environment, so they were not executed here. The change is template-only and is structurally guarded by the new `templates.test.ts` assertions; the eval run should be performed before relying on SC-001 invocation behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
