### PR TITLE
forge: validated local-fixture declarations for eval scenarios

### DIFF
--- a/evals/lib/scenario-loader.test.ts
+++ b/evals/lib/scenario-loader.test.ts
@@ -21,6 +21,8 @@ import { loadScenarios, loadScenarioFromFile } from './scenario-loader.js';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const realCasesDir = path.resolve(here, '..', 'cases');
+const validIssueFixture = 'evals/fixture/issues/fix-from-issue-health-check.md';
+const validCiLogFixture = 'evals/fixture/ci-logs/fix-from-issue-health-check.log';
 
 /**
  * Create an isolated temp directory under the OS temp root. Returns its path.
@@ -258,6 +260,165 @@ describe('loadScenarios', () => {
       expect(scenarios).toEqual([]);
       expect(errSpy).toHaveBeenCalled();
     });
+
+    it('preserves valid local_fixtures metadata', () => {
+      const dir = mkdir();
+      const content = [
+        'name: fixture-case',
+        'skill: /smithy.fix',
+        'prompt: diagnose from local evidence',
+        'local_fixtures:',
+        `  issue: ${validIssueFixture}`,
+        `  ci_log: ${validCiLogFixture}`,
+        'structural_expectations:',
+        '  required_headings:',
+        '    - "## Summary"',
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(dir, 'fixture-case.yaml'), content);
+
+      const scenarios = loadScenarios(dir);
+      expect(scenarios).toHaveLength(1);
+      expect(scenarios[0]!.local_fixtures).toEqual({
+        issue: validIssueFixture,
+        ci_log: validCiLogFixture,
+      });
+      expect(errSpy).not.toHaveBeenCalled();
+    });
+
+    it('leaves scenarios without local_fixtures unchanged', () => {
+      const dir = mkdir();
+      const content = [
+        'name: no-fixtures',
+        'skill: /smithy.strike',
+        'prompt: whatever',
+        'structural_expectations:',
+        '  required_headings:',
+        '    - "## Summary"',
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(dir, 'no-fixtures.yaml'), content);
+
+      const scenarios = loadScenarios(dir);
+      expect(scenarios).toHaveLength(1);
+      expect(scenarios[0]!.local_fixtures).toBeUndefined();
+      expect(errSpy).not.toHaveBeenCalled();
+    });
+
+    it('skips local_fixtures with unsupported fields', () => {
+      const dir = mkdir();
+      const content = [
+        'name: unsupported-fixture-field',
+        'skill: /smithy.fix',
+        'prompt: diagnose',
+        'local_fixtures:',
+        `  issue: ${validIssueFixture}`,
+        `  ci_log: ${validCiLogFixture}`,
+        '  transcript: evals/fixture/transcripts/run.txt',
+        'structural_expectations:',
+        '  required_headings:',
+        '    - "## Summary"',
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(dir, 'unsupported.yaml'), content);
+
+      expect(loadScenarios(dir)).toEqual([]);
+      const joined = joinErrorCalls(errSpy);
+      expect(joined).toContain('unsupported.yaml');
+      expect(joined).toContain('local_fixtures.transcript');
+    });
+
+    it('skips local_fixtures with escaping paths', () => {
+      const dir = mkdir();
+      const content = [
+        'name: escaping-fixture',
+        'skill: /smithy.fix',
+        'prompt: diagnose',
+        'local_fixtures:',
+        '  issue: evals/fixture/issues/../ci-logs/fix-from-issue-health-check.log',
+        `  ci_log: ${validCiLogFixture}`,
+        'structural_expectations:',
+        '  required_headings:',
+        '    - "## Summary"',
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(dir, 'escaping.yaml'), content);
+
+      expect(loadScenarios(dir)).toEqual([]);
+      const joined = joinErrorCalls(errSpy);
+      expect(joined).toContain('escaping.yaml');
+      expect(joined).toContain('local_fixtures.issue');
+      expect(joined).toContain('parent-directory');
+    });
+
+    it('skips local_fixtures outside the allowed fixture area', () => {
+      const dir = mkdir();
+      const content = [
+        'name: wrong-fixture-area',
+        'skill: /smithy.fix',
+        'prompt: diagnose',
+        'local_fixtures:',
+        `  issue: ${validCiLogFixture}`,
+        `  ci_log: ${validCiLogFixture}`,
+        'structural_expectations:',
+        '  required_headings:',
+        '    - "## Summary"',
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(dir, 'wrong-area.yaml'), content);
+
+      expect(loadScenarios(dir)).toEqual([]);
+      const joined = joinErrorCalls(errSpy);
+      expect(joined).toContain('wrong-area.yaml');
+      expect(joined).toContain("local_fixtures.issue");
+      expect(joined).toContain('evals/fixture/issues/');
+    });
+
+    it('skips local_fixtures that point at missing files', () => {
+      const dir = mkdir();
+      const content = [
+        'name: missing-fixture',
+        'skill: /smithy.fix',
+        'prompt: diagnose',
+        'local_fixtures:',
+        '  issue: evals/fixture/issues/does-not-exist.md',
+        `  ci_log: ${validCiLogFixture}`,
+        'structural_expectations:',
+        '  required_headings:',
+        '    - "## Summary"',
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(dir, 'missing.yaml'), content);
+
+      expect(loadScenarios(dir)).toEqual([]);
+      const joined = joinErrorCalls(errSpy);
+      expect(joined).toContain('missing.yaml');
+      expect(joined).toContain('local_fixtures.issue');
+      expect(joined).toContain('does-not-exist.md');
+    });
+
+    it('skips local_fixtures that point at directories', () => {
+      const dir = mkdir();
+      const content = [
+        'name: directory-fixture',
+        'skill: /smithy.fix',
+        'prompt: diagnose',
+        'local_fixtures:',
+        '  issue: evals/fixture/issues',
+        `  ci_log: ${validCiLogFixture}`,
+        'structural_expectations:',
+        '  required_headings:',
+        '    - "## Summary"',
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(dir, 'directory.yaml'), content);
+
+      expect(loadScenarios(dir)).toEqual([]);
+      const joined = joinErrorCalls(errSpy);
+      expect(joined).toContain('directory.yaml');
+      expect(joined).toContain('local_fixtures.issue');
+      expect(joined).toContain('evals/fixture/issues/');
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -427,5 +588,27 @@ describe('loadScenarioFromFile', () => {
     const file = path.join(dir, 'invalid.yaml');
     fs.writeFileSync(file, 'skill: /smithy.strike\n');
     expect(() => loadScenarioFromFile(file)).toThrow(/failed validation/i);
+  });
+
+  it('throws field-specific validation errors for invalid local_fixtures', () => {
+    const dir = mkdir();
+    const file = path.join(dir, 'invalid-local-fixtures.yaml');
+    const content = [
+      'name: invalid-local-fixtures',
+      'skill: /smithy.fix',
+      'prompt: diagnose',
+      'local_fixtures:',
+      `  issue: ${validIssueFixture}`,
+      '  ci_log: evals/fixture/ci-logs/does-not-exist.log',
+      'structural_expectations:',
+      '  required_headings:',
+      '    - "## Summary"',
+      '',
+    ].join('\n');
+    fs.writeFileSync(file, content);
+
+    expect(() => loadScenarioFromFile(file)).toThrow(
+      /local_fixtures\.ci_log.*does-not-exist\.log/i,
+    );
   });
 });

--- a/evals/lib/scenario-loader.test.ts
+++ b/evals/lib/scenario-loader.test.ts
@@ -419,6 +419,41 @@ describe('loadScenarios', () => {
       expect(joined).toContain('local_fixtures.issue');
       expect(joined).toContain('evals/fixture/issues/');
     });
+
+    it('skips local_fixtures whose real path escapes the area via symlink', () => {
+      // The declared string is inside the allowed area, so only a real-path
+      // resolution can catch the escape. Plant a symlink in the real issues
+      // area that points to a file outside it (the ci-log fixture).
+      const repoRoot = path.resolve(here, '..', '..');
+      const linkName = 'symlink-escape-fixture.md';
+      const linkPath = path.join(repoRoot, 'evals', 'fixture', 'issues', linkName);
+      const target = path.join(repoRoot, validCiLogFixture);
+      fs.symlinkSync(target, linkPath);
+      try {
+        const dir = mkdir();
+        const content = [
+          'name: symlink-escape',
+          'skill: /smithy.fix',
+          'prompt: diagnose',
+          'local_fixtures:',
+          `  issue: evals/fixture/issues/${linkName}`,
+          `  ci_log: ${validCiLogFixture}`,
+          'structural_expectations:',
+          '  required_headings:',
+          '    - "## Summary"',
+          '',
+        ].join('\n');
+        fs.writeFileSync(path.join(dir, 'symlink.yaml'), content);
+
+        expect(loadScenarios(dir)).toEqual([]);
+        const joined = joinErrorCalls(errSpy);
+        expect(joined).toContain('symlink.yaml');
+        expect(joined).toContain('local_fixtures.issue');
+        expect(joined).toContain('symlink escape');
+      } finally {
+        fs.rmSync(linkPath, { force: true });
+      }
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/evals/lib/scenario-loader.ts
+++ b/evals/lib/scenario-loader.ts
@@ -21,6 +21,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { parse as parseYaml } from 'yaml';
 
 import type {
@@ -35,6 +36,14 @@ const localFixtureAreas: Record<(typeof localFixtureFields)[number], string> = {
   issue: 'evals/fixture/issues',
   ci_log: 'evals/fixture/ci-logs',
 };
+
+// Repository root derived from this module's own location, not `process.cwd()`.
+// The eval helpers resolve scenario files via `import.meta.url` so they stay
+// CWD-independent; fixture resolution must do the same, otherwise a scenario
+// loaded from an absolute path while the process runs outside the checkout
+// would reject valid fixtures with a misleading "file is not readable" error.
+// `evals/lib/scenario-loader.ts` -> `../../` is the repository root.
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 /**
  * Load every valid `*.yaml` scenario in `casesDir`.
@@ -398,7 +407,7 @@ function validateLocalFixtures(
       return null;
     }
 
-    const repoPath = path.resolve(process.cwd(), normalized);
+    const repoPath = path.resolve(repoRoot, normalized);
     let stats: fs.Stats;
     try {
       stats = fs.statSync(repoPath);
@@ -411,6 +420,28 @@ function validateLocalFixtures(
 
     if (!stats.isFile()) {
       skip(`'local_fixtures.${field}' must point to a readable file: ${normalized}`);
+      return null;
+    }
+
+    // The declared-string check above only constrains the path *text*. Resolve
+    // the real paths and confirm the fixture still lies under the real
+    // allowed-area directory, so a symlink inside the area cannot redirect to a
+    // file outside the repository / allowed directory.
+    let realFixturePath: string;
+    let realAreaPath: string;
+    try {
+      realFixturePath = fs.realpathSync(repoPath);
+      realAreaPath = fs.realpathSync(path.resolve(repoRoot, allowedArea));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      skip(`'local_fixtures.${field}' could not be resolved: ${normalized} (${msg})`);
+      return null;
+    }
+
+    if (!isContainedIn(realFixturePath, realAreaPath)) {
+      skip(
+        `'local_fixtures.${field}' resolves outside '${allowedArea}/' (symlink escape): ${normalized}`,
+      );
       return null;
     }
 
@@ -433,4 +464,10 @@ function normalizeFixturePath(rawPath: string): string | null {
 
 function isPathUnderArea(repoPath: string, allowedArea: string): boolean {
   return repoPath.startsWith(`${allowedArea}/`) && repoPath.length > allowedArea.length + 1;
+}
+
+/** True when `childAbs` is a strict descendant of `parentAbs` (both absolute). */
+function isContainedIn(childAbs: string, parentAbs: string): boolean {
+  const rel = path.relative(parentAbs, childAbs);
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
 }

--- a/evals/lib/scenario-loader.ts
+++ b/evals/lib/scenario-loader.ts
@@ -25,9 +25,16 @@ import { parse as parseYaml } from 'yaml';
 
 import type {
   EvalScenario,
+  LocalFixtureSet,
   StructuralExpectations,
   SubAgentEvidence,
 } from './types.js';
+
+const localFixtureFields = ['issue', 'ci_log'] as const;
+const localFixtureAreas: Record<(typeof localFixtureFields)[number], string> = {
+  issue: 'evals/fixture/issues',
+  ci_log: 'evals/fixture/ci-logs',
+};
 
 /**
  * Load every valid `*.yaml` scenario in `casesDir`.
@@ -308,6 +315,13 @@ function validateScenario(
     scenario.timeout = obj['timeout'];
   }
 
+  // Optional: local_fixtures ({ issue: string, ci_log: string })
+  if (obj['local_fixtures'] !== undefined) {
+    const localFixtures = validateLocalFixtures(obj['local_fixtures'], skip);
+    if (!localFixtures) return null;
+    scenario.local_fixtures = localFixtures;
+  }
+
   // Optional: sub_agent_evidence ([{ agent: string, pattern: string }])
   if (obj['sub_agent_evidence'] !== undefined) {
     const v = obj['sub_agent_evidence'];
@@ -342,4 +356,81 @@ function validateScenario(
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
+}
+
+function validateLocalFixtures(
+  value: unknown,
+  skip: (reason: string) => void,
+): LocalFixtureSet | null {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    skip("'local_fixtures' must be a mapping with 'issue' and 'ci_log' strings");
+    return null;
+  }
+
+  const rec = value as Record<string, unknown>;
+  const allowed = new Set<string>(localFixtureFields);
+  for (const key of Object.keys(rec)) {
+    if (!allowed.has(key)) {
+      skip(`'local_fixtures.${key}' is not supported`);
+      return null;
+    }
+  }
+
+  const fixtures: Partial<LocalFixtureSet> = {};
+  for (const field of localFixtureFields) {
+    const rawPath = rec[field];
+    if (!isNonEmptyString(rawPath)) {
+      skip(`'local_fixtures.${field}' must be a non-empty string`);
+      return null;
+    }
+
+    const normalized = normalizeFixturePath(rawPath);
+    if (normalized === null) {
+      skip(
+        `'local_fixtures.${field}' must be a repository-relative path without parent-directory segments`,
+      );
+      return null;
+    }
+
+    const allowedArea = localFixtureAreas[field];
+    if (!isPathUnderArea(normalized, allowedArea)) {
+      skip(`'local_fixtures.${field}' must be under '${allowedArea}/'`);
+      return null;
+    }
+
+    const repoPath = path.resolve(process.cwd(), normalized);
+    let stats: fs.Stats;
+    try {
+      stats = fs.statSync(repoPath);
+      fs.accessSync(repoPath, fs.constants.R_OK);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      skip(`'local_fixtures.${field}' file is not readable: ${normalized} (${msg})`);
+      return null;
+    }
+
+    if (!stats.isFile()) {
+      skip(`'local_fixtures.${field}' must point to a readable file: ${normalized}`);
+      return null;
+    }
+
+    fixtures[field] = normalized;
+  }
+
+  return fixtures as LocalFixtureSet;
+}
+
+function normalizeFixturePath(rawPath: string): string | null {
+  if (path.isAbsolute(rawPath)) return null;
+
+  const parts = rawPath.split(/[\\/]+/);
+  if (parts.some((part) => part === '' || part === '..')) return null;
+
+  const normalized = path.posix.normalize(parts.join('/'));
+  if (normalized === '.' || normalized.startsWith('../')) return null;
+  return normalized;
+}
+
+function isPathUnderArea(repoPath: string, allowedArea: string): boolean {
+  return repoPath.startsWith(`${allowedArea}/`) && repoPath.length > allowedArea.length + 1;
 }

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -97,6 +97,12 @@ export interface SubAgentEvidence {
   pattern: string;
 }
 
+/** Scenario metadata for repository-local fixture evidence consumed before invocation. */
+export interface LocalFixtureSet {
+  issue: string;
+  ci_log: string;
+}
+
 /**
  * Persisted baseline snapshot of a known-good skill output.
  * Loaded from `evals/baselines/<scenario_name>.json`; used by
@@ -116,6 +122,7 @@ export interface EvalScenario {
   prompt: string;
   model?: string | undefined;
   timeout?: number | undefined;
+  local_fixtures?: LocalFixtureSet | undefined;
   structural_expectations: StructuralExpectations;
   sub_agent_evidence?: SubAgentEvidence[] | undefined;
 }

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/02-run-smithy-fix-against-local-failure-evidence.tasks.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/02-run-smithy-fix-against-local-failure-evidence.tasks.md
@@ -18,7 +18,7 @@
 
 ### Tasks
 
-- [ ] **Add local fixture metadata to scenarios**
+- [x] **Add local fixture metadata to scenarios**
 
   Extend `evals/lib/types.ts` with optional local fixture metadata matching the data model and contracts. Keep omitted metadata compatible with all existing TypeScript and YAML scenarios, and limit this task to the scenario shape plus local validation types needed by the loader.
 
@@ -28,7 +28,7 @@
   - The new metadata does not change report, baseline, structural, or sub-agent result shapes.
   - Type comments identify local fixtures as scenario metadata consumed before invocation.
 
-- [ ] **Validate local fixture declarations in YAML**
+- [x] **Validate local fixture declarations in YAML**
 
   Update `evals/lib/scenario-loader.ts` so scenario loading preserves valid `local_fixtures` declarations and rejects malformed declarations through the existing skip or thrown-validation paths. Validation should enforce the allowed fixture areas and readable repository-local files described by the LocalFixtureSet model and Scenario Local Fixture Declaration contract.
 


### PR DESCRIPTION
## Summary
RFC 2026-001 Token-Savings → M1 Measurement Foundation → F1.4 smithy.fix End-to-End Eval Scenario → smithy.fix End-to-End Eval Scenario spec → Slice 1: Local Fixture Declaration Contract
Adds an optional `local_fixtures` declaration (issue + CI-log paths) to eval scenarios and validates it at load time, so a later runner can inject offline failure evidence without falling back to live GitHub data. This is the right first increment: it delivers the declaration/validation contract independently while keeping every existing scenario that omits local fixtures fully compatible.

## Spec debt & uncertainty
- SD-001 (inherited): exact helper-agent evidence set for the offline smithy.fix path is unknown until the fixture runs against current smithy.fix behavior; the error-description path may dispatch no helpers. (Owned by US3 — not touched here.)
- SD-002 (inherited): initial token envelope for the smithy.fix baseline cannot be calibrated until F1.3a's token-aware baseline schema is available. (Owned by US4 — not touched here.)
- Assumption: fixtures live at fixed locations — issue Markdown under `evals/fixture/issues/`, CI-log text under `evals/fixture/ci-logs/`. Validation enforces exactly these two allowed areas.
- Validation runs under Node 22 (via nvm); the worktree's default Node 18 cannot run this repo's vitest/rolldown toolchain (missing `styleText`). Reinstalled deps under Node 22 to run the suite — no source change required.

## Validation
build ✅ · typecheck ✅ · test:evals ✅ (scenario-loader 28 passed)
