### PR TITLE
Generalize screen/flow UI artifact contracts (US2 S1)

### DIFF
--- a/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/02-tool-agnostic-screen-flow-generation-from-the-projects-own-stack.tasks.md
+++ b/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/02-tool-agnostic-screen-flow-generation-from-the-projects-own-stack.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Rename screen component contract**
+- [x] **Rename screen component contract**
 
   Update `src/templates/agent-skills/skills/smithy.helper-screen-design/SKILL.prompt` so screen annotations require `component-path` instead of the Compose-specific field. Keep Compose as a worked example only, and preserve the rationale-only body rules for AS 2.3.
 
@@ -28,7 +28,7 @@
   - Review checklist validates `component-path`
   - Rationale-only screen body rules remain intact
 
-- [ ] **Rename flow test-body contract**
+- [x] **Rename flow test-body contract**
 
   Update `src/templates/agent-skills/skills/smithy.helper-flow-definition/SKILL.prompt` so flow annotations require `test-body` instead of the Maestro-specific field. Keep Maestro as one executable-body example while preserving the intent-only `.flow.md` rule for AS 2.3.
 
@@ -39,7 +39,7 @@
   - Review checklist validates `test-body`
   - `.flow.md` bodies remain intent-only with no step enumeration
 
-- [ ] **Align feature-kind documentation**
+- [x] **Align feature-kind documentation**
 
   Update `src/templates/agent-skills/snippets/feature-kinds.md` and `src/templates/agent-skills/README.md` so UI feature metadata points to neutral screen and flow artifacts. The docs should make backend versus UI output visible without implying a fixed framework or driver, satisfying AS 2.3.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -965,13 +965,13 @@ describe('getComposedTemplates', () => {
     expect(skill.prompt).toMatch(/authoring or auditing/i);
     expect(skill.prompt).toContain('kind: ui');
     // The four schema keys are the load-bearing claim of the description.
-    expect(skill.prompt).toMatch(/id\s*\/\s*composable\s*\/\s*design_system\s*\/\s*bundle/);
+    expect(skill.prompt).toMatch(/id\s*\/\s*component-path\s*\/\s*design_system\s*\/\s*bundle/);
   });
 
   it('smithy.helper-screen-design body documents the four front-matter fields', () => {
     const skill = composed.skills.get('smithy.helper-screen-design')!;
     expect(skill.prompt).toContain('## YAML front-matter schema');
-    for (const field of ['`id`', '`composable`', '`design_system`', '`bundle`']) {
+    for (const field of ['`id`', '`component-path`', '`design_system`', '`bundle`']) {
       expect(skill.prompt).toContain(field);
     }
     // Explicit YAML labeling — the front-matter is YAML between `---` fences,
@@ -996,7 +996,7 @@ describe('getComposedTemplates', () => {
   it('smithy.helper-screen-design enforces the no-re-description rule', () => {
     const skill = composed.skills.get('smithy.helper-screen-design')!;
     // The whole point of the annotation is that it is NOT a parallel screen
-    // spec — the composable owns layout/behavior, this file owns intent.
+    // spec — the component owns layout/behavior, this file owns intent.
     // Guard against a future edit that softens the rule.
     expect(skill.prompt).toMatch(/thin/i);
     expect(skill.prompt).toMatch(/intent/i);
@@ -1011,8 +1011,9 @@ describe('getComposedTemplates', () => {
     expect(skill.prompt).toContain('## Skeleton template');
     expect(skill.prompt).toContain('## Worked example — `Library.design.md`');
     // Library example must be filled out, not a placeholder — at least the
-    // composable path and the rationale sections from the issue.
+    // component path and the rationale sections from the issue.
     expect(skill.prompt).toContain('id: Library');
+    expect(skill.prompt).toContain('component-path:');
     expect(skill.prompt).toContain('LibraryScreen.kt');
     expect(skill.prompt).toContain('story-spider-design');
   });
@@ -1024,7 +1025,7 @@ describe('getComposedTemplates', () => {
     // line-by-line list of findings. Guard the items that matter most.
     expect(skill.prompt).toContain('## Review checklist');
     expect(skill.prompt).toMatch(/Missing required front-matter key/i);
-    expect(skill.prompt).toMatch(/composable[\s\S]*does not resolve/i);
+    expect(skill.prompt).toMatch(/component-path[\s\S]*does not resolve/i);
     // The forbidden body sections must be named explicitly in the checklist —
     // a vague "no layout content" wouldn't give the audit a hit-list.
     for (const heading of [
@@ -1069,10 +1070,9 @@ describe('getComposedTemplates', () => {
   // Issue #406 (EPIC #404): smithy.helper-flow-definition is a body-only,
   // lazy-loaded operational skill that owns the authoring contract for the
   // durable Flow entity pair — `design/flows/<FlowId>.flow.md` (intent
-  // annotation) + `maestro/flows/<FlowId>.yaml` (executable behavioral
-  // body), keyed 1:1 by flat FlowId. The skill body is the single source
+  // annotation) + one executable test body, keyed 1:1 by flat FlowId. The skill body is the single source
   // of truth for the YAML front-matter schema, the rationale-only body
-  // rule, the Maestro selector contract, the testID naming convention,
+  // rule, the driver-neutral selector contract, the testID naming convention,
   // and the worked AddTitle example, so downstream commands
   // (`smithy.forge` once #408 wires UI emission, `smithy.audit` /
   // `flow-lint` once #409 lands, and `flow-scaffold` once #410 lands)
@@ -1097,19 +1097,19 @@ describe('getComposedTemplates', () => {
     // and the three front-matter keys so calling agents recognize when to
     // lazy-load it.
     expect(skill.prompt).toContain('design/flows/<FlowId>.flow.md');
-    expect(skill.prompt).toContain('maestro/flows/<FlowId>.yaml');
+    expect(skill.prompt).toContain('<test-body>');
     expect(skill.prompt).toMatch(/authoring or auditing/i);
     expect(skill.prompt).toContain('kind: ui');
     expect(skill.prompt).toMatch(/phase:\s*wire/);
     // The three flow.md schema keys are the load-bearing key list of the
     // description.
-    expect(skill.prompt).toMatch(/id\s*\/\s*screens\s*\/\s*maestro/);
+    expect(skill.prompt).toMatch(/id\s*\/\s*screens\s*\/\s*test-body/);
   });
 
   it('smithy.helper-flow-definition body documents the three front-matter fields', () => {
     const skill = composed.skills.get('smithy.helper-flow-definition')!;
     expect(skill.prompt).toContain('## YAML front-matter schema');
-    for (const field of ['`id`', '`screens`', '`maestro`']) {
+    for (const field of ['`id`', '`screens`', '`test-body`']) {
       expect(skill.prompt).toContain(field);
     }
     // Explicit YAML labeling — the front-matter is YAML between `---`
@@ -1135,7 +1135,7 @@ describe('getComposedTemplates', () => {
   it('smithy.helper-flow-definition enforces the no-step-descriptions rule', () => {
     const skill = composed.skills.get('smithy.helper-flow-definition')!;
     // The whole point of the pair is that the `.flow.md` body is NOT a
-    // parallel narration of the yaml — the yaml owns the steps, the
+    // parallel narration of the test body — the test body owns the steps, the
     // `.flow.md` owns intent. Guard against a future edit that softens
     // the rule.
     expect(skill.prompt).toMatch(/thin/i);
@@ -1148,11 +1148,11 @@ describe('getComposedTemplates', () => {
     );
   });
 
-  it('smithy.helper-flow-definition pins the Maestro selector contract (testIDs, not visible text)', () => {
+  it('smithy.helper-flow-definition pins the driver-neutral selector contract (testIDs, not visible text)', () => {
     const skill = composed.skills.get('smithy.helper-flow-definition')!;
     // Issue #406's load-bearing rule: selectors keyed to testIDs /
     // accessibility IDs / semantic tags — never visible text or layout
-    // position. The yaml side becomes useless if this rule softens.
+    // position. The executable test body becomes useless if this rule softens.
     expect(skill.prompt).toMatch(/testID/);
     expect(skill.prompt).toMatch(/accessibility/i);
     expect(skill.prompt).toMatch(/never visible text/i);
@@ -1161,7 +1161,7 @@ describe('getComposedTemplates', () => {
     // the happy path is a smoke test, not a durable flow.
     expect(skill.prompt).toMatch(/traversal/i);
     expect(skill.prompt).toMatch(/guard/i);
-    expect(skill.prompt).toMatch(/cannot reach confirm[^\n]*valid URL/i);
+    expect(skill.prompt).toMatch(/confirm[\s\S]*valid URL/i);
   });
 
   it('smithy.helper-flow-definition documents the testID naming convention', () => {
@@ -1181,13 +1181,13 @@ describe('getComposedTemplates', () => {
     expect(skill.prompt).toContain('## Worked example');
     // AddTitle example must be filled out (not a placeholder), with both
     // halves of the pair: front-matter for `.flow.md` and a testID-keyed
-    // yaml exercising the URL guard.
+    // executable test body exercising the URL guard.
     expect(skill.prompt).toContain('design/flows/AddTitle.flow.md');
     expect(skill.prompt).toContain('maestro/flows/AddTitle.yaml');
     expect(skill.prompt).toMatch(/id:\s*AddTitle/);
     expect(skill.prompt).toMatch(/screens:\s*\[Library,\s*AddTitle\]/);
-    expect(skill.prompt).toMatch(/maestro:\s*maestro\/flows\/AddTitle\.yaml/);
-    // The yaml side must include the URL-guard assertion the issue calls
+    expect(skill.prompt).toMatch(/test-body:\s*maestro\/flows\/AddTitle\.yaml/);
+    // The executable test body must include the URL-guard assertion the issue calls
     // out: confirm is not visible until URL is valid.
     expect(skill.prompt).toContain('add-title-url-field');
     expect(skill.prompt).toContain('add-title-confirm-button-enabled');
@@ -1196,9 +1196,9 @@ describe('getComposedTemplates', () => {
 
   it('smithy.helper-flow-definition documents the audio-service coverage caveat', () => {
     const skill = composed.skills.get('smithy.helper-flow-definition')!;
-    // Issue #406 coverage caveat: Maestro covers navigable bookends.
+    // Coverage caveat: UI-driver flow tests cover navigable bookends.
     // Audio-service behaviors (auto-advance under lock, foreground TTS)
-    // need instrumentation-level tests. A green Maestro run must NOT
+    // need instrumentation-level tests. A green UI-driver run must NOT
     // imply TTS coverage.
     expect(skill.prompt).toMatch(/navigable bookends/i);
     expect(skill.prompt).toMatch(/auto-advance/i);
@@ -1214,7 +1214,7 @@ describe('getComposedTemplates', () => {
     // line-by-line list of findings. Guard the items that matter most.
     expect(skill.prompt).toContain('## Review checklist');
     expect(skill.prompt).toMatch(/Missing required front-matter key/i);
-    expect(skill.prompt).toMatch(/maestro[\s\S]*does not resolve/i);
+    expect(skill.prompt).toMatch(/test-body[\s\S]*does not resolve/i);
     // The forbidden body sections must be named explicitly in the
     // checklist — a vague "no walkthrough content" wouldn't give the
     // audit a hit-list.
@@ -1227,7 +1227,7 @@ describe('getComposedTemplates', () => {
       expect(skill.prompt).toContain(heading);
     }
     // Selector-quality checks: visible text and layout-index selectors
-    // are the failure modes the yaml side guards against.
+    // are the failure modes the executable test body guards against.
     expect(skill.prompt).toMatch(/text:[^\n]*selector|visible-text matcher/i);
     expect(skill.prompt).toMatch(/layout[- ]index/i);
   });

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1161,7 +1161,7 @@ describe('getComposedTemplates', () => {
     // the happy path is a smoke test, not a durable flow.
     expect(skill.prompt).toMatch(/traversal/i);
     expect(skill.prompt).toMatch(/guard/i);
-    expect(skill.prompt).toMatch(/confirm[\s\S]*valid URL/i);
+    expect(skill.prompt).toMatch(/cannot reach\s+confirm without a valid URL/i);
   });
 
   it('smithy.helper-flow-definition documents the testID naming convention', () => {

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -206,7 +206,7 @@ schema; the same field set is captured once in the `feature-kinds` snippet
 |-----|------|----------|-------|
 | `kind` | both | Yes | `backend` or `ui`. Selects the downstream `forge` profile. |
 | `phase` | ui | Yes | `build` or `wire` — a **feature-level** attribute. |
-| `design_system` | ui | Yes | Reference to the committed design skill (e.g. `story-spider-design`); source of truth even when a bundle is present. |
+| `design_system` | ui | Yes | Reference to the committed design skill (for example `story-spider-design`); source of truth even when a bundle is present. |
 | `bundle` | ui | No | Repo-relative path to a Claude Design export — a visual/structural reference, not a drop-in. Bundle wins on layout & visual intent; the design skill wins on implementation dialect. |
 | `flag` | ui | Yes (flag-gated) | Feature-flag name; the shared contract joining a `build` feature to its `wire` feature. |
 | `screens` | ui | Yes | List of `ScreenId`, e.g. `[AddTitle]`. |
@@ -219,8 +219,8 @@ spec (prose delta).
 
 | `phase` | Means | Done when |
 |---------|-------|-----------|
-| `build` | Implement the screen against a mock, behind `flag`. No real data. | Screen renders every brief state using only design-system tokens/components, gated by the flag. |
-| `wire` | Connect the screen to real data/actions and flip the flag. | Real data wired **and** the Maestro flow + `flow.md` emitted/updated for every flow in `flows`. |
+| `build` | Implement the screen component against a mock, behind `flag`. No real data. | Screen renders every brief state using only design-system tokens/components, gated by the flag. |
+| `wire` | Connect the screen to real data/actions and flip the flag. | Real data wired **and** the executable test body + `flow.md` emitted/updated for every flow in `flows` using the project's UI driver. |
 
 ### The seam = two features sharing one flag
 
@@ -283,7 +283,8 @@ flows: [AddTitle]
 ```
 
 **Description**: Connect AddTitle to `LibraryStore` and flip `add_title_v1`. Confirm
-persists a real `Title`; done includes emitting `maestro/flows/AddTitle.yaml` and
+persists a real `Title`; done includes emitting the executable test body
+(`maestro/flows/AddTitle.yaml` in this Maestro example) and
 `design/flows/AddTitle.flow.md`.
 ````
 
@@ -303,11 +304,12 @@ on `—` (build-ahead-of-backend).
 
 Each `ScreenId` listed under a UI feature's `screens:` field resolves — in the
 **app repo, not in Smithy** — to a thin durable annotation at
-`design/screens/<ScreenId>.design.md`. The composable is the screen's body; this
-file carries the screen's *intent* (why it exists, deliberate choices, deferred
-bits) colocated with the code so it travels and versions with the composable.
+`design/screens/<ScreenId>.design.md`. The screen's component file is the body;
+this file carries the screen's *intent* (why it exists, deliberate choices,
+deferred bits) colocated with the code so it travels and versions with the
+component.
 
-The full authoring contract — YAML front-matter schema (`id`, `composable`,
+The full authoring contract — YAML front-matter schema (`id`, `component-path`,
 `design_system`, `bundle`), the rationale-only body rule, the skeleton template,
 a worked `Library.design.md` example, naming decisions, and a review checklist
 — lives in the body-on-demand skill **`smithy.helper-screen-design`**
@@ -321,17 +323,17 @@ cannot drift.
 Each `FlowId` listed under a UI feature's `flows:` field resolves — in the
 **app repo, not in Smithy** — to a durable **1:1 pair** of files:
 `design/flows/<FlowId>.flow.md` (thin intent annotation) and
-`maestro/flows/<FlowId>.yaml` (executable behavioral body). The yaml owns
-the steps and guard assertions a UI driver replays; the `.flow.md` owns
-*why* — the product truth the flow preserves, why the guards exist,
-deliberate entry / exit, and a coverage caveat for anything below what a UI
-driver can observe.
+an executable test body in the project's UI driver (for example
+`maestro/flows/<FlowId>.yaml`). The test body owns the steps and guard
+assertions a UI driver replays; the `.flow.md` owns *why* — the product truth
+the flow preserves, why the guards exist, deliberate entry / exit, and a
+coverage caveat for anything below what a UI driver can observe.
 
 The full authoring contract — YAML front-matter schema (`id`, `screens`,
-`maestro`), the rationale-only body rule, the Maestro selector contract
-(testID-keyed only, asserts traversal AND guards), the testID naming
-convention, skeleton templates for both halves, a worked `AddTitle` example,
-naming decisions, the audio-service coverage caveat, and a review checklist
+`test-body`), the rationale-only body rule, the driver-neutral selector
+contract (testID-keyed only, asserts traversal AND guards), the testID naming
+convention, skeleton templates for both halves, worked examples including
+Maestro, naming decisions, the audio-service coverage caveat, and a review checklist
 — lives in the body-on-demand skill **`smithy.helper-flow-definition`**
 (`skills/smithy.helper-flow-definition/SKILL.prompt`). Agents lazy-load it
 via `Skill("smithy.helper-flow-definition")` when authoring or auditing a

--- a/src/templates/agent-skills/skills/smithy.helper-flow-definition/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.helper-flow-definition/SKILL.prompt
@@ -1,6 +1,6 @@
 ---
 name: smithy.helper-flow-definition
-description: "Schema and authoring rules for the durable Flow entity pair — `design/flows/<FlowId>.flow.md` (thin intent annotation) and `maestro/flows/<FlowId>.yaml` (executable behavioral body) — keyed 1:1 by flat FlowId. Use when authoring or auditing a flow definition, when emitting a flow as part of a UI feature's wire phase (kind: ui, phase: wire), or when validating an existing flow stays thin and testID-keyed. Provides the YAML front-matter field schema (id / screens / maestro), the rationale-only body rule, the Maestro yaml selector contract, the testID naming convention, a skeleton template, and a worked AddTitle example."
+description: "Schema and authoring rules for the durable Flow entity pair — `design/flows/<FlowId>.flow.md` (thin intent annotation) and a paired executable test body — keyed 1:1 by flat FlowId. Use when authoring or auditing a flow definition, when emitting a flow as part of a UI feature's wire phase (kind: ui, phase: wire), or when validating an existing flow stays thin and testID-keyed. Provides the YAML front-matter field schema (id / screens / test-body), the rationale-only body rule, the driver-neutral selector contract, the testID naming convention, a skeleton template, and a worked AddTitle example."
 ---
 # smithy.helper-flow-definition
 
@@ -10,16 +10,16 @@ represented by a **1:1 pair** keyed by a flat `FlowId`:
 
 ```
 design/flows/<FlowId>.flow.md      # durable INTENT annotation (why)
-maestro/flows/<FlowId>.yaml        # durable BEHAVIORAL body (what runs)
+<test-body>                        # durable BEHAVIORAL body (what runs)
 ```
 
 Both files live in the **app repo**, alongside the code, not in Smithy. Load
 this skill when:
 
-- Writing or updating a `<FlowId>.flow.md` + `<FlowId>.yaml` pair for a
+- Writing or updating a `<FlowId>.flow.md` + executable test-body pair for a
   `kind: ui` feature at `phase: wire`.
 - Auditing an existing flow for drift, redundancy, fragile selectors, or
-  step-leakage from yaml into prose.
+  step-leakage from the executable test body into prose.
 - Emitting a flow as part of `forge`'s UI wire phase
   (EPIC #404 / issue #408).
 - Validating cross-references during `flow-lint` (issue #409).
@@ -34,22 +34,23 @@ features have no flow artifact at all — flows are only emitted at `wire`.
 ## Why a thin annotation + an executable body (not a single spec)
 
 The "third lifetime" question for flows — *what is durable about a user
-journey?* — resolves to: **the Maestro yaml**. Every spec we could write
-that re-narrates the path in prose is either already encoded in the yaml or
-destined to drift against it. So the pair splits cleanly:
+journey?* — resolves to: **the executable test body**. Every spec we could
+write that re-narrates the path in prose is either already encoded in the
+project's UI-driver test file or destined to drift against it. So the pair
+splits cleanly:
 
-- **The Maestro yaml owns behavior** — the actual taps, asserts, and
-  guards a UI driver replays. It is the executable proof that the journey
+- **The executable test body owns behavior** — the actual actions, asserts,
+  and guards a UI driver replays. It is the executable proof that the journey
   still works.
 - **The `.flow.md` owns intent** — *why* the flow is a durable truth, *why*
   the guards exist, where the user comes from and where they end up, and
-  what the yaml cannot cover. Colocated with the design folder so neither
-  half moves without the other.
+  what the UI driver cannot cover. Colocated with the design folder so
+  neither half moves without the other.
 
 If a contributor can replay the journey by reading the `.flow.md`, the file
-is wrong (those steps belong in the yaml). If the yaml lists taps but
-asserts no guards, the yaml is wrong (it has regressed to a smoke test).
-The pair stays honest only when each file owns its lane.
+is wrong (those steps belong in the executable test body). If the test body
+lists actions but asserts no guards, the test body is wrong (it has regressed
+to a smoke test). The pair stays honest only when each file owns its lane.
 
 ---
 
@@ -60,9 +61,9 @@ Three keys, all required:
 
 | Key | Required | Notes |
 |-----|----------|-------|
-| `id` | Yes | Flat, stable `FlowId` (e.g. `AddTitle`). Matches the `.flow.md` and `.yaml` filename stems and the `flows:` list of the originating UI feature in `.features.md`. Never reused across flows. |
+| `id` | Yes | Flat, stable `FlowId` (e.g. `AddTitle`). Matches the `.flow.md` filename stem and the paired executable test body named by `test-body`, plus the `flows:` list of the originating UI feature in `.features.md`. Never reused across flows. |
 | `screens` | Yes | List of `ScreenId` the flow traverses, in entry order (e.g. `[Library, AddTitle]`). Each entry must appear in some feature's `screens:` field; cross-file resolution is enforced by `flow-lint` (#409). |
-| `maestro` | Yes | Repo-relative path to the paired Maestro yaml (e.g. `maestro/flows/AddTitle.yaml`). The path is the contract; renaming the yaml without updating this field is a `flow-lint` failure. |
+| `test-body` | Yes | Repo-relative path to the paired executable test body in the project's UI driver (for example `maestro/flows/AddTitle.yaml` for Maestro, or `tests/e2e/add-title.spec.ts` for Playwright/Cypress). The path is the contract; renaming the test without updating this field is a `flow-lint` failure. |
 
 No other keys. In particular, **no `feature:` or `kind:` field here** — flow
 membership is declared on the originating feature in `.features.md`;
@@ -78,43 +79,45 @@ in this order, followed by a mandatory coverage caveat:
 | Section | What goes here | What does *not* go here |
 |---------|----------------|--------------------------|
 | `## Intent` | The durable product truth this flow preserves — one short paragraph. *Why* this journey is worth a permanent test. | Step descriptions, taps, screen transitions. |
-| `## Guards` | The guarantees that must hold along the path, stated as invariants the yaml asserts (e.g. "Confirm is disabled until the URL is valid"). State the invariant **and the why**. | The yaml lines that check them — those live in the yaml. |
+| `## Guards` | The guarantees that must hold along the path, stated as invariants the executable test body asserts (e.g. "Confirm is disabled until the URL is valid"). State the invariant **and the why**. | The test lines that check them — those live in the test body. |
 | `## Entry / Exit` | Where the user enters from (the testID or surface that starts the flow) and where they end up. Two short bullets. | The intermediate steps. |
-| `## Coverage Caveat` | What this Maestro flow does **not** observe (audio-service behaviors, background work, anything below the UI driver). Mandatory whenever the screen touches an audio surface. | Aspirational coverage; coverage lives where the test does. |
+| `## Coverage Caveat` | What this UI-driver flow does **not** observe (audio-service behaviors, background work, anything below the UI driver). Mandatory whenever the screen touches an audio surface. | Aspirational coverage; coverage lives where the test does. |
 
 There is **no `## Steps`, `## Walkthrough`, `## Flow`, or `## Path` section.**
-The yaml owns the steps. If you find yourself typing "the user taps the
-FAB, then the AddTitle screen appears, then…" — stop. That belongs in the
-yaml, not here. No tap-by-tap walkthroughs, no copy strings, no per-step
-screenshots.
+The executable test body owns the steps. If you find yourself typing "the user
+taps the FAB, then the AddTitle screen appears, then…" — stop. That belongs
+in the executable test body, not here. No tap-by-tap walkthroughs, no copy
+strings, no per-step screenshots.
 
 ---
 
-## Maestro yaml contract
+## Executable test-body contract
 
-The yaml is the executable behavioral body. Three load-bearing rules:
+The test body is the executable behavioral body. It uses the project's UI test
+driver; Maestro yaml is one valid example, not the required format. Three
+load-bearing rules:
 
-1. **1:1 with `FlowId`.** One flow = one Maestro flow. Variants that earn a
-   durable name earn their own `FlowId`; never fold multiple paths
-   ("happy + error path") into one yaml.
+1. **1:1 with `FlowId`.** One flow = one executable test body. Variants that
+   earn a durable name earn their own `FlowId`; never fold multiple paths
+   ("happy + error path") into one test body.
 2. **Selectors are keyed to testIDs, accessibility IDs, or semantic tags —
    never visible text and never layout position.** Flow tests must fail
    on *path* changes (a tap moved, a guard removed, a screen reordered)
    and survive *visual* changes (copy edits, palette swaps, spacing
    tweaks). Visual iteration happens upstream on the design canvas, not
    here.
-3. **Assert the traversal AND the guards.** A Maestro flow that only walks
-   the happy path provides no durability — the guard assertions
-   (`cannot reach confirm without a valid URL`) are what catch path
-   regressions. Every guard named in the `.flow.md` body must have at
-   least one corresponding `assertVisible` / `assertNotVisible` in the
-   yaml.
+3. **Assert the traversal AND the guards.** A test body that only walks the
+   happy path provides no durability — the guard assertions (`cannot reach
+   confirm without a valid URL`) are what catch path regressions. Every guard
+   named in the `.flow.md` body must have at least one corresponding assertion
+   in the test body.
 
 ---
 
 ## testID naming convention
 
-Composables expose stable test IDs so the Maestro yaml can key off them:
+UI components expose stable test IDs so the executable test body can key off
+them:
 
 - **kebab-case**, ASCII-lowercase, hyphens only. No camelCase, no
   underscores, no spaces.
@@ -153,7 +156,7 @@ Composables expose stable test IDs so the Maestro yaml can key off them:
 ---
 id: <FlowId>
 screens: [<ScreenId>, <ScreenId>]
-maestro: maestro/flows/<FlowId>.yaml
+test-body: <repo-relative path to the paired executable test body>
 ---
 
 # Flow: <FlowId>
@@ -165,8 +168,8 @@ journey is worth a permanent test — not what the user taps.>
 
 ## Guards
 
-- **<invariant>.** <Why it matters; the yaml asserts it.>
-- **<invariant>.** <Why it matters; the yaml asserts it.>
+- **<invariant>.** <Why it matters; the test body asserts it.>
+- **<invariant>.** <Why it matters; the test body asserts it.>
 
 ## Entry / Exit
 
@@ -181,7 +184,7 @@ audio-service surface. Audio-service behaviors (auto-advance under lock,
 foreground TTS, audio-focus handling) need instrumentation-level tests.>
 ````
 
-**`maestro/flows/<FlowId>.yaml`:**
+**Example `test-body` (`maestro/flows/<FlowId>.yaml`):**
 
 ```yaml
 # Selectors are keyed to testIDs. Never visible text, never layout position.
@@ -211,7 +214,7 @@ appId: <reverse-domain.app.id>
 
 ---
 
-## Worked example — `AddTitle.flow.md` and `AddTitle.yaml`
+## Worked example — `AddTitle.flow.md` and a Maestro `AddTitle.yaml`
 
 **`design/flows/AddTitle.flow.md`:**
 
@@ -219,7 +222,7 @@ appId: <reverse-domain.app.id>
 ---
 id: AddTitle
 screens: [Library, AddTitle]
-maestro: maestro/flows/AddTitle.yaml
+test-body: maestro/flows/AddTitle.yaml
 ---
 
 # Flow: AddTitle
@@ -300,9 +303,10 @@ appId: com.storyspider.app
 
 Note what is *not* in the `.flow.md` body: no list of taps, no screen
 transitions, no copy strings, no per-step screenshots. Note what *is* in
-the yaml: not just the happy path, but the `assertNotVisible` →
+the executable test body: not just the happy path, but the `assertNotVisible` →
 `assertVisible` pair around `add-title-confirm-button-enabled` that proves
-the URL guard fires.
+the URL guard fires. The example uses Maestro yaml because that is Story
+Spider's driver; it is illustrative, not required by the schema.
 
 ---
 
@@ -314,9 +318,9 @@ the URL guard fires.
 - **`screens` is a list, in entry order.** A flow traverses more than one
   screen (that's what makes it a flow); listing them in entry order
   makes the resolution at `flow-lint` time deterministic.
-- **`maestro` is a path, not a derived convention.** Renaming the yaml
-  without updating the field is a `flow-lint` failure — the path is the
-  contract, not a derived guess.
+- **`test-body` is a path, not a derived convention or driver-specific field.**
+  Renaming the executable test without updating the field is a `flow-lint`
+  failure — the path is the contract, not a derived guess.
 - **No `feature:` or `kind:` field on the flow.** Feature membership is
   declared on the originating feature in `.features.md` via
   `flows: [FlowId]`; duplicating it here would create two places to
@@ -326,12 +330,13 @@ the URL guard fires.
 
 ## Coverage caveat — applies to every audio-touching flow
 
-Maestro covers **navigable bookends** — what a UI driver can observe by
-tapping, asserting visibility, and reading testID-keyed views.
+UI-driver flow tests cover **navigable bookends** — what a UI driver can
+observe by tapping/activating controls, asserting visibility, and reading
+testID-keyed views. Maestro yaml is one example of such a test body.
 **Audio-service behaviors** (auto-advance under lock, foreground TTS,
 audio-focus handling) sit below that layer; their durable body is
-**instrumentation-level tests**, not the Maestro flow.
-**A green Maestro run must not be read as TTS coverage.** Every `.flow.md`
+**instrumentation-level tests**, not the UI-driver flow body.
+**A green UI-driver run must not be read as TTS coverage.** Every `.flow.md`
 that touches an audio-service surface states this caveat explicitly under
 `## Coverage Caveat` so reviewers don't infer coverage that isn't there.
 
@@ -339,10 +344,10 @@ that touches an audio-service surface states this caveat explicitly under
 
 ## Don't over-apply
 
-Reserve Maestro-as-flow for **long-lived product truths** (Library add,
+Reserve executable flow bodies for **long-lived product truths** (Library add,
 read, TTS auto-advance). Marginal paths stay prose until they prove
-load-bearing. The cost of a Maestro flow is the maintenance commitment to
-its `.flow.md` + yaml pair forever — only pay it for journeys you would
+load-bearing. The cost of a flow is the maintenance commitment to its
+`.flow.md` + test-body pair forever — only pay it for journeys you would
 refuse to ship a release that broke.
 
 ---
@@ -352,26 +357,24 @@ refuse to ship a release that broke.
 When auditing an existing flow pair, flag any of the following:
 
 - [ ] Missing required front-matter key in `.flow.md` (`id`, `screens`,
-      `maestro`).
-- [ ] `maestro:` path does not resolve to an existing file in the repo.
+      `test-body`).
+- [ ] `test-body:` path does not resolve to an existing file in the repo.
 - [ ] `id` does not match the originating feature's `flows:` list, or is
       reused across flows.
 - [ ] `screens:` references a `ScreenId` that no feature declares.
 - [ ] `.flow.md` body contains a `## Steps`, `## Walkthrough`, `## Flow`,
       or `## Path` section.
-- [ ] `## Guards` lists invariants the yaml does **not** assert (every
-      guard must have a matching `assertVisible` / `assertNotVisible`).
+- [ ] `## Guards` lists invariants the test body does **not** assert.
 - [ ] `## Coverage Caveat` is missing on a flow whose screen touches an
       audio-service surface.
-- [ ] Maestro yaml uses `text:` selectors, visible-text matchers, or
-      layout-index selectors instead of `id:`-based testIDs / accessibility
-      IDs.
-- [ ] Maestro yaml asserts only the happy path (no `assertNotVisible` or
-      negative-state check anywhere) — guards must be testable, not just
-      narrated.
-- [ ] testID referenced in the yaml does not follow
+- [ ] Executable test body uses visible-text matchers or layout-index
+      selectors instead of testIDs / accessibility IDs / semantic tags.
+- [ ] Executable test body asserts only the happy path (no negative-state or
+      guard check anywhere) — guards must be testable, not just narrated.
+- [ ] testID referenced in the test body does not follow
       `<scope>-<element>[-<modifier>]` kebab-case naming.
-- [ ] Two yamls share one `FlowId`, or one `FlowId` has no matching yaml.
+- [ ] Two test bodies share one `FlowId`, or one `FlowId` has no matching
+      test body.
 
 Surface each as a finding for the parent command (`smithy.forge` review
 pass, `smithy.audit`, or `flow-lint`) to act on. This skill itself does

--- a/src/templates/agent-skills/skills/smithy.helper-screen-design/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.helper-screen-design/SKILL.prompt
@@ -1,13 +1,13 @@
 ---
 name: smithy.helper-screen-design
-description: "Schema and authoring rules for `design/screens/<ScreenId>.design.md` — the thin durable intent annotation that colocates with a UI screen's Jetpack Compose body. Use when authoring or auditing a screen design-context annotation, when emitting a screen as part of a UI feature (kind: ui), or when validating that an existing annotation stays thin. Provides the YAML front-matter field schema (id / composable / design_system / bundle), the rationale-only body rule, a skeleton template, and a worked Library example."
+description: "Schema and authoring rules for `design/screens/<ScreenId>.design.md` — the thin durable intent annotation that colocates with a UI screen's component body. Use when authoring or auditing a screen design-context annotation, when emitting a screen as part of a UI feature (kind: ui), or when validating that an existing annotation stays thin. Provides the YAML front-matter field schema (id / component-path / design_system / bundle), the rationale-only body rule, a skeleton template, and a worked Library example."
 ---
 # smithy.helper-screen-design
 
 Authoring contract for the thin durable annotation that carries a UI screen's
-*intent*. The composable is the screen's body; the `<ScreenId>.design.md` file
-at `design/screens/<ScreenId>.design.md` (in the **app repo**, alongside the
-code) is metadata *about* that body — why the screen exists, what was
+*intent*. The UI component is the screen's body; the `<ScreenId>.design.md`
+file at `design/screens/<ScreenId>.design.md` (in the **app repo**, alongside
+the code) is metadata *about* that body — why the screen exists, what was
 deliberately chosen, what was deferred. Load this skill when:
 
 - Writing a new `<ScreenId>.design.md` for a `kind: ui` feature.
@@ -26,13 +26,14 @@ features have no screen artifact at all.
 ## Why a thin annotation (not a screen spec)
 
 The "third lifetime" question for UI work — *what is durable about a screen?*
-— resolves to: **the composable**. Every spec we could write about layout,
-structure, or steps is either already encoded in the composable or destined
-to drift against it. So the durable artifact is rationale only:
+— resolves to: **the component body**. Every spec we could write about layout,
+structure, or steps is either already encoded in the project framework's
+component or destined to drift against it. So the durable artifact is rationale
+only:
 
-- **The composable owns layout, structure, and behavior** (verified by the
-  bundle when present, the design skill always, and the Maestro flow at
-  `wire`).
+- **The component owns layout, structure, and behavior** (verified by the
+  bundle when present, the design skill always, and the executable flow body
+  at `wire`).
 - **The `.design.md` owns intent** — the product reason, the choices, the
   non-decisions — colocated with the code so neither moves without the
   other.
@@ -51,7 +52,7 @@ fences. Four keys, three required:
 | Key | Required | Notes |
 |-----|----------|-------|
 | `id` | Yes | Flat, stable `ScreenId`. Matches the `screens:` list of the originating UI feature in `.features.md`; never reused across screens. |
-| `composable` | Yes | Repo-relative path to the owning Compose file (e.g. `app/src/main/kotlin/io/balexda/readercompose/ui/views/library/LibraryScreen.kt`). Paths survive package renames; the path is the contract, not a fully-qualified Kotlin name. |
+| `component-path` | Yes | Repo-relative path to the owning UI component file in the project's framework (for example a Compose file such as `app/src/main/kotlin/io/balexda/readercompose/ui/views/library/LibraryScreen.kt`, or a React component such as `src/screens/LibraryScreen.tsx`). Paths survive package/module renames; the path is the contract, not a framework-specific symbol name. |
 | `design_system` | Yes | Reference to the committed design skill (e.g. `story-spider-design`). Source of truth even when a `bundle` is present — bundle wins on layout & visual intent, skill wins on implementation dialect. |
 | `bundle` | No | Repo-relative path to the originating Claude Design export (e.g. `design/bundles/library.zip`). A visual/structural reference, not a drop-in. Omit the key entirely when no bundle exists — do not set it to `null` or an empty string. |
 
@@ -72,11 +73,11 @@ order:
 | `## Deliberate choices` | Decisions a future contributor (or `forge`) would otherwise re-litigate (list vs. grid, FAB vs. app-bar action, empty-state weight). State the choice **and the why**. | Step-by-step descriptions, pixel-level layout, copy text. |
 | `## Deferred` | Things this screen explicitly does *not* do, with enough context that they don't get reinvented. | Backlog grooming for other screens. |
 
-There is **no `## Layout`, `## States`, or `## Flow` section.** The
-composable and the Maestro flow (at `wire`) own those. If you find yourself
-typing "the top of the screen contains…" — stop. That belongs in the
-composable or the bundle, not here. No layout description, no step-by-step
-walkthrough, no copy strings, no state-machine diagrams.
+There is **no `## Layout`, `## States`, or `## Flow` section.** The component
+and the executable flow body (at `wire`) own those. If you find yourself typing
+"the top of the screen contains…" — stop. That belongs in the component or the
+bundle, not here. No layout description, no step-by-step walkthrough, no copy
+strings, no state-machine diagrams.
 
 ---
 
@@ -85,7 +86,7 @@ walkthrough, no copy strings, no state-machine diagrams.
 ````markdown
 ---
 id: <ScreenId>
-composable: <repo-relative path to the owning Compose file>
+component-path: <repo-relative path to the owning UI component file>
 design_system: <committed design skill, e.g. story-spider-design>
 bundle: <repo-relative path to the Claude Design export, or omit the key>
 ---
@@ -114,7 +115,7 @@ looks like — why it is here at all.>
 ````markdown
 ---
 id: Library
-composable: app/src/main/kotlin/io/balexda/readercompose/ui/views/library/LibraryScreen.kt
+component-path: app/src/main/kotlin/io/balexda/readercompose/ui/views/library/LibraryScreen.kt
 design_system: story-spider-design
 bundle: design/bundles/library.zip
 ---
@@ -157,7 +158,9 @@ from the launcher.
 
 Note what is *not* in the example: no list-row anatomy, no FAB position, no
 copy strings, no state-machine diagram. All of those belong in the
-composable (or, for navigation, the Maestro flow at `wire`).
+component (or, for navigation, the executable flow body at `wire`). The
+example uses a Compose component path because that is Story Spider's stack;
+it is illustrative, not required by the schema.
 
 ---
 
@@ -166,9 +169,9 @@ composable (or, for navigation, the Maestro flow at `wire`).
 - **`id` is flat**, matching the rest of the repo-resident UI graph
   (`ScreenId`, `FlowId`). The repo is the namespace; no scoping prefix,
   no path-encoded hierarchy.
-- **`composable` is a path, not a fully-qualified Kotlin name.** Paths
-  survive package renames; fully-qualified names do not, and the file
-  already encodes the package.
+- **`component-path` is a path, not a framework-specific symbol name.** Paths
+  survive package/module renames; fully-qualified Kotlin names, exported React
+  symbols, Swift type names, and equivalent framework identifiers do not.
 - **`design_system` is the *committed skill*, not the bundle.** A bundle
   is optional and per-screen; the skill is the foundation and applies
   even when no bundle exists, so it owns the source-of-truth slot.
@@ -183,8 +186,9 @@ composable (or, for navigation, the Maestro flow at `wire`).
 When auditing an existing `<ScreenId>.design.md`, flag any of the
 following:
 
-- [ ] Missing required front-matter key (`id`, `composable`, `design_system`).
-- [ ] `composable:` path does not resolve to an existing file in the repo.
+- [ ] Missing required front-matter key (`id`, `component-path`,
+      `design_system`).
+- [ ] `component-path:` path does not resolve to an existing file in the repo.
 - [ ] `id` does not match the feature's `screens:` list, or is reused
       across screens.
 - [ ] `design_system:` empty even when a `bundle:` is set (bundle without

--- a/src/templates/agent-skills/snippets/feature-kinds.md
+++ b/src/templates/agent-skills/snippets/feature-kinds.md
@@ -6,14 +6,15 @@ declaring its kind and, for UI work, its design and phase fields. The kind selec
 the downstream `forge` profile.
 
 - **`backend`** — server/library functionality; the prose body is a behavioral delta.
-- **`ui`** — screen/flow work; renders a screen from a committed design skill and, in
-  the `wire` phase, emits/updates the durable flow for any flow the screen joins.
+- **`ui`** — screen/flow work; renders a framework-appropriate screen
+  component from a committed design skill and, in the `wire` phase,
+  emits/updates the durable flow artifacts for any flow the screen joins.
 
 | Key | Kind | Required | Notes |
 |-----|------|----------|-------|
 | `kind` | both | Yes | `backend` or `ui`. |
 | `phase` | ui | Yes | `build` or `wire` (feature-level). |
-| `design_system` | ui | Yes | Committed design-skill ref (e.g. `story-spider-design`); source of truth even when a bundle is present. |
+| `design_system` | ui | Yes | Committed design-skill ref (for example `story-spider-design`); source of truth even when a bundle is present. |
 | `bundle` | ui | No | Path to a Claude Design export — a visual/structural reference, not a drop-in. Bundle wins on layout/visual intent; the skill wins on implementation dialect. |
 | `flag` | ui | Yes (flag-gated) | Feature-flag name; the shared contract joining a `build` feature to its `wire` feature. |
 | `screens` | ui | Yes | List of `ScreenId`, e.g. `[AddTitle]`. |
@@ -35,10 +36,11 @@ screens: [AddTitle]
 flows: [AddTitle]
 ```
 
-**Phase semantics.** `build` implements the screen against a mock behind `flag`
-(rendering every brief state with design-system tokens only); `wire` connects real
-data, flips the flag, and emits/updates the Maestro flow + `flow.md` for every flow
-in `flows`.
+**Phase semantics.** `build` implements the screen component against a mock behind
+`flag` (rendering every brief state with design-system tokens only); `wire`
+connects real data, flips the flag, and emits/updates the executable test body +
+`flow.md` for every flow in `flows` using the project's UI driver. Compose,
+Maestro, and `story-spider-design` are examples, not required stacks.
 
 **The build/wire seam.** Flag-gated UI is two features sharing one `flag`: a `build`
 feature and a `wire` feature that lists the build feature in its `Depends On` cell.


### PR DESCRIPTION
## Summary

Implements **Slice 1** of User Story 2 (Tool-Agnostic Screen/Flow Generation From the Project's Own Stack) for EPIC #404.

Generalizes Smithy's durable UI artifact contracts so screen annotations and flow definitions no longer encode Compose/Maestro as the default stack. Downstream prompts can now populate neutral path fields from the target repo.

**Artifact:** `specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/02-tool-agnostic-screen-flow-generation-from-the-projects-own-stack.tasks.md` — Slice 1

## Changes

- **Screen contract** (`smithy.helper-screen-design/SKILL.prompt`): rename the Compose-specific field to `component-path` (repo-relative, framework-neutral). Compose kept as a worked example only; review checklist validates `component-path`; rationale-only body rules preserved.
- **Flow contract** (`smithy.helper-flow-definition/SKILL.prompt`): rename the Maestro-specific field to `test-body` (repo-relative, driver-neutral). Maestro kept as one executable-body example; review checklist validates `test-body`; `.flow.md` bodies remain intent-only.
- **Feature-kind docs** (`snippets/feature-kinds.md`, `README.md`): point UI feature metadata at neutral screen/flow artifacts; wire-phase docs name executable test bodies; Compose/Maestro/`story-spider-design` appear only as examples; backend docs unchanged.
- **Tests** (`src/templates.test.ts`): updated to assert the neutral `component-path` / `test-body` vocabulary.

All three tasks.md rows flipped `[ ]` -> `[x]` in the same commit.

Satisfies **AS 2.3** (FR-008, FR-010, FR-012).

## Verification

- `npm run typecheck` — clean
- `npx vitest run src/templates.test.ts` — 202 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
