### PR TITLE
render: tighten UI feature metadata with explicit design mode

### DIFF
--- a/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/05-render-is-a-clean-ui-aware-entry-point-with-prototype-ingestion.tasks.md
+++ b/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/05-render-is-a-clean-ui-aware-entry-point-with-prototype-ingestion.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Require complete UI feature metadata in render output**
+- [x] **Require complete UI feature metadata in render output**
 
   Update `src/templates/agent-skills/commands/smithy.render.prompt` and the shared `feature-kinds` snippet it consumes so every rendered UI feature carries the complete UI metadata needed by downstream `mark`: `kind`, `phase`, `design_system`, per-node design mode, `flag` when flag-gated, and the screen/flow identifiers appropriate to the feature's phase. Keep backend features typed as backend without UI-only fields.
 
@@ -28,7 +28,7 @@
   - Feature-map prose makes backend-to-spec versus UI-to-screen/flow fan-out evident
   - Existing legacy backend rendering behavior remains supported
 
-- [ ] **Express the build/wire seam in Dependency Order**
+- [x] **Express the build/wire seam in Dependency Order**
 
   Strengthen render's feature-map instructions so flag-gated UI work is split into a build feature and a wire feature sharing one `flag`, with ordering captured only in the feature map's `## Dependency Order` table. The build feature should be able to run ahead of backend work; the wire feature depends on the build feature and any backend prerequisite.
 

--- a/src/status/parser.test.ts
+++ b/src/status/parser.test.ts
@@ -190,6 +190,50 @@ ${FENCE}
     ).toBe(true);
   });
 
+  it('does not require flows on a build feature but does on wire', () => {
+    const md = `### Feature 1: Build without flows
+
+${FENCE}yaml
+kind: ui
+phase: build
+design_system: ds
+design: none
+flag: f
+screens: [S]
+${FENCE}
+
+### Feature 2: Wire without flows
+
+${FENCE}yaml
+kind: ui
+phase: wire
+design_system: ds
+design: none
+flag: f
+screens: [S]
+${FENCE}
+`;
+    const { warnings } = parseFeatures(md);
+    // build feature omitting flows must NOT warn about missing flows
+    expect(
+      warnings.some(
+        (w) =>
+          w.startsWith('feature_ui_fields:') &&
+          w.includes('F1') &&
+          w.includes('flows'),
+      ),
+    ).toBe(false);
+    // wire feature omitting flows MUST warn
+    expect(
+      warnings.some(
+        (w) =>
+          w.startsWith('feature_ui_fields:') &&
+          w.includes('F2') &&
+          w.includes('missing required flows'),
+      ),
+    ).toBe(true);
+  });
+
   it('does not throw on a features file with no Feature sections', () => {
     const md = `# Feature Map: Empty
 

--- a/src/status/parser.test.ts
+++ b/src/status/parser.test.ts
@@ -59,6 +59,7 @@ ${FENCE}yaml
 kind: ui
 phase: build
 design_system: story-spider-design
+design: import
 bundle: design/bundles/add-title.zip
 flag: add_title_v1
 screens: [AddTitle]
@@ -73,6 +74,7 @@ ${FENCE}yaml
 kind: ui
 phase: wire
 design_system: story-spider-design
+design: import
 flag: add_title_v1
 screens: [AddTitle]
 flows: [AddTitle]
@@ -95,6 +97,7 @@ ${FENCE}
       kind: 'ui',
       phase: 'build',
       design_system: 'story-spider-design',
+      design: 'import',
       bundle: 'design/bundles/add-title.zip',
       flag: 'add_title_v1',
       screens: ['AddTitle'],
@@ -149,6 +152,7 @@ ${FENCE}
 
 ${FENCE}yaml
 kind: backend
+design: brief
 flag: stray_flag
 ${FENCE}
 `;
@@ -156,6 +160,11 @@ ${FENCE}
     expect(
       warnings.some(
         (w) => w.startsWith('feature_ui_fields:') && w.includes('ui-only key flag'),
+      ),
+    ).toBe(true);
+    expect(
+      warnings.some(
+        (w) => w.startsWith('feature_ui_fields:') && w.includes('ui-only key design'),
       ),
     ).toBe(true);
   });
@@ -167,6 +176,7 @@ ${FENCE}yaml
 kind: ui
 phase: build
 design_system: ds
+design: none
 flag: lonely_flag
 screens: [S]
 flows: [F]

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -576,7 +576,10 @@ export function parseFeatures(content: string): {
       if (feature.design === undefined) missing.push('design');
       if (feature.screens === undefined || feature.screens.length === 0)
         missing.push('screens');
-      if (feature.flows === undefined) missing.push('flows');
+      // `flows` is optional for `build` (mock-satisfiable candidates) and
+      // required only for `wire`, which connects flows to real data.
+      if (feature.phase === 'wire' && feature.flows === undefined)
+        missing.push('flows');
       for (const key of missing) {
         warnings.push(
           `feature_ui_fields: ui ${feature.id} missing required ${key}`,

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -460,9 +460,9 @@ function countSlices(content: string): {
  * into a list of {@link FeatureSummary}. Each feature's typed metadata is
  * read from a fenced ` ```yaml ` block placed right after the heading,
  * carrying flat keys (`kind`, and for `ui` features `phase`,
- * `design_system`, `bundle`, `flag`, `screens`, `flows`). The block is a
- * flat scalar/inline-list map — nested YAML is not expected. The 4-column
- * `## Dependency Order` table is left untouched: kind/phase live in the
+ * `design_system`, `design`, `bundle`, `flag`, `screens`, `flows`). The block
+ * is a flat scalar/inline-list map — nested YAML is not expected. The 4-column
+ * `## Dependency Order` table is left untouched: kind/phase/design live in the
  * feature body, not the table.
  *
  * Best-effort and side-effect free: a missing block or invalid value is
@@ -557,6 +557,9 @@ export function parseFeatures(content: string): {
     if (phase === 'build' || phase === 'wire') feature.phase = phase;
     const designSystem = scalar('design_system');
     if (designSystem !== undefined) feature.design_system = designSystem;
+    const design = scalar('design');
+    if (design === 'none' || design === 'import' || design === 'brief')
+      feature.design = design;
     const bundle = scalar('bundle');
     if (bundle !== undefined) feature.bundle = bundle;
     const flag = scalar('flag');
@@ -570,6 +573,7 @@ export function parseFeatures(content: string): {
       const missing: string[] = [];
       if (feature.phase === undefined) missing.push('phase');
       if (feature.design_system === undefined) missing.push('design_system');
+      if (feature.design === undefined) missing.push('design');
       if (feature.screens === undefined || feature.screens.length === 0)
         missing.push('screens');
       if (feature.flows === undefined) missing.push('flows');
@@ -579,16 +583,16 @@ export function parseFeatures(content: string): {
         );
       }
     } else if (feature.kind === 'backend') {
-      const uiOnly: Array<[string, unknown]> = [
-        ['phase', feature.phase],
-        ['design_system', feature.design_system],
-        ['bundle', feature.bundle],
-        ['flag', feature.flag],
-        ['screens', feature.screens],
-        ['flows', feature.flows],
-      ];
-      for (const [key, val] of uiOnly) {
-        if (val !== undefined) {
+      for (const key of [
+        'phase',
+        'design_system',
+        'design',
+        'bundle',
+        'flag',
+        'screens',
+        'flows',
+      ]) {
+        if (meta.has(key)) {
           warnings.push(
             `feature_ui_fields: backend ${feature.id} carries ui-only key ${key}`,
           );

--- a/src/status/types.test.ts
+++ b/src/status/types.test.ts
@@ -17,6 +17,7 @@ describe('status type surface — FeatureSummary', () => {
       kind: 'ui',
       phase: 'build',
       design_system: 'story-spider-design',
+      design: 'import',
       bundle: 'design/bundles/add-title.zip',
       flag: 'add_title_v1',
       screens: ['AddTitle'],
@@ -24,7 +25,12 @@ describe('status type surface — FeatureSummary', () => {
     };
     expect(backend.kind).toBe('backend');
     expect(backend.phase).toBeUndefined();
-    expect(ui).toMatchObject({ kind: 'ui', phase: 'build', flag: 'add_title_v1' });
+    expect(ui).toMatchObject({
+      kind: 'ui',
+      phase: 'build',
+      design: 'import',
+      flag: 'add_title_v1',
+    });
     expect(ui.screens).toEqual(['AddTitle']);
   });
 });

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -269,6 +269,9 @@ export type FeatureKind = 'backend' | 'ui';
 /** Build/wire phase declared by a `**Phase**` field on a `ui` feature. */
 export type FeaturePhase = 'build' | 'wire';
 
+/** Screen-node design mode declared by a `ui` feature. */
+export type FeatureDesignMode = 'none' | 'import' | 'brief';
+
 /**
  * Per-feature summary captured from a feature map's `### Feature N:` H3
  * sections. Mirrors {@link SliceSummary} for tasks files: the scanner
@@ -288,7 +291,9 @@ export interface FeatureSummary {
   phase?: FeaturePhase;
   /** Reference to the committed design skill; `ui` features only. */
   design_system?: string;
-  /** Optional path to a Claude Design export; `ui` features only. */
+  /** Screen-node design mode; `ui` features only. */
+  design?: FeatureDesignMode;
+  /** Optional path to a visual prototype bundle/export; `ui` features only. */
   bundle?: string;
   /** Feature-flag name; the shared build/wire contract. `ui` features only. */
   flag?: string;

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -461,6 +461,7 @@ describe('feature-kinds snippet', () => {
       'wire',
       'kind',
       'phase',
+      'design',
       'flag',
       'screens',
       'flows',
@@ -3290,6 +3291,7 @@ describe('getComposedTemplates', () => {
     expect(render).toContain('## Feature Kinds');
     expect(render).toContain('kind: ui');
     expect(render).toContain('phase: build');
+    expect(render).toContain('design: <none|import|brief>');
     expect(render).toMatch(/build\/wire/i);
     expect(render).not.toContain('{{>feature-kinds}}');
     expect(render).not.toContain('{{>');

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -210,7 +210,7 @@ artifacts that downstream commands consume.
 | `kind` | both | Yes (new) | `backend` or `ui`. Selects the `smithy.mark` authoring path. A missing `kind` on legacy feature maps defaults to `backend`. |
 | `phase` | ui | Yes | `build` or `wire` — a **feature-level** attribute. |
 | `design_system` | ui | Yes | Reference to the committed design skill (for example `story-spider-design`); source of truth even when a bundle is present. |
-| `design` | ui | Yes | Screen-node design mode: `none`, `import`, or `brief`. Render sets this explicitly; mark copies it into the UI ledger's `Design` column. |
+| `design` | ui | Yes | Screen-node design mode: `none`, `import`, or `brief`, shared by every `ScreenId` the feature lists. Render sets this explicitly; mark copies it into the `Design` cell of each `SC<N>` row. Screens needing distinct modes go in separate features. |
 | `bundle` | ui | No | Repo-relative path to a visual prototype bundle/export — a visual/structural reference, not a drop-in. Bundle wins on layout & visual intent; the design skill wins on implementation dialect. |
 | `flag` | ui | Yes (flag-gated) | Feature-flag name; the shared contract joining a `build` feature to its `wire` feature. |
 | `screens` | ui | Yes | List of `ScreenId`, e.g. `[AddTitle]`. |

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -192,8 +192,8 @@ for the prose-level pass.
 Features in a `.features.md` map are **typed**. Each `### Feature N:` carries a
 fenced `yaml` metadata block — right after the heading, before the prose
 (`**Description**:` etc.) — declaring its **kind** (`backend` or `ui`) and, for
-UI work, its design and phase fields. This README is the source of truth for the
-schema; the same field set is captured once in the `feature-kinds` snippet
+UI work, its design mode and phase fields. This README is the source of truth
+for the schema; the same field set is captured once in the `feature-kinds` snippet
 (`snippets/feature-kinds.md`) and pulled into `smithy.render` (authoring) and
 `smithy.audit` (validation) via `{{>feature-kinds}}` so the surfaces never drift.
 When `smithy.mark` consumes a `.features.md` file, it branches on the selected
@@ -210,13 +210,22 @@ artifacts that downstream commands consume.
 | `kind` | both | Yes (new) | `backend` or `ui`. Selects the `smithy.mark` authoring path. A missing `kind` on legacy feature maps defaults to `backend`. |
 | `phase` | ui | Yes | `build` or `wire` — a **feature-level** attribute. |
 | `design_system` | ui | Yes | Reference to the committed design skill (for example `story-spider-design`); source of truth even when a bundle is present. |
-| `bundle` | ui | No | Repo-relative path to a Claude Design export — a visual/structural reference, not a drop-in. Bundle wins on layout & visual intent; the design skill wins on implementation dialect. |
+| `design` | ui | Yes | Screen-node design mode: `none`, `import`, or `brief`. Render sets this explicitly; mark copies it into the UI ledger's `Design` column. |
+| `bundle` | ui | No | Repo-relative path to a visual prototype bundle/export — a visual/structural reference, not a drop-in. Bundle wins on layout & visual intent; the design skill wins on implementation dialect. |
 | `flag` | ui | Yes (flag-gated) | Feature-flag name; the shared contract joining a `build` feature to its `wire` feature. |
 | `screens` | ui | Yes | List of `ScreenId`, e.g. `[AddTitle]`. |
 | `flows` | ui | No (build) / Yes (wire) | List of `FlowId` the screen participates in. |
 
 `backend` features carry none of the ui-only keys; their body is the behavioral
 spec (prose delta).
+
+### Design mode semantics
+
+| `design` | Means |
+|----------|-------|
+| `none` | No visual loop; build from the committed design skill. |
+| `import` | Prototype-first; a bundle is supplied at render and rides forward. |
+| `brief` | Mark-authored durable intent can be handed to a visual tool. |
 
 ### Phase semantics
 
@@ -267,6 +276,7 @@ no-op; `all()` returns `[]` (never null) before any add.
 kind: ui
 phase: build
 design_system: story-spider-design
+design: import
 bundle: design/bundles/add-title.zip
 flag: add_title_v1
 screens: [AddTitle]
@@ -283,6 +293,7 @@ Library FAB, behind `add_title_v1` against an in-memory mock. Render all brief s
 kind: ui
 phase: wire
 design_system: story-spider-design
+design: import
 flag: add_title_v1
 screens: [AddTitle]
 flows: [AddTitle]

--- a/src/templates/agent-skills/commands/smithy.render.prompt
+++ b/src/templates/agent-skills/commands/smithy.render.prompt
@@ -323,7 +323,8 @@ kind: backend
 kind: ui
 phase: build
 design_system: <committed design skill, e.g. story-spider-design>
-bundle: <optional Claude Design export path, or omit the key>
+design: <none|import|brief>
+bundle: <optional visual prototype bundle path, or omit the key>
 flag: <feature-flag name gating this screen>
 screens: [<ScreenId>]
 flows: [<FlowId>]
@@ -343,13 +344,14 @@ flows: [<FlowId>]
 kind: ui
 phase: wire
 design_system: <same skill as the build feature>
+design: <same screen-node design mode as the build feature>
 flag: <same flag as the build feature — the shared contract>
 screens: [<ScreenId>]
 flows: [<FlowId>]
 ```
 
 **Description**: <Connect the screen to real data and flip the flag; done includes
-emitting/updating the Maestro flow + flow.md for each flow above.>
+emitting/updating the executable test body for each flow above.>
 
 **User-Facing Value**: <Why a user cares about this feature.>
 
@@ -506,6 +508,22 @@ here, by render.
 - **DO** type every feature with a `yaml` metadata block per the `feature-kinds`
   schema in Phase 3 (every feature has a `kind`; flag-gated UI splits into a
   `build` + `wire` pair sharing one `flag`).
+- **DO** make UI fan-out evident from metadata: `kind: ui` means mark will fan
+  out to screens/flows, `phase` says whether this is build or wire work,
+  `design` is the explicit screen-node mode (`none`, `import`, or `brief`), and
+  `screens`/`flows` name the candidate identifiers that downstream `mark` will
+  turn into the typed ledger and durable artifacts. Do not rely on feature
+  titles to communicate any of those facts.
+- **DO** keep backend features visibly backend: emit only `kind: backend` in the
+  metadata block, and do not add `phase`, `design_system`, `design`, `bundle`,
+  `flag`, `screens`, or `flows` to backend feature metadata. Missing `kind` on
+  legacy feature maps is still interpreted as backend during review, but new
+  render output should write `kind: backend` explicitly.
+- **DO** express flag-gated UI as a build + wire pair sharing exactly one
+  `flag` value. The build feature may be ordered before backend prerequisites;
+  attach backend prerequisites only to the wire feature's `## Dependency Order`
+  row, alongside the build feature dependency. The seam must be visible from
+  `phase`, the shared `flag`, and `Depends On`, not from naming convention alone.
 
 ---
 

--- a/src/templates/agent-skills/snippets/feature-kinds.md
+++ b/src/templates/agent-skills/snippets/feature-kinds.md
@@ -19,7 +19,7 @@ durable design truth.
 | `kind` | both | Yes (new) | `backend` or `ui`. Missing on legacy maps → `backend`. |
 | `phase` | ui | Yes | `build` or `wire` (feature-level). |
 | `design_system` | ui | Yes | Committed design-skill ref (for example `story-spider-design`); source of truth even when a bundle is present. |
-| `design` | ui | Yes | Screen-node design mode: `none`, `import`, or `brief`. Render must set this explicitly; downstream `mark` copies it into the UI ledger's `Design` column instead of inferring from the title. |
+| `design` | ui | Yes | Screen-node design mode: `none`, `import`, or `brief`, shared by every `ScreenId` the feature lists. Render must set this explicitly; downstream `mark` copies it into the `Design` cell of each of the feature's `SC<N>` ledger rows instead of inferring from the title. Screens needing distinct modes go in separate features. |
 | `bundle` | ui | No | Path to a visual prototype bundle/export — a visual/structural reference, not a drop-in. Bundle wins on layout/visual intent; the skill wins on implementation dialect. |
 | `flag` | ui | Yes (flag-gated) | Feature-flag name; the shared contract joining a `build` feature to its `wire` feature. |
 | `screens` | ui | Yes | List of `ScreenId`, e.g. `[AddTitle]`. |
@@ -46,6 +46,10 @@ flows: [AddTitle]
 prototype bundle is supplied at render and rides forward; `brief` means mark will
 author durable intent that can be handed to a visual tool. The mode is carried in
 metadata so readers and downstream commands do not infer it from feature titles.
+It is **feature-level**: every `ScreenId` in the feature's `screens` list shares
+the one `design` value, so a feature that would need two different modes for two
+screens must be split into separate features (one per mode) — which the
+one-screen-per-build model already favors.
 
 **Phase semantics.** `build` implements the screen component against a mock
 behind `flag` (rendering every brief state with design-system tokens only);

--- a/src/templates/agent-skills/snippets/feature-kinds.md
+++ b/src/templates/agent-skills/snippets/feature-kinds.md
@@ -2,10 +2,10 @@
 
 Every feature in a `.features.md` map is **typed**. Each `### Feature N:` carries a
 fenced `yaml` metadata block — placed right after the heading, before the prose —
-declaring its kind and, for UI work, its design and phase fields. The kind selects
-the `smithy.mark` authoring path: `backend` keeps the existing spec-triad flow,
-while `ui` enters the UI authoring path for the typed ledger and durable design
-truth.
+declaring its kind and, for UI work, its design mode and phase fields. The kind
+selects the `smithy.mark` authoring path: `backend` keeps the existing
+spec-triad flow, while `ui` enters the UI authoring path for the typed ledger and
+durable design truth.
 
 - **`backend`** — server/library functionality; the prose body is a behavioral delta.
 - **`ui`** — screen/flow work; `mark` authors the UI spec ledger and durable
@@ -19,10 +19,11 @@ truth.
 | `kind` | both | Yes (new) | `backend` or `ui`. Missing on legacy maps → `backend`. |
 | `phase` | ui | Yes | `build` or `wire` (feature-level). |
 | `design_system` | ui | Yes | Committed design-skill ref (for example `story-spider-design`); source of truth even when a bundle is present. |
-| `bundle` | ui | No | Path to a Claude Design export — a visual/structural reference, not a drop-in. Bundle wins on layout/visual intent; the skill wins on implementation dialect. |
+| `design` | ui | Yes | Screen-node design mode: `none`, `import`, or `brief`. Render must set this explicitly; downstream `mark` copies it into the UI ledger's `Design` column instead of inferring from the title. |
+| `bundle` | ui | No | Path to a visual prototype bundle/export — a visual/structural reference, not a drop-in. Bundle wins on layout/visual intent; the skill wins on implementation dialect. |
 | `flag` | ui | Yes (flag-gated) | Feature-flag name; the shared contract joining a `build` feature to its `wire` feature. |
 | `screens` | ui | Yes | List of `ScreenId`, e.g. `[AddTitle]`. |
-| `flows` | ui | No (build) / Yes (wire) | List of `FlowId` the screen participates in. |
+| `flows` | ui | No (build) / Yes (wire) | List of `FlowId` the screen participates in. Build features may list mock-satisfiable candidate flows; wire features must list the flows they connect to real data. |
 
 ```yaml
 # backend feature
@@ -34,15 +35,21 @@ kind: backend
 kind: ui
 phase: build
 design_system: story-spider-design
+design: import
 bundle: design/bundles/add-title.zip   # optional
 flag: add_title_v1
 screens: [AddTitle]
 flows: [AddTitle]
 ```
 
-**Phase semantics.** `build` implements the screen component against a mock behind
-`flag` (rendering every brief state with design-system tokens only); `wire`
-connects real data, flips the flag, and fills/updates the mark-created
+**Design mode semantics.** `none` means no visual loop; `import` means a
+prototype bundle is supplied at render and rides forward; `brief` means mark will
+author durable intent that can be handed to a visual tool. The mode is carried in
+metadata so readers and downstream commands do not infer it from feature titles.
+
+**Phase semantics.** `build` implements the screen component against a mock
+behind `flag` (rendering every brief state with design-system tokens only);
+`wire` connects real data, flips the flag, and fills/updates the mark-created
 executable test-body stub for every flow in `flows` using the project's UI
 driver; the `.flow.md` design truth is authored by `mark`. Compose, Maestro,
 and `story-spider-design` are examples, not required stacks.
@@ -50,6 +57,5 @@ and `story-spider-design` are examples, not required stacks.
 **The build/wire seam.** Flag-gated UI is two features sharing one `flag`: a `build`
 feature and a `wire` feature that lists the build feature in its `Depends On` cell.
 Build-ahead-of-backend is legal — only the `wire` feature depends on the backend
-feature. The shared `flag`, not a naming convention, is the contract of record. See
-the "Feature Kinds and the Build/Wire Seam" section of the agent-skills README for a
-worked example.
+feature. The shared `flag`, the `phase` metadata, and the dependency row are the
+contract of record; naming conventions are only descriptive.


### PR DESCRIPTION
## Summary
EPIC #404 → Spec: Screens and Flows as UI Feature Kinds → User Story 5 (render is a clean, UI-aware entry point) → Slice 1: Tighten Rendered UI Feature Metadata

Render now emits complete, internally consistent typed UI feature metadata — including an explicit per-node `design` mode (`none`/`import`/`brief`) so design mode is read from metadata rather than inferred from feature titles — and requires the flag-gated build/wire seam to be expressed in the feature map's `## Dependency Order`. This is the right first increment because the ordinary no-bundle path must reliably distinguish backend from UI work before import-mode structure derivation (Slice 2) is layered on.

## Spec debt & uncertainty
- SD-005 (open): fidelity of `import`-mode structure derivation from a prototype/bundle — deferred to Slice 2; this slice only adds the `design` mode field, not derivation.
- SD-006 (open): whether `SC`/`FL` nodes are always atomic or can be sub-sliced.
- SD-007 (open): build-phase coverage honesty (a build screen can be "done" with a missing brief state and no executable gate).
- SD-008 (open): visual-intent honesty for a `brief`-mode node that never received a bundle.
- Assumption: the non-blocking visual-design gate defines three modes (`import`/`brief`/`none`) with `bundle` as the boundary object; this slice adds `design` as a first-class metadata key carrying that mode forward to `mark`'s UI ledger.
- The new backend ui-only-key warning keys off the raw yaml block (`meta.has(key)`), so a stray `design:` on a backend feature now warns — a slight behavior tightening over the prior parsed-value check.

## Validation
typecheck ✅ · test ✅ (289 passed across the three touched test files: status parser, status types, templates). Full `npm run build` and whole-suite run not executed; change is templates + status parser/types only.
