### PR TITLE
forge: define the design-mode and bundle contract for UI templates

### DIFF
--- a/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/04-a-non-blocking-visual-design-gate-with-import-brief-none-modes.tasks.md
+++ b/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/04-a-non-blocking-visual-design-gate-with-import-brief-none-modes.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Document per-screen design modes**
+- [x] **Document per-screen design modes**
 
   Update `src/templates/agent-skills/snippets/feature-kinds.md`, `src/templates/agent-skills/commands/smithy.mark.prompt`, and directly related source-template documentation so `Design` mode is described as a screen-node field with exactly `none`, `import`, and `brief`. Keep backend feature behavior and backend spec output unchanged.
 
@@ -28,7 +28,7 @@
   - `brief` is described as mark-authored intent for a visual tool
   - Backend feature and backend spec-triad behavior remains unchanged
 
-- [ ] **Generalize bundle boundary language**
+- [x] **Generalize bundle boundary language**
 
   Update the screen helper, feature-kind snippet, and command templates that describe `bundle` so it is a tool-neutral prototype reference rather than a Claude Design-only export. Preserve the existing conflict rule: the bundle wins layout and visual intent, while the committed design skill wins implementation dialect.
 
@@ -39,7 +39,7 @@
   - A screen with a bundle still requires `design_system`
   - The conflict rule is stated consistently where bundle handling is described
 
-- [ ] **Keep import structure derivation scoped to render**
+- [x] **Keep import structure derivation scoped to render**
 
   Align the shared design-gate text with `smithy.render` ownership so `import` mode may carry a bundle from render for downstream honoring, while detailed prototype-to-screen/flow derivation remains owned by User Story 5. This story should make the boundary clear without implementing render's full import ingestion.
 

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -389,9 +389,9 @@ artifacts that downstream commands consume.
 |-----|------|----------|-------|
 | `kind` | both | Yes (new) | `backend` or `ui`. Selects the `smithy.mark` authoring path. A missing `kind` on legacy feature maps defaults to `backend`. |
 | `phase` | ui | Yes | `build` or `wire` — a **feature-level** attribute. |
-| `design_system` | ui | Yes | Reference to the committed design skill (for example `story-spider-design`); source of truth even when a bundle is present. |
+| `design_system` | ui | Yes | Reference to the committed design skill (for example `story-spider-design`); source of truth even when a bundle is present. A screen with a `bundle` still requires `design_system`. |
 | `design` | ui | Yes | Screen-node design mode: `none`, `import`, or `brief`, shared by every `ScreenId` the feature lists. Render sets this explicitly; mark copies it into the `Design` cell of each `SC<N>` row. Screens needing distinct modes go in separate features. |
-| `bundle` | ui | No | Repo-relative path to a visual prototype bundle/export — a visual/structural reference, not a drop-in. Bundle wins on layout & visual intent; the design skill wins on implementation dialect. |
+| `bundle` | ui | No | Repo-relative path to a visual prototype boundary object, such as a Figma export, Claude Design export, or equivalent visual-tool bundle — a visual/structural reference, not a drop-in. Bundle wins on layout & visual intent; the design skill wins on implementation dialect. |
 | `flag` | ui | Yes (flag-gated) | Feature-flag name; the shared contract joining a `build` feature to its `wire` feature. |
 | `screens` | ui | Yes | List of `ScreenId`, e.g. `[AddTitle]`. |
 | `flows` | ui | No (build) / Yes (wire) | List of `FlowId` the screen participates in. |
@@ -401,11 +401,15 @@ spec (prose delta).
 
 ### Design mode semantics
 
-| `design` | Means |
-|----------|-------|
-| `none` | No visual loop; build from the committed design skill. |
-| `import` | Prototype-first; a bundle is supplied at render and rides forward. |
-| `brief` | Mark-authored durable intent can be handed to a visual tool. |
+`design` is a feature-level key that render sets explicitly and mark copies into
+the `Design` cell of each `SC<N>` row of the UI spec ledger. It is not used by
+the backend spec-triad path. The only valid values are:
+
+| `design` | Means | Bundle behavior |
+|----------|-------|-----------------|
+| `none` | No visual loop; simple pass-through screen work builds from the committed design skill. | No bundle required. |
+| `import` | Prototype-first; a prototype already exists before `mark`. | A bundle may enter at `render`, ride to `forge` as visual source context, and be honored under the conflict rule. Detailed prototype-to-screen/flow derivation belongs to the render import-ingestion story. |
+| `brief` | Mark-authored intent for a visual tool; the `.design.md`/`.flow.md` artifacts are the brief. | A bundle may be attached later; if present, downstream build honors it under the conflict rule. |
 
 ### Phase semantics
 
@@ -508,8 +512,8 @@ choices, deferred bits) colocated with the code so it travels and versions with
 the component.
 
 The full authoring contract — YAML front-matter schema (`id`, `component-path`,
-`design_system`, `bundle`), the rationale-only body rule, the skeleton template,
-a worked `Library.design.md` example, naming decisions, and a review checklist
+`design_system`, optional `bundle`), the rationale-only body rule, the skeleton
+template, a worked `Library.design.md` example, naming decisions, and a review checklist
 — lives in the body-on-demand skill **`smithy.helper-screen-design`**
 (`skills/smithy.helper-screen-design/SKILL.prompt`). Agents lazy-load it via
 `Skill("smithy.helper-screen-design")` when authoring or auditing a screen

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -404,6 +404,13 @@ UI ledger rules:
   is the only place intra-feature ordering and parallelism are expressed.
 - `Design` is required for `screen` rows and is one of `none`, `import`, or
   `brief`; use `—` for `flow` and `story` rows.
+  - `none` means no visual loop; no bundle or prototype recommendation is
+    required for a simple pass-through screen.
+  - `import` means prototype-first; a visual prototype boundary object may
+    have entered at `render` and rides forward as downstream visual source
+    context. Do not derive detailed prototype structure here.
+  - `brief` means mark-authored intent for a visual tool; the durable
+    `.design.md` and `.flow.md` artifacts are self-sufficient briefs.
 - `Artifact` is `—` for every row in mark's output. It holds the
   `cut`-produced `.tasks.md` path only after `smithy.cut` runs; mark never
   pre-fills a tasks path in this column.
@@ -447,6 +454,11 @@ it cannot be satisfied (per contracts C1):
   with a message naming the node.
 - The UI feature must name a non-empty `design_system`. If it is missing, abort
   before writing the spec or any durable UI artifact.
+- If a `bundle` is present, treat it as an optional visual prototype boundary
+  object from a visual tool such as Figma, Claude Design, or an equivalent
+  export. The bundle wins layout and visual intent, while the committed
+  design skill wins implementation dialect; a screen with a bundle still
+  requires `design_system`.
 
 Then write, matching the ledger pointers:
 - One `design/screens/<ScreenId>.design.md` per `SC<N>` row, per

--- a/src/templates/agent-skills/commands/smithy.render.prompt
+++ b/src/templates/agent-skills/commands/smithy.render.prompt
@@ -327,7 +327,7 @@ kind: ui
 phase: build
 design_system: <committed design skill, e.g. story-spider-design>
 design: <none|import|brief>
-bundle: <optional visual prototype bundle path, or omit the key>
+bundle: <optional visual prototype boundary object path, or omit the key>
 flag: <feature-flag name gating this screen>
 screens: [<ScreenId>]
 flows: [<FlowId>]

--- a/src/templates/agent-skills/commands/smithy.render.prompt
+++ b/src/templates/agent-skills/commands/smithy.render.prompt
@@ -327,7 +327,7 @@ kind: ui
 phase: build
 design_system: <committed design skill, e.g. story-spider-design>
 design: <none|import|brief>
-bundle: <optional visual prototype boundary object path, or omit the key>
+bundle: <optional repo-relative path to a visual prototype boundary object, or omit the key>
 flag: <feature-flag name gating this screen>
 screens: [<ScreenId>]
 flows: [<FlowId>]

--- a/src/templates/agent-skills/skills/smithy.helper-screen-design/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.helper-screen-design/SKILL.prompt
@@ -53,8 +53,8 @@ fences. Four keys, three required:
 |-----|----------|-------|
 | `id` | Yes | Flat, stable `ScreenId`. Matches the `screens:` list of the originating UI feature in `.features.md`; never reused across screens. |
 | `component-path` | Yes | Repo-relative path to the owning UI component file in the project's framework (for example a Compose file such as `app/src/main/kotlin/io/balexda/readercompose/ui/views/library/LibraryScreen.kt`, or a React component such as `src/screens/LibraryScreen.tsx`). Paths survive package/module renames; the path is the contract, not a framework-specific symbol name. |
-| `design_system` | Yes | Reference to the committed design skill (e.g. `story-spider-design`). Source of truth even when a `bundle` is present — bundle wins on layout & visual intent, skill wins on implementation dialect. |
-| `bundle` | No | Repo-relative path to the originating Claude Design export (e.g. `design/bundles/library.zip`). A visual/structural reference, not a drop-in. Omit the key entirely when no bundle exists — do not set it to `null` or an empty string. |
+| `design_system` | Yes | Reference to the committed design skill (e.g. `story-spider-design`). Source of truth even when a `bundle` is present — bundle wins on layout & visual intent, skill wins on implementation dialect. A screen with a `bundle` is invalid without `design_system`. |
+| `bundle` | No | Repo-relative path to the originating visual prototype boundary object (for example a Figma export, Claude Design export, or equivalent visual-tool bundle). A visual/structural reference, not a drop-in. Omit the key entirely when no bundle exists — do not set it to `null` or an empty string. |
 
 No other keys. In particular, **no `flows:` field here** — flow membership is
 declared on the originating feature in `.features.md`; duplicating it on the
@@ -88,7 +88,7 @@ strings, no state-machine diagrams.
 id: <ScreenId>
 component-path: <repo-relative path to the owning UI component file>
 design_system: <committed design skill, e.g. story-spider-design>
-bundle: <repo-relative path to the Claude Design export, or omit the key>
+bundle: <repo-relative path to the visual prototype boundary object, or omit the key>
 ---
 
 # <ScreenId> — design context

--- a/src/templates/agent-skills/snippets/feature-kinds.md
+++ b/src/templates/agent-skills/snippets/feature-kinds.md
@@ -20,7 +20,7 @@ durable design truth.
 | `phase` | ui | Yes | `build` or `wire` (feature-level). |
 | `design_system` | ui | Yes | Committed design-skill ref (for example `story-spider-design`); source of truth even when a bundle is present. A screen with a `bundle` still requires `design_system`. |
 | `design` | ui | Yes | Screen-node design mode: `none`, `import`, or `brief`, shared by every `ScreenId` the feature lists. Render must set this explicitly; downstream `mark` copies it into the `Design` cell of each of the feature's `SC<N>` ledger rows instead of inferring from the title. Screens needing distinct modes go in separate features. |
-| `bundle` | ui | No | Path to a visual prototype boundary object (for example a Figma export, Claude Design export, or equivalent visual-tool bundle) — a visual/structural reference, not a drop-in. Bundle wins on layout/visual intent; the skill wins on implementation dialect. |
+| `bundle` | ui | No | Repo-relative path to a visual prototype boundary object (for example a Figma export, Claude Design export, or equivalent visual-tool bundle) — a visual/structural reference, not a drop-in. Bundle wins on layout/visual intent; the skill wins on implementation dialect. |
 | `flag` | ui | Yes (flag-gated) | Feature-flag name; the shared contract joining a `build` feature to its `wire` feature. |
 | `screens` | ui | Yes | List of `ScreenId`, e.g. `[AddTitle]`. |
 | `flows` | ui | No (build) / Yes (wire) | List of `FlowId` the screen participates in. Build features may list mock-satisfiable candidate flows; wire features must list the flows they connect to real data. |

--- a/src/templates/agent-skills/snippets/feature-kinds.md
+++ b/src/templates/agent-skills/snippets/feature-kinds.md
@@ -18,9 +18,9 @@ durable design truth.
 |-----|------|----------|-------|
 | `kind` | both | Yes (new) | `backend` or `ui`. Missing on legacy maps → `backend`. |
 | `phase` | ui | Yes | `build` or `wire` (feature-level). |
-| `design_system` | ui | Yes | Committed design-skill ref (for example `story-spider-design`); source of truth even when a bundle is present. |
+| `design_system` | ui | Yes | Committed design-skill ref (for example `story-spider-design`); source of truth even when a bundle is present. A screen with a `bundle` still requires `design_system`. |
 | `design` | ui | Yes | Screen-node design mode: `none`, `import`, or `brief`, shared by every `ScreenId` the feature lists. Render must set this explicitly; downstream `mark` copies it into the `Design` cell of each of the feature's `SC<N>` ledger rows instead of inferring from the title. Screens needing distinct modes go in separate features. |
-| `bundle` | ui | No | Path to a visual prototype bundle/export — a visual/structural reference, not a drop-in. Bundle wins on layout/visual intent; the skill wins on implementation dialect. |
+| `bundle` | ui | No | Path to a visual prototype boundary object (for example a Figma export, Claude Design export, or equivalent visual-tool bundle) — a visual/structural reference, not a drop-in. Bundle wins on layout/visual intent; the skill wins on implementation dialect. |
 | `flag` | ui | Yes (flag-gated) | Feature-flag name; the shared contract joining a `build` feature to its `wire` feature. |
 | `screens` | ui | Yes | List of `ScreenId`, e.g. `[AddTitle]`. |
 | `flows` | ui | No (build) / Yes (wire) | List of `FlowId` the screen participates in. Build features may list mock-satisfiable candidate flows; wire features must list the flows they connect to real data. |
@@ -42,14 +42,19 @@ screens: [AddTitle]
 flows: [AddTitle]
 ```
 
-**Design mode semantics.** `none` means no visual loop; `import` means a
-prototype bundle is supplied at render and rides forward; `brief` means mark will
-author durable intent that can be handed to a visual tool. The mode is carried in
-metadata so readers and downstream commands do not infer it from feature titles.
-It is **feature-level**: every `ScreenId` in the feature's `screens` list shares
-the one `design` value, so a feature that would need two different modes for two
+**Design mode semantics.** The mode is carried in metadata so readers and
+downstream commands do not infer it from feature titles. It is
+**feature-level**: every `ScreenId` in the feature's `screens` list shares the
+one `design` value, so a feature that would need two different modes for two
 screens must be split into separate features (one per mode) — which the
-one-screen-per-build model already favors.
+one-screen-per-build model already favors. `mark` copies the value into the
+`Design` cell of each `SC<N>` ledger row; flow and story rows use `—`.
+
+| Mode | Meaning | Bundle behavior |
+|------|---------|-----------------|
+| `none` | No visual loop. Build from the committed design skill with no bundle ceremony. | Omit `bundle`. |
+| `import` | Prototype-first: a visual prototype already exists. `render` may carry the supplied bundle forward for downstream honoring. | Bundle enters at `render` and rides to `forge` as visual source context; downstream prompts do not derive detailed prototype-to-screen/flow structure. |
+| `brief` | Mark-authored intent for a visual tool: the `.design.md`/`.flow.md` artifacts are the brief. | Bundle may be attached later; if present, downstream build honors it under the conflict rule. |
 
 **Phase semantics.** `build` implements the screen component against a mock
 behind `flag` (rendering every brief state with design-system tokens only);


### PR DESCRIPTION
## Summary
EPIC #404 → Screens and Flows as UI Feature Kinds spec → User Story 4 (non-blocking visual-design gate) → Slice 1: Define the design mode and bundle contract.
Establishes one shared vocabulary across Smithy's deployable UI templates before mark, render, or forge apply mode-specific behavior: `none`/`import`/`brief` are the only screen-node `Design` modes, and `bundle` is a tool-neutral visual prototype boundary object rather than a Claude Design-only export. Text-and-schema only — no prototype ingestion is implemented here.

## Spec debt & uncertainty
- SD-005 (inherited): fidelity of `import`-mode structure derivation (how reliably render extracts screens/flows from a bundle) — remains owned by User Story 5; this slice only defines the boundary object.
- SD-006 (inherited): whether `SC`/`FL` nodes are always atomic or can be sub-sliced — owned by User Story 3.
- SD-007 (inherited): build-phase coverage honesty for a build screen with a missing brief state — flow coverage owned by User Stories 3 and 6.
- SD-008 (inherited, owned by this story): visual-intent honesty for a bundle-less `brief` node — this slice defines the contract; the surfacing implementation path lands in Slice 3.
- Assumption: the non-blocking gate has exactly three modes and `bundle` is the single boundary object (per the spec's Critical Assumption on the visual-design gate); this slice is prose/schema alignment only and intentionally leaves import ingestion and mark/forge routing to later slices.

## Validation
build ✅ · typecheck ✅ · test ✅ (1035 passed) — run under Node 22 via nvm (repo requires Node ≥20; the ambient Node 18 cannot run the vitest 4 / rolldown toolchain).
