### PR TITLE
forge: resolve and inject local fixtures into eval invocations

### DIFF
--- a/evals/lib/fixture-paths.ts
+++ b/evals/lib/fixture-paths.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared repository-relative path validation for eval local fixtures.
+ *
+ * Two call sites must apply the same containment rules to `local_fixtures`
+ * paths: the YAML scenario loader validates declarations against the source
+ * checkout, and the runner resolves those declarations inside the temp fixture
+ * copy. Keeping the logic here prevents the two from drifting — an earlier copy
+ * in the runner rejected Windows drive-letter paths that the loader's local
+ * copy accepted.
+ */
+import path from 'node:path';
+
+export type LocalFixtureField = 'issue' | 'ci_log';
+
+/** Repository-relative directory each local fixture kind must stay within. */
+export const LOCAL_FIXTURE_AREAS: Record<LocalFixtureField, string> = {
+  issue: 'evals/fixture/issues',
+  ci_log: 'evals/fixture/ci-logs',
+};
+
+/**
+ * Normalize a declared fixture path to a clean repository-relative POSIX path,
+ * or return `null` when it is absolute, drive-relative, or escapes via `..`.
+ */
+export function normalizeRepositoryPath(rawPath: string): string | null {
+  if (path.isAbsolute(rawPath) || path.win32.isAbsolute(rawPath)) return null;
+  // Reject Windows drive-letter prefixes (e.g. `C:tmp`). These are
+  // drive-relative rather than absolute, so `win32.isAbsolute` returns false,
+  // yet they escape the fixture root on Windows.
+  if (/^[a-zA-Z]:/.test(rawPath)) return null;
+
+  const parts = rawPath.split(/[\\/]+/);
+  if (parts.some((part) => part === '' || part === '..')) return null;
+
+  const normalized = path.posix.normalize(parts.join('/'));
+  if (normalized === '.' || normalized.startsWith('../')) return null;
+  return normalized;
+}
+
+/** True when `repoPath` is strictly under `allowedArea` (both repo-relative). */
+export function isPathUnderAllowedArea(repoPath: string, allowedArea: string): boolean {
+  return repoPath.startsWith(`${allowedArea}/`) && repoPath.length > allowedArea.length + 1;
+}
+
+/** True when `childAbs` is a strict descendant of `parentAbs` (both absolute). */
+export function isContainedIn(childAbs: string, parentAbs: string): boolean {
+  const rel = path.relative(parentAbs, childAbs);
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}

--- a/evals/lib/runner.test.ts
+++ b/evals/lib/runner.test.ts
@@ -151,6 +151,21 @@ function createRealFixture(): { dir: string; cleanup: () => void } {
   };
 }
 
+function createFixtureWithLocalEvidence(): { dir: string; cleanup: () => void } {
+  const fixture = createRealFixture();
+  fs.mkdirSync(path.join(fixture.dir, 'issues'), { recursive: true });
+  fs.mkdirSync(path.join(fixture.dir, 'ci-logs'), { recursive: true });
+  fs.writeFileSync(
+    path.join(fixture.dir, 'issues', 'offline-issue.md'),
+    '# Offline issue\n',
+  );
+  fs.writeFileSync(
+    path.join(fixture.dir, 'ci-logs', 'offline-run.log'),
+    'FAIL offline run\n',
+  );
+  return fixture;
+}
+
 // ---------------------------------------------------------------------------
 // Test setup
 // ---------------------------------------------------------------------------
@@ -291,6 +306,110 @@ describe('runScenario', () => {
           cwd: expect.stringContaining('smithy-eval-'),
         }),
       );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it.each([
+    {
+      agent: 'claude' as const,
+      command: 'claude',
+      invocationIndex: 6,
+      expectedPrefix: '/smithy.fix ',
+    },
+    {
+      agent: 'gemini' as const,
+      command: 'gemini',
+      invocationIndex: 6,
+      expectedPrefix: '/smithy.fix ',
+    },
+    {
+      agent: 'codex' as const,
+      command: 'codex',
+      invocationIndex: 6,
+      expectedPrefix: 'Use the smithy-fix skill.\n\nInput:\n',
+    },
+  ])(
+    'injects resolved local fixture paths into $agent invocations',
+    async ({ agent, command, invocationIndex, expectedPrefix }) => {
+      const stdout = ndjsonLines(resultEvent('output'));
+      const { child } = createMockChild(stdout, 0);
+      vi.mocked(spawn).mockReturnValue(child as never);
+
+      const fixture = createFixtureWithLocalEvidence();
+      try {
+        await runScenario(
+          makeScenario({
+            skill: '/smithy.fix',
+            prompt: 'Diagnose {{issue_path}} with {{ci_log_path}}.',
+            local_fixtures: {
+              issue: 'evals/fixture/issues/offline-issue.md',
+              ci_log: 'evals/fixture/ci-logs/offline-run.log',
+            },
+          }),
+          fixture.dir,
+          agent,
+        );
+
+        const call = vi.mocked(spawn).mock.calls[0]!;
+        const args = call[1] as string[];
+        const invocation = args[invocationIndex]!;
+
+        expect(call[0]).toBe(command);
+        expect(invocation.startsWith(expectedPrefix)).toBe(true);
+        expect(invocation).toContain('Use the repository-local fixture evidence below.');
+        expect(invocation).toContain('Do not fetch live GitHub issue, pull request, or Actions data');
+        expect(invocation).toContain('Issue fixture: issues/offline-issue.md');
+        expect(invocation).toContain('CI log fixture: ci-logs/offline-run.log');
+        expect(invocation).toContain(
+          'Diagnose issues/offline-issue.md with ci-logs/offline-run.log.',
+        );
+        expect(invocation).not.toContain('{{issue_path}}');
+        expect(invocation).not.toContain('{{ci_log_path}}');
+        expect(invocation).not.toContain(fixture.dir);
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it('keeps no-fixture scenarios on the existing invocation path', async () => {
+    const stdout = ndjsonLines(resultEvent('output'));
+    const { child } = createMockChild(stdout, 0);
+    vi.mocked(spawn).mockReturnValue(child as never);
+
+    const fixture = createRealFixture();
+    try {
+      await runScenario(makeScenario(), fixture.dir);
+
+      const call = vi.mocked(spawn).mock.calls[0]!;
+      const args = call[1] as string[];
+      expect(args[6]).toBe('/smithy.strike do something');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('fails before spawning when a declared local fixture is missing from the temp copy', async () => {
+    const fixture = createRealFixture();
+    try {
+      await expect(
+        runScenario(
+          makeScenario({
+            skill: '/smithy.fix',
+            local_fixtures: {
+              issue: 'evals/fixture/issues/missing.md',
+              ci_log: 'evals/fixture/ci-logs/missing.log',
+            },
+          }),
+          fixture.dir,
+        ),
+      ).rejects.toThrow(
+        'local_fixtures.issue is not readable in temp fixture copy: evals/fixture/issues/missing.md',
+      );
+
+      expect(spawn).not.toHaveBeenCalled();
     } finally {
       fixture.cleanup();
     }

--- a/evals/lib/runner.ts
+++ b/evals/lib/runner.ts
@@ -45,6 +45,18 @@ const CHECKSUM_EXCLUDE_DIRS = new Set([
   'dist',
 ]);
 
+const LOCAL_FIXTURE_AREAS = {
+  issue: 'evals/fixture/issues',
+  ci_log: 'evals/fixture/ci-logs',
+} as const;
+
+interface LocalFixtureBindings {
+  issue_path: string;
+  ci_log_path: string;
+}
+
+type LocalFixtureField = 'issue' | 'ci_log';
+
 // ---------------------------------------------------------------------------
 // Fixture checksum
 // ---------------------------------------------------------------------------
@@ -392,9 +404,11 @@ export async function runScenario(
     // FR-011: Checksum the source fixture *before* execution.
     const checksumBefore = hashDirectory(fixtureDir);
 
+    const fixtureBindings = resolveLocalFixtureBindings(scenario, tmpDir);
+
     // Build the invocation string. Claude/Gemini scenarios use slash-command
     // form; Codex uses deployed skills, so name the matching skill directly.
-    const invocation = buildInvocation(scenario, agent);
+    const invocation = buildInvocation(scenario, agent, fixtureBindings);
 
     // Determine timeout: scenario-level override (in seconds) → default.
     const timeoutMs = scenario.timeout != null
@@ -466,10 +480,97 @@ function buildAgentArgs(agent: EvalAgent, invocation: string, tmpDir: string): s
   ];
 }
 
-function buildInvocation(scenario: EvalScenario, agent: EvalAgent): string {
-  const prompt = scenario.prompt.trim();
+function resolveLocalFixtureBindings(
+  scenario: EvalScenario,
+  tmpDir: string,
+): LocalFixtureBindings | undefined {
+  if (!scenario.local_fixtures) return undefined;
+
+  return {
+    issue_path: resolveLocalFixturePath(
+      scenario.local_fixtures.issue,
+      LOCAL_FIXTURE_AREAS.issue,
+      tmpDir,
+      'issue',
+    ),
+    ci_log_path: resolveLocalFixturePath(
+      scenario.local_fixtures.ci_log,
+      LOCAL_FIXTURE_AREAS.ci_log,
+      tmpDir,
+      'ci_log',
+    ),
+  };
+}
+
+function resolveLocalFixturePath(
+  declaredPath: string,
+  allowedArea: string,
+  tmpDir: string,
+  field: LocalFixtureField,
+): string {
+  const normalized = normalizeRepositoryPath(declaredPath);
+  if (!normalized || !isPathUnderAllowedArea(normalized, allowedArea)) {
+    throw new Error(
+      `local_fixtures.${field} must stay under ${allowedArea}/: ${declaredPath}`,
+    );
+  }
+
+  const tempRelativePath = fixtureTempRelativePath(normalized);
+  const tmpFixturePath = path.resolve(tmpDir, tempRelativePath);
+  const tmpAreaPath = path.resolve(tmpDir, fixtureTempRelativePath(allowedArea));
+
+  let stats: fs.Stats;
+  try {
+    stats = fs.statSync(tmpFixturePath);
+    fs.accessSync(tmpFixturePath, fs.constants.R_OK);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `local_fixtures.${field} is not readable in temp fixture copy: ${normalized} (${msg})`,
+    );
+  }
+
+  if (!stats.isFile()) {
+    throw new Error(
+      `local_fixtures.${field} must resolve to a readable file in temp fixture copy: ${normalized}`,
+    );
+  }
+
+  let realFixturePath: string;
+  let realAreaPath: string;
+  try {
+    realFixturePath = fs.realpathSync(tmpFixturePath);
+    realAreaPath = fs.realpathSync(tmpAreaPath);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `local_fixtures.${field} could not be resolved in temp fixture copy: ${normalized} (${msg})`,
+    );
+  }
+
+  if (!isContainedIn(realFixturePath, realAreaPath)) {
+    throw new Error(
+      `local_fixtures.${field} resolves outside ${allowedArea}/ in temp fixture copy: ${normalized}`,
+    );
+  }
+
+  return tempRelativePath;
+}
+
+function buildInvocation(
+  scenario: EvalScenario,
+  agent: EvalAgent,
+  fixtureBindings?: LocalFixtureBindings,
+): string {
+  if (scenario.local_fixtures && !fixtureBindings) {
+    throw new Error(
+      `Scenario '${scenario.name}' declares local_fixtures but no fixture bindings were provided`,
+    );
+  }
+
+  const prompt = renderPromptWithLocalFixtures(scenario.prompt, fixtureBindings);
   if (agent !== 'codex') {
-    return `${scenario.skill} ${scenario.prompt}`;
+    return `${scenario.skill} ${prompt}`;
   }
 
   const skillName = codexSkillName(scenario.skill);
@@ -478,7 +579,51 @@ function buildInvocation(scenario: EvalScenario, agent: EvalAgent): string {
   return `Use the ${skillName} skill.\n\nInput:\n${prompt}`;
 }
 
+function renderPromptWithLocalFixtures(
+  prompt: string,
+  fixtureBindings: LocalFixtureBindings | undefined,
+): string {
+  const trimmedPrompt = prompt.trim();
+  if (!fixtureBindings) return trimmedPrompt;
+  const renderedPrompt = trimmedPrompt
+    .replaceAll('{{issue_path}}', fixtureBindings.issue_path)
+    .replaceAll('{{ci_log_path}}', fixtureBindings.ci_log_path);
+
+  return [
+    'Use the repository-local fixture evidence below. Do not fetch live GitHub issue, pull request, or Actions data for this evidence.',
+    `Issue fixture: ${fixtureBindings.issue_path}`,
+    `CI log fixture: ${fixtureBindings.ci_log_path}`,
+    '',
+    renderedPrompt,
+  ].join('\n');
+}
+
 function codexSkillName(skill: string): string {
   const normalized = skill.trim().replace(/^\//, '').replace(/\./g, '-');
   return normalized;
+}
+
+function normalizeRepositoryPath(rawPath: string): string | null {
+  if (path.isAbsolute(rawPath) || path.win32.isAbsolute(rawPath)) return null;
+  if (/^[a-zA-Z]:/.test(rawPath)) return null;
+
+  const parts = rawPath.split(/[\\/]+/);
+  if (parts.some((part) => part === '' || part === '..')) return null;
+
+  const normalized = path.posix.normalize(parts.join('/'));
+  if (normalized === '.' || normalized.startsWith('../')) return null;
+  return normalized;
+}
+
+function isPathUnderAllowedArea(repoPath: string, allowedArea: string): boolean {
+  return repoPath.startsWith(`${allowedArea}/`) && repoPath.length > allowedArea.length + 1;
+}
+
+function fixtureTempRelativePath(repoFixturePath: string): string {
+  return repoFixturePath.replace(/^evals\/fixture\//, '');
+}
+
+function isContainedIn(childAbs: string, parentAbs: string): boolean {
+  const rel = path.relative(parentAbs, childAbs);
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
 }

--- a/evals/lib/runner.ts
+++ b/evals/lib/runner.ts
@@ -18,6 +18,13 @@ import {
   extractCanonicalText,
   extractTokenTotals,
 } from './parse-stream.js';
+import {
+  LOCAL_FIXTURE_AREAS,
+  type LocalFixtureField,
+  normalizeRepositoryPath,
+  isPathUnderAllowedArea,
+  isContainedIn,
+} from './fixture-paths.js';
 
 /** Path to the built Smithy CLI, resolved relative to this module. */
 const CLI_PATH = path.resolve(
@@ -45,17 +52,10 @@ const CHECKSUM_EXCLUDE_DIRS = new Set([
   'dist',
 ]);
 
-const LOCAL_FIXTURE_AREAS = {
-  issue: 'evals/fixture/issues',
-  ci_log: 'evals/fixture/ci-logs',
-} as const;
-
 interface LocalFixtureBindings {
   issue_path: string;
   ci_log_path: string;
 }
-
-type LocalFixtureField = 'issue' | 'ci_log';
 
 // ---------------------------------------------------------------------------
 // Fixture checksum
@@ -523,10 +523,13 @@ function resolveLocalFixturePath(
   try {
     stats = fs.statSync(tmpFixturePath);
     fs.accessSync(tmpFixturePath, fs.constants.R_OK);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+  } catch {
+    // Deliberately omit the raw fs error text: it embeds absolute temp-dir
+    // paths (under os.tmpdir()), which leak the environment and make the
+    // offline eval's diagnostics non-deterministic. The normalized
+    // repository-relative path already identifies the offending fixture.
     throw new Error(
-      `local_fixtures.${field} is not readable in temp fixture copy: ${normalized} (${msg})`,
+      `local_fixtures.${field} is not readable in temp fixture copy: ${normalized}`,
     );
   }
 
@@ -541,10 +544,11 @@ function resolveLocalFixturePath(
   try {
     realFixturePath = fs.realpathSync(tmpFixturePath);
     realAreaPath = fs.realpathSync(tmpAreaPath);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+  } catch {
+    // As above, omit the raw fs error text to avoid leaking absolute temp-dir
+    // paths into the thrown message.
     throw new Error(
-      `local_fixtures.${field} could not be resolved in temp fixture copy: ${normalized} (${msg})`,
+      `local_fixtures.${field} could not be resolved in temp fixture copy: ${normalized}`,
     );
   }
 
@@ -603,27 +607,6 @@ function codexSkillName(skill: string): string {
   return normalized;
 }
 
-function normalizeRepositoryPath(rawPath: string): string | null {
-  if (path.isAbsolute(rawPath) || path.win32.isAbsolute(rawPath)) return null;
-  if (/^[a-zA-Z]:/.test(rawPath)) return null;
-
-  const parts = rawPath.split(/[\\/]+/);
-  if (parts.some((part) => part === '' || part === '..')) return null;
-
-  const normalized = path.posix.normalize(parts.join('/'));
-  if (normalized === '.' || normalized.startsWith('../')) return null;
-  return normalized;
-}
-
-function isPathUnderAllowedArea(repoPath: string, allowedArea: string): boolean {
-  return repoPath.startsWith(`${allowedArea}/`) && repoPath.length > allowedArea.length + 1;
-}
-
 function fixtureTempRelativePath(repoFixturePath: string): string {
   return repoFixturePath.replace(/^evals\/fixture\//, '');
-}
-
-function isContainedIn(childAbs: string, parentAbs: string): boolean {
-  const rel = path.relative(parentAbs, childAbs);
-  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
 }

--- a/evals/lib/scenario-loader.ts
+++ b/evals/lib/scenario-loader.ts
@@ -30,12 +30,14 @@ import type {
   StructuralExpectations,
   SubAgentEvidence,
 } from './types.js';
+import {
+  LOCAL_FIXTURE_AREAS,
+  normalizeRepositoryPath,
+  isPathUnderAllowedArea,
+  isContainedIn,
+} from './fixture-paths.js';
 
 const localFixtureFields = ['issue', 'ci_log'] as const;
-const localFixtureAreas: Record<(typeof localFixtureFields)[number], string> = {
-  issue: 'evals/fixture/issues',
-  ci_log: 'evals/fixture/ci-logs',
-};
 
 // Repository root derived from this module's own location, not `process.cwd()`.
 // The eval helpers resolve scenario files via `import.meta.url` so they stay
@@ -413,7 +415,7 @@ function validateLocalFixtures(
       return null;
     }
 
-    const normalized = normalizeFixturePath(rawPath);
+    const normalized = normalizeRepositoryPath(rawPath);
     if (normalized === null) {
       skip(
         `'local_fixtures.${field}' must be a repository-relative path without parent-directory segments`,
@@ -421,8 +423,8 @@ function validateLocalFixtures(
       return null;
     }
 
-    const allowedArea = localFixtureAreas[field];
-    if (!isPathUnderArea(normalized, allowedArea)) {
+    const allowedArea = LOCAL_FIXTURE_AREAS[field];
+    if (!isPathUnderAllowedArea(normalized, allowedArea)) {
       skip(`'local_fixtures.${field}' must be under '${allowedArea}/'`);
       return null;
     }
@@ -469,27 +471,6 @@ function validateLocalFixtures(
   }
 
   return fixtures as LocalFixtureSet;
-}
-
-function normalizeFixturePath(rawPath: string): string | null {
-  if (path.isAbsolute(rawPath)) return null;
-
-  const parts = rawPath.split(/[\\/]+/);
-  if (parts.some((part) => part === '' || part === '..')) return null;
-
-  const normalized = path.posix.normalize(parts.join('/'));
-  if (normalized === '.' || normalized.startsWith('../')) return null;
-  return normalized;
-}
-
-function isPathUnderArea(repoPath: string, allowedArea: string): boolean {
-  return repoPath.startsWith(`${allowedArea}/`) && repoPath.length > allowedArea.length + 1;
-}
-
-/** True when `childAbs` is a strict descendant of `parentAbs` (both absolute). */
-function isContainedIn(childAbs: string, parentAbs: string): boolean {
-  const rel = path.relative(parentAbs, childAbs);
-  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
 }
 
 function isValidFixtureSelector(value: unknown): value is string {

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/02-run-smithy-fix-against-local-failure-evidence.tasks.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/02-run-smithy-fix-against-local-failure-evidence.tasks.md
@@ -54,7 +54,7 @@
 
 ### Tasks
 
-- [ ] **Resolve fixtures in the temp copy**
+- [x] **Resolve fixtures in the temp copy**
 
   Update `evals/lib/runner.ts` so `runScenario` resolves declared local fixtures after copying `evals/fixture/` into the temp execution directory and before spawning the agent. Preserve the source fixture checksum invariant and fail before invocation when a declared file is unavailable in the execution context.
 
@@ -65,7 +65,7 @@
   - Scenarios without local fixtures retain current runner behavior.
   - Fixture resolution never exposes paths outside the allowed fixture area.
 
-- [ ] **Inject fixture paths into invocations**
+- [x] **Inject fixture paths into invocations**
 
   Extend the runner invocation path so local fixture bindings are rendered into the scenario prompt in a deterministic form for Claude, Gemini, and Codex. Keep the existing agent-specific command wrapping intact while satisfying the Local Fixture Prompt Injection contract.
 


### PR DESCRIPTION
## Summary
RFC 2026-001-token-savings → M1 deterministic smithy.fix end-to-end eval coverage → F1.4 smithy.fix End-to-End Eval Scenario → smithy.fix End-to-End Eval Scenario (US2) → Slice 2: Deterministic Fixture Prompt Injection

`runScenario` now resolves a scenario's declared `local_fixtures` inside the temp fixture copy and renders stable issue/CI-log references into the invocation for Claude, Gemini, and Codex. This is the increment that turns validated fixture metadata (Slice 1) into the actual offline evidence smithy.fix will receive, without yet committing the `fix-from-issue` case (Slice 3).

## Spec debt & uncertainty
- SD-001 (inherited): The exact helper-agent evidence set for the offline smithy.fix path is unknown until the fixture runs against current smithy.fix behavior; owned by US3, not this slice.
- SD-002 (inherited): The initial token envelope for the smithy.fix baseline cannot be calibrated until F1.3a's token-aware baseline schema exists and a clean run is captured; owned by US4, not this slice.
- Assumption: Local fixtures live at fixed areas (`evals/fixture/issues/`, `evals/fixture/ci-logs/`); the resolver hard-codes these allowed areas and rejects any declared path outside them.
- Verification gap: Ran the runner unit suite (public runner-facing path) and typecheck only; did not run the full build or the broader eval suite. The worktree also required a Node 22 dependency reinstall (installed Node was 18, too old for the vendored vitest/rolldown) — an environment quirk, not a code concern.

## Validation
typecheck ✅ · test ✅ (runner suite, 21 passed)
