### PR TITLE
Scaffold drift-tracking issue for Temporary invariant exceptions

### DIFF
--- a/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/03-engrave-scaffolds-a-drift-tracking-issue-for-temporary-exceptions.tasks.md
+++ b/specs/2026-06-06-012-engraved-knowledge-recall-and-reference/03-engrave-scaffolds-a-drift-tracking-issue-for-temporary-exceptions.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Add drift issue creation to engrave**
+- [x] **Add drift issue creation to engrave**
 
   Update `src/templates/agent-skills/commands/smithy.engrave.prompt` so Phase 6 creates a drift-tracking issue only when adding a `Temporary:` row to an invariant's Known-Exceptions ledger. The prompt must load `smithy.gh-issue`, write an issue body to a temporary file, invoke that skill's `create-issue.sh` path for the current agent, capture its JSON `number`, and write `#NNN` into the new row's `Tracking Issue` column for AS 3.1.
 
@@ -28,7 +28,7 @@
   - The invariant frontmatter status is still recomputed from remaining `Temporary:` rows
   - Template coverage proves the temporary-only create path is retained
 
-- [ ] **Render the drift issue body**
+- [x] **Render the drift issue body**
 
   Add the prompt instructions and body template needed for the drift-tracking issue in `smithy.engrave.prompt`. The body must identify the invariant id and title, state the divergence, cite the establishing decision or decisions from `established_by`, and keep engraved records out of `smithy.orders` template type handling for AS 3.1 and AS 3.2.
 
@@ -39,7 +39,7 @@
   - No engraved record type is added to orders template registries or defaults
   - Template coverage proves accepted exceptions and orders registries stay out of the drift path
 
-- [ ] **Preserve exceptions when issue creation fails**
+- [x] **Preserve exceptions when issue creation fails**
 
   Define Phase 6 failure handling so an auth, network, or script failure leaves the newly added `Temporary:` ledger row in place with `Tracking Issue` set to `—`, surfaces the failure in the terminal summary, and does not roll back the invariant edit. Also state that resolving or converting a `Temporary:` exception leaves any linked issue open and performs no comment or close action for AS 3.3 and AS 3.4.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -11,7 +11,7 @@ import {
   getComposedTemplates,
   type ComposedTemplates,
 } from './templates.js';
-import { ORDERS_DEFAULT_TEMPLATES } from './orders-templates.js';
+import { ORDERS_DEFAULT_TEMPLATES, ORDERS_TEMPLATE_TYPES } from './orders-templates.js';
 
 describe('stripFrontmatter', () => {
   it('removes YAML frontmatter from content', () => {
@@ -3137,6 +3137,47 @@ describe('getComposedTemplates', () => {
     expect(engrave).toMatch(/status: aligned/);
     expect(engrave).toMatch(/\bdrifting\b/);
     expect(engrave).toMatch(/recompute/i);
+  });
+
+  it('engrave template creates drift issues only for new Temporary exceptions', () => {
+    const engrave = composed.commands.get('smithy.engrave.md')!;
+    expect(engrave).toContain('Skill("smithy.gh-issue")');
+    expect(engrave).toContain('create-issue.sh');
+    expect(engrave).toMatch(/only when adding a new `Temporary:` ledger row/i);
+    expect(engrave).toMatch(/write the issue body to a temporary file/i);
+    expect(engrave).toMatch(/JSON `number`/);
+    expect(engrave).toMatch(/write `#NNN` into that new row's `Tracking Issue` cell/i);
+    expect(engrave).toMatch(/Accepted:` rows[\s\S]*do not create/i);
+  });
+
+  it('engrave template renders drift issue bodies from invariant context', () => {
+    const engrave = composed.commands.get('smithy.engrave.md')!;
+    expect(engrave).toMatch(/title from the `What diverges` text/i);
+    expect(engrave).toMatch(/Invariant: `<INV id>` — `<invariant title>`/);
+    expect(engrave).toMatch(/Divergence: `<What diverges>`/);
+    expect(engrave).toMatch(/Establishing decisions: `<established_by ids>`/);
+    expect(engrave).toMatch(/Accepted:` row.*`Tracking Issue`.*`—`/is);
+  });
+
+  it('engrave template preserves exception edits when drift issue creation fails', () => {
+    const engrave = composed.commands.get('smithy.engrave.md')!;
+    expect(engrave).toMatch(/auth, network, script, or JSON parsing failure/i);
+    expect(engrave).toMatch(/leave the newly\s+added `Temporary:` ledger row in place/i);
+    expect(engrave).toMatch(/`Tracking Issue` cell as `—`/);
+    expect(engrave).toMatch(/terminal summary/i);
+    expect(engrave).toMatch(/do not roll back/i);
+    expect(engrave).toMatch(/do not close, comment on, label, or otherwise mutate/i);
+  });
+
+  it('engraved records stay out of orders template registries', () => {
+    expect(ORDERS_TEMPLATE_TYPES).toEqual(['rfc', 'features', 'spec', 'tasks']);
+    expect(Object.keys(ORDERS_DEFAULT_TEMPLATES).sort()).toEqual(
+      [...ORDERS_TEMPLATE_TYPES].sort(),
+    );
+    const orderTypes: readonly string[] = ORDERS_TEMPLATE_TYPES;
+    expect(orderTypes).not.toContain('decision');
+    expect(orderTypes).not.toContain('invariant');
+    expect(orderTypes).not.toContain('principle');
   });
 
   it('engrave template states the "engraved records are not Dependency Order rows" rule', () => {

--- a/src/templates/agent-skills/commands/smithy.engrave.prompt
+++ b/src/templates/agent-skills/commands/smithy.engrave.prompt
@@ -412,12 +412,64 @@ its alignment status from the ledger.
 Ask the user which sub-operation:
 
 - **Add exception** — append a row. Capture `Where`, `What diverges`,
-  disposition (`Accepted: <reason>` or `Temporary: <reason>`),
-  `Tracking Issue` (`#NNN` for `Temporary` rows; `—` for `Accepted`
-  rows), `Severity` (`low` / `medium` / `high`).
+  disposition (`Accepted: <reason>` or `Temporary: <reason>`), and
+  `Severity` (`low` / `medium` / `high`). For `Accepted:` rows, set
+  `Tracking Issue` to `—` and do not create or query GitHub. For a newly
+  added `Temporary:` row, start with `Tracking Issue` as `—`, then run the
+  drift-tracking issue step below and replace that cell with `#NNN` only if
+  issue creation succeeds.
 - **Resolve exception** — identify the row (by `Where` or row index)
   and either remove it (the divergence is gone) or change a `Temporary:`
   row to `Accepted:` (the team has decided to live with it indefinitely).
+  Do not close, comment on, label, or otherwise mutate any linked issue.
+
+### Temporary exception drift-tracking issue
+
+Run this step only when adding a new `Temporary:` ledger row. Do not run it
+for `Accepted:` rows, existing rows, resolution, removal, or conversion of a
+`Temporary:` row to `Accepted:`.
+
+1. Load `Skill("smithy.gh-issue")`.
+2. Build the issue title from the `What diverges` text. Keep it concise and
+   action-oriented, for example: `Close invariant drift: <What diverges>`.
+3. Write the issue body to a temporary file using this template:
+
+   ```markdown
+   ## Drift
+
+   Invariant: `<INV id>` — `<invariant title>`
+
+   Divergence: `<What diverges>`
+
+   Where: `<Where>`
+
+   Disposition: `Temporary: <reason>`
+
+   Severity: `<low|medium|high>`
+
+   Establishing decisions: `<established_by ids>`
+
+   ## Done When
+
+   The divergence is removed or the invariant ledger is explicitly updated
+   to show the team accepts the carve-out.
+   ```
+
+4. Invoke the `smithy.gh-issue` `create-issue.sh` script for the current
+   agent with the title and temporary body file:
+
+   ```bash
+   {{#ifAgent 'claude'}}${CLAUDE_SKILL_DIR}/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'gemini'}}./.gemini/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}}{{#ifAgent 'codex'}}./.agents/skills/smithy.gh-issue/scripts/create-issue.sh{{/ifAgent}} "<title>" <temporary-body-file>
+   ```
+
+5. Parse the script output as JSON, capture the JSON `number`, format it as
+   `#NNN`, and write `#NNN` into that new row's `Tracking Issue` cell.
+   Clean up the temporary body file after the create attempt.
+
+If any auth, network, script, or JSON parsing failure occurs, leave the newly
+added `Temporary:` ledger row in place with its `Tracking Issue` cell as `—`.
+Do not roll back the invariant edit. Capture the failure text and surface it in
+the terminal summary after the engrave operation completes.
 
 After patching the ledger, **recompute** `status` and patch the
 frontmatter (`aligned` if zero `Temporary:` rows remain; `drifting`
@@ -568,9 +620,12 @@ Superseded <old id> <old title>
 ```
 
 For Phase 6 (exception edits), print the recomputed status and the
-operation summary:
+operation summary. If drift-tracking issue creation failed, include one
+additional line that names the failure and says the ledger row was kept with
+`Tracking Issue: —`:
 
 ```
 Updated <INV id> ledger: <added|resolved> row "<Where>"
   status: <aligned|drifting>
+  drift issue: <#NNN|not created — failure summary>
 ```

--- a/src/templates/agent-skills/commands/smithy.engrave.prompt
+++ b/src/templates/agent-skills/commands/smithy.engrave.prompt
@@ -99,9 +99,11 @@ Column rules:
 - **What diverges** — what reality does, vs. what the rule says. One sentence.
 - **Disposition + Why** — `Accepted: <reason>` for a permanent carve-out
   the team has decided to live with, or `Temporary: <reason>` for a known
-  gap with an open tracking issue. The Capitalized `Accepted:` /
+  gap that should be tracked toward closure. The Capitalized `Accepted:` /
   `Temporary:` token is the canonical on-disk form.
-- **Tracking Issue** — `#NNN` for `Temporary` rows; `—` for `Accepted` rows.
+- **Tracking Issue** — `#NNN` for a `Temporary` row whose drift-tracking
+  issue exists, or `—` if that issue could not be created yet (see Phase 6
+  failure fallback); always `—` for `Accepted` rows.
 - **Severity** — `low` \| `medium` \| `high`. `high` rows MAY block
   planning artifacts that would compound the drift.
 
@@ -620,9 +622,11 @@ Superseded <old id> <old title>
 ```
 
 For Phase 6 (exception edits), print the recomputed status and the
-operation summary. If drift-tracking issue creation failed, include one
-additional line that names the failure and says the ledger row was kept with
-`Tracking Issue: —`:
+operation summary. When a `Temporary:` row was added, include a
+`drift issue:` line — show `#NNN` if the drift-tracking issue was created, or
+`not created — <failure summary>` if creation failed (the ledger row is kept
+with `Tracking Issue: —`). Omit the line for `Accepted:` rows, resolutions,
+removals, and conversions, which never create an issue:
 
 ```
 Updated <INV id> ledger: <added|resolved> row "<Where>"


### PR DESCRIPTION
## Summary

Implements Slice 1 of User Story 3 (engraved-knowledge-recall-and-reference): `smithy.engrave` now scaffolds a drift-tracking GitHub issue when a `Temporary:` exception is added to an invariant's Known-Exceptions ledger.

Artifact: `specs/2026-06-06-012-engraved-knowledge-recall-and-reference/03-engrave-scaffolds-a-drift-tracking-issue-for-temporary-exceptions.tasks.md` (Slice 1)

## What changed

`src/templates/agent-skills/commands/smithy.engrave.prompt` (Phase 6 exception editing):
- Adding a new `Temporary:` row now loads `smithy.gh-issue`, writes the issue body to a temp file, invokes `create-issue.sh` for the current agent, parses the JSON `number`, and writes `#NNN` into the row's `Tracking Issue` cell.
- A drift issue body template identifies the invariant id/title, the divergence, where, disposition, severity, and the establishing decision ids (`established_by`).
- `Accepted:` rows keep `Tracking Issue` as `—` and make no GitHub call.
- Resolve/convert operations explicitly do not close, comment on, label, or otherwise mutate any linked issue.
- Failure handling: any auth/network/script/JSON-parse failure leaves the new `Temporary:` row in place with `Tracking Issue: —`, does not roll back the invariant edit, and surfaces the failure in the terminal summary (new summary line `drift issue: <#NNN|not created — failure summary>`).
- Invariant `status` is still recomputed from remaining `Temporary:` rows.

`src/templates.test.ts`: 4 new template-coverage tests proving the temporary-only create path, drift body rendering, failure fallback + non-mutating resolve, and that engraved record types stay out of `ORDERS_TEMPLATE_TYPES`/`ORDERS_DEFAULT_TEMPLATES`.

## Acceptance criteria

All three tasks in Slice 1 are satisfied and flipped to `[x]` in the tasks file. Covers FR-011/012/013 and Acceptance Scenarios 3.1–3.4.

## Verification

- `npm run typecheck` — passes
- `npm test -- src/templates.test.ts` — 212 passed (incl. 4 new tests)

No verification gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
