### PR TITLE
forge: route eval scenarios through fixture metadata and git opt-in

### DIFF
--- a/evals/lib/runner.test.ts
+++ b/evals/lib/runner.test.ts
@@ -219,6 +219,52 @@ describe('runScenario', () => {
     }
   });
 
+  it('uses scenario fixture metadata to select the JVM fixture directory', async () => {
+    const stdout = ndjsonLines(resultEvent('jvm output'));
+    const { child } = createMockChild(stdout, 0);
+
+    let spawnObservedCwd = '';
+    let sawJvmFixtureFile = false;
+    let sawRootFixtureFile = false;
+    vi.mocked(spawn).mockImplementation(
+      ((_cmd: string, _args: readonly string[], opts: { cwd?: string }) => {
+        spawnObservedCwd = opts.cwd ?? '';
+        sawJvmFixtureFile = fs.existsSync(path.join(spawnObservedCwd, 'jvm-only.txt'));
+        sawRootFixtureFile = fs.existsSync(path.join(spawnObservedCwd, 'root-only.txt'));
+        return child as never;
+      }) as never,
+    );
+
+    const fixture = createRealFixture();
+    fs.writeFileSync(path.join(fixture.dir, 'root-only.txt'), 'root');
+    fs.mkdirSync(path.join(fixture.dir, 'jvm'));
+    fs.writeFileSync(path.join(fixture.dir, 'jvm', 'jvm-only.txt'), 'jvm');
+
+    try {
+      await runScenario(makeScenario({ fixture: 'jvm' }), fixture.dir);
+
+      expect(spawnObservedCwd).toContain('smithy-eval-');
+      expect(sawJvmFixtureFile).toBe(true);
+      expect(sawRootFixtureFile).toBe(false);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('fails clearly when the requested JVM fixture directory is missing', async () => {
+    const fixture = createRealFixture();
+    try {
+      await expect(
+        runScenario(makeScenario({ name: 'forge-tdd-slice-jvm', fixture: 'jvm' }), fixture.dir),
+      ).rejects.toThrow(
+        /forge-tdd-slice-jvm.*fixture "jvm".*not found/,
+      );
+      expect(spawn).not.toHaveBeenCalled();
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   it('non-zero exit code is surfaced', async () => {
     const stdout = ndjsonLines(
       assistantTextEvent('partial'),
@@ -392,7 +438,7 @@ describe('runScenario', () => {
     }
   });
 
-  it('initializes git in the temp fixture copy before invoking claude (Slice 1 / SD-001 / SD-007)', async () => {
+  it('initializes git in the temp fixture copy before invoking claude by default', async () => {
     // Route `execFileSync` so git calls hit the real binary (we need a real
     // `.git/` to inspect) while the smithy `node CLI init` invocation is a
     // no-op. preflight/auth calls aren't on this path.
@@ -463,6 +509,66 @@ describe('runScenario', () => {
     } finally {
       fixture.cleanup();
       mkdtempSpy.mockRestore();
+    }
+  });
+
+  it('initializes git when requires_git is true', async () => {
+    vi.mocked(execFileSync).mockImplementation(
+      ((command: string, args: readonly string[] | undefined, options: unknown) => {
+        if (command === 'git') {
+          return realExecFileSync(command, args as string[] | undefined, options as Parameters<typeof realExecFileSync>[2]);
+        }
+        return Buffer.from('');
+      }) as never,
+    );
+
+    let gitDirPresentAtSpawn = false;
+    const stdout = ndjsonLines(resultEvent('output'));
+    const { child } = createMockChild(stdout, 0);
+    vi.mocked(spawn).mockImplementation(
+      ((_cmd: string, _args: readonly string[], opts: { cwd?: string }) => {
+        const cwd = opts.cwd ?? '';
+        gitDirPresentAtSpawn = fs.existsSync(path.join(cwd, '.git'));
+        return child as never;
+      }) as never,
+    );
+
+    const fixture = createRealFixture();
+    try {
+      await runScenario(makeScenario({ requires_git: true }), fixture.dir);
+
+      expect(gitDirPresentAtSpawn).toBe(true);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('does not initialize git when requires_git is explicitly false', async () => {
+    const stdout = ndjsonLines(resultEvent('output'));
+    const { child } = createMockChild(stdout, 0);
+
+    let spawnObservedCwd = '';
+    let gitDirPresentAtSpawn = false;
+    vi.mocked(spawn).mockImplementation(
+      ((_cmd: string, _args: readonly string[], opts: { cwd?: string }) => {
+        spawnObservedCwd = opts.cwd ?? '';
+        gitDirPresentAtSpawn = fs.existsSync(path.join(spawnObservedCwd, '.git'));
+        return child as never;
+      }) as never,
+    );
+
+    const fixture = createRealFixture();
+    try {
+      await runScenario(makeScenario({ requires_git: false }), fixture.dir);
+
+      expect(spawnObservedCwd).toContain('smithy-eval-');
+      expect(gitDirPresentAtSpawn).toBe(false);
+      const gitCalls = vi.mocked(execFileSync).mock.calls.filter(
+        ([command]) => command === 'git',
+      );
+      expect(gitCalls).toEqual([]);
+    } finally {
+      fixture.cleanup();
     }
   });
 

--- a/evals/lib/runner.test.ts
+++ b/evals/lib/runner.test.ts
@@ -251,6 +251,48 @@ describe('runScenario', () => {
     }
   });
 
+  it('resolves an explicit fixture selector from the canonical root, not the --fixture override', async () => {
+    const stdout = ndjsonLines(resultEvent('jvm output'));
+    const { child } = createMockChild(stdout, 0);
+
+    let sawCanonicalJvmFile = false;
+    let sawOverrideJvmFile = false;
+    vi.mocked(spawn).mockImplementation(
+      ((_cmd: string, _args: readonly string[], opts: { cwd?: string }) => {
+        const cwd = opts.cwd ?? '';
+        sawCanonicalJvmFile = fs.existsSync(path.join(cwd, 'canonical-jvm.txt'));
+        sawOverrideJvmFile = fs.existsSync(path.join(cwd, 'override-jvm.txt'));
+        return child as never;
+      }) as never,
+    );
+
+    // The `--fixture` override points at a different directory than the
+    // canonical fixture root; a `jvm/` exists under both. The explicit selector
+    // must win and resolve under the canonical root (F1.6 contract).
+    const override = createRealFixture();
+    fs.mkdirSync(path.join(override.dir, 'jvm'));
+    fs.writeFileSync(path.join(override.dir, 'jvm', 'override-jvm.txt'), 'override');
+
+    const canonical = createRealFixture();
+    fs.mkdirSync(path.join(canonical.dir, 'jvm'));
+    fs.writeFileSync(path.join(canonical.dir, 'jvm', 'canonical-jvm.txt'), 'canonical');
+
+    try {
+      await runScenario(
+        makeScenario({ fixture: 'jvm' }),
+        override.dir,
+        'claude',
+        canonical.dir,
+      );
+
+      expect(sawCanonicalJvmFile).toBe(true);
+      expect(sawOverrideJvmFile).toBe(false);
+    } finally {
+      override.cleanup();
+      canonical.cleanup();
+    }
+  });
+
   it('fails clearly when the requested JVM fixture directory is missing', async () => {
     const fixture = createRealFixture();
     try {

--- a/evals/lib/runner.ts
+++ b/evals/lib/runner.ts
@@ -357,8 +357,13 @@ export async function runScenario(
   scenario: EvalScenario,
   fixtureDir: string,
   agent: EvalAgent = 'claude',
+  canonicalFixtureRoot: string = fixtureDir,
 ): Promise<RunOutput> {
-  const selectedFixtureDir = resolveScenarioFixtureDir(scenario, fixtureDir);
+  const selectedFixtureDir = resolveScenarioFixtureDir(
+    scenario,
+    fixtureDir,
+    canonicalFixtureRoot,
+  );
   const requiresGit = scenario.requires_git ?? true;
 
   // Create a unique temp directory and copy the fixture into it.
@@ -456,16 +461,19 @@ export async function runScenario(
 function resolveScenarioFixtureDir(
   scenario: EvalScenario,
   fixtureDir: string,
+  canonicalFixtureRoot: string,
 ): string {
   const fixture = scenario.fixture;
 
-  // No selector: use the default fixture root (which honors the --fixture
-  // override). The loader has already validated any selector as a safe
-  // relative path under the fixture root (no absolute roots, no '..'), so
-  // join it directly.
+  // No selector: use the default fixture root, which honors the `--fixture`
+  // override. An explicit selector overrides that default per the F1.6 fixture
+  // contract and always resolves to its committed location under the canonical
+  // fixture root, so a `--fixture` override aimed at other cases never redirects
+  // (or hides) it. The loader has already validated any selector as a safe
+  // relative path under the fixture root (no absolute roots, no '..').
   const selectedDir = fixture === undefined
     ? fixtureDir
-    : path.join(fixtureDir, fixture);
+    : path.join(canonicalFixtureRoot, fixture);
   const stat = fs.statSync(selectedDir, { throwIfNoEntry: false });
   if (!stat) {
     throw new Error(

--- a/evals/lib/runner.ts
+++ b/evals/lib/runner.ts
@@ -358,6 +358,9 @@ export async function runScenario(
   fixtureDir: string,
   agent: EvalAgent = 'claude',
 ): Promise<RunOutput> {
+  const selectedFixtureDir = resolveScenarioFixtureDir(scenario, fixtureDir);
+  const requiresGit = scenario.requires_git ?? true;
+
   // Create a unique temp directory and copy the fixture into it.
   const tmpDir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'smithy-eval-'),
@@ -365,16 +368,18 @@ export async function runScenario(
 
   try {
     // FR-002: Copy fixture to temp directory.
-    fs.cpSync(fixtureDir, tmpDir, { recursive: true });
+    fs.cpSync(selectedFixtureDir, tmpDir, { recursive: true });
 
-    // Initialize the temp copy as a git repository with a baseline commit
-    // BEFORE any skill invocation. Scenarios whose producing command runs
-    // `git checkout -b` (mark / cut / render / ignite) fail at branch creation
-    // unless the working tree is a real git repo with a HEAD commit. Doing
-    // this here decouples the runner from whether `evals/fixture/` is itself
-    // under git (SD-001 / SD-007). A repo-local identity is configured so the
-    // developer's global git config is never touched.
-    initGitInTempCopy(tmpDir);
+    if (requiresGit) {
+      // Initialize the temp copy as a git repository with a baseline commit
+      // BEFORE any skill invocation. Scenarios whose producing command runs
+      // `git checkout -b` (mark / cut / render / ignite) fail at branch creation
+      // unless the working tree is a real git repo with a HEAD commit. Doing
+      // this here decouples the runner from whether the fixture source is
+      // itself under git (SD-001 / SD-007). A repo-local identity is configured
+      // so the developer's global git config is never touched.
+      initGitInTempCopy(tmpDir);
+    }
 
     // Deploy Smithy skills into the temp copy.
     execFileSync('node', [CLI_PATH, 'init', '-a', agent, '-y'], {
@@ -382,15 +387,17 @@ export async function runScenario(
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
-    // Commit a second baseline so the worktree is clean when `claude` spawns.
-    // `smithy init` writes `.claude/`, `.smithy/`, and may update `.gitignore`,
-    // which would otherwise leave the temp repo dirty for the whole scenario.
-    // Producing commands that gate behavior on `git status --porcelain` clean
-    // (e.g. refine paths in mark / cut) need this to detect no-op runs.
-    commitAllInTempCopy(tmpDir, 'eval: post-init baseline');
+    if (requiresGit) {
+      // Commit a second baseline so the worktree is clean when `claude` spawns.
+      // `smithy init` writes `.claude/`, `.smithy/`, and may update `.gitignore`,
+      // which would otherwise leave the temp repo dirty for the whole scenario.
+      // Producing commands that gate behavior on `git status --porcelain` clean
+      // (e.g. refine paths in mark / cut) need this to detect no-op runs.
+      commitAllInTempCopy(tmpDir, 'eval: post-init baseline');
+    }
 
     // FR-011: Checksum the source fixture *before* execution.
-    const checksumBefore = hashDirectory(fixtureDir);
+    const checksumBefore = hashDirectory(selectedFixtureDir);
 
     // Build the invocation string. Claude/Gemini scenarios use slash-command
     // form; Codex uses deployed skills, so name the matching skill directly.
@@ -424,7 +431,7 @@ export async function runScenario(
     }
 
     // FR-011: Re-verify the source fixture after execution.
-    const checksumAfter = hashDirectory(fixtureDir);
+    const checksumAfter = hashDirectory(selectedFixtureDir);
     if (checksumAfter !== checksumBefore) {
       throw new Error(
         'Source fixture directory was modified during eval execution. ' +
@@ -444,6 +451,34 @@ export async function runScenario(
     // FR-013: Always clean up the temp directory.
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
+}
+
+function resolveScenarioFixtureDir(
+  scenario: EvalScenario,
+  fixtureDir: string,
+): string {
+  const fixture = scenario.fixture;
+
+  // No selector: use the default fixture root (which honors the --fixture
+  // override). The loader has already validated any selector as a safe
+  // relative path under the fixture root (no absolute roots, no '..'), so
+  // join it directly.
+  const selectedDir = fixture === undefined
+    ? fixtureDir
+    : path.join(fixtureDir, fixture);
+  const stat = fs.statSync(selectedDir, { throwIfNoEntry: false });
+  if (!stat) {
+    throw new Error(
+      `Scenario "${scenario.name}" requested fixture "${fixture}", but fixture directory was not found: ${selectedDir}`,
+    );
+  }
+  if (!stat.isDirectory()) {
+    throw new Error(
+      `Scenario "${scenario.name}" requested fixture "${fixture}", but fixture path is not a directory: ${selectedDir}`,
+    );
+  }
+
+  return selectedDir;
 }
 
 function buildAgentArgs(agent: EvalAgent, invocation: string, tmpDir: string): string[] {

--- a/evals/run-evals.ts
+++ b/evals/run-evals.ts
@@ -99,6 +99,16 @@ if (dumpFlag !== undefined) {
 const fixtureDir = path.resolve(process.cwd(), values['fixture'] as string);
 const casesDir = path.resolve(process.cwd(), 'evals/cases');
 
+// Canonical committed fixture root, resolved relative to this source file (like
+// `baselinesDir`) so it is independent of both `process.cwd()` and the
+// `--fixture` override. `--fixture` only redirects the default (js) fixture; an
+// explicit scenario-level selector (e.g. `fixture: jvm`) always resolves to its
+// committed sibling under this root per the F1.6 fixture contract.
+const canonicalFixtureRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixture',
+);
+
 // Resolve the baselines directory relative to this source file so baseline
 // lookups work regardless of process cwd (matching the pattern used by
 // `strike-scenario.ts` for YAML loading). Without this, invoking the
@@ -261,7 +271,7 @@ for (const scenario of finalScenarios) {
 
   let output;
   try {
-    output = await runScenario(scenario, fixtureDir, agent);
+    output = await runScenario(scenario, fixtureDir, agent, canonicalFixtureRoot);
   } catch (err) {
     console.error(`Error running scenario: ${err instanceof Error ? err.message : String(err)}`);
     process.exit(1);

--- a/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/01-add-the-forge-jvm-eval-scenario.tasks.md
+++ b/specs/2026-06-06-012-forge-jvm-eval-scenario-m1-baseline-set-completeness-gate/01-add-the-forge-jvm-eval-scenario.tasks.md
@@ -18,7 +18,7 @@
 
 ### Tasks
 
-- [ ] **Extend scenario metadata for fixture selection**
+- [x] **Extend scenario metadata for fixture selection**
 
   Update the eval scenario types and loader in `evals/lib/types.ts` and `evals/lib/scenario-loader.ts` so YAML declarations may carry the Forge-JVM scenario fields from the Forge-JVM Scenario entity. Keep existing scenarios valid when they omit optional fields, while rejecting invalid metadata clearly for AS 1.1.
 
@@ -29,7 +29,7 @@
   - Invalid fixture metadata fails with a named scenario-file validation error.
   - Loader coverage includes the JVM fixture metadata path.
 
-- [ ] **Route runner preparation through scenario metadata**
+- [x] **Route runner preparation through scenario metadata**
 
   Update `evals/lib/runner.ts` so scenario preparation consumes fixture and git metadata when building the temp execution context. Preserve the F1.5 git initialization behavior for forge scenarios and make unavailable JVM fixture selection fail clearly for AS 1.2.
 


### PR DESCRIPTION
## Summary
RFC 2026-001-token-savings → M1 Measurement Foundation → F1.7 Forge-JVM Eval Scenario + M1 Baseline-Set Completeness Gate → Forge-JVM Eval Scenario spec → Slice 1: Load Forge Scenarios With Fixture Metadata

Adds `fixture` (`js`|`jvm`) and `requires_git` fields to the eval scenario model, validates them in the YAML loader, and routes runner preparation through that metadata — selecting the fixture directory and gating git initialization. This is the right first increment because it makes the Forge-JVM contracts observable through loader/runner coverage before the end-to-end JVM forge case (Slice 2) is authored, and it leaves existing fixture-less scenarios on their current default behavior (js fixture, git on).

## Spec debt & uncertainty
- SD-001 (inherited): The baseline-set audit format is specified functionally but not tied to a specific implementation surface — not exercised by this slice (US3 owns the gate).
- SD-002 (inherited): Feature map allows the JVM scenario as a separate YAML file or a parameterized run of the forge scenario; the spec chose a separate `forge-tdd-slice-jvm` scenario — this slice only adds the metadata plumbing, not the scenario itself.
- Assumption: the JVM fixture lives at a `jvm/` subdirectory of the fixture root; the runner resolves `fixture: jvm` to `<fixtureDir>/jvm` and fails clearly when that directory is absent. Slice 2/3 will commit the actual fixture.
- Verification: typecheck and the full evals unit suite ran green under Node 22 (the repo requires Node ≥20; the default Node 18 here could not run them, so deps were reinstalled under Node 22 to validate).

## Validation
typecheck ✅ · test:evals ✅ (205 passed; touched files: runner + scenario-loader, 42 passed)
