### PR TITLE
forge: ask-fallback and one-shot summary for free-text persona

### DIFF
--- a/specs/2026-06-05-011-smithy-persona-command/02-generate-persona-from-free-text-description.tasks.md
+++ b/specs/2026-06-05-011-smithy-persona-command/02-generate-persona-from-free-text-description.tasks.md
@@ -53,7 +53,7 @@
 
 ### Tasks
 
-- [ ] **Add unclear-input fallback**
+- [x] **Add unclear-input fallback**
 
   Update `src/templates/agent-skills/commands/smithy.persona.prompt` so empty, literal, or otherwise unclear `$ARGUMENTS` asks the user what persona to generate. Keep the fallback focused on free-text persona creation and do not introduce RFC-mode parsing behavior reserved for US3 and US6.
 
@@ -63,7 +63,7 @@
   - Clear free-text input still runs without an extra prompt.
   - The fallback does not add an intermediate approval STOP after input is clarified.
 
-- [ ] **Render a one-shot command summary**
+- [x] **Render a one-shot command summary**
 
   Add spark-style completion reporting to `src/templates/agent-skills/commands/smithy.persona.prompt` for the free-text path. The summary should communicate the written artifact, any skip due to collision, and the absence of intermediate approval gates for AS 2.3.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -584,15 +584,17 @@ describe('getComposedTemplates', () => {
   it('smithy.persona renders the free-text persona writer contract', () => {
     const persona = claudeComposed.commands.get('smithy.persona.md')!;
     expect(persona).toContain('## Input Routing');
-    expect(persona).toContain('the literal string `$ARGUMENTS`');
+    expect(persona).toContain('If the resolved persona input is empty');
+    expect(persona).toContain('command-argument placeholder');
+    expect(persona).toContain('use it as the effective command input for');
     expect(persona).toContain('what persona to generate');
     expect(persona).toContain('continue directly through free-text mode');
-    expect(persona).toContain('do not add an approval STOP after the input is clarified');
+    expect(persona).toContain('do not add an approval STOP');
     expect(persona).toContain('If the input is non-empty and does **not** end in `.rfc.md`, select');
     expect(persona).toContain('**free-text mode**');
     expect(persona).toContain('Dispatch **smithy-prose** with:');
     expect(persona).toContain('`section_assignment`: "Personas"');
-    expect(persona).toContain('`idea_description`: the free-text description from `$ARGUMENTS`');
+    expect(persona).toContain('`idea_description`: the resolved persona input');
     expect(persona).toContain('Write one file at the target path using the canonical file shape');
     expect(persona).toContain('leave the existing file untouched');
     expect(persona).toContain('the skipped slug/path');
@@ -600,8 +602,7 @@ describe('getComposedTemplates', () => {
     expect(persona).toContain('one durable persona file was');
     expect(persona).toContain('written from free text with no intermediate approval gates');
     expect(persona).toContain('target persona slug already exists');
-    expect(persona).toContain('written and');
-    expect(persona).toContain('skipped persona paths as explicit result fields');
+    expect(persona).toContain('written and skipped persona paths as explicit result fields');
   });
 
   it('smithy.persona renders shared persona convention and artifact policy snippets across agents', async () => {

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -584,6 +584,10 @@ describe('getComposedTemplates', () => {
   it('smithy.persona renders the free-text persona writer contract', () => {
     const persona = claudeComposed.commands.get('smithy.persona.md')!;
     expect(persona).toContain('## Input Routing');
+    expect(persona).toContain('the literal string `$ARGUMENTS`');
+    expect(persona).toContain('what persona to generate');
+    expect(persona).toContain('continue directly through free-text mode');
+    expect(persona).toContain('do not add an approval STOP after the input is clarified');
     expect(persona).toContain('If the input is non-empty and does **not** end in `.rfc.md`, select');
     expect(persona).toContain('**free-text mode**');
     expect(persona).toContain('Dispatch **smithy-prose** with:');
@@ -592,6 +596,12 @@ describe('getComposedTemplates', () => {
     expect(persona).toContain('Write one file at the target path using the canonical file shape');
     expect(persona).toContain('leave the existing file untouched');
     expect(persona).toContain('the skipped slug/path');
+    expect(persona).toContain('## One-Shot Summary');
+    expect(persona).toContain('one durable persona file was');
+    expect(persona).toContain('written from free text with no intermediate approval gates');
+    expect(persona).toContain('target persona slug already exists');
+    expect(persona).toContain('written and');
+    expect(persona).toContain('skipped persona paths as explicit result fields');
   });
 
   it('smithy.persona renders shared persona convention and artifact policy snippets across agents', async () => {

--- a/src/templates/agent-skills/commands/smithy.persona.prompt
+++ b/src/templates/agent-skills/commands/smithy.persona.prompt
@@ -17,6 +17,11 @@ capabilities ship.
 
 Read `$ARGUMENTS` as the command input.
 
+- If the input is empty, whitespace-only, the literal string `$ARGUMENTS`, or
+  otherwise does not contain a usable persona description or RFC path, ask the
+  user what persona to generate. Use the user's answer as the free-text
+  persona description and continue directly through free-text mode. This is the
+  only ask-fallback: do not add an approval STOP after the input is clarified.
 - If the input is non-empty and does **not** end in `.rfc.md`, select
   **free-text mode**.
 - If the input ends in `.rfc.md`, RFC extraction is not implemented yet
@@ -69,3 +74,28 @@ If smithy-prose returns a `## Personas` heading, remove that wrapper and keep
 only the single persona's narrative prose before writing the `.persona.md`
 file. The final file must contain exactly one persona and must follow the
 Persona Artifact Convention section above.
+
+## One-Shot Summary
+
+After free-text mode completes, present a compact terminal summary. Do not dump
+the full persona file contents into the terminal.
+
+For a successful write, report:
+
+1. **Phase summary** — one line stating that one durable persona file was
+   written from free text with no intermediate approval gates.
+2. **Persona path** — the full written path:
+   `{{artifactsRoot}}docs/personas/<slug>.persona.md`.
+3. **Slug** — the derived slug used for filename identity.
+
+For a slug collision skip, report:
+
+1. **Phase summary** — one line stating that no file was written because the
+   target persona slug already exists.
+2. **Skipped path** — the existing path left untouched:
+   `{{artifactsRoot}}docs/personas/<slug>.persona.md`.
+3. **Next step** — tell the user to choose a different persona name/role or
+   edit the existing file directly.
+
+Keep the summary shape compatible with future RFC mode by reporting written and
+skipped persona paths as explicit result fields, not as a free-form diff.

--- a/src/templates/agent-skills/commands/smithy.persona.prompt
+++ b/src/templates/agent-skills/commands/smithy.persona.prompt
@@ -15,13 +15,17 @@ capabilities ship.
 
 ## Input Routing
 
-Read `$ARGUMENTS` as the command input.
+Read `$ARGUMENTS` as the command input, and treat that value as the **resolved
+persona input** for the rest of this run.
 
-- If the input is empty, whitespace-only, the literal string `$ARGUMENTS`, or
-  otherwise does not contain a usable persona description or RFC path, ask the
-  user what persona to generate. Use the user's answer as the free-text
-  persona description and continue directly through free-text mode. This is the
-  only ask-fallback: do not add an approval STOP after the input is clarified.
+- If the resolved persona input is empty, whitespace-only, an unsubstituted
+  command-argument placeholder (an agent that never replaced its argument
+  token), or otherwise does not contain a usable persona description or RFC
+  path, ask the user what persona to generate. Replace the resolved persona
+  input with the user's answer and use it as the effective command input for
+  the remainder of the run, then continue directly through free-text mode. This
+  is the only ask-fallback: do not add an approval STOP after the input is
+  clarified.
 - If the input is non-empty and does **not** end in `.rfc.md`, select
   **free-text mode**.
 - If the input ends in `.rfc.md`, RFC extraction is not implemented yet
@@ -49,7 +53,7 @@ Given a clear free-text persona description, create exactly one durable
    - If it does not exist, continue.
 5. Dispatch **smithy-prose** with:
    - `section_assignment`: "Personas"
-   - `idea_description`: the free-text description from `$ARGUMENTS`
+   - `idea_description`: the resolved persona input (the free-text description)
    - `clarify_output`: the free-text description plus the inferred persona
      name or role
    - `rfc_file_path`: do not pass (free-text drafting has no accumulating
@@ -97,5 +101,5 @@ For a slug collision skip, report:
 3. **Next step** — tell the user to choose a different persona name/role or
    edit the existing file directly.
 
-Keep the summary shape compatible with future RFC mode by reporting written and
-skipped persona paths as explicit result fields, not as a free-form diff.
+Report the written and skipped persona paths as explicit result fields rather
+than a free-form diff, so the run's outcome is unambiguous.


### PR DESCRIPTION
## Summary
smithy-persona-command spec → User Story 2 (Generate a Persona from a Free-Text Description) → Slice 2: Add Ask-Fallback and One-Shot Reporting. (This spec was authored directly from a feature description; it has no upstream RFC/milestone/feature-map ancestry to breadcrumb.)

This slice completes the US2 free-text command contract: it adds the sole ask-fallback for unclear `$ARGUMENTS` and a spark-style one-shot completion summary, making the command ergonomic and consistent with `smithy.spark` without introducing any RFC-extraction behavior (reserved for US3/US6).

## Spec debt & uncertainty
- SD-001 (inherited): Unresolved rule by which ignite Sub-phase 3b decides a pre-existing `.persona.md` "covers" a needed RFC persona (exact match vs. fuzzy/semantic vs. user-confirmed). Out of scope for this slice.
- SD-003 (inherited): Unresolved mechanism for feeding an existing `.persona.md`'s content to smithy-prose, whose input contract has no existing-persona parameter. Out of scope for this slice.
- SD-004 (inherited): Unresolved mechanism for ignite Sub-phase 3g to detect file-sourced `## Personas` provenance on resume. Out of scope for this slice.
- (SD-002 is resolved in the artifact — filename-slug identity, no machine-readable key — and is honored by this slice's summary, which reports slug/path as result fields rather than introducing an identity field.)
- Assumption (Critical, from spec): `smithy.persona` follows `smithy.spark`'s structural contract exactly — one-shot, no STOP gates, `$ARGUMENTS` routing with an ask-fallback when no input is clear. This slice implements precisely that fallback + summary shape.
- Verification gap: validated via the template-composition unit suite (the deployable-surface contract). The prompt's runtime behavior when invoked by a live agent is not exercised by automated tests.

## Validation
build ✅ · typecheck ✅ · test ✅ (src/templates.test.ts, 225 passed)
