### PR TITLE
Emit typed UI ordering ledger in smithy.mark (US1 S2)

### DIFF
--- a/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/01-mark-authors-a-ui-spec-with-a-typed-ordering-ledger-durable-artifacts.tasks.md
+++ b/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/01-mark-authors-a-ui-spec-with-a-typed-ordering-ledger-durable-artifacts.tasks.md
@@ -51,7 +51,7 @@
 
 ### Tasks
 
-- [ ] **Author the UI dependency ledger**
+- [x] **Author the UI dependency ledger**
 
   Extend the UI path in `src/templates/agent-skills/commands/smithy.mark.prompt` to write a `## Dependency Order` table shaped as the UI Spec Ledger in the data model. The table must support `SC<N>`, `FL<N>`, and `US<N>` rows, same-table dependencies, a `Design` column for screen rows, and an `Artifact` column for every row, satisfying AS 1.1 and AS 1.3.
 
@@ -63,7 +63,7 @@
   - Each row has `Depends On` set to `—` or same-table IDs
   - Every row's `Artifact` cell is `—` in mark's output — it holds the `cut`-produced `tasks.md` only after `cut` runs (data model Entity 2); mark never pre-fills a path
 
-- [ ] **Keep ledger rows pointer-only**
+- [x] **Keep ledger rows pointer-only**
 
   Constrain the UI ledger instructions in `src/templates/agent-skills/commands/smithy.mark.prompt` so row titles point to durable screen and flow files but never carry layout, state, or step prose. Reference the UI Spec Ledger and Screen/Flow node entities from the data model rather than duplicating artifact body schemas, satisfying AS 1.2 and FR-004.
 
@@ -73,7 +73,7 @@
   - Flow rows are first-class table rows, not values inside a `flows: [...]` list
   - The prompt directs artifact intent into the durable files, not the spec row
 
-- [ ] **Allow minimal single-node UI ledgers**
+- [x] **Allow minimal single-node UI ledgers**
 
   Add UI ledger guidance for features with no internal ordering so `mark` may emit a minimal single-node graph when that honestly represents the work. Keep the same table shape and node typing even when only one row exists, satisfying AS 1.5.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1519,6 +1519,38 @@ describe('getComposedTemplates', () => {
     expect(mark).toContain('auto-selection semantics');
   });
 
+  it('mark template defines the typed UI spec ledger', () => {
+    const mark = composed.commands.get('smithy.mark.md')!;
+    expect(mark).toContain('### UI Authoring Path Spec Ledger');
+    expect(mark).toContain('| ID | Kind | Title | Depends On | Design | Artifact |');
+    expect(mark).toContain('| SC1 | screen |');
+    expect(mark).toContain('| FL1 | flow |');
+    expect(mark).toContain('| US1 | story |');
+    expect(mark).toContain('`SC<N>` for screen-build rows');
+    expect(mark).toContain('`FL<N>` for flow-wire rows');
+    expect(mark).toContain('`US<N>` for backend story rows');
+    expect(mark).toContain('`Depends On` is exactly `—` or a comma-separated list of same-table IDs');
+    expect(mark).toContain('`Design` is required for `screen` rows');
+    expect(mark).toContain('`Artifact` is `—` for every row in mark');
+    expect(mark).toContain('mark never');
+    expect(mark).toContain('pre-fills a tasks path');
+  });
+
+  it('mark template keeps UI ledger rows pointer-only and allows minimal graphs', () => {
+    const mark = composed.commands.get('smithy.mark.md')!;
+    expect(mark).toContain('→ design/screens/<ScreenId>.design.md');
+    expect(mark).toContain('→ design/flows/<FlowId>.flow.md');
+    expect(mark).toContain('must not carry layout');
+    expect(mark).toContain('state, interaction-step, visual-positioning');
+    expect(mark).toContain('Flow rows are first-class `FL<N>` rows');
+    expect(mark).toContain('not entries in a `flows: [...]` list');
+    expect(mark).toContain('UI Spec Ledger and Screen/Flow node entities in the data model');
+    expect(mark).toContain('A single pass-through screen');
+    expect(mark).toMatch(/one `SC<N>`\s+row/);
+    expect(mark).toContain('full UI ledger column set');
+    expect(mark).toContain('Do not add UI-only columns');
+  });
+
   it('cut template resolves the one-shot-output partial', () => {
     const cut = composed.commands.get('smithy.cut.md')!;
     expect(cut).toBeDefined();

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -395,9 +395,11 @@ UI ledger rules:
 - `Artifact` is `—` for every row in mark's output. It holds the
   `cut`-produced `.tasks.md` path only after `smithy.cut` runs; mark never
   pre-fills a tasks path in this column.
-- Screen and flow row titles may name their durable files with pointer text
-  such as `→ design/screens/<ScreenId>.design.md` and
-  `→ design/flows/<FlowId>.flow.md`. Titles and cells must not carry layout,
+- Screen and flow row titles must name their durable files with pointer text
+  — `→ design/screens/<ScreenId>.design.md` for screen rows and
+  `→ design/flows/<FlowId>.flow.md` for flow rows — so the title is the stable
+  reference edge downstream tooling and later artifact creation resolve to the
+  durable file. Titles and cells must not carry layout,
   state, interaction-step, visual-positioning, or implementation prose.
 - Flow rows are first-class `FL<N>` rows, not entries in a `flows: [...]` list
   and not nested under a screen row.
@@ -748,7 +750,7 @@ Use the **smithy-refine** sub-agent. Pass it:
   | **Ambiguity & Risk** | Are there vague terms, unstated assumptions, or scope boundaries that could be interpreted multiple ways? |
   | **Specification Debt** | Are there open debt items that can now be resolved based on new information or user answers? Are all debt items structured with required metadata columns? Are inherited items attributed to their source artifact? |
   | **Staleness** | Does the spec still reflect the current codebase reality? Have upstream changes invalidated any assumptions? |
-  | **Dependency Order** | Does the spec contain a `## Dependency Order` 4-column table (`ID \| Title \| Depends On \| Artifact`)? Does it list every user story with a `US<N>` ID (no leading zeros)? Does each `Depends On` cell contain `—` or comma-separated same-table IDs (no prose)? Does each `Artifact` cell contain `—` or a repo-relative path to the corresponding `.tasks.md` file? Are any `- [ ]`/`- [x]` checkboxes present in the section (an error if so)? |
+  | **Dependency Order** | For `kind: backend` (or absent-kind) specs: does the spec contain a `## Dependency Order` 4-column table (`ID \| Title \| Depends On \| Artifact`) listing every user story with a `US<N>` ID (no leading zeros)? For `kind: ui` specs: does it instead contain the typed UI Spec Ledger — a 6-column table (`ID \| Kind \| Title \| Depends On \| Design \| Artifact`) with `SC<N>`/`FL<N>`/`US<N>` rows whose `Kind` matches the ID prefix (`screen`/`flow`/`story`), `Design` (`none`/`import`/`brief`) set on screen rows and `—` elsewhere, and screen/flow titles naming their durable `.design.md`/`.flow.md` files? Do not flag a valid UI ledger as missing the backend shape, and do not rewrite it back to the 4-column US-only table. In both shapes: does each `Depends On` cell contain `—` or comma-separated same-table IDs (no prose)? Does each `Artifact` cell contain `—` or a repo-relative path to the corresponding `.tasks.md` file (always `—` in mark's own output)? Are any `- [ ]`/`- [x]` checkboxes present in the section (an error if so)? |
 
 - **Target files**: the spec (`.spec.md`), data model (`.data-model.md`), and
   contracts (`.contracts.md`) in the spec folder.

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -366,6 +366,50 @@ Guidelines for the spec:
   column starts as `—` and is populated by `smithy.cut` when it creates the
   tasks file. Do NOT use checkboxes in the `## Dependency Order` section.
 
+### UI Authoring Path Spec Ledger
+
+When the selected feature's authoring path is `kind: ui`, keep the same
+`.spec.md` structure above but replace the backend-only `## Dependency Order`
+table with a typed UI Spec Ledger. This is the ordering graph for the UI
+feature; it is not a layout or flow-body document.
+
+Use this exact column set for the UI ledger:
+
+```markdown
+| ID | Kind | Title | Depends On | Design | Artifact |
+|----|------|-------|------------|--------|----------|
+| SC1 | screen | <Screen title> → `design/screens/<ScreenId>.design.md` | — | <none/import/brief> | — |
+| FL1 | flow | <Flow title> → `design/flows/<FlowId>.flow.md` | SC1 | — | — |
+| US1 | story | <Backend story title> | — | — | — |
+```
+
+UI ledger rules:
+- `ID` values are typed and unique in the table: `SC<N>` for screen-build rows,
+  `FL<N>` for flow-wire rows, and `US<N>` for backend story rows. Use no leading
+  zeros.
+- `Kind` is exactly `screen`, `flow`, or `story`, matching the row's ID prefix.
+- `Depends On` is exactly `—` or a comma-separated list of same-table IDs. This
+  is the only place intra-feature ordering and parallelism are expressed.
+- `Design` is required for `screen` rows and is one of `none`, `import`, or
+  `brief`; use `—` for `flow` and `story` rows.
+- `Artifact` is `—` for every row in mark's output. It holds the
+  `cut`-produced `.tasks.md` path only after `smithy.cut` runs; mark never
+  pre-fills a tasks path in this column.
+- Screen and flow row titles may name their durable files with pointer text
+  such as `→ design/screens/<ScreenId>.design.md` and
+  `→ design/flows/<FlowId>.flow.md`. Titles and cells must not carry layout,
+  state, interaction-step, visual-positioning, or implementation prose.
+- Flow rows are first-class `FL<N>` rows, not entries in a `flows: [...]` list
+  and not nested under a screen row.
+- Direct all screen and flow intent into the durable artifacts described by the
+  UI Spec Ledger and Screen/Flow node entities in the data model. Do not
+  duplicate the screen or flow artifact body schemas in the spec ledger.
+- If the feature has no internal ordering, emit the smallest honest typed graph.
+  A single pass-through screen with no flows or backend work may be one `SC<N>`
+  row, but it must still use the full UI ledger column set.
+- Do not add UI-only columns (`Kind` or `Design`) to backend spec-triad output
+  for `kind: backend` or absent-kind feature inputs.
+
 ---
 
 ## Phase 4: Model


### PR DESCRIPTION
## Summary

Implements **Slice 2 — Emit the Typed UI Ordering Ledger** of User Story 1
(`specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/01-mark-authors-a-ui-spec-with-a-typed-ordering-ledger-durable-artifacts.tasks.md`).

Adds a `### UI Authoring Path Spec Ledger` section to `smithy.mark.prompt`.
When the selected feature is `kind: ui`, mark now writes its
`## Dependency Order` as a typed node graph instead of the backend-only table.

## What changed

- **`src/templates/agent-skills/commands/smithy.mark.prompt`** — new UI Spec
  Ledger guidance with the typed column set `| ID | Kind | Title | Depends On | Design | Artifact |`,
  matching data-model Entity 2:
  - `SC<N>` / `FL<N>` / `US<N>` typed IDs with matching `Kind` of `screen` / `flow` / `story`.
  - `Depends On` is `—` or same-table IDs only.
  - `Design` (`none`/`import`/`brief`) required for screen rows, `—` otherwise.
  - `Artifact` is `—` for every row in mark's output (cut fills the tasks path later).
  - Rows are pointer-only: titles may point at `design/screens/<ScreenId>.design.md`
    and `design/flows/<FlowId>.flow.md` but carry no layout/state/step prose.
  - Flows are first-class `FL<N>` rows, never nested in a `flows: [...]` list.
  - Minimal single-node graphs allowed (one `SC<N>` row) while keeping the full column set.
  - Backend specs do not gain UI-only columns.
- **`src/templates.test.ts`** — two new tests asserting the ledger column set,
  typed-ID rules, pointer-only/minimal-graph guidance.
- **tasks.md** — flipped all three Slice 2 task rows from `[ ]` to `[x]`.

## Acceptance criteria

All acceptance criteria for the three Slice 2 tasks (Author the UI dependency
ledger / Keep ledger rows pointer-only / Allow minimal single-node UI ledgers)
are satisfied; ledger columns match data-model Entity 2. Addresses
FR-002, FR-003, FR-004, FR-005; AS 1.1, AS 1.3, AS 1.5.

## Verification

- `vitest run templates.test` — **223 passed** (incl. the two new ledger tests).
- `npm run typecheck` — clean.

Per repo guidance, `.claude/` and `.smithy/` snapshots were intentionally not
regenerated for this source-template change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
