### PR TITLE
forge: resolve and validate the screen/flow/test artifact graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -992,9 +992,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1012,9 +1009,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1032,9 +1026,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1052,9 +1043,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1072,9 +1060,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1092,9 +1077,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2202,9 +2184,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2226,9 +2205,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2250,9 +2226,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2274,9 +2247,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/06-flow-lint-validates-the-screen-flow-test-graph-in-app-ci.tasks.md
+++ b/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/06-flow-lint-validates-the-screen-flow-test-graph-in-app-ci.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Discover durable UI artifacts from the repo tree**
+- [x] **Discover durable UI artifacts from the repo tree**
 
   Add a pure graph-discovery path that walks the selected repository root and reads `design/screens/*.design.md` and `design/flows/*.flow.md` artifacts using their YAML front matter. The discovery result should record each screen `id`, flow `id`, flow `screens` references, and flow `test-body` path, while treating the repo filesystem as the source of truth instead of any smithy session state.
 
@@ -32,7 +32,7 @@
   - Discovery can run from an arbitrary repo root or subpath
   - Discovery performs no agent, network, or forge-specific calls
 
-- [ ] **Validate graph references and uniqueness**
+- [x] **Validate graph references and uniqueness**
 
   Implement the `flow-lint` validation rules over the discovered graph. A `.flow.md` must fail when any `screens:` entry has no matching screen annotation, when its `test-body` file is missing, when an executable test body exists without a matching `.flow.md`, or when a flat `ScreenId` or `FlowId` is reused in the repo.
 
@@ -43,7 +43,7 @@
   - Duplicate `ScreenId` values fail with every conflicting artifact named
   - Duplicate `FlowId` values fail with every conflicting artifact named
 
-- [ ] **Cover resolved and broken graph fixtures**
+- [x] **Cover resolved and broken graph fixtures**
 
   Add focused tests for the graph resolver and validator using minimal fixture trees. The fixtures should include one fully resolved graph and separate broken graphs for dangling screen references, missing or orphaned test bodies, and duplicate IDs so the user story's independent test can be run without a real app.
 

--- a/src/flow-lint.test.ts
+++ b/src/flow-lint.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  discoverFlowGraph,
+  lintFlowGraph,
+  validateFlowGraph,
+} from './flow-lint.js';
+
+let root: string;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-flow-lint-'));
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function write(relPath: string, contents: string): void {
+  const absPath = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(absPath), { recursive: true });
+  fs.writeFileSync(absPath, contents);
+}
+
+function screen(id: string): string {
+  return `---
+id: ${id}
+component-path: src/${id}.tsx
+design_system: test-system
+---
+
+## Why this screen exists
+`;
+}
+
+function flow(id: string, screens: string[], testBodyPath: string): string {
+  return `---
+id: ${id}
+screens: [${screens.join(', ')}]
+test-body: ${testBodyPath}
+---
+
+## Intent
+`;
+}
+
+describe('flow-lint graph discovery', () => {
+  it('discovers screen annotations, flow definitions, and declared test-body paths', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'tests/e2e/add-title.spec.ts'));
+    write('tests/e2e/add-title.spec.ts', 'test("add title", () => {});\n');
+    write('tests/e2e/unrelated.spec.ts', 'test("unrelated", () => {});\n');
+
+    const graph = discoverFlowGraph(root);
+
+    expect(graph.screens).toEqual([{ id: 'Library', path: 'design/screens/Library.design.md' }]);
+    expect(graph.flows).toEqual([
+      {
+        id: 'AddTitle',
+        path: 'design/flows/AddTitle.flow.md',
+        screens: ['Library'],
+        testBodyPath: 'tests/e2e/add-title.spec.ts',
+      },
+    ]);
+    expect(graph.declaredTestBodyPaths).toEqual(['tests/e2e/add-title.spec.ts']);
+    expect(graph.orphanTestBodies).toEqual({ status: 'not-run', roots: [], paths: [] });
+  });
+
+  it('resolves the artifact root from a nested subpath', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'maestro/flows/AddTitle.yaml'));
+    write('maestro/flows/AddTitle.yaml', '# flow\n');
+    write('src/app/nested/file.ts', 'export {};\n');
+
+    const graph = discoverFlowGraph(path.join(root, 'src/app/nested'));
+
+    expect(graph.root).toBe(root);
+    expect(graph.screens.map((artifact) => artifact.id)).toEqual(['Library']);
+    expect(graph.flows.map((artifact) => artifact.id)).toEqual(['AddTitle']);
+  });
+
+  it('scopes orphan test-body discovery to the explicit flow-test root', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'ui-flows/AddTitle.yaml'));
+    write('ui-flows/AddTitle.yaml', '# flow\n');
+    write('ui-flows/RemovedFlow.yaml', '# orphan\n');
+    write('tests/e2e/unrelated.spec.ts', 'test("unrelated", () => {});\n');
+
+    const graph = discoverFlowGraph(root, { flowTestRoot: 'ui-flows' });
+
+    expect(graph.orphanTestBodies).toEqual({
+      status: 'scanned',
+      roots: ['ui-flows'],
+      paths: ['ui-flows/RemovedFlow.yaml'],
+    });
+  });
+
+  it('scopes orphan test-body discovery to the conventional stub location when present', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'maestro/flows/AddTitle.yaml'));
+    write('maestro/flows/AddTitle.yaml', '# flow\n');
+    write('maestro/flows/RemovedFlow.yaml', '# orphan\n');
+
+    const graph = discoverFlowGraph(root);
+
+    expect(graph.orphanTestBodies).toEqual({
+      status: 'scanned',
+      roots: ['maestro/flows'],
+      paths: ['maestro/flows/RemovedFlow.yaml'],
+    });
+  });
+});
+
+describe('flow-lint graph validation', () => {
+  it('reports no findings for a fully resolved fixture', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'maestro/flows/AddTitle.yaml'));
+    write('maestro/flows/AddTitle.yaml', '# flow\n');
+
+    const { findings } = lintFlowGraph(root);
+
+    expect(findings).toEqual([]);
+  });
+
+  it('fails dangling screen references with the missing ScreenId and flow named', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library', 'AddTitleScreen'], 'maestro/flows/AddTitle.yaml'));
+    write('maestro/flows/AddTitle.yaml', '# flow\n');
+
+    const { findings } = lintFlowGraph(root);
+
+    expect(findings).toContainEqual({
+      type: 'missing-screen',
+      flowId: 'AddTitle',
+      flowPath: 'design/flows/AddTitle.flow.md',
+      screenId: 'AddTitleScreen',
+    });
+  });
+
+  it('fails missing paired test bodies with the owning flow named', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'maestro/flows/AddTitle.yaml'));
+
+    const { findings } = lintFlowGraph(root);
+
+    expect(findings).toContainEqual({
+      type: 'missing-test-body',
+      flowId: 'AddTitle',
+      flowPath: 'design/flows/AddTitle.flow.md',
+      testBodyPath: 'maestro/flows/AddTitle.yaml',
+    });
+  });
+
+  it('fails orphan executable test bodies within the scoped flow-test root', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'ui-flows/AddTitle.yaml'));
+    write('ui-flows/AddTitle.yaml', '# flow\n');
+    write('ui-flows/RemovedFlow.yaml', '# orphan\n');
+
+    const { findings } = lintFlowGraph(root, { flowTestRoot: 'ui-flows' });
+
+    expect(findings).toContainEqual({
+      type: 'orphan-test-body',
+      testBodyPath: 'ui-flows/RemovedFlow.yaml',
+    });
+  });
+
+  it('fails duplicate ScreenId values with every conflicting artifact named', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/screens/Nested/LibraryCopy.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'maestro/flows/AddTitle.yaml'));
+    write('maestro/flows/AddTitle.yaml', '# flow\n');
+
+    const findings = validateFlowGraph(discoverFlowGraph(root));
+
+    expect(findings).toContainEqual({
+      type: 'duplicate-screen-id',
+      screenId: 'Library',
+      paths: [
+        'design/screens/Library.design.md',
+        'design/screens/Nested/LibraryCopy.design.md',
+      ],
+    });
+  });
+
+  it('fails duplicate FlowId values with every conflicting artifact named', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'maestro/flows/AddTitle.yaml'));
+    write('design/flows/Nested/AddTitleCopy.flow.md', flow('AddTitle', ['Library'], 'maestro/flows/AddTitleCopy.yaml'));
+    write('maestro/flows/AddTitle.yaml', '# flow\n');
+    write('maestro/flows/AddTitleCopy.yaml', '# flow\n');
+
+    const findings = validateFlowGraph(discoverFlowGraph(root));
+
+    expect(findings).toContainEqual({
+      type: 'duplicate-flow-id',
+      flowId: 'AddTitle',
+      paths: [
+        'design/flows/AddTitle.flow.md',
+        'design/flows/Nested/AddTitleCopy.flow.md',
+      ],
+    });
+  });
+});

--- a/src/flow-lint.test.ts
+++ b/src/flow-lint.test.ts
@@ -98,6 +98,42 @@ describe('flow-lint graph discovery', () => {
     });
   });
 
+  it('reports orphan discovery as not-run when the explicit flow-test root is missing', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'ui-flows/AddTitle.yaml'));
+    write('ui-flows/AddTitle.yaml', '# flow\n');
+
+    const graph = discoverFlowGraph(root, { flowTestRoot: 'does-not-exist' });
+
+    expect(graph.orphanTestBodies).toEqual({ status: 'not-run', roots: [], paths: [] });
+  });
+
+  it('reports orphan discovery as not-run when the flow-test root escapes the artifact root', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'ui-flows/AddTitle.yaml'));
+    write('ui-flows/AddTitle.yaml', '# flow\n');
+
+    const graph = discoverFlowGraph(root, { flowTestRoot: '../..' });
+
+    expect(graph.orphanTestBodies).toEqual({ status: 'not-run', roots: [], paths: [] });
+  });
+
+  it('ignores hidden files under the scoped flow-test root', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'ui-flows/AddTitle.yaml'));
+    write('ui-flows/AddTitle.yaml', '# flow\n');
+    write('ui-flows/.gitkeep', '');
+    write('ui-flows/.DS_Store', '');
+
+    const graph = discoverFlowGraph(root, { flowTestRoot: 'ui-flows' });
+
+    expect(graph.orphanTestBodies).toEqual({
+      status: 'scanned',
+      roots: ['ui-flows'],
+      paths: [],
+    });
+  });
+
   it('scopes orphan test-body discovery to the conventional stub location when present', () => {
     write('design/screens/Library.design.md', screen('Library'));
     write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'maestro/flows/AddTitle.yaml'));
@@ -183,6 +219,38 @@ describe('flow-lint graph validation', () => {
         'design/screens/Library.design.md',
         'design/screens/Nested/LibraryCopy.design.md',
       ],
+    });
+  });
+
+  it('fails duplicate test-body declarations shared across flows', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'maestro/flows/Shared.yaml'));
+    write('design/flows/EditTitle.flow.md', flow('EditTitle', ['Library'], 'maestro/flows/Shared.yaml'));
+    write('maestro/flows/Shared.yaml', '# flow\n');
+
+    const findings = validateFlowGraph(discoverFlowGraph(root));
+
+    expect(findings).toContainEqual({
+      type: 'duplicate-test-body',
+      testBodyPath: 'maestro/flows/Shared.yaml',
+      paths: [
+        'design/flows/AddTitle.flow.md',
+        'design/flows/EditTitle.flow.md',
+      ],
+    });
+  });
+
+  it('fails a test-body path that escapes the artifact root', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], '../escapes/AddTitle.yaml'));
+
+    const { findings } = lintFlowGraph(root);
+
+    expect(findings).toContainEqual({
+      type: 'missing-test-body',
+      flowId: 'AddTitle',
+      flowPath: 'design/flows/AddTitle.flow.md',
+      testBodyPath: '../escapes/AddTitle.yaml',
     });
   });
 

--- a/src/flow-lint.ts
+++ b/src/flow-lint.ts
@@ -1,0 +1,316 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+export interface ScreenArtifact {
+  id: string;
+  path: string;
+}
+
+export interface FlowArtifact {
+  id: string;
+  path: string;
+  screens: string[];
+  testBodyPath: string;
+}
+
+export interface OrphanScanResult {
+  status: 'scanned' | 'not-run';
+  roots: string[];
+  paths: string[];
+}
+
+export interface FlowGraph {
+  root: string;
+  screens: ScreenArtifact[];
+  flows: FlowArtifact[];
+  declaredTestBodyPaths: string[];
+  orphanTestBodies: OrphanScanResult;
+}
+
+export type FlowLintFinding =
+  | {
+      type: 'missing-screen';
+      flowId: string;
+      flowPath: string;
+      screenId: string;
+    }
+  | {
+      type: 'missing-test-body';
+      flowId: string;
+      flowPath: string;
+      testBodyPath: string;
+    }
+  | {
+      type: 'orphan-test-body';
+      testBodyPath: string;
+    }
+  | {
+      type: 'duplicate-screen-id';
+      screenId: string;
+      paths: string[];
+    }
+  | {
+      type: 'duplicate-flow-id';
+      flowId: string;
+      paths: string[];
+    };
+
+export interface DiscoverFlowGraphOptions {
+  flowTestRoot?: string;
+}
+
+interface Frontmatter {
+  id?: unknown;
+  screens?: unknown;
+  'test-body'?: unknown;
+}
+
+const CONVENTIONAL_FLOW_TEST_ROOT = 'maestro/flows';
+
+export function discoverFlowGraph(
+  rootOrSubpath: string,
+  options: DiscoverFlowGraphOptions = {},
+): FlowGraph {
+  const root = resolveArtifactRoot(rootOrSubpath);
+  const screens = discoverScreens(root);
+  const flows = discoverFlows(root);
+  const declaredTestBodyPaths = uniqueSorted(
+    flows.map((flow) => normalizeRelativePath(flow.testBodyPath)).filter(Boolean),
+  );
+  const orphanTestBodies = discoverOrphanTestBodies(
+    root,
+    new Set(declaredTestBodyPaths),
+    options.flowTestRoot,
+  );
+
+  return {
+    root,
+    screens,
+    flows,
+    declaredTestBodyPaths,
+    orphanTestBodies,
+  };
+}
+
+export function validateFlowGraph(graph: FlowGraph): FlowLintFinding[] {
+  const findings: FlowLintFinding[] = [];
+  const screensById = groupById(graph.screens);
+  const flowsById = groupById(graph.flows);
+
+  for (const [id, artifacts] of screensById) {
+    if (id !== '' && artifacts.length > 1) {
+      findings.push({
+        type: 'duplicate-screen-id',
+        screenId: id,
+        paths: artifacts.map((artifact) => artifact.path).sort(),
+      });
+    }
+  }
+
+  for (const [id, artifacts] of flowsById) {
+    if (id !== '' && artifacts.length > 1) {
+      findings.push({
+        type: 'duplicate-flow-id',
+        flowId: id,
+        paths: artifacts.map((artifact) => artifact.path).sort(),
+      });
+    }
+  }
+
+  for (const flow of graph.flows) {
+    for (const screenId of flow.screens) {
+      if (!screensById.has(screenId)) {
+        findings.push({
+          type: 'missing-screen',
+          flowId: flow.id,
+          flowPath: flow.path,
+          screenId,
+        });
+      }
+    }
+
+    const absoluteTestBodyPath = path.join(graph.root, flow.testBodyPath);
+    if (!isFile(absoluteTestBodyPath)) {
+      findings.push({
+        type: 'missing-test-body',
+        flowId: flow.id,
+        flowPath: flow.path,
+        testBodyPath: flow.testBodyPath,
+      });
+    }
+  }
+
+  for (const testBodyPath of graph.orphanTestBodies.paths) {
+    findings.push({
+      type: 'orphan-test-body',
+      testBodyPath,
+    });
+  }
+
+  return findings;
+}
+
+export function lintFlowGraph(
+  rootOrSubpath: string,
+  options: DiscoverFlowGraphOptions = {},
+): { graph: FlowGraph; findings: FlowLintFinding[] } {
+  const graph = discoverFlowGraph(rootOrSubpath, options);
+  return { graph, findings: validateFlowGraph(graph) };
+}
+
+function discoverScreens(root: string): ScreenArtifact[] {
+  const screenDir = path.join(root, 'design', 'screens');
+  return listFiles(screenDir, '.design.md').map((artifactPath) => {
+    const frontmatter = readFrontmatter(artifactPath);
+    return {
+      id: stringField(frontmatter.id),
+      path: relativePath(root, artifactPath),
+    };
+  });
+}
+
+function discoverFlows(root: string): FlowArtifact[] {
+  const flowDir = path.join(root, 'design', 'flows');
+  return listFiles(flowDir, '.flow.md').map((artifactPath) => {
+    const frontmatter = readFrontmatter(artifactPath);
+    return {
+      id: stringField(frontmatter.id),
+      path: relativePath(root, artifactPath),
+      screens: stringListField(frontmatter.screens),
+      testBodyPath: normalizeRelativePath(stringField(frontmatter['test-body'])),
+    };
+  });
+}
+
+function discoverOrphanTestBodies(
+  root: string,
+  declaredTestBodyPaths: Set<string>,
+  explicitFlowTestRoot?: string,
+): OrphanScanResult {
+  const scopedRoots = explicitFlowTestRoot
+    ? [resolveScopedRoot(root, explicitFlowTestRoot)]
+    : conventionalFlowTestRoots(root);
+
+  if (scopedRoots.length === 0) {
+    return { status: 'not-run', roots: [], paths: [] };
+  }
+
+  const orphanPaths = scopedRoots.flatMap((scanRoot) =>
+    listFiles(scanRoot).map((filePath) => relativePath(root, filePath)),
+  ).filter((testBodyPath) => !declaredTestBodyPaths.has(testBodyPath));
+
+  return {
+    status: 'scanned',
+    roots: scopedRoots.map((scanRoot) => relativePath(root, scanRoot)),
+    paths: uniqueSorted(orphanPaths),
+  };
+}
+
+function resolveArtifactRoot(rootOrSubpath: string): string {
+  const realStart = fs.realpathSync(rootOrSubpath);
+  const start = isDirectory(realStart) ? realStart : path.dirname(realStart);
+  let current = start;
+
+  while (true) {
+    if (
+      isDirectory(path.join(current, 'design', 'screens')) ||
+      isDirectory(path.join(current, 'design', 'flows'))
+    ) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return start;
+    current = parent;
+  }
+}
+
+function resolveScopedRoot(root: string, scopedRoot: string): string {
+  return path.isAbsolute(scopedRoot)
+    ? fs.realpathSync(scopedRoot)
+    : fs.realpathSync(path.join(root, scopedRoot));
+}
+
+function conventionalFlowTestRoots(root: string): string[] {
+  const conventionalRoot = path.join(root, CONVENTIONAL_FLOW_TEST_ROOT);
+  return isDirectory(conventionalRoot) ? [fs.realpathSync(conventionalRoot)] : [];
+}
+
+function listFiles(root: string, suffix?: string): string[] {
+  if (!isDirectory(root)) return [];
+  const files: string[] = [];
+  walk(root, files, suffix);
+  return files.sort();
+}
+
+function walk(dir: string, files: string[], suffix?: string): void {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(entryPath, files, suffix);
+    } else if (entry.isFile() && (suffix === undefined || entry.name.endsWith(suffix))) {
+      files.push(entryPath);
+    }
+  }
+}
+
+function readFrontmatter(filePath: string): Frontmatter {
+  const contents = fs.readFileSync(filePath, 'utf8');
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(contents);
+  if (match === null) return {};
+  const parsed = parseYaml(match[1] ?? '') as unknown;
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {};
+  }
+  return parsed as Frontmatter;
+}
+
+function stringField(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function stringListField(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function groupById<T extends { id: string }>(artifacts: T[]): Map<string, T[]> {
+  const grouped = new Map<string, T[]>();
+  for (const artifact of artifacts) {
+    const existing = grouped.get(artifact.id) ?? [];
+    existing.push(artifact);
+    grouped.set(artifact.id, existing);
+  }
+  return grouped;
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return Array.from(new Set(values)).sort();
+}
+
+function relativePath(root: string, target: string): string {
+  return normalizeRelativePath(path.relative(root, target));
+}
+
+function normalizeRelativePath(value: string): string {
+  return value.split(path.sep).join('/').replace(/^\.\//, '');
+}
+
+function isDirectory(target: string): boolean {
+  try {
+    return fs.statSync(target).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isFile(target: string): boolean {
+  try {
+    return fs.statSync(target).isFile();
+  } catch {
+    return false;
+  }
+}

--- a/src/flow-lint.ts
+++ b/src/flow-lint.ts
@@ -46,6 +46,11 @@ export type FlowLintFinding =
       testBodyPath: string;
     }
   | {
+      type: 'duplicate-test-body';
+      testBodyPath: string;
+      paths: string[];
+    }
+  | {
       type: 'duplicate-screen-id';
       screenId: string;
       paths: string[];
@@ -118,6 +123,23 @@ export function validateFlowGraph(graph: FlowGraph): FlowLintFinding[] {
     }
   }
 
+  const flowsByTestBody = new Map<string, string[]>();
+  for (const flow of graph.flows) {
+    if (flow.testBodyPath === '') continue;
+    const existing = flowsByTestBody.get(flow.testBodyPath) ?? [];
+    existing.push(flow.path);
+    flowsByTestBody.set(flow.testBodyPath, existing);
+  }
+  for (const [testBodyPath, paths] of flowsByTestBody) {
+    if (paths.length > 1) {
+      findings.push({
+        type: 'duplicate-test-body',
+        testBodyPath,
+        paths: paths.sort(),
+      });
+    }
+  }
+
   for (const flow of graph.flows) {
     for (const screenId of flow.screens) {
       if (!screensById.has(screenId)) {
@@ -130,8 +152,8 @@ export function validateFlowGraph(graph: FlowGraph): FlowLintFinding[] {
       }
     }
 
-    const absoluteTestBodyPath = path.join(graph.root, flow.testBodyPath);
-    if (!isFile(absoluteTestBodyPath)) {
+    const absoluteTestBodyPath = resolveWithinRoot(graph.root, flow.testBodyPath);
+    if (absoluteTestBodyPath === null || !isFile(absoluteTestBodyPath)) {
       findings.push({
         type: 'missing-test-body',
         flowId: flow.id,
@@ -188,17 +210,21 @@ function discoverOrphanTestBodies(
   declaredTestBodyPaths: Set<string>,
   explicitFlowTestRoot?: string,
 ): OrphanScanResult {
-  const scopedRoots = explicitFlowTestRoot
-    ? [resolveScopedRoot(root, explicitFlowTestRoot)]
-    : conventionalFlowTestRoots(root);
+  const scopedRoots =
+    explicitFlowTestRoot !== undefined
+      ? [resolveScopedRoot(root, explicitFlowTestRoot)].filter(
+          (scanRoot): scanRoot is string => scanRoot !== null,
+        )
+      : conventionalFlowTestRoots(root);
 
   if (scopedRoots.length === 0) {
     return { status: 'not-run', roots: [], paths: [] };
   }
 
-  const orphanPaths = scopedRoots.flatMap((scanRoot) =>
-    listFiles(scanRoot).map((filePath) => relativePath(root, filePath)),
-  ).filter((testBodyPath) => !declaredTestBodyPaths.has(testBodyPath));
+  const orphanPaths = scopedRoots
+    .flatMap((scanRoot) => listFiles(scanRoot).map((filePath) => relativePath(root, filePath)))
+    .filter((testBodyPath) => !isHiddenPath(testBodyPath))
+    .filter((testBodyPath) => !declaredTestBodyPaths.has(testBodyPath));
 
   return {
     status: 'scanned',
@@ -225,10 +251,13 @@ function resolveArtifactRoot(rootOrSubpath: string): string {
   }
 }
 
-function resolveScopedRoot(root: string, scopedRoot: string): string {
-  return path.isAbsolute(scopedRoot)
-    ? fs.realpathSync(scopedRoot)
-    : fs.realpathSync(path.join(root, scopedRoot));
+function resolveScopedRoot(root: string, scopedRoot: string): string | null {
+  const joined = path.isAbsolute(scopedRoot) ? scopedRoot : path.join(root, scopedRoot);
+  // A missing/broken flow-test root must degrade to a not-run orphan scan
+  // (Slice 1 contract), never throw; and it must not escape the artifact root.
+  if (!isDirectory(joined)) return null;
+  const resolved = fs.realpathSync(joined);
+  return isWithinRoot(root, resolved) ? resolved : null;
 }
 
 function conventionalFlowTestRoots(root: string): string[] {
@@ -296,7 +325,28 @@ function relativePath(root: string, target: string): string {
 }
 
 function normalizeRelativePath(value: string): string {
-  return value.split(path.sep).join('/').replace(/^\.\//, '');
+  // Normalize both the host separator and a foreign (Windows) separator so a
+  // repo-relative `test-body` authored on Windows resolves deterministically
+  // when the check runs on a POSIX CI host.
+  return value.split(/[\\/]/).join('/').replace(/^\.\//, '');
+}
+
+// Resolve a repo-relative path against the artifact root, returning null when
+// it escapes the root (absolute path or `..` traversal). `test-body` is a
+// repo-relative contract, so an out-of-root target is never a valid body.
+function resolveWithinRoot(root: string, relativeTarget: string): string | null {
+  if (relativeTarget === '') return null;
+  const resolved = path.resolve(root, relativeTarget);
+  return isWithinRoot(root, resolved) ? resolved : null;
+}
+
+function isWithinRoot(root: string, target: string): boolean {
+  const rel = path.relative(root, target);
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+function isHiddenPath(relativePathValue: string): boolean {
+  return relativePathValue.split('/').some((segment) => segment.startsWith('.'));
 }
 
 function isDirectory(target: string): boolean {


### PR DESCRIPTION
## Summary
EPIC #404 → Screens and Flows as UI Feature Kinds → User Story 6 (flow-lint validates the screen/flow/test graph in app CI) → Slice 1: Resolve the Screen/Flow/Test Artifact Graph

Adds a deterministic, smithy-state-free graph resolver (`src/flow-lint.ts`) that discovers durable screen annotations and flow definitions from the repo tree and validates the cross-reference rules — dangling `screens:` references, missing paired test bodies, orphan executable test bodies, and duplicate flat `ScreenId`/`FlowId` values. This is the load-bearing behavior behind the future `smithy flow-lint` command; Slice 1 stops at the resolver + validator so failure and success cases are provable through fixtures before CLI/CI ergonomics (Slices 2–3) are added.

## Spec debt & uncertainty
- SD-010 (open): Fully driver-neutral enumeration of orphan test bodies is reliable only within the declared `test-body:` set or an explicitly supplied flow-test root; a general machine-readable stub marker is deferred. Scoped here — the candidate universe is the declared `test-body:` paths, and orphan detection runs only against a supplied flow-test root or the conventional stub location (`maestro/flows`), reporting `not-run` otherwise rather than blind-scanning the repo.
- SD-005 (inherited): Fidelity of `import`-mode structure derivation — owned by US5; flow-lint validates the confirmed graph after it exists.
- SD-006 (inherited): Whether `SC`/`FL` nodes are always atomic — owned by US3; validation is agnostic to how producing tasks were sliced.
- SD-007 (inherited): Build-phase coverage honesty — flow-lint checks graph integrity, not whether every brief state has executable coverage.
- SD-008 (inherited): Visual-intent honesty under the non-blocking gate — owned by US4; not validated here.
- Assumption: `test-body` is a driver-neutral repo-relative path that may live anywhere in the test tree (per `smithy.helper-flow-definition`); the declared path is treated as the authoritative contract rather than inferring a test layout.
- Verification note: the resolver is not yet wired into the CLI bundle (that is Slice 2), so `npm run build` exercises the existing CLI only; the new module is covered by its own vitest suite. The repo toolchain requires Node ≥ 20.12 (`styleText`); I ran the suite under Node 22 after the initial Node 18 install produced a mismatched native binding.

## Validation
build ✅ · typecheck ✅ · test ✅ (10 passed, `src/flow-lint.test.ts`)
