### PR TITLE
forge: capture per-case token totals in eval runner output

### DIFF
--- a/evals/lib/parse-stream.test.ts
+++ b/evals/lib/parse-stream.test.ts
@@ -179,6 +179,36 @@ describe('extractTokenTotals', () => {
     expect(extractTokenTotals(events)).toEqual({ input: 20, output: 12 });
   });
 
+  it('reads nested assistant message.usage in the non-terminal fallback', () => {
+    const events: StreamEvent[] = [
+      { type: 'assistant', message: { usage: { input_tokens: 10, output_tokens: 3 } } },
+      { type: 'assistant', message: { usage: { input_tokens: 4, output_tokens: 8 } } },
+    ];
+
+    expect(extractTokenTotals(events)).toEqual({ input: 14, output: 11 });
+  });
+
+  it('reads nested message.usage on terminal result events', () => {
+    const events: StreamEvent[] = [
+      { type: 'assistant', message: { usage: { input_tokens: 100, output_tokens: 50 } } },
+      { type: 'result', message: { usage: { input_tokens: 42, output_tokens: 12 } } },
+    ];
+
+    expect(extractTokenTotals(events)).toEqual({ input: 42, output: 12 });
+  });
+
+  it('prefers top-level usage over nested message.usage on the same event', () => {
+    const events: StreamEvent[] = [
+      {
+        type: 'assistant',
+        usage: { input_tokens: 5, output_tokens: 2 },
+        message: { usage: { input_tokens: 999, output_tokens: 999 } },
+      },
+    ];
+
+    expect(extractTokenTotals(events)).toEqual({ input: 5, output: 2 });
+  });
+
   it('ignores malformed usage fields while preserving valid fields', () => {
     const events: StreamEvent[] = [
       { type: 'assistant', usage: { input_tokens: null, output_tokens: 5 } },

--- a/evals/lib/parse-stream.test.ts
+++ b/evals/lib/parse-stream.test.ts
@@ -3,6 +3,7 @@ import {
   parseStreamString,
   extractCanonicalText,
   extractSubAgentDispatches,
+  extractTokenTotals,
 } from './parse-stream.js';
 import type { StreamEvent } from './types.js';
 
@@ -156,6 +157,57 @@ describe('extractCanonicalText', () => {
     ];
 
     expect(extractCanonicalText(events)).toBe('Completed item text');
+  });
+});
+
+describe('extractTokenTotals', () => {
+  it('returns zero totals for empty or usage-free event arrays', () => {
+    expect(extractTokenTotals([])).toEqual({ input: 0, output: 0 });
+    expect(extractTokenTotals([assistantTextEvent('no usage')])).toEqual({
+      input: 0,
+      output: 0,
+    });
+  });
+
+  it('sums valid non-terminal usage when no terminal usage exists', () => {
+    const events: StreamEvent[] = [
+      { type: 'assistant', usage: { input_tokens: 10, output_tokens: 3 } },
+      { type: 'message_delta', usage: { input_tokens: 4, output_tokens: 8 } },
+      { type: 'future_event_type', usage: { input_tokens: 6, output_tokens: 1 } },
+    ];
+
+    expect(extractTokenTotals(events)).toEqual({ input: 20, output: 12 });
+  });
+
+  it('ignores malformed usage fields while preserving valid fields', () => {
+    const events: StreamEvent[] = [
+      { type: 'assistant', usage: { input_tokens: null, output_tokens: 5 } },
+      { type: 'assistant', usage: { input_tokens: '7', output_tokens: 2.5 } },
+      { type: 'assistant', usage: { input_tokens: -1, output_tokens: Number.NaN } },
+      { type: 'assistant', usage: { input_tokens: Number.POSITIVE_INFINITY, output_tokens: 9 } },
+      { type: 'assistant', usage: { input_tokens: 12, output_tokens: 0 } },
+    ];
+
+    expect(extractTokenTotals(events)).toEqual({ input: 12, output: 14 });
+  });
+
+  it('uses terminal result usage instead of summing non-terminal usage', () => {
+    const events: StreamEvent[] = [
+      { type: 'assistant', usage: { input_tokens: 100, output_tokens: 50 } },
+      { type: 'result', usage: { input_tokens: 42, output_tokens: 12 } },
+    ];
+
+    expect(extractTokenTotals(events)).toEqual({ input: 42, output: 12 });
+  });
+
+  it('takes per-field maximum usage across terminal result events', () => {
+    const events: StreamEvent[] = [
+      { type: 'assistant', usage: { input_tokens: 100, output_tokens: 100 } },
+      { type: 'result', usage: { input_tokens: 40, output_tokens: 12 } },
+      { type: 'result', usage: { input_tokens: 35, output_tokens: 18 } },
+    ];
+
+    expect(extractTokenTotals(events)).toEqual({ input: 40, output: 18 });
   });
 });
 

--- a/evals/lib/parse-stream.ts
+++ b/evals/lib/parse-stream.ts
@@ -257,7 +257,7 @@ export function extractCanonicalText(events: StreamEvent[]): string {
 export function extractTokenTotals(events: StreamEvent[]): TokenTotals {
   const terminalUsages = events
     .filter((event) => event.type === 'result')
-    .map((event) => normalizeUsage(event.usage))
+    .map((event) => normalizeEventUsage(event))
     .filter(hasUsageValue);
 
   if (terminalUsages.length > 0) {
@@ -272,7 +272,7 @@ export function extractTokenTotals(events: StreamEvent[]): TokenTotals {
 
   return events
     .filter((event) => event.type !== 'result')
-    .map((event) => normalizeUsage(event.usage))
+    .map((event) => normalizeEventUsage(event))
     .reduce<TokenTotals>(
       (totals, usage) => ({
         input: totals.input + (usage.input ?? 0),
@@ -306,6 +306,26 @@ function extractContentText(content: unknown): string[] {
 interface NormalizedUsage {
   input?: number | undefined;
   output?: number | undefined;
+}
+
+/**
+ * Resolve usage from either the top-level `event.usage` (terminal `result`
+ * events) or the nested `event.message.usage` (Claude assistant events), so
+ * partial/error/timeout runs that only emit assistant events still report
+ * their parseable usage. Top-level usage wins when both carry a value.
+ */
+function normalizeEventUsage(event: StreamEvent): NormalizedUsage {
+  const topLevel = normalizeUsage(event.usage);
+  if (hasUsageValue(topLevel)) {
+    return topLevel;
+  }
+
+  const { message } = event;
+  if (message && typeof message === 'object' && !Array.isArray(message)) {
+    return normalizeUsage((message as Record<string, unknown>)['usage']);
+  }
+
+  return {};
 }
 
 function normalizeUsage(usage: unknown): NormalizedUsage {

--- a/evals/lib/parse-stream.ts
+++ b/evals/lib/parse-stream.ts
@@ -18,6 +18,7 @@ import type {
   ToolResult,
   AgentDispatch,
   EventSummary,
+  TokenTotals,
 } from './types.js';
 
 /**
@@ -246,6 +247,41 @@ export function extractCanonicalText(events: StreamEvent[]): string {
   return extractText(events);
 }
 
+/**
+ * Extract normalized token totals from stream usage metadata.
+ *
+ * Terminal `result` events report cumulative totals when present, so they take
+ * precedence over non-terminal usage to avoid double-counting. If no terminal
+ * result has valid usage, valid non-terminal usage values are summed.
+ */
+export function extractTokenTotals(events: StreamEvent[]): TokenTotals {
+  const terminalUsages = events
+    .filter((event) => event.type === 'result')
+    .map((event) => normalizeUsage(event.usage))
+    .filter(hasUsageValue);
+
+  if (terminalUsages.length > 0) {
+    return terminalUsages.reduce<TokenTotals>(
+      (totals, usage) => ({
+        input: Math.max(totals.input, usage.input ?? 0),
+        output: Math.max(totals.output, usage.output ?? 0),
+      }),
+      zeroTokenTotals(),
+    );
+  }
+
+  return events
+    .filter((event) => event.type !== 'result')
+    .map((event) => normalizeUsage(event.usage))
+    .reduce<TokenTotals>(
+      (totals, usage) => ({
+        input: totals.input + (usage.input ?? 0),
+        output: totals.output + (usage.output ?? 0),
+      }),
+      zeroTokenTotals(),
+    );
+}
+
 function getObjectField(
   object: Record<string, unknown>,
   field: string,
@@ -265,4 +301,38 @@ function extractContentText(content: unknown): string[] {
       if (typeof block['output_text'] === 'string') return [block['output_text']];
       return [];
     });
+}
+
+interface NormalizedUsage {
+  input?: number | undefined;
+  output?: number | undefined;
+}
+
+function normalizeUsage(usage: unknown): NormalizedUsage {
+  if (!usage || typeof usage !== 'object' || Array.isArray(usage)) {
+    return {};
+  }
+
+  const usageRecord = usage as Record<string, unknown>;
+  return {
+    input: normalizeTokenCount(usageRecord['input_tokens']),
+    output: normalizeTokenCount(usageRecord['output_tokens']),
+  };
+}
+
+function normalizeTokenCount(value: unknown): number | undefined {
+  return typeof value === 'number' &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value >= 0
+    ? value
+    : undefined;
+}
+
+function hasUsageValue(usage: NormalizedUsage): boolean {
+  return usage.input !== undefined || usage.output !== undefined;
+}
+
+function zeroTokenTotals(): TokenTotals {
+  return { input: 0, output: 0 };
 }

--- a/evals/lib/report.test.ts
+++ b/evals/lib/report.test.ts
@@ -27,6 +27,7 @@ function makeOutput(overrides: Partial<RunOutput> = {}): RunOutput {
   return {
     extracted_text: '## Plan\n\nDetails here.',
     stream_events: [],
+    tokens: { input: 0, output: 0 },
     duration_ms: 1234,
     exit_code: 0,
     timed_out: false,

--- a/evals/lib/runner.test.ts
+++ b/evals/lib/runner.test.ts
@@ -63,6 +63,20 @@ function resultEvent(text: string): StreamEvent {
   };
 }
 
+function usageEvent(
+  type: string,
+  inputTokens: number,
+  outputTokens: number,
+): StreamEvent {
+  return {
+    type,
+    usage: {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+    },
+  };
+}
+
 /**
  * Create a mock child process object that emits data on stdout and then closes.
  * `stdoutData` is the full string to emit. `exitCode` is the code passed to
@@ -175,6 +189,7 @@ describe('runScenario', () => {
       expect(output.stream_events).toHaveLength(2);
       expect(output.stream_events[0]!.type).toBe('assistant');
       expect(output.stream_events[1]!.type).toBe('result');
+      expect(output.tokens).toEqual({ input: 0, output: 0 });
 
       // Timing and exit info.
       expect(output.duration_ms).toBeGreaterThanOrEqual(0);
@@ -205,7 +220,10 @@ describe('runScenario', () => {
   });
 
   it('non-zero exit code is surfaced', async () => {
-    const stdout = ndjsonLines(assistantTextEvent('partial'));
+    const stdout = ndjsonLines(
+      assistantTextEvent('partial'),
+      usageEvent('assistant', 17, 5),
+    );
     const { child } = createMockChild(stdout, 1);
     vi.mocked(spawn).mockReturnValue(child as never);
 
@@ -213,6 +231,28 @@ describe('runScenario', () => {
     try {
       const output = await runScenario(makeScenario(), fixture.dir);
       expect(output.exit_code).toBe(1);
+      expect(output.tokens).toEqual({ input: 17, output: 5 });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('successful run includes token totals from terminal usage', async () => {
+    const stdout = ndjsonLines(
+      usageEvent('assistant', 10, 2),
+      {
+        ...resultEvent('output'),
+        usage: { input_tokens: 24, output_tokens: 9 },
+      },
+    );
+    const { child } = createMockChild(stdout, 0);
+    vi.mocked(spawn).mockReturnValue(child as never);
+
+    const fixture = createRealFixture();
+    try {
+      const output = await runScenario(makeScenario(), fixture.dir);
+
+      expect(output.tokens).toEqual({ input: 24, output: 9 });
     } finally {
       fixture.cleanup();
     }
@@ -260,7 +300,8 @@ describe('runScenario', () => {
     // Use fake timers so we can advance the timeout without real waiting.
     vi.useFakeTimers();
 
-    const { child, triggerClose } = createMockChild('', 0, {
+    const stdout = ndjsonLines(usageEvent('message_delta', 11, 4));
+    const { child, triggerClose } = createMockChild(stdout, 0, {
       delayClose: true,
     });
     vi.mocked(spawn).mockReturnValue(child as never);
@@ -282,6 +323,24 @@ describe('runScenario', () => {
 
       const output = await promise;
       expect(output.timed_out).toBe(true);
+      expect(output.tokens).toEqual({ input: 11, output: 4 });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('malformed stream output returns zero token totals without token-specific failure', async () => {
+    const { child } = createMockChild('not json\n', 1);
+    vi.mocked(spawn).mockReturnValue(child as never);
+
+    const fixture = createRealFixture();
+    try {
+      const output = await runScenario(makeScenario(), fixture.dir);
+
+      expect(output.exit_code).toBe(1);
+      expect(output.extracted_text).toBe('');
+      expect(output.stream_events).toEqual([]);
+      expect(output.tokens).toEqual({ input: 0, output: 0 });
     } finally {
       fixture.cleanup();
     }

--- a/evals/lib/runner.ts
+++ b/evals/lib/runner.ts
@@ -13,7 +13,11 @@ import os from 'node:os';
 import path from 'node:path';
 
 import type { EvalAgent, EvalScenario, RunOutput, StreamEvent } from './types.js';
-import { parseStreamString, extractCanonicalText } from './parse-stream.js';
+import {
+  parseStreamString,
+  extractCanonicalText,
+  extractTokenTotals,
+} from './parse-stream.js';
 
 /** Path to the built Smithy CLI, resolved relative to this module. */
 const CLI_PATH = path.resolve(
@@ -431,6 +435,7 @@ export async function runScenario(
     return {
       extracted_text: extractedText,
       stream_events: events,
+      tokens: extractTokenTotals(events),
       duration_ms: result.duration_ms,
       exit_code: result.exit_code,
       timed_out: result.timed_out,

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -22,6 +22,11 @@ export type EvalAgent = 'claude' | 'gemini' | 'codex';
  */
 export interface StreamEvent {
   type: string;
+  usage?: {
+    input_tokens?: unknown;
+    output_tokens?: unknown;
+    [key: string]: unknown;
+  } | undefined;
   message?: string | {
     content?: Array<Record<string, unknown>>;
     [key: string]: unknown;
@@ -124,10 +129,17 @@ export interface EvalScenario {
 // Runner output
 // ---------------------------------------------------------------------------
 
+/** Normalized token totals for a single scenario run or aggregate report. */
+export interface TokenTotals {
+  input: number;
+  output: number;
+}
+
 /** Output produced by `runScenario`. */
 export interface RunOutput {
   extracted_text: string;
   stream_events: StreamEvent[];
+  tokens: TokenTotals;
   duration_ms: number;
   exit_code: number;
   timed_out: boolean;

--- a/specs/2026-05-18-007-per-case-token-totals-in-evalreport/01-capture-per-case-token-totals.tasks.md
+++ b/specs/2026-05-18-007-per-case-token-totals-in-evalreport/01-capture-per-case-token-totals.tasks.md
@@ -18,7 +18,7 @@
 
 ### Tasks
 
-- [ ] **Declare token totals on runner output**
+- [x] **Declare token totals on runner output**
 
   Extend `evals/lib/types.ts` with the token-count value object from the data model and add it to `RunOutput`. Keep the stream event type loose enough to preserve unknown event shapes while permitting optional usage payloads for AS 1.1-1.3.
 
@@ -28,7 +28,7 @@
   - `StreamEvent` remains tolerant of unknown fields and event types.
   - Existing type exports remain import-compatible for current eval modules.
 
-- [ ] **Extract valid usage from stream events**
+- [x] **Extract valid usage from stream events**
 
   Add a pure extraction helper in `evals/lib/parse-stream.ts` that implements the Stream Usage Extraction contract. It must normalize valid usage metadata, ignore invalid fields, and apply the terminal-event precedence rule so AS 1.1 and the edge-case deduplication requirement are satisfied.
 
@@ -39,7 +39,7 @@
   - Empty or usage-free event arrays return zero totals.
   - Unit coverage exercises valid usage, missing usage, malformed usage, and deduplication paths.
 
-- [ ] **Populate runner tokens for every outcome**
+- [x] **Populate runner tokens for every outcome**
 
   Update `evals/lib/runner.ts` so `runScenario` sets `RunOutput.tokens` from parseable events and falls back to zero totals when no usable usage metadata is available. Preserve the existing extracted-text and timeout/error behavior while satisfying AS 1.2 and AS 1.3.
 


### PR DESCRIPTION
## Summary
RFC 2026-001-token-savings → M1 Measurement Foundation → F1.3a Per-Case Token Totals in EvalReport → Per-Case Token Totals in EvalReport spec → Slice 1: Extract Token Totals from Stream Events

This slice adds normalized token-total extraction to the evals runner so every `RunOutput` carries input/output token counts. It's the right first increment because the runner already owns parsed stream events and the success/error/timeout fallback behavior, so capture lands here as a self-contained, data-only step before report assembly (Slice 2) consumes it.

## Spec debt & uncertainty
- SD-001 (inherited): stream-json event placement for usage metadata may vary by Claude CLI version; implementers must verify whether usage appears on terminal `result` events, assistant events, or both, and apply the deduplication rule. **Addressed in extraction logic** — `extractTokenTotals` applies terminal `result`-event precedence with non-terminal sum as fallback, matching the contract.
- SD-002 (inherited): token envelope tolerance not calibrated until first token-aware strike baseline; out of scope for this data-capture slice (US3).
- SD-003 (inherited): RFC touched-files matrix omits some token-threading surfaces; matrix amendment not made in this slice (no RFC edits in scope here) — flagging for follow-up.
- Assumption: missing/unparseable usage is represented as zero totals rather than failing an otherwise valid run (per spec Clarification 2026-05-18).
- Verification gap: unit suite run under Node 22 (repo requires ≥20; the default env Node is 18, which cannot run the rolldown/vitest toolchain). No live token totals captured (SD-002), as this slice is data-only with no report rendering.

## Validation
typecheck ✅ · test:evals ✅ (89 passed: parse-stream, runner, report)
