### PR TITLE
forge: classify dispatch-level usage evidence

### DIFF
--- a/evals/lib/dispatch-usage-evidence.test.ts
+++ b/evals/lib/dispatch-usage-evidence.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { classifyDispatchUsageEvidence } from './dispatch-usage-evidence.js';
+import type { StreamEvent } from './types.js';
+
+const reviewedAt = '2026-05-20T00:00:00.000Z';
+const sourceCapture = 'evals/captures/example.events.jsonl';
+
+function agentToolUseEvent(id: string): StreamEvent {
+  return {
+    type: 'assistant',
+    message: {
+      content: [
+        {
+          type: 'tool_use',
+          name: 'Agent',
+          id,
+          input: { description: 'Scout repo', prompt: 'scan' },
+        },
+      ],
+    },
+  };
+}
+
+describe('classifyDispatchUsageEvidence', () => {
+  it('classifies dispatch-attributable streams when usage has a stable parent_tool_use_id relationship', () => {
+    const events: StreamEvent[] = [
+      agentToolUseEvent('toolu_dispatch_1'),
+      {
+        type: 'assistant',
+        parent_tool_use_id: 'toolu_dispatch_1',
+        message: {
+          content: [{ type: 'text', text: 'sub-agent output' }],
+          usage: { input_tokens: 10, output_tokens: 4 },
+        },
+      },
+    ];
+
+    const evidence = classifyDispatchUsageEvidence(events, {
+      sourceCapture,
+      reviewedAt,
+    });
+
+    expect(evidence).toEqual({
+      classification: 'dispatch_attributable',
+      source_capture: sourceCapture,
+      observed_relationship:
+        'Usage metadata has a stable dispatch relationship via parent_tool_use_id=toolu_dispatch_1',
+      reviewed_at: reviewedAt,
+    });
+  });
+
+  it('classifies parent-only streams when usage is present only on parent events', () => {
+    const events: StreamEvent[] = [
+      agentToolUseEvent('toolu_dispatch_1'),
+      {
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'parent output' }],
+          usage: { input_tokens: 50, output_tokens: 12 },
+        },
+      },
+      {
+        type: 'result',
+        result: 'done',
+      },
+    ];
+
+    const evidence = classifyDispatchUsageEvidence(events, {
+      sourceCapture,
+      reviewedAt,
+    });
+
+    expect(evidence.classification).toBe('parent_only');
+    expect(evidence.source_capture).toBe(sourceCapture);
+    expect(evidence.observed_relationship).toBe(
+      'Observed 1 parseable usage record(s), but none included parent_tool_use_id or tool_use_id matching a known Agent dispatch',
+    );
+    expect(evidence.reviewed_at).toBe(reviewedAt);
+  });
+
+  it('does not infer attribution from malformed or ambiguous usage metadata', () => {
+    const events: StreamEvent[] = [
+      agentToolUseEvent('toolu_dispatch_1'),
+      {
+        type: 'assistant',
+        parent_tool_use_id: 'unknown_dispatch',
+        message: {
+          content: [{ type: 'text', text: 'ambiguous usage' }],
+          usage: { input_tokens: 8, output_tokens: 3 },
+        },
+      },
+      {
+        type: 'system',
+        tool_use_id: 'toolu_dispatch_1',
+        usage: { input_tokens: '8', output_tokens: null },
+      },
+    ];
+
+    const evidence = classifyDispatchUsageEvidence(events, {
+      sourceCapture,
+      reviewedAt,
+    });
+
+    expect(evidence.classification).toBe('parent_only');
+    expect(evidence.observed_relationship).toBe(
+      'Observed 1 parseable usage record(s), but none included parent_tool_use_id or tool_use_id matching a known Agent dispatch',
+    );
+  });
+
+  it('keeps usable dispatch evidence while ignoring malformed or ambiguous records', () => {
+    const events: StreamEvent[] = [
+      agentToolUseEvent('toolu_dispatch_1'),
+      {
+        type: 'system',
+        tool_use_id: 'toolu_dispatch_1',
+        usage: { total_tokens: 14 },
+      },
+      {
+        type: 'assistant',
+        parent_tool_use_id: 'unknown_dispatch',
+        message: {
+          content: [{ type: 'text', text: 'ambiguous parent' }],
+          usage: { input_tokens: 6 },
+        },
+      },
+      {
+        type: 'system',
+        tool_use_id: 'toolu_dispatch_1',
+        usage: { total_tokens: 'bad' },
+      },
+    ];
+
+    const evidence = classifyDispatchUsageEvidence(events, {
+      sourceCapture,
+      reviewedAt,
+    });
+
+    expect(evidence.classification).toBe('dispatch_attributable');
+    expect(evidence.observed_relationship).toBe(
+      'Usage metadata has a stable dispatch relationship via tool_use_id=toolu_dispatch_1; ignored 2 malformed, partial, or unattributable usage record(s)',
+    );
+  });
+});

--- a/evals/lib/dispatch-usage-evidence.test.ts
+++ b/evals/lib/dispatch-usage-evidence.test.ts
@@ -141,4 +141,37 @@ describe('classifyDispatchUsageEvidence', () => {
       'Usage metadata has a stable dispatch relationship via tool_use_id=toolu_dispatch_1; ignored 2 malformed, partial, or unattributable usage record(s)',
     );
   });
+
+  it('does not throw on a malformed Agent tool-use block with a missing id', () => {
+    const events: StreamEvent[] = [
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              name: 'Agent',
+              // id intentionally omitted to simulate provider-shape drift
+              input: { description: 'Scout repo', prompt: 'scan' },
+            },
+          ],
+        },
+      },
+      {
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'parent output' }],
+          usage: { input_tokens: 50, output_tokens: 12 },
+        },
+      },
+    ];
+
+    const evidence = classifyDispatchUsageEvidence(events, {
+      sourceCapture,
+      reviewedAt,
+    });
+
+    expect(evidence.classification).toBe('parent_only');
+  });
 });

--- a/evals/lib/dispatch-usage-evidence.ts
+++ b/evals/lib/dispatch-usage-evidence.ts
@@ -35,7 +35,7 @@ export function classifyDispatchUsageEvidence(
     extractToolUses(events)
       .filter((toolUse) => toolUse.name === 'Agent' || toolUse.name === 'invoke_agent')
       .map((toolUse) => toolUse.id)
-      .filter((id) => id.length > 0),
+      .filter((id) => typeof id === 'string' && id.length > 0),
   );
 
   const observations = events

--- a/evals/lib/dispatch-usage-evidence.ts
+++ b/evals/lib/dispatch-usage-evidence.ts
@@ -1,0 +1,145 @@
+import { extractToolUses } from './parse-stream.js';
+import type { DispatchUsageEvidence, StreamEvent } from './types.js';
+
+export interface DispatchUsageEvidenceOptions {
+  sourceCapture?: string;
+  reviewedAt?: string;
+}
+
+interface UsageObservation {
+  relationship?: 'parent_tool_use_id' | 'tool_use_id';
+  dispatchId?: string;
+  hasValidUsage: boolean;
+}
+
+const TOKEN_USAGE_FIELDS = [
+  'input_tokens',
+  'output_tokens',
+  'cache_creation_input_tokens',
+  'cache_read_input_tokens',
+  'total_tokens',
+] as const;
+
+/**
+ * Classify whether parsed stream usage metadata is attributable to sub-agent
+ * dispatches. This intentionally stops at evidence classification; it does not
+ * compute token totals or alter report rendering.
+ */
+export function classifyDispatchUsageEvidence(
+  events: StreamEvent[],
+  options: DispatchUsageEvidenceOptions = {},
+): DispatchUsageEvidence {
+  const source_capture = options.sourceCapture ?? 'unknown';
+  const reviewed_at = options.reviewedAt ?? new Date().toISOString();
+  const dispatchIds = new Set(
+    extractToolUses(events)
+      .filter((toolUse) => toolUse.name === 'Agent' || toolUse.name === 'invoke_agent')
+      .map((toolUse) => toolUse.id)
+      .filter((id) => id.length > 0),
+  );
+
+  const observations = events
+    .map((event) => observeUsage(event, dispatchIds))
+    .filter((observation): observation is UsageObservation => observation !== null);
+
+  const attributable = observations.filter(
+    (observation) => observation.hasValidUsage && observation.dispatchId,
+  );
+
+  if (attributable.length > 0) {
+    const relationships = unique(
+      attributable.map(
+        (observation) => `${observation.relationship}=${observation.dispatchId}`,
+      ),
+    );
+    const ignoredCount = observations.length - attributable.length;
+    const ignoredSuffix =
+      ignoredCount > 0
+        ? `; ignored ${ignoredCount} malformed, partial, or unattributable usage record(s)`
+        : '';
+    return {
+      classification: 'dispatch_attributable',
+      source_capture,
+      observed_relationship:
+        `Usage metadata has a stable dispatch relationship via ${relationships.join(', ')}` +
+        ignoredSuffix,
+      reviewed_at,
+    };
+  }
+
+  const validUsageCount = observations.filter(
+    (observation) => observation.hasValidUsage,
+  ).length;
+  const observed_relationship =
+    validUsageCount > 0
+      ? `Observed ${validUsageCount} parseable usage record(s), but none included parent_tool_use_id or tool_use_id matching a known Agent dispatch`
+      : 'No parseable usage metadata with non-negative token counts was observed';
+
+  return {
+    classification: 'parent_only',
+    source_capture,
+    observed_relationship,
+    reviewed_at,
+  };
+}
+
+function observeUsage(
+  event: StreamEvent,
+  dispatchIds: Set<string>,
+): UsageObservation | null {
+  const usage = getUsageObject(event);
+  if (!usage) return null;
+
+  const relationship = getDispatchRelationship(event, dispatchIds);
+  return {
+    ...relationship,
+    hasValidUsage: hasValidTokenUsage(usage),
+  };
+}
+
+function getUsageObject(event: StreamEvent): Record<string, unknown> | null {
+  if (isRecord(event['usage'])) return event['usage'];
+  if (isRecord(event.message) && isRecord(event.message['usage'])) {
+    return event.message['usage'];
+  }
+  if (isRecord(event['item']) && isRecord(event['item']['usage'])) {
+    return event['item']['usage'];
+  }
+  if (isRecord(event['payload']) && isRecord(event['payload']['usage'])) {
+    return event['payload']['usage'];
+  }
+  return null;
+}
+
+function getDispatchRelationship(
+  event: StreamEvent,
+  dispatchIds: Set<string>,
+): Pick<UsageObservation, 'relationship' | 'dispatchId'> {
+  const parentToolUseId = event['parent_tool_use_id'];
+  if (typeof parentToolUseId === 'string' && dispatchIds.has(parentToolUseId)) {
+    return { relationship: 'parent_tool_use_id', dispatchId: parentToolUseId };
+  }
+
+  const toolUseId = event['tool_use_id'];
+  if (typeof toolUseId === 'string' && dispatchIds.has(toolUseId)) {
+    return { relationship: 'tool_use_id', dispatchId: toolUseId };
+  }
+
+  return {};
+}
+
+function hasValidTokenUsage(usage: Record<string, unknown>): boolean {
+  return TOKEN_USAGE_FIELDS.some((field) => isNonNegativeInteger(usage[field]));
+}
+
+function isNonNegativeInteger(value: unknown): boolean {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -79,6 +79,18 @@ export interface EventSummary {
   textLength: number;
 }
 
+export type DispatchUsageEvidenceClassification =
+  | 'dispatch_attributable'
+  | 'parent_only';
+
+/** Classification record for whether stream usage can be tied to a dispatch. */
+export interface DispatchUsageEvidence {
+  classification: DispatchUsageEvidenceClassification;
+  source_capture: string;
+  observed_relationship: string;
+  reviewed_at: string;
+}
+
 // ---------------------------------------------------------------------------
 // Scenario / expectation types (from YAML definitions)
 // ---------------------------------------------------------------------------

--- a/specs/2026-05-20-008-per-sub-agent-token-attribution/01-verify-dispatch-level-usage-evidence.tasks.md
+++ b/specs/2026-05-20-008-per-sub-agent-token-attribution/01-verify-dispatch-level-usage-evidence.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Add dispatch usage evidence classification**
+- [x] **Add dispatch usage evidence classification**
 
   Extend the eval stream parsing layer under `evals/lib/` with a dispatch usage evidence classifier that consumes parsed `StreamEvent` values and returns the data-model classification shape. Keep the classifier limited to reliable dispatch-identifier relationships for AS 1.1-1.3; do not add sub-agent token aggregation or report rows from later stories.
 
@@ -29,7 +29,7 @@
   - Existing text extraction and sub-agent evidence behavior remains unchanged.
   - Unit coverage spans AS 1.1, AS 1.2, and AS 1.3.
 
-- [ ] **Record the committed evidence decision**
+- [x] **Record the committed evidence decision**
 
   Add `specs/2026-05-20-008-per-sub-agent-token-attribution/dispatch-usage-evidence.md` for the reviewed eval capture. The note should identify the capture reviewed, the classifier result, and the selected downstream path while keeping US2 attribution and US4 RFC fallback edits out of scope.
 

--- a/specs/2026-05-20-008-per-sub-agent-token-attribution/dispatch-usage-evidence.md
+++ b/specs/2026-05-20-008-per-sub-agent-token-attribution/dispatch-usage-evidence.md
@@ -1,0 +1,27 @@
+# Dispatch Usage Evidence
+
+**Capture reviewed**: `evals/captures/scout-fixture-shallow.events.jsonl`
+**Classifier**: `classifyDispatchUsageEvidence`
+**Reviewed at**: `2026-05-20T00:00:00.000Z`
+
+## Classification
+
+```json
+{
+  "classification": "dispatch_attributable",
+  "source_capture": "evals/captures/scout-fixture-shallow.events.jsonl",
+  "observed_relationship": "Usage metadata has a stable dispatch relationship via tool_use_id=toolu_01J2xpdkVW6WQfnGhg2aR5eb, parent_tool_use_id=toolu_01J2xpdkVW6WQfnGhg2aR5eb; ignored 4 malformed, partial, or unattributable usage record(s)",
+  "reviewed_at": "2026-05-20T00:00:00.000Z"
+}
+```
+
+## Decision
+
+The feature proceeds to the attribution implementation path. The reviewed
+capture contains a known `Agent` dispatch with id
+`toolu_01J2xpdkVW6WQfnGhg2aR5eb`, and usage-bearing sub-agent events tie back
+to that dispatch through `parent_tool_use_id` and task progress `tool_use_id`.
+
+This note records only the dispatch usage evidence classification for US1. It
+does not add per-sub-agent token totals, nested report rows, or RFC fallback
+resolution changes.


### PR DESCRIPTION
## Summary
RFC 2026-001-token-savings → M1 Measurement Foundation → F1.3b Per-Sub-Agent Token Attribution → Per-Sub-Agent Token Attribution spec → Slice 1: Classify Committed Dispatch Usage Evidence

Adds the evidence-classification path that inspects committed eval stream events and decides whether per-sub-agent token attribution is eligible (`dispatch_attributable`) or must fall back to parent-only reporting. This is the right first increment because the classification selects the implementation path that US2/US3/US4 all depend on — it ships code-backed evidence plus a recorded decision without introducing any token aggregation or report rendering.

## Spec debt & uncertainty
- None outstanding — the tasks artifact and spec both record "None — all ambiguities resolved."
- Assumption (Critical): the spec targets Dependency Order row `F2` = Feature 1.3b, and dispatch-level attribution is trusted only when stream events carry a stable relationship (`parent_tool_use_id`/`tool_use_id`) to a known `Agent` dispatch.
- Decision recorded: the reviewed capture (`evals/captures/scout-fixture-shallow.events.jsonl`) classifies as `dispatch_attributable`, so the feature proceeds to the attribution path rather than the parent-only fallback (RFC SD-001 untouched, per scope).
- Environment note: the worktree shipped without `node_modules` and the active node was v18 (toolchain requires ≥20); validation was run under nvm node v22.16.0.

## Validation
build ✅ · typecheck ✅ · test ✅ (evals suite 201 passed; dispatch-usage-evidence 4/4)
