### PR TITLE
Cut US4 of engraved-knowledge spec into task slices

### DIFF
--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/04-audit-validates-engraved-record-quality.tasks.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/04-audit-validates-engraved-record-quality.tasks.md
@@ -1,0 +1,85 @@
+# Tasks: Audit Validates Engraved Record Quality
+
+**Source**: `specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.spec.md` — User Story 4
+**Data Model**: `specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.data-model.md`
+**Contracts**: `specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.contracts.md`
+**Story Number**: 04
+
+---
+
+## Slice 1: Engraved Audit Checklist
+
+**Goal**: Extend `smithy.audit` so engraved records are recognized as a dedicated artifact type and audited with checks for decision/invariant quality, stale citations, ledger structure, and pivot-level inclusion.
+
+**Justification**: The audit behavior has one coherent review surface: selecting the engraved checklist and applying the full quality gate to decisions, invariants, and principles. Splitting checklist authoring from type-selection wiring would leave either unreachable checklist content or recognized artifacts without the required engraved-specific criteria.
+
+**Addresses**: FR-014; Acceptance Scenarios 4.1, 4.2, 4.3, 4.4
+
+### Tasks
+
+- [ ] **Create the engraved audit checklist snippet**
+
+  Add `audit-checklist-engraved.md` beside the existing audit checklist snippets and register it in the snippets README. The checklist must cover engraved records as durable knowledge roots, distinguish decisions, invariants, and principles, and apply the pivot-level inclusion test to every record.
+
+  _Acceptance criteria:_
+  - `audit-checklist-engraved.md` exists under the agent-skills snippets directory
+  - Snippets README includes an `audit-checklist-engraved.md` row for `smithy.audit`
+  - Checklist describes decisions, invariants, and principles as engraved record kinds
+  - Checklist applies the pivot-level inclusion test to every engraved record
+
+- [ ] **Wire engraved records into audit type selection**
+
+  Extend `smithy.audit` artifact selection and context-gathering guidance so engraved record paths select the new checklist. Recognition must cover decision, invariant, and principle records without treating them as Smithy planning artifacts or `smithy.orders` types.
+
+  _Acceptance criteria:_
+  - Audit type-selection guidance recognizes engraved record paths
+  - Decision records select the engraved checklist
+  - Invariant records select the engraved checklist
+  - Principle records select the engraved checklist
+  - Unknown non-engraved paths keep the existing fallback behavior
+
+- [ ] **Add engraved quality checks to the checklist**
+
+  Define the concrete audit checks for the engraved schema: decisions state desired invariants where applicable, decision/invariant `establishes` and `established_by` references are reciprocal, citations do not point at superseded decisions, invariants cite establishing decisions, and the Known-Exceptions ledger keeps the frozen load-bearing column order with no silent divergence.
+
+  _Acceptance criteria:_
+  - Decision checks include desired invariant guidance
+  - Reciprocity checks cover `establishes` and `established_by`
+  - Stale-citation checks flag references to superseded or deprecated decisions
+  - Invariant checks require establishing-decision citations
+  - Known-Exceptions ledger checks require the frozen column order and visible exception handling
+
+- [ ] **Assert engraved audit composition**
+
+  Extend template coverage so the composed `smithy.audit` command includes the engraved checklist, type-selection rules route engraved records to it, and the checklist text preserves the decision, invariant, stale-citation, ledger, and pivot-level checks.
+
+  _Acceptance criteria:_
+  - Tests assert the engraved checklist snippet is loaded and composed
+  - Tests assert `smithy.audit` no longer contains an unresolved engraved checklist partial
+  - Tests assert type-selection text recognizes engraved record paths
+  - Tests assert composed audit content includes desired invariant, reciprocity, stale-citation, Known-Exceptions ledger, and pivot-level checks
+
+**PR Outcome**: Running `smithy.audit` on a decision, invariant, or principle uses an engraved-record checklist that validates durable-knowledge quality and flags missing citations, stale references, malformed exception ledgers, and non-pivot records.
+
+---
+
+## Specification Debt
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | inherited from spec: Which agent-context files projection manages by default (CLAUDE.md only, also AGENTS.md, also `.github/copilot-instructions.md`) and whether the target set is configurable. | Integration | Medium | Medium | inherited | — |
+| SD-002 | inherited from spec: Whether the optional `design`-domain locations (`docs/design/{decisions,invariants,constitution}`) are in scope for recall and the projection pointer now, or deferred. | Functional Scope | Low | Medium | inherited | — |
+
+---
+
+## Dependency Order
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| S1 | Engraved Audit Checklist | — | — |
+
+### Cross-Story Dependencies
+
+None — this story is self-contained.

--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.spec.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.spec.md
@@ -112,7 +112,7 @@ Recommended implementation sequence:
 | US1 | Planning Commands Recall Relevant Engraved Knowledge | — | specs/2026-06-06-012-engraved-knowledge-recall-and-reference/01-planning-commands-recall-relevant-engraved-knowledge.tasks.md |
 | US2 | Engrave Projects an Engraved-Knowledge Pointer into Agent-Context Files | — | specs/2026-06-06-012-engraved-knowledge-recall-and-reference/02-engrave-projects-an-engraved-knowledge-pointer-into-agent-context-files.tasks.md |
 | US3 | Engrave Scaffolds a Drift-Tracking Issue for Temporary Exceptions | — | specs/2026-06-06-012-engraved-knowledge-recall-and-reference/03-engrave-scaffolds-a-drift-tracking-issue-for-temporary-exceptions.tasks.md |
-| US4 | Audit Validates Engraved Record Quality | — | — |
+| US4 | Audit Validates Engraved Record Quality | — | specs/2026-06-06-012-engraved-knowledge-recall-and-reference/04-audit-validates-engraved-record-quality.tasks.md |
 
 All four user stories are independent — four parallel entry points with no cross-story prerequisites. They share only the frozen engraved-record frontmatter schema as a read-only input.
 


### PR DESCRIPTION
## Summary

`smithy.cut` step for User Story 4 of the engraved-knowledge-recall-and-reference spec.

Decomposes **US4: Audit Validates Engraved Record Quality** into a single coherent slice and links it from the spec's Dependency Order table.

Artifact: `specs/2026-06-06-012-engraved-knowledge-recall-and-reference/engraved-knowledge-recall-and-reference.spec.md`

## Changes

- **New** `04-audit-validates-engraved-record-quality.tasks.md` — one slice (`S1: Engraved Audit Checklist`) with four tasks:
  - Create the `audit-checklist-engraved.md` snippet + register in snippets README
  - Wire engraved record paths into `smithy.audit` type selection
  - Add engraved quality checks (desired invariant, `establishes`/`established_by` reciprocity, stale/superseded citation, Known-Exceptions ledger column order, pivot-level inclusion)
  - Assert engraved audit composition in template tests
- **Spec update** — US4's Dependency Order `Artifact` column flipped from `—` to the new tasks file path (the durable done-signal for a `cut` step).

## Coverage

Slice addresses **FR-014** and Acceptance Scenarios **4.1–4.4** in full:
- 4.1 type-selection recognizes engraved records → engraved checklist
- 4.2 decision checks: desired invariant, reciprocity, no superseded citation
- 4.3 invariant checks: establishing-decision citations, ledger column order, no silent divergence
- 4.4 pivot-level inclusion test for any engraved record

Specification Debt SD-001/SD-002 carried over from the spec as `inherited`.

## Notes

- Task checkboxes inside the new tasks file intentionally remain `[ ]` — they are downstream forge implementation work. The completion signal for this `cut` step is the spec Dependency Order `Artifact` linkage, which is set.
- No code changed; `dist/` is unbuilt in this fresh worktree, so verification was structural (slice-to-acceptance-criteria mapping + dependency-table linkage). No verification gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
