### PR TITLE
forge: discover and reuse durable personas in ignite

### DIFF
--- a/specs/2026-06-05-011-smithy-persona-command/04-ignite-reuses-existing-persona-files-before-generating-new-ones.tasks.md
+++ b/specs/2026-06-05-011-smithy-persona-command/04-ignite-reuses-existing-persona-files-before-generating-new-ones.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Add pre-draft persona discovery**
+- [x] **Add pre-draft persona discovery**
 
   Update `src/templates/agent-skills/commands/smithy.ignite.prompt` so Sub-phase 3b reads the README-defined persona convention and checks the resolved persona directory before dispatching `smithy-prose` for Personas. Keep discovery scoped to the active `{{artifactsRoot}}` so in-repo and external-artifacts modes do not cross-contaminate persona stores.
 
@@ -27,7 +27,7 @@
   - If no persona files exist, ignite follows the existing cold-draft path.
   - Discovery does not change RFC-mode behavior for `smithy.persona`.
 
-- [ ] **Match needed personas by canonical slug identity**
+- [x] **Match needed personas by canonical slug identity**
 
   Define the Sub-phase 3b reuse match as a deterministic filename-slug comparison: derive kebab-case slugs from personas named or clearly described during Phase 2 clarification, and treat matching `<slug>.persona.md` files as covering those personas. Avoid fuzzy matching, interactive selection, or a new registry.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -611,6 +611,30 @@ describe('getComposedTemplates', () => {
     }
   });
 
+  it('smithy.ignite discovers and slug-matches durable personas before cold drafting', () => {
+    const ignite = claudeComposed.commands.get('smithy.ignite.md')!;
+    expect(ignite).toContain('## Persona Artifact Convention');
+    expect(ignite).toContain('docs/personas/<slug>.persona.md');
+    expect(ignite).not.toContain('{{>persona-convention}}');
+
+    const subphase3bIdx = ignite.indexOf('Sub-phase 3b: Personas');
+    const subphase3cIdx = ignite.indexOf('Sub-phase 3c: Goals + Out of Scope');
+    expect(subphase3bIdx).toBeGreaterThan(-1);
+    expect(subphase3cIdx).toBeGreaterThan(subphase3bIdx);
+    const subphase3bBlock = ignite.slice(subphase3bIdx, subphase3cIdx);
+
+    const discoveryIdx = subphase3bBlock.indexOf('Before drafting Personas cold');
+    const dispatchIdx = subphase3bBlock.indexOf('dispatch **smithy-prose**');
+    expect(discoveryIdx).toBeGreaterThan(-1);
+    expect(dispatchIdx).toBeGreaterThan(discoveryIdx);
+    expect(subphase3bBlock).toContain('active artifacts root');
+    expect(subphase3bBlock).toContain('derive deterministic kebab-case slugs');
+    expect(subphase3bBlock).toMatch(/exact\s+filename-slug identity/);
+    expect(subphase3bBlock).toContain('`<slug>.persona.md` covers');
+    expect(subphase3bBlock).toMatch(/Avoid fuzzy\s+matching/);
+    expect(subphase3bBlock).toContain('If no `.persona.md` files exist');
+  });
+
   it('smithy.pr-review scripts start with bash shebang', () => {
     const skill = claudeComposed.skills.get('smithy.pr-review')!;
     for (const [, content] of skill.scripts) {

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -12,6 +12,8 @@ into a solid, reviewable plan.
 
 {{>artifact-location-policy}}
 
+{{>persona-convention}}
+
 ## Input
 
 The user's idea or document path: $ARGUMENTS
@@ -502,7 +504,24 @@ After smithy-prose returns, append the returned content to `<slug>.rfc.md`.
 
 ### Sub-phase 3b: Personas
 
-Dispatch **smithy-prose** with:
+Before drafting Personas cold, discover reusable durable personas:
+
+1. Read the **Persona Artifact Convention** above as the canonical storage,
+   filename-slug identity, and matching contract. Do not introduce a separate
+   schema, registry, index, or identity field for this sub-phase.
+2. Resolve the active persona directory from the same `{{artifactsRoot}}` used
+   for this ignite run and list existing `.persona.md` files there. Keep this
+   discovery scoped to that active artifacts root so in-repo and
+   external-artifacts modes never cross-contaminate persona stores.
+3. From personas named or clearly described during Phase 2 clarification,
+   derive deterministic kebab-case slugs from each persona name or role.
+4. Compare those needed slugs to discovered persona filenames using exact
+   filename-slug identity: `<slug>.persona.md` covers the matching needed
+   persona. A needed slug with no matching file remains uncovered. Avoid fuzzy
+   matching, semantic similarity, interactive selection, or any new registry.
+
+If no `.persona.md` files exist, or if every needed persona remains uncovered,
+follow the existing cold-draft path and dispatch **smithy-prose** with:
 
 - **section_assignment**: "Personas"
 - **idea_description**: the user's idea description or PRD content from intake

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -520,7 +520,12 @@ Before drafting Personas cold, discover reusable durable personas:
    persona. A needed slug with no matching file remains uncovered. Avoid fuzzy
    matching, semantic similarity, interactive selection, or any new registry.
 
-If no `.persona.md` files exist, or if every needed persona remains uncovered,
+This slice adds coverage detection only — it does not yet change how the
+`## Personas` section is drafted. Record which needed personas are covered by a
+matching `<slug>.persona.md` file and which remain uncovered as informational
+notes for the projection and gap-only drafting that a later slice introduces.
+If no `.persona.md` files exist, there is simply nothing to reuse. Then,
+**regardless of the match results** (no files, some covered, or all covered),
 follow the existing cold-draft path and dispatch **smithy-prose** with:
 
 - **section_assignment**: "Personas"


### PR DESCRIPTION
## Summary
smithy.persona Command and Ignite Persona Reuse spec → User Story 4 → Slice 1: Discover and Match Durable Personas in Ignite
This slice adds the reuse *decision point* to ignite Sub-phase 3b — it discovers existing `.persona.md` files via the canonical persona convention and matches needed personas by exact filename-slug identity, before any cold persona drafting. It is the right increment because it establishes coverage detection without yet changing the final RFC `## Personas` prose path (that lands in Slice 2).

(No RFC/feature-map ancestry exists: this spec was authored directly from a feature description, not an RFC milestone/feature lineage, so the breadcrumb stops at the spec.)

## Spec debt & uncertainty
- SD-001 (inherited): coverage-match rule for whether a pre-existing `.persona.md` "covers" a needed RFC persona — **bound by this slice** to deterministic filename-slug comparison (no fuzzy/semantic/interactive matching).
- SD-002 (inherited): whether `.persona.md` carries a machine-readable identity field — resolved by US1's convention (filename-slug identity, no per-file key, no registry); this slice matches accordingly.
- SD-003 (inherited): how covered persona content is fed to smithy-prose — out of scope here; bound by Slice 2's projection task.
- SD-004 (inherited): how Sub-phase 3g detects file-sourced `## Personas` content on resume — out of scope here; belongs to US5, still open (no resolution recorded).
- Assumption: slugs are derived from Phase-2 clarification persona names/roles into kebab-case; determinism is load-bearing only for this cross-RFC match.
- Verification: validated via the template-composition test suite (partial resolution + Sub-phase 3b discovery/match assertions). No agent-execution eval was run for the ignite path.

## Validation
build ✅ · typecheck ✅ · test ✅ (src/templates.test.ts: 226 passed)
