### PR TITLE
Cut US1 (per-scenario fixture selection) into a slice

### DIFF
--- a/specs/2026-06-06-011-jvm-multi-language-fixture/01-declare-per-scenario-fixture-selection.tasks.md
+++ b/specs/2026-06-06-011-jvm-multi-language-fixture/01-declare-per-scenario-fixture-selection.tasks.md
@@ -1,0 +1,72 @@
+# Tasks: Declare Per-Scenario Fixture Selection
+
+**Source**: `specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.spec.md` — User Story 1
+**Data Model**: `specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.data-model.md`
+**Contracts**: `specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.contracts.md`
+**Story Number**: 01
+
+---
+
+## Slice 1: Load and Validate Fixture Metadata
+<!-- audience: builder; mode: how-to; length: 5-15 steps; diagram: optional; examples: forbidden -->
+
+**Goal**: Scenario YAML can optionally declare a fixture selector, valid selectors are preserved on `EvalScenario`, and malformed selectors are rejected through the existing loader skip-or-throw paths.
+
+**Justification**: User Story 1 is entirely bounded by the scenario model and loader. A single PR can add the additive type field, loader validation, and regression coverage without touching runner path resolution or authoring the JVM fixture.
+
+**Addresses**: FR-001, FR-002, FR-003, FR-004, FR-005; AS 1.1, AS 1.2, AS 1.3
+
+### Tasks
+
+- [ ] **Expose optional fixture metadata on scenarios**
+
+  Extend the eval scenario model in `evals/lib/types.ts` and loader output in `evals/lib/scenario-loader.ts` so valid scenario YAML may carry an optional fixture selector. Preserve omitted fixture metadata as the existing default behavior for AS 1.1, and keep validation for all existing fields unchanged.
+
+  _Acceptance criteria:_
+  - `EvalScenario` supports an optional `fixture` string without requiring current scenarios to set it.
+  - Loaded scenarios that omit `fixture` are unchanged except for the field remaining absent.
+  - A scenario with a valid relative fixture selector exposes that selector to callers.
+  - Existing scenario ordering, duplicate-name handling, `model`, `timeout`, structural expectations, and sub-agent evidence behavior are unchanged.
+  - Focused loader coverage exercises omitted and valid fixture metadata.
+
+- [ ] **Reject malformed fixture selectors in the loader**
+
+  Add fixture selector validation to `evals/lib/scenario-loader.ts` using the contract's scenario fixture declaration rules. Invalid fixture metadata must follow the existing loader policy: `loadScenarios` skips only the offending file with one stderr line naming `fixture`, while `loadScenarioFromFile` throws for the same invalid content.
+
+  _Acceptance criteria:_
+  - Empty, non-string, absolute, parent-traversing, and escaping fixture values are invalid per AS 1.3.
+  - `loadScenarios` continues loading other valid files when one fixture value is malformed.
+  - `loadScenarioFromFile` reports validation failure for malformed fixture metadata.
+  - The stderr path for skipped files names the `fixture` field once per offending file.
+  - Unit coverage includes both directory loading and exact-file loading failure paths.
+
+**PR Outcome**: Scenario loading accepts `fixture: jvm` as additive metadata, keeps existing scenarios on default fixture behavior when the field is omitted, and rejects malformed fixture selectors through the established skip-or-throw loader contract.
+
+---
+
+## Specification Debt
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
+
+| ID | Description | Source Category | Impact | Confidence | Status | Resolution |
+|----|-------------|-----------------|--------|------------|--------|------------|
+| SD-001 | inherited from spec: The fixture selector is specified as `fixture:` with relative paths under `evals/fixture/`, resolving feature-map SD-002 for F1.6. If implementation discovers a current CLI flag path assumption that makes this precedence hard to preserve, update this debt row with the exact compatibility tradeoff before changing the contract. | Integration Points | Medium | High | inherited | — |
+| SD-002 | inherited from spec: The Gradle wrapper choice is left to implementation. Including a wrapper improves reproducibility but adds binary/script files; requiring system Gradle keeps the fixture smaller but depends on developer tooling. The fixture README must document whichever option is chosen. | Non-Functional Quality | Medium | Medium | inherited | — |
+| SD-003 | inherited from spec: F1.5 and F1.6 both touch `evals/lib/runner.ts`. F1.5 owns git setup around temp-copy initialization; F1.6 owns fixture path resolution before the copy. Second-to-land implementation must rebase and keep both contracts intact. | Integration | Medium | High | inherited | — |
+
+---
+
+## Dependency Order
+<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: recommended; examples: discouraged -->
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| S1 | Load and Validate Fixture Metadata | — | — |
+
+### Cross-Story Dependencies
+
+| Dependency | Direction | Notes |
+|------------|-----------|-------|
+| User Story 2: Resolve Fixture Paths in the Runner | depended upon by | US2 consumes the optional `EvalScenario.fixture` selector introduced by this story and applies fixture precedence in the runner. |
+| User Story 4: Preserve Existing Fixture Behavior | depended upon by | US4 verifies existing scenarios that omit `fixture` remain compatible after loader and runner support land. |

--- a/specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.spec.md
+++ b/specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.spec.md
@@ -103,7 +103,7 @@ Recommended implementation sequence:
 
 | ID | Title | Depends On | Artifact |
 |----|-------|------------|----------|
-| US1 | Declare Per-Scenario Fixture Selection | — | — |
+| US1 | Declare Per-Scenario Fixture Selection | — | specs/2026-06-06-011-jvm-multi-language-fixture/01-declare-per-scenario-fixture-selection.tasks.md |
 | US2 | Resolve Fixture Paths in the Runner | US1 | — |
 | US3 | Provide a Minimal JVM Gradle Fixture | — | — |
 | US4 | Preserve Existing Fixture Behavior | US1, US2, US3 | — |


### PR DESCRIPTION
## Summary

`/smithy.cut` step for **User Story 1 — Declare Per-Scenario Fixture Selection** of the JVM Multi-Language Fixture spec (`specs/2026-06-06-011-jvm-multi-language-fixture/jvm-multi-language-fixture.spec.md`).

Decomposes US1 into one PR-sized slice and links the new tasks file into the spec's Dependency Order table.

## What changed

- **New:** `specs/2026-06-06-011-jvm-multi-language-fixture/01-declare-per-scenario-fixture-selection.tasks.md`
  - **Slice 1 — Load and Validate Fixture Metadata** (FR-001…FR-005; AS 1.1, 1.2, 1.3): additive optional `fixture` string on `EvalScenario` (`evals/lib/types.ts`) and loader output (`evals/lib/scenario-loader.ts`); validation rejecting empty, non-string, absolute, parent-traversing, and escaping selectors through the **existing** skip-or-throw loader contract (`loadScenarios` skips the offending file with one stderr line naming `fixture`; `loadScenarioFromFile` throws); focused loader coverage for omitted and valid metadata.
  - Inherits spec debt rows **SD-001…SD-003** (no new debt introduced).
- **Edited:** `jvm-multi-language-fixture.spec.md` — US1's Dependency Order `Artifact` column flipped from `—` to the new tasks path. For a cut step this column population is the loop's durable "started" signal (matching the prior cut #475); the per-task `[ ]` checkboxes inside the tasks file are forge implementation work and intentionally remain unchecked.

## Verification

- Cut targets US1 (arg `1`); the slice's **Addresses** line (FR-001…FR-005, AS 1.1–1.3) is an exact match for US1's scope in the spec.
- Slice acceptance criteria align with the **Scenario Fixture Declaration** contract (invalid-value classes + skip-or-throw policy).
- Referenced source files (`evals/lib/types.ts`, `evals/lib/scenario-loader.ts`) exist on this branch.
- Doc-only change (markdown under `specs/`); no source code touched, so no code tests apply. Verification is structural review of the artifact against the spec and contracts. **No verification gaps.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
