### PR TITLE
Author durable screen/flow artifacts at mark (US1 S3)

### DIFF
--- a/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/01-mark-authors-a-ui-spec-with-a-typed-ordering-ledger-durable-artifacts.tasks.md
+++ b/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/01-mark-authors-a-ui-spec-with-a-typed-ordering-ledger-durable-artifacts.tasks.md
@@ -97,7 +97,7 @@
 
 ### Tasks
 
-- [ ] **Emit screen design artifacts**
+- [x] **Emit screen design artifacts**
 
   Extend `src/templates/agent-skills/commands/smithy.mark.prompt` so the UI path writes one `design/screens/<ScreenId>.design.md` artifact for each screen node. The artifacts should follow `smithy.helper-screen-design` ownership and rationale-only rules, satisfying AS 1.2.
 
@@ -107,7 +107,7 @@
   - Screen artifacts name a `component-path` for the owning UI component (per `smithy.helper-screen-design`); the framework-neutral stack-detection generalization is FR-010/C6, owned by User Story 2, and is out of scope here
   - Missing `ScreenId` or `design_system` remains an abort condition per contracts C1
 
-- [ ] **Emit flow intent artifacts**
+- [x] **Emit flow intent artifacts**
 
   Extend `src/templates/agent-skills/commands/smithy.mark.prompt` so the UI path writes one `design/flows/<FlowId>.flow.md` artifact for each flow node **and the paired stub test body** at the `.flow.md`'s `test-body` path, so the 1:1 flow↔test-body pairing exists immediately after `mark` (contracts C1 lists `.flow.md (+ stub test body)` as a mark output). The `.flow.md` follows `smithy.helper-flow-definition` intent-only rules and avoids enumerating steps; the stub is an empty/placeholder test that `forge` later fills with executable behavior (data model Entity 4), so mark must not author executable assertions. Satisfies AS 1.2.
 
@@ -119,7 +119,7 @@
   - Flow artifact bodies remain intent-only
   - Flow artifacts do not contain step lists or layout-position guidance
 
-- [ ] **Record mark ownership of durable design truth**
+- [x] **Record mark ownership of durable design truth**
 
   Update `src/templates/agent-skills/commands/smithy.mark.prompt` and any directly conflicting source-template docs so the durable `.design.md` and `.flow.md` files are authored at `mark` and only consumed downstream. Keep `.claude/` snapshots untouched, per repository guidance.
 

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -223,7 +223,7 @@ spec (prose delta).
 | `phase` | Means | Done when |
 |---------|-------|-----------|
 | `build` | Implement the screen component against a mock, behind `flag`. No real data. | Screen renders every brief state using only design-system tokens/components, gated by the flag. |
-| `wire` | Connect the screen to real data/actions and flip the flag. | Real data wired and the executable test body emitted/updated for every flow in `flows` using the project's UI driver; the `.flow.md` design truth is authored by `mark`. |
+| `wire` | Connect the screen to real data/actions and flip the flag. | Real data wired and the mark-created stub test body filled/updated for every flow in `flows` using the project's UI driver; the `.flow.md` design truth is authored by `mark`. |
 
 ### The seam = two features sharing one flag
 
@@ -289,8 +289,8 @@ flows: [AddTitle]
 ```
 
 **Description**: Connect AddTitle to `LibraryStore` and flip `add_title_v1`. Confirm
-persists a real `Title`; done includes emitting the executable test body
-(`maestro/flows/AddTitle.yaml` in this Maestro example), while
+persists a real `Title`; done includes filling the mark-created executable test
+body stub (`maestro/flows/AddTitle.yaml` in this Maestro example), while
 `design/flows/AddTitle.flow.md` remains mark-authored design truth.
 ````
 
@@ -332,8 +332,8 @@ Each `FlowId` listed under a UI feature's `flows:` field resolves — in the
 `design/flows/<FlowId>.flow.md` (thin intent annotation) and
 an executable test body in the project's UI driver (for example
 `maestro/flows/<FlowId>.yaml`). `smithy.mark` authors the `.flow.md` design
-truth; downstream build steps consume it and write or update the executable
-body. The test body owns the steps and guard
+truth and creates the paired test-body stub; downstream build steps consume
+that pair and fill or update the executable body. The test body owns the steps and guard
 assertions a UI driver replays; the `.flow.md` owns *why* — the product truth
 the flow preserves, why the guards exist, deliberate entry / exit, and a
 coverage caveat for anything below what a UI driver can observe.

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -415,49 +415,37 @@ UI ledger rules:
 ### UI Authoring Path Durable Artifacts
 
 When the selected feature's authoring path is `kind: ui`, `smithy.mark` also
-writes the durable screen and flow artifacts referenced by the UI ledger. These
-files are mark-owned design truth; downstream commands consume them and may fill
-or update the paired executable test body, but they do not author
-`.design.md` or `.flow.md` from scratch.
+writes the durable screen and flow artifacts the UI ledger points at. These are
+mark-owned design truth; downstream commands consume them and may fill or update
+the paired executable test body, but never author `.design.md` or `.flow.md`
+from scratch.
 
-Before writing any UI artifact, validate the selected feature's UI metadata:
-- Every screen node must resolve to a flat `ScreenId` from the feature metadata
-  or the confirmed UI structure. If a screen node has no `ScreenId`, abort with
-  a message naming the node.
-- The UI feature must name `design_system`. If it is missing or empty, abort
-  before writing the spec or any durable UI artifacts.
+The artifact schemas and body rules are **not** restated here — they live in the
+two lazy-loaded helper skills so this command stays light for backend and
+non-UI runs. Load the relevant skill before writing each artifact and follow it
+verbatim:
+- `smithy.helper-screen-design` — `.design.md` front-matter schema (including
+  `component-path` and `design_system`) and the rationale-only body rules.
+- `smithy.helper-flow-definition` — `.flow.md` front-matter schema, the
+  intent-only body rules, and the paired executable test-body contract.
 
-For each `SC<N>` screen row:
-- Load and follow `smithy.helper-screen-design`.
-- Write exactly one `design/screens/<ScreenId>.design.md` file matching the row's
-  pointer.
-- Include the required front matter: `id`, `component-path`, and
-  `design_system`; include `bundle` only when the selected feature supplied one
-  for that screen or feature.
-- Name a repo-relative `component-path` for the owning UI component. Use the
-  project's existing component path conventions when they are evident; do not
-  add framework-specific stack-detection gates here.
-- Keep the body rationale-only: why the screen exists, deliberate choices, and
-  deferred decisions. Do not write layout, state-machine, interaction-step,
-  visual-positioning, or copy-string prose.
+Before writing any UI artifact, validate the feature's UI metadata and abort if
+it cannot be satisfied (per contracts C1):
+- Every screen node must resolve to a flat `ScreenId`. If a node has none, abort
+  with a message naming the node.
+- The UI feature must name a non-empty `design_system`. If it is missing, abort
+  before writing the spec or any durable UI artifact.
 
-For each `FL<N>` flow row:
-- Load and follow `smithy.helper-flow-definition`.
-- Write exactly one `design/flows/<FlowId>.flow.md` file matching the row's
-  pointer.
-- Include the required front matter: `id`, `screens`, and `test-body`. `screens`
-  names the referenced `ScreenId` values; `test-body` is the repo-relative path
-  to the paired executable body in the project's UI-driver convention.
-- Also write the paired stub test body at the `test-body` path immediately, so
-  every flow has a 1:1 `.flow.md` + test-body pair after `mark`.
-- The stub test body is a placeholder only. It may contain comments or a skipped
-  placeholder in the target driver's format, but it must contain no executable
-  assertions, traversal steps, real selectors, or behavior that could pass as
-  the completed flow. `smithy.forge` fills in executable behavior during the
-  flow-wire build.
-- Keep the `.flow.md` body intent-only: durable intent, guards, entry / exit,
-  and coverage caveat. Do not include step lists, tap-by-tap walkthroughs,
-  layout-position guidance, or copy strings.
+Then write, matching the ledger pointers:
+- One `design/screens/<ScreenId>.design.md` per `SC<N>` row, per
+  `smithy.helper-screen-design`.
+- One `design/flows/<FlowId>.flow.md` per `FL<N>` row, per
+  `smithy.helper-flow-definition`, **and** the paired stub test body at that
+  flow's `test-body` path, so every flow has a 1:1 `.flow.md` + test-body pair
+  immediately after `mark`. The stub is a placeholder only — comments or a
+  skipped placeholder in the driver's format, with no executable assertions,
+  traversal steps, or real selectors that could pass as the completed flow.
+  `smithy.forge` fills in the executable behavior during the flow-wire build.
 
 The mark output set for `kind: ui` is:
 - the UI `.spec.md` with the typed `## Dependency Order` ledger;

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -412,6 +412,61 @@ UI ledger rules:
 - Do not add UI-only columns (`Kind` or `Design`) to backend spec-triad output
   for `kind: backend` or absent-kind feature inputs.
 
+### UI Authoring Path Durable Artifacts
+
+When the selected feature's authoring path is `kind: ui`, `smithy.mark` also
+writes the durable screen and flow artifacts referenced by the UI ledger. These
+files are mark-owned design truth; downstream commands consume them and may fill
+or update the paired executable test body, but they do not author
+`.design.md` or `.flow.md` from scratch.
+
+Before writing any UI artifact, validate the selected feature's UI metadata:
+- Every screen node must resolve to a flat `ScreenId` from the feature metadata
+  or the confirmed UI structure. If a screen node has no `ScreenId`, abort with
+  a message naming the node.
+- The UI feature must name `design_system`. If it is missing or empty, abort
+  before writing the spec or any durable UI artifacts.
+
+For each `SC<N>` screen row:
+- Load and follow `smithy.helper-screen-design`.
+- Write exactly one `design/screens/<ScreenId>.design.md` file matching the row's
+  pointer.
+- Include the required front matter: `id`, `component-path`, and
+  `design_system`; include `bundle` only when the selected feature supplied one
+  for that screen or feature.
+- Name a repo-relative `component-path` for the owning UI component. Use the
+  project's existing component path conventions when they are evident; do not
+  add framework-specific stack-detection gates here.
+- Keep the body rationale-only: why the screen exists, deliberate choices, and
+  deferred decisions. Do not write layout, state-machine, interaction-step,
+  visual-positioning, or copy-string prose.
+
+For each `FL<N>` flow row:
+- Load and follow `smithy.helper-flow-definition`.
+- Write exactly one `design/flows/<FlowId>.flow.md` file matching the row's
+  pointer.
+- Include the required front matter: `id`, `screens`, and `test-body`. `screens`
+  names the referenced `ScreenId` values; `test-body` is the repo-relative path
+  to the paired executable body in the project's UI-driver convention.
+- Also write the paired stub test body at the `test-body` path immediately, so
+  every flow has a 1:1 `.flow.md` + test-body pair after `mark`.
+- The stub test body is a placeholder only. It may contain comments or a skipped
+  placeholder in the target driver's format, but it must contain no executable
+  assertions, traversal steps, real selectors, or behavior that could pass as
+  the completed flow. `smithy.forge` fills in executable behavior during the
+  flow-wire build.
+- Keep the `.flow.md` body intent-only: durable intent, guards, entry / exit,
+  and coverage caveat. Do not include step lists, tap-by-tap walkthroughs,
+  layout-position guidance, or copy strings.
+
+The mark output set for `kind: ui` is:
+- the UI `.spec.md` with the typed `## Dependency Order` ledger;
+- one `design/screens/<ScreenId>.design.md` per `SC<N>` row;
+- one `design/flows/<FlowId>.flow.md` per `FL<N>` row;
+- one paired stub test body at each `.flow.md` `test-body` path;
+- the `.features.md` dependency-order write-back when the input was a feature
+  map.
+
 ---
 
 ## Phase 4: Model
@@ -591,7 +646,11 @@ N/A — <one-sentence reason this feature has no code-shaped interface changes (
 
 ## Phase 6: Write & PR
 
-Create the spec folder and write all three files to disk first.
+Create the spec folder and write the spec artifact set to disk first. For the
+backend spec-triad path, this is the existing three files:
+`<slug>.spec.md`, `<slug>.data-model.md`, and `<slug>.contracts.md`. For the UI
+authoring path, this also includes the mark-owned durable screen artifacts,
+flow artifacts, and paired stub test bodies described above.
 
 **Feature map write-back** (when input was a `.features.md`): Update the
 `## Dependency Order` 4-column table in the `.features.md` so its `Artifact`
@@ -693,6 +752,8 @@ artifacts. The files are on disk and the PR is the review surface.
 
 1. Stage and commit all written files on the current branch:
    - the three spec artifacts in the new spec folder
+   - the durable UI artifacts and paired stub test bodies, when this run used
+     the UI authoring path
    - the updated `.features.md` (if this run performed a feature-map
      write-back)
 2. Push the current branch to `origin` as-is — do not rename it or
@@ -903,6 +964,9 @@ through Phase 0).
    - `{{artifactsRoot}}specs/<date>-<NNN>-<slug>/<slug>.spec.md`
    - `{{artifactsRoot}}specs/<date>-<NNN>-<slug>/<slug>.data-model.md`
    - `{{artifactsRoot}}specs/<date>-<NNN>-<slug>/<slug>.contracts.md`
+   - for `kind: ui`, `design/screens/<ScreenId>.design.md`,
+     `design/flows/<FlowId>.flow.md`, and each paired stub test body named by
+     the flow artifact's `test-body`
 3. Summary report containing:
    - Spec folder path and branch name.
    - User story list with priorities.

--- a/src/templates/agent-skills/skills/smithy.helper-flow-definition/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.helper-flow-definition/SKILL.prompt
@@ -1,6 +1,6 @@
 ---
 name: smithy.helper-flow-definition
-description: "Schema and authoring rules for the durable Flow entity pair — `design/flows/<FlowId>.flow.md` (thin intent annotation) and a paired executable test body — keyed 1:1 by flat FlowId. Use when authoring or auditing a flow definition, when emitting a flow as part of a UI feature's wire phase (kind: ui, phase: wire), or when validating an existing flow stays thin and testID-keyed. Provides the YAML front-matter field schema (id / screens / test-body), the rationale-only body rule, the driver-neutral selector contract, the testID naming convention, a skeleton template, and a worked AddTitle example."
+description: "Schema and authoring rules for the durable Flow entity pair — `design/flows/<FlowId>.flow.md` (thin intent annotation) and a paired executable test body — keyed 1:1 by flat FlowId. Use when authoring or auditing a flow definition, when emitting a mark-owned flow artifact and paired stub test body for a UI feature's wire phase (kind: ui, phase: wire), or when validating an existing flow stays thin and testID-keyed. Provides the YAML front-matter field schema (id / screens / test-body), the rationale-only body rule, the driver-neutral selector contract, the testID naming convention, a skeleton template, and a worked AddTitle example."
 ---
 # smithy.helper-flow-definition
 
@@ -16,12 +16,13 @@ design/flows/<FlowId>.flow.md      # durable INTENT annotation (why)
 Both files live in the **app repo**, alongside the code, not in Smithy. Load
 this skill when:
 
-- Writing or updating a `<FlowId>.flow.md` + executable test-body pair for a
-  `kind: ui` feature at `phase: wire`.
+- Writing a `<FlowId>.flow.md` + placeholder test-body pair from `smithy.mark`
+  for a `kind: ui` feature at `phase: wire`, or updating the executable
+  behavior in that existing test body downstream.
 - Auditing an existing flow for drift, redundancy, fragile selectors, or
   step-leakage from the executable test body into prose.
-- Emitting a flow as part of `forge`'s UI wire phase
-  (EPIC #404 / issue #408).
+- Emitting a mark-owned flow artifact and paired stub test body for a UI wire
+  feature.
 - Validating cross-references during `flow-lint` (issue #409).
 
 Do **not** load this skill for backend features, for screen-only work

--- a/src/templates/agent-skills/skills/smithy.helper-screen-design/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.helper-screen-design/SKILL.prompt
@@ -13,8 +13,8 @@ deliberately chosen, what was deferred. Load this skill when:
 - Writing a new `<ScreenId>.design.md` for a `kind: ui` feature.
 - Auditing an existing annotation for drift, redundancy, or layout
   re-description.
-- Emitting a screen annotation as part of `forge`'s UI build phase
-  (EPIC #404 / issue #408).
+- Emitting a screen annotation from `smithy.mark` for a UI feature's typed
+  ledger.
 - Validating cross-references during `flow-lint` (issue #409).
 
 Do **not** load this skill for backend features or for general voice/audience

--- a/src/templates/agent-skills/snippets/feature-kinds.md
+++ b/src/templates/agent-skills/snippets/feature-kinds.md
@@ -9,10 +9,10 @@ truth.
 
 - **`backend`** — server/library functionality; the prose body is a behavioral delta.
 - **`ui`** — screen/flow work; `mark` authors the UI spec ledger and durable
-  screen/flow design artifacts, then downstream build steps render a
-  framework-appropriate screen component from a committed design skill and, in
-  the `wire` phase, emit/update the executable flow body for any flow the screen
-  joins.
+  screen/flow design artifacts plus placeholder flow test bodies, then
+  downstream build steps render a framework-appropriate screen component from a
+  committed design skill and, in the `wire` phase, fill/update the executable
+  flow body for any flow the screen joins.
 
 | Key | Kind | Required | Notes |
 |-----|------|----------|-------|
@@ -42,10 +42,10 @@ flows: [AddTitle]
 
 **Phase semantics.** `build` implements the screen component against a mock behind
 `flag` (rendering every brief state with design-system tokens only); `wire`
-connects real data, flips the flag, and emits/updates the executable test body for
-every flow in `flows` using the project's UI driver; the `.flow.md` design truth is
-authored by `mark`. Compose, Maestro, and `story-spider-design` are examples, not
-required stacks.
+connects real data, flips the flag, and fills/updates the mark-created
+executable test-body stub for every flow in `flows` using the project's UI
+driver; the `.flow.md` design truth is authored by `mark`. Compose, Maestro,
+and `story-spider-design` are examples, not required stacks.
 
 **The build/wire seam.** Flag-gated UI is two features sharing one `flag`: a `build`
 feature and a `wire` feature that lists the build feature in its `Depends On` cell.


### PR DESCRIPTION
## Summary

Implements **User Story 1, Slice 3 — Author Durable Screen and Flow Artifacts at Mark** from
`specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/01-mark-authors-a-ui-spec-with-a-typed-ordering-ledger-durable-artifacts.tasks.md`.

The UI authoring path in `smithy.mark` now writes the durable design artifacts the typed UI ledger points at, and the source-template docs are corrected so `mark` — not `forge` — owns that design truth.

## Changes

- **`commands/smithy.mark.prompt`** — adds a "UI Authoring Path Durable Artifacts" section to the `kind: ui` path:
  - Validates UI metadata (abort on a screen node with no `ScreenId`, or a missing/empty `design_system`) per contracts C1.
  - For each `SC<N>` row: writes one `design/screens/<ScreenId>.design.md` (front matter `id` / `component-path` / `design_system`, optional `bundle`; rationale-only body) following `smithy.helper-screen-design`.
  - For each `FL<N>` row: writes one `design/flows/<FlowId>.flow.md` (front matter `id` / `screens` / `test-body`; intent-only body) **and** a paired stub test body at the `test-body` path, so the 1:1 flow<->test-body pairing exists right after `mark`. The stub is a placeholder only — no executable assertions; `forge` fills behavior at flow-wire.
  - Enumerates the `kind: ui` mark output set and threads it through Phase 6 (Write & PR) and the success-report file list.
- **`README.md`, `snippets/feature-kinds.md`, `skills/smithy.helper-screen-design`, `skills/smithy.helper-flow-definition`** — correct ownership prose so `mark` authors `.design.md`/`.flow.md` and creates the test-body stub; downstream `wire`/`forge` only fills/updates the executable body.

## Acceptance criteria

All three task rows for Slice 3 satisfied and flipped to `[x]`:
- **Emit screen design artifacts** — one `.design.md` per `SC<N>`, rationale-only, names `component-path`, aborts on missing `ScreenId`/`design_system`.
- **Emit flow intent artifacts** — one `.flow.md` per `FL<N>` plus a placeholder stub test body at the `test-body` path; intent-only, no step lists, no executable assertions.
- **Record mark ownership of durable design truth** — mark output list includes spec + screen + flow artifacts + stub bodies; downstream prose no longer directs `forge` to author the durable files; `.claude/`/`.smithy/` snapshots left untouched.

## Verification

- `npm test -- templates` -> **227 passed** (Tier 2: template composition + partial resolution) under Node 22.
- `tsup` build succeeds.
- Source templates only — no `.claude/` or `.smithy/` snapshot regeneration (per CLAUDE.md repository guidance).

> Note: the repo requires Node >=20; the default environment Node (18) cannot run vitest or the CLI, so verification was run under Node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
