### PR TITLE
Add free-text persona creation to smithy.persona (US2 S1)

### DIFF
--- a/specs/2026-06-05-011-smithy-persona-command/02-generate-persona-from-free-text-description.tasks.md
+++ b/specs/2026-06-05-011-smithy-persona-command/02-generate-persona-from-free-text-description.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Implement free-text persona creation**
+- [x] **Implement free-text persona creation**
 
   Update `src/templates/agent-skills/commands/smithy.persona.prompt` to route non-RFC description input through a one-shot free-text creation path. The prompt should use `smithy-prose` for drafting and write exactly one file that follows the README-defined persona convention for AS 2.1.
 
@@ -29,7 +29,7 @@
   - A pre-existing target slug is skipped and reported without overwriting.
   - RFC-mode behavior remains out of scope for this slice.
 
-- [ ] **Preserve command deployment coverage**
+- [x] **Preserve command deployment coverage**
 
   Keep the implementation within the deployable command template surface so Claude, Gemini, and Codex receive the same `smithy.persona` behavior through normal `smithy init` rendering. Update template coverage where the existing tests validate command discovery, rendering, or snippet inclusion so AS 2.1 remains protected across agents.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -522,6 +522,36 @@ describe('getComposedTemplates', () => {
     expect(fix).not.toContain('Post your reply to\n   `comments[0].databaseId`');
   });
 
+  it('smithy.persona renders the free-text persona writer contract', () => {
+    const persona = claudeComposed.commands.get('smithy.persona.md')!;
+    expect(persona).toContain('## Input Routing');
+    expect(persona).toContain('If the input is non-empty and does **not** end in `.rfc.md`, select');
+    expect(persona).toContain('**free-text mode**');
+    expect(persona).toContain('Dispatch **smithy-prose** with:');
+    expect(persona).toContain('`section_assignment`: "Personas"');
+    expect(persona).toContain('`idea_description`: the free-text description from `$ARGUMENTS`');
+    expect(persona).toContain('Write one file at the target path using the canonical file shape');
+    expect(persona).toContain('leave the existing file untouched');
+    expect(persona).toContain('the skipped slug/path');
+  });
+
+  it('smithy.persona renders shared persona convention and artifact policy snippets across agents', async () => {
+    const geminiComposed = await getComposedTemplates('gemini');
+    for (const [agent, templates] of [
+      ['claude', claudeComposed],
+      ['codex', codexComposed],
+      ['gemini', geminiComposed],
+    ] as const) {
+      const persona = templates.commands.get('smithy.persona.md')!;
+      expect(persona, agent).toContain('## Authored Smithy Artifacts Location');
+      expect(persona, agent).toContain('## Persona Artifact Convention');
+      expect(persona, agent).toContain('docs/personas/<slug>.persona.md');
+      expect(persona, agent).toContain('Persona files sit outside the `## Dependency Order` lineage');
+      expect(persona, agent).not.toContain('{{>persona-convention}}');
+      expect(persona, agent).not.toContain('{{artifactsRoot}}');
+    }
+  });
+
   it('smithy.pr-review scripts start with bash shebang', () => {
     const skill = claudeComposed.skills.get('smithy.pr-review')!;
     for (const [, content] of skill.scripts) {
@@ -3444,7 +3474,7 @@ describe('getComposedTemplates artifactsRoot', () => {
     expect(strike).not.toContain('{{artifactsRoot}}');
   });
 
-  it('propagates to the ignite, mark, cut, render, spark, audit, and orders prompts', async () => {
+  it('propagates to the ignite, mark, cut, render, spark, audit, orders, and persona prompts', async () => {
     const c = await getComposedTemplates('claude', '~/.smithy/myrepo/');
     for (const file of [
       'smithy.ignite.md',
@@ -3454,6 +3484,7 @@ describe('getComposedTemplates artifactsRoot', () => {
       'smithy.spark.md',
       'smithy.audit.md',
       'smithy.orders.md',
+      'smithy.persona.md',
     ]) {
       const body = c.commands.get(file)!;
       expect(body, file).not.toContain('{{artifactsRoot}}');
@@ -3472,6 +3503,7 @@ describe('getComposedTemplates artifactsRoot', () => {
       'smithy.spark.md',
       'smithy.audit.md',
       'smithy.orders.md',
+      'smithy.persona.md',
     ]) {
       const body = c.commands.get(file)!;
       expect(body, file).toContain('## Authored Smithy Artifacts Location');

--- a/src/templates/agent-skills/commands/smithy.persona.prompt
+++ b/src/templates/agent-skills/commands/smithy.persona.prompt
@@ -9,4 +9,55 @@ You are the **smithy-persona agent** for this repository. You author durable
 role, the friction they experience, and how their work changes when relevant
 capabilities ship.
 
+{{>artifact-location-policy}}
+
 {{>persona-convention}}
+
+## Input Routing
+
+Read `$ARGUMENTS` as the command input.
+
+- If the input is non-empty and does **not** end in `.rfc.md`, select
+  **free-text mode**.
+- Do not parse RFC `## Personas` sections in free-text mode. RFC extraction is
+  a separate route from this writer.
+
+## Free-Text Mode
+
+Given a clear free-text persona description, create exactly one durable
+`.persona.md` file.
+
+1. Infer the persona's human-readable name or role from the description.
+2. Derive the filename slug from that name or role:
+   - lower-case ASCII where possible;
+   - words separated by single hyphens;
+   - no spaces, underscores, date prefix, or sequence prefix.
+3. Resolve the target path using the Persona Artifact Convention section:
+   `{{artifactsRoot}}docs/personas/<slug>.persona.md`.
+4. Before drafting, check whether the target path already exists.
+   - If it exists, skip creation, leave the existing file untouched, and report
+     the skipped slug/path.
+   - If it does not exist, continue.
+5. Dispatch **smithy-prose** with:
+   - `section_assignment`: "Personas"
+   - `idea_description`: the free-text description from `$ARGUMENTS`
+   - `clarify_output`: the free-text description plus the inferred persona
+     name or role
+   - `rfc_file_path`: empty
+   - `tone_directives`: "Draft exactly one reusable persona file body for the
+     inferred persona. Cover role/context, friction today, and how their work
+     changes when relevant capabilities ship. Return narrative prose grounded
+     only in the supplied free-text description; do not add a `## Personas`
+     heading, bullets, dependency-order content, specification debt, registry
+     metadata, or a machine-readable identity field."
+6. Write one file at the target path using the canonical file shape:
+   - `# Persona: <Name/Role>`
+   - blank line
+   - `**Created**: YYYY-MM-DD` using the current date
+   - blank line
+   - the smithy-prose narrative body
+
+If smithy-prose returns a `## Personas` heading, remove that wrapper and keep
+only the single persona's narrative prose before writing the `.persona.md`
+file. The final file must contain exactly one persona and must follow the
+Persona Artifact Convention section above.

--- a/src/templates/agent-skills/commands/smithy.persona.prompt
+++ b/src/templates/agent-skills/commands/smithy.persona.prompt
@@ -19,6 +19,10 @@ Read `$ARGUMENTS` as the command input.
 
 - If the input is non-empty and does **not** end in `.rfc.md`, select
   **free-text mode**.
+- If the input ends in `.rfc.md`, RFC extraction is not implemented yet
+  (reserved for a later user story). Stop and tell the user that RFC-mode
+  persona extraction is not available yet — do not fall through to free-text
+  mode or any undefined path.
 - Do not parse RFC `## Personas` sections in free-text mode. RFC extraction is
   a separate route from this writer.
 
@@ -43,14 +47,18 @@ Given a clear free-text persona description, create exactly one durable
    - `idea_description`: the free-text description from `$ARGUMENTS`
    - `clarify_output`: the free-text description plus the inferred persona
      name or role
-   - `rfc_file_path`: empty
+   - `rfc_file_path`: do not pass (free-text drafting has no accumulating
+     artifact to read)
    - `tone_directives`: "Draft exactly one reusable persona file body for the
      inferred persona. Cover role/context, friction today, and how their work
      changes when relevant capabilities ship. Return narrative prose grounded
      only in the supplied free-text description; do not add a `## Personas`
      heading, bullets, dependency-order content, specification debt, registry
      metadata, or a machine-readable identity field."
-6. Write one file at the target path using the canonical file shape:
+6. Create the `{{artifactsRoot}}docs/personas/` directory if it does not
+   already exist — on a fresh repository that has never authored a persona the
+   first write fails otherwise.
+   Write one file at the target path using the canonical file shape:
    - `# Persona: <Name/Role>`
    - blank line
    - `**Created**: YYYY-MM-DD` using the current date


### PR DESCRIPTION
## Summary

Implements **Slice 1** of US2 (Generate a Persona from a Free-Text Description) for the `smithy.persona` command.

Artifact: `specs/2026-06-05-011-smithy-persona-command/02-generate-persona-from-free-text-description.tasks.md` (Slice 1)

Adds a one-shot free-text creation path to `src/templates/agent-skills/commands/smithy.persona.prompt`:

- **Input Routing** — non-empty input not ending in `.rfc.md` selects free-text mode; RFC parsing stays out of scope (reserved for US3/US6).
- **Free-Text Mode** — infers the persona name/role, derives a kebab-case slug, resolves the target path via the Persona Artifact Convention, skips and reports a pre-existing target without overwriting, dispatches `smithy-prose` with the Personas drafting assignment, and writes exactly one canonical `.persona.md` file.
- Pulls in the `artifact-location-policy` and `persona-convention` snippets so the contract renders identically across Claude, Gemini, and Codex.

## Acceptance criteria (Slice 1)

**Implement free-text persona creation**
- ✅ Non-RFC free-text input selects free-text mode
- ✅ Dispatches `smithy-prose` with the persona drafting assignment
- ✅ Generated artifact follows the canonical persona convention
- ✅ Filename slug is kebab-case, derived from name/role
- ✅ Pre-existing target slug skipped and reported without overwriting
- ✅ RFC-mode behavior out of scope

**Preserve command deployment coverage**
- ✅ Command remains a deployable Smithy command template
- ✅ Persona convention snippet renders in deployed output
- ✅ Tests cover the free-text behavior (no deployed snapshots regenerated)
- ✅ No `.claude/`, `.gemini/`, `.agents/`, `.codex/`, or manifest snapshots touched

Both Slice 1 task rows flipped from `[ ]` to `[x]`. Slice 2 rows left unchecked (out of scope).

## Verification

`npm test -- src/templates.test.ts -t "persona"` → 3 passed.

Note: this worktree had no installed deps and the default `node` is v18 (repo requires v20+); ran the suite under the available Node v22 toolchain. The unrelated `package-lock.json` churn from a reinstall was reverted and is not part of this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
