### PR TITLE
forge: declare requires_git scenario flag in eval loader

### DIFF
--- a/evals/lib/scenario-loader.test.ts
+++ b/evals/lib/scenario-loader.test.ts
@@ -100,6 +100,45 @@ describe('loadScenarios', () => {
       ]);
     });
 
+    it('preserves a boolean requires_git flag when present', () => {
+      const dir = mkdir();
+      const content = [
+        'name: git-backed-case',
+        'skill: /smithy.forge',
+        'prompt: specs/example.tasks.md 1',
+        'requires_git: true',
+        'structural_expectations:',
+        '  required_headings:',
+        '    - "## Summary"',
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(dir, 'git-backed.yaml'), content);
+
+      const scenarios = loadScenarios(dir);
+      expect(scenarios).toHaveLength(1);
+      expect(scenarios[0]!.requires_git).toBe(true);
+      expect(errSpy).not.toHaveBeenCalled();
+    });
+
+    it('leaves requires_git unset when omitted', () => {
+      const dir = mkdir();
+      const content = [
+        'name: plain-case',
+        'skill: /smithy.strike',
+        'prompt: add a health check endpoint',
+        'structural_expectations:',
+        '  required_headings:',
+        '    - "## Summary"',
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(dir, 'plain.yaml'), content);
+
+      const scenarios = loadScenarios(dir);
+      expect(scenarios).toHaveLength(1);
+      expect(scenarios[0]!.requires_git).toBeUndefined();
+      expect(errSpy).not.toHaveBeenCalled();
+    });
+
     it('emits nothing on stdout or stderr for a clean load', () => {
       loadScenarios(realCasesDir);
       expect(outSpy).not.toHaveBeenCalled();
@@ -528,6 +567,28 @@ describe('loadScenarios', () => {
         expect(String(matchingCalls[0]![0]).match(/fixture/g)).toHaveLength(1);
       }
     });
+
+    it('skips a file with a non-boolean requires_git value and reports the field', () => {
+      const dir = mkdir();
+      const content = [
+        'name: invalid-git-flag',
+        'skill: /smithy.forge',
+        'prompt: specs/example.tasks.md 1',
+        'requires_git: yes please',
+        'structural_expectations:',
+        '  required_headings:',
+        '    - "## Summary"',
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(dir, 'invalid-git-flag.yaml'), content);
+
+      const scenarios = loadScenarios(dir);
+      expect(scenarios).toEqual([]);
+      expect(errSpy).toHaveBeenCalled();
+      const joined = joinErrorCalls(errSpy);
+      expect(joined).toContain('invalid-git-flag.yaml');
+      expect(joined).toContain('requires_git');
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -677,6 +738,44 @@ describe('loadScenarioFromFile', () => {
     );
     expect(scenario.skill).toBe('/smithy.strike');
     expect(scenario.prompt).toBe('add a health check endpoint');
+  });
+
+  it('preserves a boolean requires_git flag when loading by exact path', () => {
+    const dir = mkdir();
+    const file = path.join(dir, 'git-backed.yaml');
+    const content = [
+      'name: git-backed-case',
+      'skill: /smithy.forge',
+      'prompt: specs/example.tasks.md 1',
+      'requires_git: true',
+      'structural_expectations:',
+      '  required_headings:',
+      '    - "## Summary"',
+      '',
+    ].join('\n');
+    fs.writeFileSync(file, content);
+
+    const scenario = loadScenarioFromFile(file);
+    expect(scenario.requires_git).toBe(true);
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-boolean requires_git value when loading by exact path', () => {
+    const dir = mkdir();
+    const file = path.join(dir, 'invalid-git-flag.yaml');
+    const content = [
+      'name: invalid-git-flag',
+      'skill: /smithy.forge',
+      'prompt: specs/example.tasks.md 1',
+      'requires_git: 1',
+      'structural_expectations:',
+      '  required_headings:',
+      '    - "## Summary"',
+      '',
+    ].join('\n');
+    fs.writeFileSync(file, content);
+
+    expect(() => loadScenarioFromFile(file)).toThrow(/requires_git/);
   });
 
   it('throws when the file does not exist', () => {

--- a/evals/lib/scenario-loader.ts
+++ b/evals/lib/scenario-loader.ts
@@ -313,6 +313,15 @@ function validateScenario(
     scenario.fixture = obj['fixture'];
   }
 
+  // Optional scenario metadata: requires_git (boolean)
+  if (obj['requires_git'] !== undefined) {
+    if (typeof obj['requires_git'] !== 'boolean') {
+      skip("'requires_git' must be a boolean when provided");
+      return null;
+    }
+    scenario.requires_git = obj['requires_git'];
+  }
+
   // Optional: model (string)
   if (obj['model'] !== undefined) {
     if (typeof obj['model'] !== 'string') {

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -138,6 +138,8 @@ export interface EvalScenario {
   skill: string;
   prompt: string;
   fixture?: string | undefined;
+  /** Scenario metadata: true when this case requires a git-backed temp copy. */
+  requires_git?: boolean | undefined;
   model?: string | undefined;
   timeout?: number | undefined;
   local_fixtures?: LocalFixtureSet | undefined;

--- a/specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/01-declare-forge-scenarios-that-require-git.tasks.md
+++ b/specs/2026-06-05-010-smithy-forge-end-to-end-eval-scenario-runner-git-init/01-declare-forge-scenarios-that-require-git.tasks.md
@@ -18,7 +18,7 @@
 
 ### Tasks
 
-- [ ] **Add the scenario git requirement field**
+- [x] **Add the scenario git requirement field**
 
   Extend the shared eval scenario type in `evals/lib/types.ts` with the optional git requirement metadata from the data model. Keep the field absent by default for existing in-memory scenarios and YAML cases, and avoid changing unrelated scenario fields or report shapes.
 
@@ -28,7 +28,7 @@
   - No runner behavior is introduced by this type-only change.
   - Public type comments identify the field as scenario metadata, not a runner default.
 
-- [ ] **Validate `requires_git` in the YAML loader**
+- [x] **Validate `requires_git` in the YAML loader**
 
   Update `evals/lib/scenario-loader.ts` so `loadScenarios` and `loadScenarioFromFile` preserve a boolean `requires_git` value when present and reject malformed values through the existing scenario-validation path. The loader should keep omitted values unset or false-equivalent for AS 1.2 while emitting a field-specific validation reason for AS 1.3.
 


### PR DESCRIPTION
## Summary
RFC 2026-001-token-savings → M1 Measurement Foundation → F1.5 smithy.forge End-to-End Eval Scenario + Runner git-init → smithy-forge-end-to-end-eval-scenario-runner-git-init.spec → Slice 1: Scenario Git Requirement Loader Contract

Adds an optional `requires_git` boolean to the eval `EvalScenario` type and validates it in the YAML loader. This is the declaration-contract increment: scenarios can now opt into git-backed temp-copy setup via explicit metadata, while existing scenarios that omit the field load unchanged and runner git initialization is deliberately left to US2.

## Spec debt & uncertainty
- SD-001 (inherited): runner currently initializes every temp copy as a git repo unconditionally; forge and other git-dependent scenarios must be moved onto the explicit flag without regressing planning-command evals, with required scenarios documented (later slices).
- SD-002 (inherited): exact single-slice forge task input path is finalized at implementation time; reuse the existing JavaScript fixture, no unrelated language fixtures.
- SD-003 (inherited): initial forge token envelope cannot be calibrated until F1.3a's token-aware baseline schema lands and a clean run is captured.
- Assumption: the current runner's temp-copy git initialization can be reused once reconciled with this explicit `requires_git` gating contract.
- This slice is type-and-loader only — no runner behavior is introduced or exercised here, by design.

## Validation
build ✅ · typecheck ✅ · test ✅ (25 passed, evals/lib/scenario-loader.test.ts)
