### PR TITLE
forge: declare optional per-scenario fixture selector

### DIFF
--- a/evals/lib/scenario-loader.test.ts
+++ b/evals/lib/scenario-loader.test.ts
@@ -502,6 +502,8 @@ describe('loadScenarios', () => {
         ['absolute.yaml', 'fixture: /tmp/custom-fixture'],
         ['parent.yaml', 'fixture: ../jvm'],
         ['escape.yaml', 'fixture: jvm/../../other'],
+        ['win-drive-rel.yaml', 'fixture: "C:tmp"'],
+        ['win-drive-abs.yaml', 'fixture: "C:\\\\fixtures"'],
       ] as const;
       for (const [filename, fixtureLine] of malformedFixtures) {
         fs.writeFileSync(

--- a/evals/lib/scenario-loader.test.ts
+++ b/evals/lib/scenario-loader.test.ts
@@ -41,6 +41,22 @@ function joinErrorCalls(spy: ReturnType<typeof vi.spyOn>): string {
   return calls.map((args) => args.map((a) => String(a)).join(' ')).join('\n');
 }
 
+function scenarioYaml(
+  name: string,
+  extraLines: string[] = [],
+): string {
+  return [
+    `name: ${name}`,
+    'skill: /smithy.strike',
+    'prompt: do the thing',
+    ...extraLines,
+    'structural_expectations:',
+    '  required_headings:',
+    '    - "## Summary"',
+    '',
+  ].join('\n');
+}
+
 describe('loadScenarios', () => {
   let errSpy: ReturnType<typeof vi.spyOn>;
   let outSpy: ReturnType<typeof vi.spyOn>;
@@ -87,6 +103,29 @@ describe('loadScenarios', () => {
     it('emits nothing on stdout or stderr for a clean load', () => {
       loadScenarios(realCasesDir);
       expect(outSpy).not.toHaveBeenCalled();
+      expect(errSpy).not.toHaveBeenCalled();
+    });
+
+    it('leaves omitted fixture metadata absent', () => {
+      const dir = mkdir();
+      fs.writeFileSync(path.join(dir, 'default.yaml'), scenarioYaml('default-case'));
+
+      const scenarios = loadScenarios(dir);
+      expect(scenarios).toHaveLength(1);
+      expect(scenarios[0]).not.toHaveProperty('fixture');
+      expect(errSpy).not.toHaveBeenCalled();
+    });
+
+    it('preserves a valid relative fixture selector', () => {
+      const dir = mkdir();
+      fs.writeFileSync(
+        path.join(dir, 'jvm.yaml'),
+        scenarioYaml('jvm-case', ['fixture: jvm']),
+      );
+
+      const scenarios = loadScenarios(dir);
+      expect(scenarios).toHaveLength(1);
+      expect(scenarios[0]!.fixture).toBe('jvm');
       expect(errSpy).not.toHaveBeenCalled();
     });
   });
@@ -454,6 +493,39 @@ describe('loadScenarios', () => {
         fs.rmSync(linkPath, { force: true });
       }
     });
+
+    it('skips malformed fixture selectors and continues loading valid files', () => {
+      const dir = mkdir();
+      const malformedFixtures = [
+        ['empty.yaml', 'fixture: ""'],
+        ['non-string.yaml', 'fixture: 123'],
+        ['absolute.yaml', 'fixture: /tmp/custom-fixture'],
+        ['parent.yaml', 'fixture: ../jvm'],
+        ['escape.yaml', 'fixture: jvm/../../other'],
+      ] as const;
+      for (const [filename, fixtureLine] of malformedFixtures) {
+        fs.writeFileSync(
+          path.join(dir, filename),
+          scenarioYaml(filename.replace('.yaml', ''), [fixtureLine]),
+        );
+      }
+      fs.writeFileSync(
+        path.join(dir, 'valid.yaml'),
+        scenarioYaml('valid-case', ['fixture: jvm']),
+      );
+
+      const scenarios = loadScenarios(dir);
+      expect(scenarios.map((scenario) => scenario.name)).toEqual(['valid-case']);
+      expect(scenarios[0]!.fixture).toBe('jvm');
+      expect(errSpy).toHaveBeenCalledTimes(malformedFixtures.length);
+      for (const [filename] of malformedFixtures) {
+        const matchingCalls = (errSpy.mock.calls as unknown[][]).filter((args) =>
+          String(args[0]).includes(filename),
+        );
+        expect(matchingCalls).toHaveLength(1);
+        expect(String(matchingCalls[0]![0]).match(/fixture/g)).toHaveLength(1);
+      }
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -645,5 +717,14 @@ describe('loadScenarioFromFile', () => {
     expect(() => loadScenarioFromFile(file)).toThrow(
       /local_fixtures\.ci_log.*does-not-exist\.log/i,
     );
+  });
+
+  it('throws with a fixture validation failure for malformed fixture metadata', () => {
+    const dir = mkdir();
+    const file = path.join(dir, 'invalid-fixture.yaml');
+    fs.writeFileSync(file, scenarioYaml('invalid-fixture', ['fixture: ../jvm']));
+
+    expect(() => loadScenarioFromFile(file)).toThrow(/fixture/i);
+    expect(errSpy).not.toHaveBeenCalled();
   });
 });

--- a/evals/lib/scenario-loader.ts
+++ b/evals/lib/scenario-loader.ts
@@ -490,5 +490,11 @@ function isValidFixtureSelector(value: unknown): value is string {
   if (path.isAbsolute(value) || path.win32.isAbsolute(value)) {
     return false;
   }
+  // Reject Windows drive-letter prefixes (e.g. `C:tmp`). These are
+  // drive-relative rather than absolute, so `win32.isAbsolute` returns false,
+  // yet they escape the fixture root on Windows.
+  if (/^[a-zA-Z]:/.test(value)) {
+    return false;
+  }
   return !value.split(/[\\/]+/).some((segment) => segment === '..');
 }

--- a/evals/lib/scenario-loader.ts
+++ b/evals/lib/scenario-loader.ts
@@ -302,6 +302,17 @@ function validateScenario(
     structural_expectations,
   };
 
+  // Optional: fixture selector (relative path under evals/fixture)
+  if (obj['fixture'] !== undefined) {
+    if (!isValidFixtureSelector(obj['fixture'])) {
+      skip(
+        "'fixture' must be a non-empty relative path without absolute roots or '..' segments",
+      );
+      return null;
+    }
+    scenario.fixture = obj['fixture'];
+  }
+
   // Optional: model (string)
   if (obj['model'] !== undefined) {
     if (typeof obj['model'] !== 'string') {
@@ -470,4 +481,14 @@ function isPathUnderArea(repoPath: string, allowedArea: string): boolean {
 function isContainedIn(childAbs: string, parentAbs: string): boolean {
   const rel = path.relative(parentAbs, childAbs);
   return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+function isValidFixtureSelector(value: unknown): value is string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return false;
+  }
+  if (path.isAbsolute(value) || path.win32.isAbsolute(value)) {
+    return false;
+  }
+  return !value.split(/[\\/]+/).some((segment) => segment === '..');
 }

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -120,6 +120,7 @@ export interface EvalScenario {
   name: string;
   skill: string;
   prompt: string;
+  fixture?: string | undefined;
   model?: string | undefined;
   timeout?: number | undefined;
   local_fixtures?: LocalFixtureSet | undefined;

--- a/specs/2026-06-06-011-jvm-multi-language-fixture/01-declare-per-scenario-fixture-selection.tasks.md
+++ b/specs/2026-06-06-011-jvm-multi-language-fixture/01-declare-per-scenario-fixture-selection.tasks.md
@@ -18,7 +18,7 @@
 
 ### Tasks
 
-- [ ] **Expose optional fixture metadata on scenarios**
+- [x] **Expose optional fixture metadata on scenarios**
 
   Extend the eval scenario model in `evals/lib/types.ts` and loader output in `evals/lib/scenario-loader.ts` so valid scenario YAML may carry an optional fixture selector. Preserve omitted fixture metadata as the existing default behavior for AS 1.1, and keep validation for all existing fields unchanged.
 
@@ -29,7 +29,7 @@
   - Existing scenario ordering, duplicate-name handling, `model`, `timeout`, structural expectations, and sub-agent evidence behavior are unchanged.
   - Focused loader coverage exercises omitted and valid fixture metadata.
 
-- [ ] **Reject malformed fixture selectors in the loader**
+- [x] **Reject malformed fixture selectors in the loader**
 
   Add fixture selector validation to `evals/lib/scenario-loader.ts` using the contract's scenario fixture declaration rules. Invalid fixture metadata must follow the existing loader policy: `loadScenarios` skips only the offending file with one stderr line naming `fixture`, while `loadScenarioFromFile` throws for the same invalid content.
 


### PR DESCRIPTION
## Summary
RFC 2026-001-token-savings → M1 Measurement Foundation → F1.6 JVM Multi-Language Fixture → JVM Multi-Language Fixture spec → Slice 1: Load and Validate Fixture Metadata

Adds an optional `fixture` selector to the eval scenario model and loader so a scenario YAML can declare a fixture under `evals/fixture/`. Valid relative selectors are preserved on `EvalScenario`; omitted metadata keeps the existing default behavior. This is the right first increment because US1 is entirely bounded by the scenario model and loader — runner path resolution (US2) and the JVM fixture itself land in later stories.

## Spec debt & uncertainty
- SD-001 (inherited): Fixture selector is `fixture:` with relative paths under `evals/fixture/`, resolving feature-map SD-002 for F1.6. If a CLI `--fixture` flag precedence conflict surfaces during US2, the compatibility tradeoff must be recorded before changing the contract.
- SD-002 (inherited): Gradle wrapper choice for the JVM fixture is left to implementation (US3+); not touched here.
- SD-003 (inherited): F1.5 and F1.6 both touch `evals/lib/runner.ts`; second-to-land must rebase. This slice does not touch the runner, so no conflict yet.
- Assumption: malformed selectors follow the established loader skip-or-throw policy — `loadScenarios` skips the offending file with one stderr line naming `fixture`, `loadScenarioFromFile` throws. Validation rejects empty, non-string, absolute (POSIX + Windows), and any `..`-segment path, matching the contract's rejection table.

## Validation
build ✅ · typecheck ✅ · test ✅ (24 passed — `evals/lib/scenario-loader.test.ts`)
