### PR TITLE
fix: repo-key external artifact store and make it worktree-stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,26 @@ smithy init
 - **Gemini CLI:** Installs workspace skills (`.gemini/skills/`) so you can type `/skills reload` and immediately use Smithy workflow commands.
 - **Codex:** Installs project skills into `.agents/skills/` and reference prompts into `tools/codex/prompts/`, with `smithy.forge` and `smithy.fix` ready for Codex-driven implementation and repair workflows.
 
+## Planning Artifact Storage
+
+`smithy init` asks where Smithy planning artifacts (RFCs, specs, tasks, strikes, PRDs) should live. Pick the mode that fits your team — the choice is persisted in the manifest, round-tripped by `smithy update`, and baked into the deployed prompts so your AI assistant always writes to the right place:
+
+- **Repo** (default): artifacts are committed in-tree under `docs/rfcs/`, `docs/prds/`, `specs/`, `specs/strikes/`, etc. Choose this when planning artifacts should live with the code and show up in PRs.
+- **External**: artifacts are written out-of-tree under your home directory, keeping planning files off the team's git history.
+
+You can also set it non-interactively with `--artifacts-location repo|external` on `init`/`update`.
+
+### External layout
+
+External artifacts are stored under a fixed, repo-keyed root:
+
+```
+~/.smithy/repos/<repoKey>/        # then docs/rfcs/, docs/prds/, specs/, specs/strikes/ underneath
+```
+
+- `repos/` is a fixed grouping segment that isolates per-repo stores from Smithy's own files in `~/.smithy/` (`templates/`, `smithy-manifest.json`, `config.yml`). It's collision-proof: a repo literally named `templates` resolves to `~/.smithy/repos/templates/`, never clobbering `~/.smithy/templates/`.
+- `<repoKey>` is **worktree-stable**. It's derived from git's shared git-common-dir (`git rev-parse --git-common-dir`) rather than the working-directory name, so every linked worktree of a repo *and* its main checkout resolve to the same key and share one store. `smithy status` therefore reports identical, repo-keyed paths no matter which worktree you run it from. When git can't identify the repo, Smithy falls back to the `origin` remote name, then the directory name. The key is always sanitized to a single filesystem-safe path segment.
+
 ## Workflow Industrial Pipeline
 
 The Smithy Industrial Pipeline follows a structured path from broad ideas to verified implementations, incorporating "Fast Track" shortcuts and built-in "Review Loops" at every stage.

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -29,7 +29,7 @@ export const SESSION_TITLE_HOOK_COMMAND =
  *
  * `artifactsRoot` is the prefix baked into deployed prompts via the
  * `{{artifactsRoot}}` template variable — empty string for in-repo planning
- * artifacts (default), `~/.smithy/<repo>/` for the external-artifacts mode.
+ * artifacts (default), `~/.smithy/repos/<repo>/` for the external-artifacts mode.
  */
 export async function deploy(
   targetDir: string,

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -143,12 +143,13 @@ describe('CLI init --yes (non-interactive)', () => {
         'Write a single strike document to `specs/strikes/YYYY-MM-DD-<slug>.strike.md`',
       );
       expect(strike).not.toContain('{{artifactsRoot}}');
-      // The policy snippet mentions ~/.smithy/<repo>/ as part of its explanation
-      // — that's expected. Make sure no actual artifact path got a tilde prefix.
-      expect(strike).not.toContain('~/.smithy/<repo>/specs/strikes/YYYY');
+      // The policy snippet mentions ~/.smithy/repos/<repo>/ as part of its
+      // explanation — that's expected. Make sure no actual artifact path got a
+      // tilde prefix.
+      expect(strike).not.toContain('~/.smithy/repos/<repo>/specs/strikes/YYYY');
     });
 
-    it('--artifacts-location external persists in the manifest and bakes ~/.smithy/<repo>/ into deployed prompts', () => {
+    it('--artifacts-location external persists in the manifest and bakes ~/.smithy/repos/<repo>/ into deployed prompts', () => {
       execFileSync(
         'node',
         [CLI, 'init', '-a', 'claude', '-y', '--artifacts-location', 'external'],
@@ -158,7 +159,7 @@ describe('CLI init --yes (non-interactive)', () => {
       const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
       expect(manifest.artifactsLocation).toBe('external');
 
-      const expectedPrefix = `~/.smithy/${path.basename(tmpDir)}/`;
+      const expectedPrefix = `~/.smithy/repos/${path.basename(tmpDir)}/`;
       const strike = fs.readFileSync(
         path.join(tmpDir, '.claude', 'commands', 'smithy.strike.md'),
         'utf8',
@@ -182,7 +183,7 @@ describe('CLI init --yes (non-interactive)', () => {
       const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
       expect(manifest.artifactsLocation).toBe('external');
 
-      const expectedPrefix = `~/.smithy/${path.basename(tmpDir)}/`;
+      const expectedPrefix = `~/.smithy/repos/${path.basename(tmpDir)}/`;
       const strike = fs.readFileSync(
         path.join(tmpDir, '.claude', 'commands', 'smithy.strike.md'),
         'utf8',
@@ -213,7 +214,7 @@ describe('CLI init --yes (non-interactive)', () => {
       expect(strike).toContain(
         'Write a single strike document to `specs/strikes/YYYY-MM-DD-<slug>.strike.md`',
       );
-      expect(strike).not.toContain('~/.smithy/<repo>/specs/strikes/YYYY');
+      expect(strike).not.toContain('~/.smithy/repos/<repo>/specs/strikes/YYYY');
     });
   });
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -52,7 +52,7 @@ export interface InitOptions {
   /**
    * Where planning artifacts (RFCs, specs, tasks, strikes, PRDs) are written.
    * 'repo' (default) → in-tree under docs/rfcs/, specs/, ...
-   * 'external' → out-of-tree under ~/.smithy/<repo-name>/, kept off git history.
+   * 'external' → out-of-tree under ~/.smithy/repos/<repoKey>/, kept off git history.
    * Surfaced through `--artifacts-location` and the interactive prompt.
    */
   artifactsLocation?: ArtifactsLocation;
@@ -130,7 +130,7 @@ export async function initAction(opts: InitOptions = {}): Promise<void> {
   const deploySessionTitles = opts.sessionTitles ?? true;
 
   // 5e. Planning artifacts location — 'repo' (in-tree, default) or 'external'
-  // (~/.smithy/<repo>/, off git history). Baked into deployed prompts via the
+  // (~/.smithy/repos/<repoKey>/, off git history). Baked into deployed prompts via the
   // `{{artifactsRoot}}` template variable so agents know where to write specs,
   // tasks, RFCs, etc. The same value is persisted in the manifest so `update`
   // can round-trip it and `smithy status` can find external artifacts.

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -31,6 +31,7 @@ import type {
   StatusTree,
 } from '../status/index.js';
 import { serializeGraphForJson } from '../status/index.js';
+import { resolveArtifactsRoot, templateArtifactsPrefix } from '../manifest.js';
 import { createTheme, type Theme } from '../status/theme.js';
 
 const theme: Theme = createTheme({ color: false, encoding: 'utf8' });
@@ -1222,7 +1223,7 @@ describe('serializeGraphForJson', () => {
 describe('statusAction artifacts-location integration', () => {
   // The scanner is taught to read `.smithy/smithy-manifest.json` (or
   // `~/.smithy/smithy-manifest.json`) and redirect its scan root to
-  // `~/.smithy/<repo>/` when `artifactsLocation === 'external'`. These
+  // `~/.smithy/repos/<repoKey>/` when `artifactsLocation === 'external'`. These
   // tests exercise that wiring end-to-end via real on-disk files.
   //
   // The redirect only fires when `opts.root` is `undefined` (the scanner
@@ -1297,16 +1298,16 @@ describe('statusAction artifacts-location integration', () => {
     expect(payload.records[0]!.path).toBe('specs/sample/01-first.tasks.md');
   });
 
-  it('omitting --root with artifactsLocation=external redirects to ~/.smithy/<repo>/ and re-prepends the prefix on records', () => {
+  it('omitting --root with artifactsLocation=external redirects to ~/.smithy/repos/<repoKey>/ and re-prepends the prefix on records', () => {
     writeManifest(workdir, 'external');
-    const externalRoot = join(fakeHome, '.smithy', `${require('path').basename(workdir)}`);
+    const externalRoot = resolveArtifactsRoot(workdir, 'external');
     writeTasksFixture(externalRoot);
 
     // No `root` field — exercises the manifest-driven redirect branch.
     statusAction({ format: 'json' });
     const payload = JSON.parse(captured()) as StatusJsonPayload;
 
-    const expectedPrefix = `~/.smithy/${require('path').basename(workdir)}/`;
+    const expectedPrefix = templateArtifactsPrefix(workdir, 'external');
     expect(payload.records.length).toBeGreaterThan(0);
     expect(payload.records[0]!.path).toBe(
       `${expectedPrefix}specs/sample/01-first.tasks.md`,
@@ -1328,7 +1329,7 @@ describe('statusAction artifacts-location integration', () => {
   });
 
   it('omitting --root with artifactsLocation=external but no external dir yet falls back to cwd (friendly empty hint)', () => {
-    // User flipped the flag but hasn't written anything to ~/.smithy/<repo>/ yet.
+    // User flipped the flag but hasn't written anything to ~/.smithy/repos/<repoKey>/ yet.
     writeManifest(workdir, 'external');
     statusAction({ format: 'json' });
     const payload = JSON.parse(captured()) as StatusJsonPayload;
@@ -1341,7 +1342,7 @@ describe('statusAction artifacts-location integration', () => {
     // Pre-create both locations with different fixtures so the test can tell
     // which root the scanner actually visited.
     writeTasksFixture(workdir);
-    const externalRoot = join(fakeHome, '.smithy', require('path').basename(workdir));
+    const externalRoot = resolveArtifactsRoot(workdir, 'external');
     mkdirSync(join(externalRoot, 'specs', 'other'), { recursive: true });
     writeFileSync(
       join(externalRoot, 'specs', 'other', '99-other.tasks.md'),

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -59,7 +59,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { readManifest, resolveArtifactsRoot } from '../manifest.js';
+import { readManifest, resolveArtifactsRoot, templateArtifactsPrefix } from '../manifest.js';
 import {
   buildDependencyGraph,
   buildTree,
@@ -321,7 +321,7 @@ export function statusAction(opts: StatusOptions = {}): void {
 
   // If the user didn't pass `--root` explicitly and the working directory has
   // a smithy manifest declaring `artifactsLocation: 'external'`, redirect the
-  // scan to `~/.smithy/<repo>/` so artifacts written off-tree are still found.
+  // scan to `~/.smithy/repos/<repoKey>/` so artifacts written off-tree are still found.
   // Explicit `--root` always wins so power users can scan an arbitrary path.
   const externalScanRoot =
     opts.root === undefined ? resolveExternalArtifactsRoot(resolvedRoot) : null;
@@ -329,12 +329,15 @@ export function statusAction(opts: StatusOptions = {}): void {
   const records = scan(scanRoot);
   // The scanner returns paths relative to `scanRoot`. When we redirected, those
   // paths read like `specs/foo/01.tasks.md` but the actual files live at
-  // `~/.smithy/<repo>/specs/foo/01.tasks.md`. Re-prepend the tilde prefix so the
-  // rendered tree, JSON records, and `Next: smithy.forge <path> <N>` hints all
-  // point at the real on-disk location. Skipped in the in-repo case (the cheap
-  // common path) where `externalScanRoot` is `null`.
+  // `~/.smithy/repos/<repoKey>/specs/foo/01.tasks.md`. Re-prepend the tilde
+  // prefix so the rendered tree, JSON records, and `Next: smithy.forge <path>
+  // <N>` hints all point at the real on-disk location. We reuse
+  // `templateArtifactsPrefix` (rather than rebuilding the prefix inline) so the
+  // displayed paths are guaranteed to match where the artifacts are actually
+  // stored — both go through the same worktree-stable `repoKey`. Skipped in the
+  // in-repo case (the cheap common path) where `externalScanRoot` is `null`.
   if (externalScanRoot !== null) {
-    const externalPrefix = `~/.smithy/${path.basename(resolvedRoot)}/`;
+    const externalPrefix = templateArtifactsPrefix(resolvedRoot, 'external');
     applyExternalPrefix(records, externalPrefix);
   }
   // US6: apply the `--status` / `--type` filters to the classified
@@ -703,7 +706,7 @@ function findNextAction(node: TreeNode): NextAction | null {
 }
 
 /**
- * When the scan was redirected to `~/.smithy/<repo>/`, every `ArtifactRecord`
+ * When the scan was redirected to `~/.smithy/repos/<repoKey>/`, every `ArtifactRecord`
  * the scanner returns carries paths relative to that external root (the
  * scanner has no concept of "this isn't the working repo"). Walk the records
  * and prepend `externalPrefix` to every path-shaped field so the rendered
@@ -734,7 +737,7 @@ function applyExternalPrefix(records: ArtifactRecord[], externalPrefix: string):
 
 /**
  * If `<resolvedRoot>` has a smithy manifest declaring `artifactsLocation:
- * 'external'`, return the absolute path to `~/.smithy/<repo>/` so the
+ * 'external'`, return the absolute path to `~/.smithy/repos/<repoKey>/` so the
  * scanner finds artifacts that were written off-tree. Returns `null` for
  * the in-repo case (the caller falls back to `resolvedRoot`). Either
  * manifest location ('repo' deploy at `.smithy/...`, 'user' deploy at

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -11,7 +11,7 @@ export type DeployablePermissionLevel = Exclude<PermissionLevel, 'none'>;
  * Where smithy planning artifacts (RFCs, specs, tasks, strikes, PRDs)
  * are written:
  *   - 'repo'     → in-tree under `docs/rfcs/`, `specs/`, etc. (default).
- *   - 'external' → out-of-tree under `~/.smithy/<repo-name>/` so the
+ *   - 'external' → out-of-tree under `~/.smithy/repos/<repoKey>/` so the
  *     planning files stay off the team's git history. The flag is
  *     persisted in the manifest and baked into the deployed prompts via
  *     the `{{artifactsRoot}}` template variable.
@@ -172,7 +172,7 @@ export async function promptArtifactsLocation(): Promise<ArtifactsLocation> {
         description: 'Committed in-tree under docs/rfcs/, specs/, ... (default)',
       },
       {
-        name: 'External (~/.smithy/<repo>/)',
+        name: 'External (~/.smithy/repos/<repo>/)',
         value: 'external',
         description: 'Stored in your user home, kept out of the repo\'s git history',
       },

--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -93,6 +93,40 @@ describe('repoKey', () => {
     expect(fromWorktree).not.toBe('wt');
   });
 
+  it('keys a submodule by its own name, not `modules`', () => {
+    passGitThrough();
+
+    const parent = makeTmpDir('smithy-manifest-sub-');
+    const subDir = path.join(parent, 'subsource');
+    const superDir = path.join(parent, 'super');
+    fs.mkdirSync(subDir);
+    fs.mkdirSync(superDir);
+
+    // A standalone repo to embed as a submodule.
+    for (const dir of [subDir, superDir]) {
+      git(['init', '-q'], dir);
+      git(['config', 'user.email', 'test@example.com'], dir);
+      git(['config', 'user.name', 'Test'], dir);
+      git(['config', 'commit.gpgsign', 'false'], dir);
+      fs.writeFileSync(path.join(dir, 'file.txt'), 'hello\n');
+      git(['add', '.'], dir);
+      git(['commit', '-q', '-m', 'init'], dir);
+    }
+    // Embed `subsource` as submodule `mysub`. Local-path submodules need the
+    // file protocol explicitly enabled on git >= 2.38.
+    git(
+      ['-c', 'protocol.file.allow=always', 'submodule', 'add', subDir, 'mysub'],
+      superDir,
+    );
+
+    // Inside the submodule, `--git-common-dir` points at
+    // `<super>/.git/modules/mysub` — the parent is `modules`, which would
+    // collide across every submodule. The key must be the submodule name.
+    const key = repoKey(path.join(superDir, 'mysub'));
+    expect(key).toBe('mysub');
+    expect(key).not.toBe('modules');
+  });
+
   it('falls back to basename(targetDir) for a non-git directory', () => {
     // No git repo here, so `git rev-parse` exits non-zero → fall through.
     vi.mocked(execFileSync).mockImplementation((() => {

--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Mock child_process
+// ---------------------------------------------------------------------------
+//
+// `repoKey` shells out to `git` via `execFileSync`. We mock the whole module
+// (keeping every other export real) so individual tests can decide what git
+// reports: route to the real binary for the worktree-stability integration
+// test, or simulate failure / a custom remote URL for the fallback paths.
+
+const actualChildProcess =
+  await vi.importActual<typeof import('child_process')>('child_process');
+const realExecFileSync = actualChildProcess.execFileSync;
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return { ...actual, execFileSync: vi.fn() };
+});
+
+const { execFileSync } = await import('child_process');
+const { repoKey, resolveArtifactsRoot, templateArtifactsPrefix } = await import(
+  './manifest.js'
+);
+
+// Run a real git command for fixture setup, bypassing the mock entirely.
+function git(args: string[], cwd: string): void {
+  realExecFileSync('git', args, { cwd, stdio: 'ignore' });
+}
+
+// Route the mocked `execFileSync` so real `git` invocations hit the binary.
+function passGitThrough(): void {
+  vi.mocked(execFileSync).mockImplementation(
+    ((command: string, args: readonly string[] | undefined, options: unknown) => {
+      if (command === 'git') {
+        return realExecFileSync(
+          command,
+          args as string[] | undefined,
+          options as Parameters<typeof realExecFileSync>[2],
+        );
+      }
+      return Buffer.from('');
+    }) as never,
+  );
+}
+
+describe('repoKey', () => {
+  const tmpDirs: string[] = [];
+
+  function makeTmpDir(prefix: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tmpDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(execFileSync).mockReset();
+    while (tmpDirs.length > 0) {
+      const dir = tmpDirs.pop()!;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves the same key from the main checkout and a linked worktree', () => {
+    passGitThrough();
+
+    const parent = makeTmpDir('smithy-manifest-wt-');
+    const mainDir = path.join(parent, 'mainrepo');
+    const wtDir = path.join(parent, 'wt');
+    fs.mkdirSync(mainDir);
+
+    git(['init', '-q'], mainDir);
+    git(['config', 'user.email', 'test@example.com'], mainDir);
+    git(['config', 'user.name', 'Test'], mainDir);
+    git(['config', 'commit.gpgsign', 'false'], mainDir);
+    fs.writeFileSync(path.join(mainDir, 'file.txt'), 'hello\n');
+    git(['add', '.'], mainDir);
+    git(['commit', '-q', '-m', 'init'], mainDir);
+    // Linked worktree — its `--git-common-dir` points back at mainDir/.git.
+    git(['worktree', 'add', '-q', wtDir], mainDir);
+
+    const fromMain = repoKey(mainDir);
+    const fromWorktree = repoKey(wtDir);
+
+    // Worktree-stable: both checkouts resolve to the repo's own folder name,
+    // never the worktree folder (`wt`).
+    expect(fromMain).toBe(fromWorktree);
+    expect(fromMain).toBe('mainrepo');
+    expect(fromWorktree).not.toBe('wt');
+  });
+
+  it('falls back to basename(targetDir) for a non-git directory', () => {
+    // No git repo here, so `git rev-parse` exits non-zero → fall through.
+    vi.mocked(execFileSync).mockImplementation((() => {
+      throw new Error('not a git repository');
+    }) as never);
+
+    expect(repoKey('/home/dev/projects/widget')).toBe('widget');
+  });
+
+  it('falls back to the origin remote basename when there is no common dir', () => {
+    vi.mocked(execFileSync).mockImplementation(
+      ((_command: string, args: readonly string[] | undefined) => {
+        const argv = (args ?? []) as string[];
+        if (argv.includes('--git-common-dir')) {
+          throw new Error('not a git repository');
+        }
+        if (argv.includes('remote.origin.url')) {
+          return 'https://github.com/acme/my-repo.git';
+        }
+        return '';
+      }) as never,
+    );
+
+    expect(repoKey('/tmp/whatever')).toBe('my-repo');
+  });
+
+  it('sanitizes the key to a single filesystem-safe segment', () => {
+    vi.mocked(execFileSync).mockImplementation((() => {
+      throw new Error('not a git repository');
+    }) as never);
+
+    const key = repoKey('/home/dev/weird name@!');
+
+    expect(key).not.toContain('/');
+    expect(key).not.toContain('\\');
+    expect(key).toMatch(/^[A-Za-z0-9._-]+$/);
+  });
+});
+
+describe('resolveArtifactsRoot', () => {
+  beforeEach(() => {
+    vi.spyOn(os, 'homedir').mockReturnValue('/fake/home');
+    // Non-git target → repoKey resolves to basename.
+    vi.mocked(execFileSync).mockImplementation((() => {
+      throw new Error('not a git repository');
+    }) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(execFileSync).mockReset();
+  });
+
+  it('returns the repo-keyed external root under ~/.smithy/repos/', () => {
+    expect(resolveArtifactsRoot('/work/widget', 'external')).toBe(
+      path.join('/fake/home', '.smithy', 'repos', 'widget'),
+    );
+  });
+
+  it('returns targetDir unchanged for repo mode', () => {
+    expect(resolveArtifactsRoot('/work/widget', 'repo')).toBe('/work/widget');
+    expect(resolveArtifactsRoot('/work/widget')).toBe('/work/widget');
+  });
+});
+
+describe('templateArtifactsPrefix', () => {
+  beforeEach(() => {
+    vi.mocked(execFileSync).mockImplementation((() => {
+      throw new Error('not a git repository');
+    }) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(execFileSync).mockReset();
+  });
+
+  it('returns the repo-keyed tilde prefix for external mode', () => {
+    expect(templateArtifactsPrefix('/work/widget', 'external')).toBe(
+      '~/.smithy/repos/widget/',
+    );
+  });
+
+  it('returns an empty prefix for repo mode', () => {
+    expect(templateArtifactsPrefix('/work/widget', 'repo')).toBe('');
+    expect(templateArtifactsPrefix('/work/widget')).toBe('');
+  });
+
+  it('renders identical prefixes from the main checkout and a worktree (display matches storage)', () => {
+    passGitThrough();
+
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-manifest-px-'));
+    try {
+      const mainDir = path.join(parent, 'mainrepo');
+      const wtDir = path.join(parent, 'wt');
+      fs.mkdirSync(mainDir);
+      git(['init', '-q'], mainDir);
+      git(['config', 'user.email', 'test@example.com'], mainDir);
+      git(['config', 'user.name', 'Test'], mainDir);
+      git(['config', 'commit.gpgsign', 'false'], mainDir);
+      fs.writeFileSync(path.join(mainDir, 'file.txt'), 'hello\n');
+      git(['add', '.'], mainDir);
+      git(['commit', '-q', '-m', 'init'], mainDir);
+      git(['worktree', 'add', '-q', wtDir], mainDir);
+
+      expect(templateArtifactsPrefix(wtDir, 'external')).toBe(
+        templateArtifactsPrefix(mainDir, 'external'),
+      );
+      expect(templateArtifactsPrefix(mainDir, 'external')).toBe(
+        '~/.smithy/repos/mainrepo/',
+      );
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -109,8 +109,12 @@ function sanitizeRepoKey(name: string): string {
  *   1. `git rev-parse --git-common-dir` → the shared `.git` dir (relative
  *      `.git` from the main worktree root, absolute path from a linked
  *      worktree). It points at the same place for every worktree.
- *   2. `repoRoot = dirname(realpath(resolve(targetDir, commonDir)))` — the
- *      main worktree's root.
+ *   2. The repo root is the common dir's parent when the common dir is the
+ *      usual `.git` directory; for a submodule the common dir is instead
+ *      `<superproject>/.git/modules/<submodule>`, whose own name is the
+ *      stable per-submodule identity (taking the parent would collapse every
+ *      submodule onto `modules`). `git init --separate-git-dir` layouts are
+ *      handled the same way.
  *   3. `repoKey = basename(repoRoot)`.
  *
  * Fallbacks, in order, when git is unavailable or yields nothing:
@@ -123,10 +127,15 @@ export function repoKey(targetDir: string): string {
   const commonDir = gitCapture(targetDir, ['rev-parse', '--git-common-dir']);
   if (commonDir) {
     try {
-      const repoRoot = path.dirname(
-        fs.realpathSync(path.resolve(targetDir, commonDir)),
-      );
-      const key = path.basename(repoRoot);
+      const realCommon = fs.realpathSync(path.resolve(targetDir, commonDir));
+      // A common dir named `.git` belongs to a normal checkout or a linked
+      // worktree, so the repo is its parent. Anything else is already a named
+      // git dir — `.git/modules/<submodule>` for submodules, or a detached
+      // dir under `--separate-git-dir` — whose basename is the repo identity.
+      const key =
+        path.basename(realCommon) === '.git'
+          ? path.basename(path.dirname(realCommon))
+          : path.basename(realCommon);
       if (key.length > 0) return sanitizeRepoKey(key);
     } catch {
       // realpath failed (e.g. the common dir vanished mid-run) — fall through.

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { execFileSync } from 'child_process';
 import { createRequire } from 'module';
 import type { ArtifactsLocation, DeployLocation } from './interactive.js';
 import { removeIfExists } from './utils.js';
@@ -9,6 +10,16 @@ const require = createRequire(import.meta.url);
 export const { version: smithyVersion } = require('../package.json') as { version: string };
 
 const MANIFEST_FILENAME = 'smithy-manifest.json';
+
+/**
+ * Fixed grouping segment under `~/.smithy/` that isolates per-repo external
+ * artifact stores from Smithy's own reserved entries (`templates/`,
+ * `smithy-manifest.json`, `config.yml`, ...). Keeping it as a dedicated
+ * namespace makes the layout collision-proof: a repo literally named
+ * `templates` resolves to `~/.smithy/repos/templates/`, never clobbering
+ * `~/.smithy/templates/`.
+ */
+const REPOS_DIR = 'repos';
 
 export interface SmithyManifest {
   version: 1;
@@ -54,11 +65,92 @@ export function resolveManifestPath(targetDir: string, location: DeployLocation)
 }
 
 /**
+ * Run `git -C <targetDir> <args...>` and return its trimmed stdout, or
+ * `null` if git is unavailable, the directory isn't a repo, or the command
+ * produces no output. Stderr is discarded so non-repo dirs fail quietly.
+ */
+function gitCapture(targetDir: string, args: string[]): string | null {
+  try {
+    const out = execFileSync('git', ['-C', targetDir, ...args], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const trimmed = out.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Make a repo identity filesystem-safe: collapse path separators and any
+ * other awkward characters to `-`, trim leading/trailing separators, and
+ * fall back to `'repo'` if nothing usable remains. Guarantees the result
+ * is a single path segment (no `/` or `\`).
+ */
+function sanitizeRepoKey(name: string): string {
+  const cleaned = name
+    .replace(/[/\\]/g, '-')
+    .replace(/[^A-Za-z0-9._-]/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '');
+  return cleaned.length > 0 ? cleaned : 'repo';
+}
+
+/**
+ * Derive a **worktree-stable** identity key for the repository containing
+ * `targetDir`, used to namespace external artifact stores under
+ * `~/.smithy/repos/<repoKey>/`.
+ *
+ * Every worktree of a repo — and its main checkout — must resolve to the
+ * same key so they share one store and `smithy status` agrees from anywhere.
+ * We achieve that by consulting git's *shared* git-common-dir rather than the
+ * working directory name:
+ *
+ *   1. `git rev-parse --git-common-dir` → the shared `.git` dir (relative
+ *      `.git` from the main worktree root, absolute path from a linked
+ *      worktree). It points at the same place for every worktree.
+ *   2. `repoRoot = dirname(realpath(resolve(targetDir, commonDir)))` — the
+ *      main worktree's root.
+ *   3. `repoKey = basename(repoRoot)`.
+ *
+ * Fallbacks, in order, when git is unavailable or yields nothing:
+ *   4. basename of the `origin` remote URL (with a trailing `.git` stripped).
+ *   5. basename of `targetDir` (non-git directories).
+ *
+ * The result is always sanitized to a single filesystem-safe segment.
+ */
+export function repoKey(targetDir: string): string {
+  const commonDir = gitCapture(targetDir, ['rev-parse', '--git-common-dir']);
+  if (commonDir) {
+    try {
+      const repoRoot = path.dirname(
+        fs.realpathSync(path.resolve(targetDir, commonDir)),
+      );
+      const key = path.basename(repoRoot);
+      if (key.length > 0) return sanitizeRepoKey(key);
+    } catch {
+      // realpath failed (e.g. the common dir vanished mid-run) — fall through.
+    }
+  }
+
+  const remote = gitCapture(targetDir, ['config', '--get', 'remote.origin.url']);
+  if (remote) {
+    const base = path.basename(remote.replace(/\/+$/, '').replace(/\.git$/, ''));
+    if (base.length > 0) return sanitizeRepoKey(base);
+  }
+
+  return sanitizeRepoKey(path.basename(targetDir));
+}
+
+/**
  * Resolve the absolute directory under which planning artifacts (RFCs,
  * specs, tasks, strikes, PRDs) are written:
  *   - 'repo'     → `<targetDir>` (paths land at `docs/rfcs/...`, `specs/...`)
- *   - 'external' → `~/.smithy/<basename(targetDir)>/` (paths land at
- *     `~/.smithy/<repo>/docs/rfcs/...`, `~/.smithy/<repo>/specs/...`)
+ *   - 'external' → `~/.smithy/repos/<repoKey(targetDir)>/` (paths land at
+ *     `~/.smithy/repos/<repo>/docs/rfcs/...`, `~/.smithy/repos/<repo>/specs/...`)
+ *
+ * The `<repoKey>` segment is worktree-stable (see {@link repoKey}), so every
+ * worktree of a repo shares one external store.
  *
  * Used by the status scanner and any other code that needs the *real*
  * filesystem location. For the template variable baked into deployed
@@ -71,7 +163,7 @@ export function resolveArtifactsRoot(
   location: ArtifactsLocation = 'repo',
 ): string {
   if (location === 'external') {
-    return path.join(os.homedir(), '.smithy', path.basename(targetDir));
+    return path.join(os.homedir(), '.smithy', REPOS_DIR, repoKey(targetDir));
   }
   return targetDir;
 }
@@ -80,8 +172,8 @@ export function resolveArtifactsRoot(
  * The prefix that gets substituted into deployed prompts via the
  * `{{artifactsRoot}}` template variable. Returns `""` for in-repo mode
  * so paths render unchanged (`docs/rfcs/...`), or the tilde form
- * `~/.smithy/<basename>/` for external mode so paths render as
- * `~/.smithy/<repo>/docs/rfcs/...`.
+ * `~/.smithy/repos/<repoKey>/` for external mode so paths render as
+ * `~/.smithy/repos/<repo>/docs/rfcs/...`.
  *
  * Tilde-form (not home-expanded) so committed deployed prompts stay
  * portable across team members. Agents (Claude Code, Gemini CLI, Codex)
@@ -92,7 +184,7 @@ export function templateArtifactsPrefix(
   location: ArtifactsLocation = 'repo',
 ): string {
   if (location === 'external') {
-    return `~/.smithy/${path.basename(targetDir)}/`;
+    return `~/.smithy/${REPOS_DIR}/${repoKey(targetDir)}/`;
   }
   return '';
 }

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -3317,7 +3317,7 @@ describe('getComposedTemplates', () => {
 describe('getComposedTemplates artifactsRoot', () => {
   // The {{artifactsRoot}} helper is the deploy-time variable that decides
   // whether planning-artifact paths in the deployed prompts render as
-  // `docs/rfcs/...` (in-repo, default) or `~/.smithy/<repo>/docs/rfcs/...`
+  // `docs/rfcs/...` (in-repo, default) or `~/.smithy/repos/<repo>/docs/rfcs/...`
   // (external mode). Each templatized command prompt must honor it; these
   // assertions lock that in against future template rewrites.
 
@@ -3327,9 +3327,10 @@ describe('getComposedTemplates artifactsRoot', () => {
     // Path in the Phase 3 write instruction renders without a prefix.
     expect(strike).toContain('Write a single strike document to `specs/strikes/YYYY-MM-DD-<slug>.strike.md`');
     expect(strike).not.toContain('{{artifactsRoot}}');
-    // The policy snippet mentions ~/.smithy/<repo>/ as part of its explanation;
-    // that's expected. Make sure no actual artifact path got a tilde prefix.
-    expect(strike).not.toContain('~/.smithy/<repo>/specs/strikes/YYYY');
+    // The policy snippet mentions ~/.smithy/repos/<repo>/ as part of its
+    // explanation; that's expected. Make sure no actual artifact path got a
+    // tilde prefix.
+    expect(strike).not.toContain('~/.smithy/repos/<repo>/specs/strikes/YYYY');
   });
 
   it('substitutes the supplied prefix into every templatized path', async () => {

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -225,8 +225,8 @@ export function getTemplateFilesByCategory(): Record<TemplateCategory, string[]>
  * `artifactsRoot` is the prefix substituted into deployed prompts via the
  * `{{artifactsRoot}}` template variable. Templates write paths like
  * `{{artifactsRoot}}docs/rfcs/...`; with an empty prefix (in-repo mode) the
- * path renders as `docs/rfcs/...`, and with `~/.smithy/<repo>/` (external
- * mode) it renders as `~/.smithy/<repo>/docs/rfcs/...`. Implemented as a
+ * path renders as `docs/rfcs/...`, and with `~/.smithy/repos/<repo>/` (external
+ * mode) it renders as `~/.smithy/repos/<repo>/docs/rfcs/...`. Implemented as a
  * zero-arg Handlebars helper so Dotprompt's `knownHelpersOnly` mode accepts
  * the reference (same plumbing pattern as `{{#ifAgent}}`).
  */

--- a/src/templates/agent-skills/commands/smithy.spark.prompt
+++ b/src/templates/agent-skills/commands/smithy.spark.prompt
@@ -1,6 +1,6 @@
 ---
 name: smithy-spark
-description: "Spark a raw idea into a one-page PRD. Clarifies the problem, surveys off-the-shelf alternatives, and produces a docs/prds/<YYYY>-<NNN>-<slug>.prd.md (or ~/.smithy/<repo>/docs/prds/... in external-artifacts mode) as an optional upstream input to smithy.ignite."
+description: "Spark a raw idea into a one-page PRD. Clarifies the problem, surveys off-the-shelf alternatives, and produces a docs/prds/<YYYY>-<NNN>-<slug>.prd.md (or ~/.smithy/repos/<repo>/docs/prds/... in external-artifacts mode) as an optional upstream input to smithy.ignite."
 ---
 # smithy-spark
 

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -219,7 +219,7 @@ After writing the strike document to disk and before committing, dispatch the
 - **artifact_paths** — the path to the strike document just written, exactly
   as it was used to write the file (for strike: the single `.strike.md` file
   at `{{artifactsRoot}}specs/strikes/YYYY-MM-DD-<slug>.strike.md`). In
-  external-artifacts mode this is a `~/.smithy/<repo>/...` path, not a
+  external-artifacts mode this is a `~/.smithy/repos/<repo>/...` path, not a
   repo-relative one — pass it through verbatim; do not strip the prefix.
 - **artifact_type** — `strike`.
 

--- a/src/templates/agent-skills/snippets/artifact-location-policy.md
+++ b/src/templates/agent-skills/snippets/artifact-location-policy.md
@@ -11,9 +11,9 @@ prefix.
 - When `{{artifactsRoot}}` is empty, artifacts live **in the repo**:
   `docs/rfcs/...`, `docs/prds/...`, `docs/personas/...`, `specs/...`,
   `specs/strikes/...`.
-- When `{{artifactsRoot}}` is `~/.smithy/repos/<repo>/`, artifacts live **outside
-  the repo, in the user's home directory**: `~/.smithy/repos/<repo>/docs/rfcs/...`,
-  `~/.smithy/repos/<repo>/docs/personas/...`, `~/.smithy/repos/<repo>/specs/...`, etc.
+- When `{{artifactsRoot}}` is `~/.smithy/repos/<repoKey>/`, artifacts live **outside
+  the repo, in the user's home directory**: `~/.smithy/repos/<repoKey>/docs/rfcs/...`,
+  `~/.smithy/repos/<repoKey>/docs/personas/...`, `~/.smithy/repos/<repoKey>/specs/...`, etc.
   Treat the resolved path as authoritative — agents (Claude Code, Gemini CLI,
   Codex) expand `~` at tool-call time, so the path is portable across team
   members even when this prompt is committed to source control.

--- a/src/templates/agent-skills/snippets/artifact-location-policy.md
+++ b/src/templates/agent-skills/snippets/artifact-location-policy.md
@@ -11,9 +11,9 @@ prefix.
 - When `{{artifactsRoot}}` is empty, artifacts live **in the repo**:
   `docs/rfcs/...`, `docs/prds/...`, `docs/personas/...`, `specs/...`,
   `specs/strikes/...`.
-- When `{{artifactsRoot}}` is `~/.smithy/<repo>/`, artifacts live **outside
-  the repo, in the user's home directory**: `~/.smithy/<repo>/docs/rfcs/...`,
-  `~/.smithy/<repo>/docs/personas/...`, `~/.smithy/<repo>/specs/...`, etc.
+- When `{{artifactsRoot}}` is `~/.smithy/repos/<repo>/`, artifacts live **outside
+  the repo, in the user's home directory**: `~/.smithy/repos/<repo>/docs/rfcs/...`,
+  `~/.smithy/repos/<repo>/docs/personas/...`, `~/.smithy/repos/<repo>/specs/...`, etc.
   Treat the resolved path as authoritative — agents (Claude Code, Gemini CLI,
   Codex) expand `~` at tool-call time, so the path is portable across team
   members even when this prompt is committed to source control.


### PR DESCRIPTION
## Problem

When `artifactsLocation: "external"` is set, Smithy stored planning artifacts under `~/.smithy/<basename-of-current-directory>/`. That broke in three ways:

1. **Worktree-sensitive.** The path came from `basename(cwd)`. In a git *worktree* (`…/WorkTrees/code/feature-foo`) the basename is the worktree folder (`feature-foo`), not the repo (`code`), so a repo checked out as N worktrees got N unrelated stores. `smithy status` from a worktree looked somewhere different from the main checkout.
2. **Collision risk.** Per-repo stores sat directly under `~/.smithy/`, alongside Smithy's own reserved entries (`templates/`, `smithy-manifest.json`, `config.yml`). A repo named `templates` collided with `~/.smithy/templates/`.
3. **No repo identity.** It never consulted git — purely the directory name.

## Fix

External artifacts now resolve to:

```
~/.smithy/repos/<repoKey>/        # then docs/rfcs/, specs/, specs/strikes/ underneath
```

- `repos/` is a fixed grouping segment that isolates per-repo stores from Smithy's own files and is collision-proof (a repo named `templates` → `~/.smithy/repos/templates/`).
- `<repoKey>` is **worktree-stable**, derived from git's shared git dir:
  1. `git rev-parse --git-common-dir` → `dirname(realpath(resolve(targetDir, commonDir)))` → `basename(repoRoot)`
  2. fallback: `origin` remote basename (`.git` stripped)
  3. fallback: `basename(targetDir)` for non-git dirs
  4. sanitized to a single filesystem-safe segment

`--git-common-dir` points at the shared git dir for every worktree, so every worktree and the main checkout resolve to the same key.

## Changes

A single exported `repoKey()` helper in `src/manifest.ts` (plus a `REPOS_DIR` constant) backs all **three** call sites:

1. `resolveArtifactsRoot` (real filesystem location)
2. `templateArtifactsPrefix` (prefix baked into deployed prompts)
3. The `status` command display prefix — now **reuses** `templateArtifactsPrefix(resolvedRoot, 'external')` instead of rebuilding the string inline, so displayed paths are guaranteed to match where files are stored.

Prose updated to the new shape: the interactive prompt choice, `artifact-location-policy.md`, the spark/strike templates, and source docstrings (`init.ts`, `status.ts`, `templates.ts`, `claude.ts`). README gains a **Planning Artifact Storage** section documenting repo vs external mode and the worktree-stable layout. Per `CLAUDE.md`, the committed `.claude/` snapshot was intentionally **not** regenerated.

## Tests

New `src/manifest.test.ts` (no manifest test existed before):

- `repoKey` returns the same value from the main checkout and a linked worktree (**real `git init` + `git worktree add`**).
- `repoKey` falls back to remote basename, then `basename(targetDir)`, for non-git dirs (mocked `execFileSync`).
- `repoKey` is filesystem-safe (no separators).
- `resolveArtifactsRoot(dir, "external")` → `<home>/.smithy/repos/<repoKey>/`; `"repo"` unchanged.
- `templateArtifactsPrefix(dir, "external")` → `~/.smithy/repos/<repoKey>/`; `""` for repo mode.
- Identical, repo-keyed prefixes from worktree and main checkout (covers the "status renders identical paths" criterion).

Updated `cli.test.ts`, `status.test.ts`, and `templates.test.ts` for the new prefix. Full suite: **983 passing**. Build + typecheck clean. Manually smoke-tested: `init --artifacts-location external` from both the main checkout and a worktree bakes the identical `~/.smithy/repos/<repo>/` prefix.

## Notes

- **Migration:** none — confirmed with the requester there are no existing external users, so no auto-migrate / notice code was added.
- **Version bump:** left to the npm publish script.
- **Out of scope** (per the request): making `repos/` configurable, and persisting `repoKey` into the manifest (recomputed from git each run — it's stable).

https://claude.ai/code/session_01TJp1xKgF3LYCwje18sYY85

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJp1xKgF3LYCwje18sYY85)_