### PR TITLE
Add offline smithy.fix issue and CI-log fixtures

### DIFF
--- a/evals/fixture/README.md
+++ b/evals/fixture/README.md
@@ -7,6 +7,8 @@ This is a minimal Express TypeScript API project used as the **reference fixture
 - `src/index.ts` — Express app entry point. Mounts the users router at `/api/users` and starts the server on a configurable `PORT`.
 - `src/types.ts` — TypeScript interfaces (`User`, `CreateUserRequest`) used by route handlers.
 - `src/routes/users.ts` — Express Router with three user CRUD handlers: list, get by id, and create.
+- `issues/` — Local issue fixtures used by offline eval scenarios that must not fetch GitHub issue or pull-request data.
+- `ci-logs/` — Local CI-log fixtures used by offline eval scenarios that must not fetch Actions logs.
 - `package.json` — Node project manifest with Express as a runtime dependency, and TypeScript, `@types/express`, and `@types/node` as dev dependencies.
 - `tsconfig.json` — TypeScript config targeting ES2022 with CommonJS module resolution.
 
@@ -27,6 +29,10 @@ Each plant maps to a row in smithy-scout's Severity Guidelines table (see `src/t
 | `evals/fixture/specs/audit-eval/audit-eval-flawed.spec.md` | Missing `## Dependency Order` section | Deliberately violates the canonical spec invariant that multi-story Smithy specs include a `## Dependency Order` table; owned by `audit-flawed-spec`. This plant must not be "fixed" by restoring the section. | **Critical** (missing required spec section) |
 
 Together with the **Intentional Gap** above, these plants are the fixture's twin purposes: the missing health-check endpoint drives eval scenarios that ask agents to add new behavior, and the planted inconsistencies drive eval scenarios that ask agents to detect existing flaws.
+
+## Local Failure Evidence
+
+Some eval scenarios exercise commands from committed evidence instead of live service APIs. The `issues/` and `ci-logs/` directories contain those local inputs. For example, the smithy.fix `fix-from-issue` scenario uses `issues/fix-from-issue-health-check.md` and `ci-logs/fix-from-issue-health-check.log` to diagnose the missing health-check endpoint without calling GitHub issue, pull-request, or Actions APIs.
 
 ## Planted Parent Artifacts
 

--- a/evals/fixture/ci-logs/fix-from-issue-health-check.log
+++ b/evals/fixture/ci-logs/fix-from-issue-health-check.log
@@ -1,0 +1,34 @@
+2026-06-03T12:00:00.000Z runner: GitHub Actions job "fixture-smoke" started
+2026-06-03T12:00:00.104Z runner: checkout complete
+2026-06-03T12:00:00.338Z runner: using Node.js 22.x
+
+$ npm run build
+
+> smithy-eval-fixture@1.0.0 build
+> tsc
+
+2026-06-03T12:00:01.912Z build: completed successfully
+
+$ npm start
+
+> smithy-eval-fixture@1.0.0 start
+> node dist/index.js
+
+Server running on port 3000
+
+$ curl --silent --show-error --fail --dump-header /tmp/headers.txt http://127.0.0.1:3000/health
+curl: (22) The requested URL returned error: 404
+
+--- response headers ---
+HTTP/1.1 404 Not Found
+X-Powered-By: Express
+Content-Security-Policy: default-src 'none'
+X-Content-Type-Options: nosniff
+Content-Type: text/html; charset=utf-8
+Content-Length: 145
+
+--- failure summary ---
+FAIL fixture-smoke: expected GET /health to return HTTP 200
+Expected route owner: src/index.ts
+Existing route reference: src/routes/users.ts is mounted at /api/users
+No network lookup is required; this log is the complete CI evidence for the failure.

--- a/evals/fixture/issues/fix-from-issue-health-check.md
+++ b/evals/fixture/issues/fix-from-issue-health-check.md
@@ -1,0 +1,24 @@
+# CI failure: health check endpoint is missing
+
+## Summary
+
+The Smithy eval fixture API starts successfully, but the deployment smoke check fails because `GET /health` returns 404. The app needs a simple health check endpoint so infrastructure can confirm the service is alive after startup.
+
+## Observed Behavior
+
+- Command under test: `npm run build && npm start`
+- Smoke check: `curl --fail http://127.0.0.1:3000/health`
+- Actual response: `HTTP/1.1 404 Not Found`
+- Expected response: `HTTP/1.1 200 OK` with a small JSON body that identifies the service as healthy.
+
+## Relevant Files
+
+- `package.json` defines the build and start scripts used by the failing CI job.
+- `src/index.ts` creates the Express app, mounts `src/routes/users.ts` at `/api/users`, and starts the server.
+- `src/routes/users.ts` is an existing route module and should not be changed for this health check unless the implementation deliberately extracts shared routing.
+
+## Constraints
+
+- Keep the fixture minimal. This repository is an eval target, not a production app.
+- Do not add live GitHub, pull request, or Actions calls while diagnosing this issue. The CI evidence is in the local log fixture paired with this issue.
+- Preserve the deliberate scout plants documented in `README.md`.

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/01-provide-offline-smithy-fix-fixtures.tasks.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/01-provide-offline-smithy-fix-fixtures.tasks.md
@@ -1,0 +1,50 @@
+# Tasks: Provide Offline smithy.fix Fixtures
+
+**Source**: `specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md` — User Story 1
+**Data Model**: `specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md`
+**Contracts**: `specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.contracts.md`
+**Story Number**: 01
+
+---
+
+## Slice 1: Offline smithy.fix Failure Evidence
+
+**Goal**: Commit the local issue and CI-log evidence that lets a future `fix-from-issue` eval drive smithy.fix without fetching GitHub issue or Actions data.
+
+**Justification**: The smithy.fix scenario cannot be deterministic until its problem statement and CI failure evidence live in the repository. This slice provides only the offline fixture inputs; scenario metadata, runner path injection, structural checks, and baselines are handled by dependent user stories.
+
+**Addresses**: FR-001, FR-002, FR-003; Acceptance Scenarios 1.1, 1.2, 1.3
+
+### Tasks
+
+- [x] **Add the issue fixture** — create a Markdown issue fixture under `evals/fixture/issues/` that describes a concrete, fixable health-check failure, names local file paths that smithy.fix can inspect, and explicitly states that live GitHub issue or pull-request data is not required.
+
+- [x] **Add the CI-log fixture** — create a text CI-log fixture under `evals/fixture/ci-logs/` with deterministic build and smoke-test output, including the failing HTTP evidence and local file references needed for diagnosis without `gh run view`.
+
+- [x] **Keep the evidence bounded and local** — ensure both fixtures are UTF-8 text, repository-local, and small enough to serve as stable prompt evidence for the offline eval path.
+
+- [x] **Document the fixture directories** — update the eval fixture README so future scenario authors can identify the issue and CI-log fixture locations without relying on source-template documentation.
+
+**PR Outcome**: The repository contains offline smithy.fix issue and CI-log evidence that can seed the later `fix-from-issue` scenario while requiring no live GitHub issue, pull-request, or Actions API access.
+
+---
+
+## Specification Debt
+
+_None — all User Story 1 fixture-authorship ambiguity is resolved._
+
+---
+
+## Dependency Order
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| S1 | Offline smithy.fix Failure Evidence | — | — |
+
+### Cross-Story Dependencies
+
+| Dependency | Direction | Notes |
+|------------|-----------|-------|
+| User Story 2: Run smithy.fix Against Local Failure Evidence | depended upon by | US2 consumes these committed fixture files when adding local fixture declarations and deterministic prompt injection. |
+| User Story 3: Validate smithy.fix Output Structure and Helper Evidence | depended upon by | US3 chooses stable validation markers from the scenario output produced with these fixtures. |
+| User Story 4: Commit the smithy.fix Token-Aware Baseline | depended upon by | US4 captures a token-aware baseline after the full scenario runs successfully against this fixture evidence. |


### PR DESCRIPTION
## Summary

Implements **User Story 1 / Slice 1** of spec `2026-06-03-009-smithy-fix-end-to-end-eval-scenario` (`/smithy.cut … 1`): commit the offline failure evidence that lets a future `fix-from-issue` eval drive `smithy.fix` without live GitHub issue, pull-request, or Actions API access.

**Addresses**: FR-001, FR-002, FR-003; Acceptance Scenarios 1.1, 1.2, 1.3.

## Changes

- `evals/fixture/issues/fix-from-issue-health-check.md` — Markdown issue fixture describing a concrete, fixable missing `GET /health` endpoint failure, naming local file paths (`package.json`, `src/index.ts`, `src/routes/users.ts`) and explicitly stating no live GitHub data is required.
- `evals/fixture/ci-logs/fix-from-issue-health-check.log` — deterministic build + smoke-test CI log with the failing `404` HTTP evidence and local file references needed to diagnose without `gh run view`.
- `evals/fixture/README.md` — documents the new `issues/` and `ci-logs/` directories and a "Local Failure Evidence" section so future scenario authors can locate the fixtures.
- `specs/.../01-provide-offline-smithy-fix-fixtures.tasks.md` — slice task list with all four Slice 1 rows flipped to `[x]`.

## Verification

Fixtures confirmed ASCII/UTF-8 text, repository-local, and bounded (1.3 KB issue, 1.0 KB log). This slice adds fixture + documentation files only — no executable code paths — so file validity is the meaningful check. Scenario wiring, runner injection, structural checks, and the baseline are deferred to dependent stories US2–US4 per the spec's Dependency Order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
