### PR TITLE
forge: carry per-case token totals through report data

### DIFF
--- a/evals/lib/report.test.ts
+++ b/evals/lib/report.test.ts
@@ -224,6 +224,55 @@ describe('scenarioRunToResult', () => {
       expect(result.duration_ms).toBe(9876);
     });
 
+    it('copies token totals from output.tokens', () => {
+      const scenario = makeScenario();
+      const output = makeOutput({ tokens: { input: 123, output: 45 } });
+      const result = scenarioRunToResult(scenario, output, [passingCheck]);
+
+      expect(result.tokens).toEqual({ input: 123, output: 45 });
+    });
+
+    it('preserves token totals across pass, fail, timeout, and error statuses', () => {
+      const cases: Array<{
+        name: string;
+        output: RunOutput;
+        checks: CheckResult[];
+      }> = [
+        {
+          name: 'pass',
+          output: makeOutput({ tokens: { input: 10, output: 1 } }),
+          checks: [passingCheck],
+        },
+        {
+          name: 'fail',
+          output: makeOutput({ tokens: { input: 20, output: 2 } }),
+          checks: [failingCheck],
+        },
+        {
+          name: 'timeout',
+          output: makeOutput({
+            timed_out: true,
+            tokens: { input: 30, output: 3 },
+          }),
+          checks: [passingCheck],
+        },
+        {
+          name: 'error',
+          output: makeOutput({
+            exit_code: 1,
+            tokens: { input: 40, output: 4 },
+          }),
+          checks: [passingCheck],
+        },
+      ];
+
+      for (const c of cases) {
+        const result = scenarioRunToResult(makeScenario(), c.output, c.checks);
+        expect(result.status).toBe(c.name);
+        expect(result.tokens).toEqual(c.output.tokens);
+      }
+    });
+
     it('populates structural_checks from the input array', () => {
       const scenario = makeScenario();
       const output = makeOutput();
@@ -283,6 +332,7 @@ function makeResult(overrides: Partial<EvalResult> = {}): EvalResult {
     scenario_name: 'sample',
     status: 'pass',
     extracted_text: '## Plan\n\nDetails.',
+    tokens: { input: 0, output: 0 },
     duration_ms: 100,
     structural_checks: [passingCheck],
     ...overrides,
@@ -352,6 +402,7 @@ describe('buildReport', () => {
       expect(report.passed).toBe(0);
       expect(report.failed).toBe(0);
       expect(report.results).toEqual([]);
+      expect(report.tokens).toEqual({ input: 0, output: 0 });
       expect(report.total_duration_ms).toBe(0);
       expect(typeof report.timestamp).toBe('string');
     });
@@ -378,6 +429,37 @@ describe('buildReport', () => {
       expect(report.results[0]?.scenario_name).toBe('first');
       expect(report.results[1]?.scenario_name).toBe('second');
       expect(report.results[2]?.scenario_name).toBe('third');
+    });
+
+    it('sums token totals from every included result across mixed statuses', () => {
+      const results: EvalResult[] = [
+        makeResult({
+          scenario_name: 'a',
+          status: 'pass',
+          tokens: { input: 10, output: 1 },
+        }),
+        makeResult({
+          scenario_name: 'b',
+          status: 'fail',
+          tokens: { input: 20, output: 2 },
+        }),
+        makeResult({
+          scenario_name: 'c',
+          status: 'timeout',
+          tokens: { input: 30, output: 3 },
+          error: 'timed out',
+        }),
+        makeResult({
+          scenario_name: 'd',
+          status: 'error',
+          tokens: { input: 40, output: 4 },
+          error: 'exit 1',
+        }),
+      ];
+
+      const report = buildReport(results, 1000);
+
+      expect(report.tokens).toEqual({ input: 100, output: 10 });
     });
   });
 

--- a/evals/lib/report.ts
+++ b/evals/lib/report.ts
@@ -68,6 +68,7 @@ export function scenarioRunToResult(
     scenario_name: scenario.name,
     status,
     extracted_text: output.extracted_text,
+    tokens: output.tokens,
     duration_ms: output.duration_ms,
     structural_checks: structuralChecks,
   };
@@ -106,10 +107,13 @@ export function buildReport(
   totalDurationMs: number,
 ): EvalReport {
   let passed = 0;
+  const tokens = { input: 0, output: 0 };
   for (const result of results) {
     if (result.status === 'pass') {
       passed += 1;
     }
+    tokens.input += result.tokens.input;
+    tokens.output += result.tokens.output;
   }
   const failed = results.length - passed;
   const overall_status: EvalReport['overall_status'] =
@@ -122,6 +126,7 @@ export function buildReport(
     failed,
     overall_status,
     results: results.slice(),
+    tokens,
     total_duration_ms: totalDurationMs,
   };
 }

--- a/evals/lib/report.ts
+++ b/evals/lib/report.ts
@@ -68,7 +68,7 @@ export function scenarioRunToResult(
     scenario_name: scenario.name,
     status,
     extracted_text: output.extracted_text,
-    tokens: output.tokens,
+    tokens: { input: output.tokens.input, output: output.tokens.output },
     duration_ms: output.duration_ms,
     structural_checks: structuralChecks,
   };

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -184,6 +184,7 @@ export interface EvalResult {
   scenario_name: string;
   status: 'pass' | 'fail' | 'timeout' | 'error';
   extracted_text: string;
+  tokens: TokenTotals;
   duration_ms: number;
   structural_checks: CheckResult[];
   sub_agent_checks?: CheckResult[] | undefined;
@@ -217,6 +218,8 @@ export interface EvalReport {
   overall_status: 'pass' | 'fail';
   /** Per-case results, in execution order. */
   results: EvalResult[];
+  /** Aggregate token totals across every included result. */
+  tokens: TokenTotals;
   /** Total wall-clock time for the entire run, in milliseconds. */
   total_duration_ms: number;
 }

--- a/specs/2026-05-18-007-per-case-token-totals-in-evalreport/01-capture-per-case-token-totals.tasks.md
+++ b/specs/2026-05-18-007-per-case-token-totals-in-evalreport/01-capture-per-case-token-totals.tasks.md
@@ -65,7 +65,7 @@
 
 ### Tasks
 
-- [ ] **Copy runner tokens into eval results**
+- [x] **Copy runner tokens into eval results**
 
   Extend `EvalResult` in `evals/lib/types.ts` and update `scenarioRunToResult` in `evals/lib/report.ts` so each result carries the `RunOutput.tokens` value. The copy must be status-independent so AS 1.3 remains true for timeout and error scenarios.
 
@@ -76,7 +76,7 @@
   - Pass, fail, timeout, and error results all preserve token totals.
   - Unit coverage verifies token preservation across status precedence paths.
 
-- [ ] **Aggregate tokens in eval reports**
+- [x] **Aggregate tokens in eval reports**
 
   Extend `EvalReport` and `buildReport` so aggregate input and output counts are summed from per-case `EvalResult.tokens`. Keep the current result ordering, status counts, timestamp behavior, and `formatReport` output stable because User Story 2 owns token rendering.
 


### PR DESCRIPTION
## Summary
RFC 2026-001 token-savings → M1 Measurement Foundation → F1.3a Per-Case Token Totals in EvalReport → Per-Case Token Totals spec (User Story 1) → Slice 2: Carry Token Totals Through Report Data

Threads the token totals measured on `RunOutput` through the report pipeline: each per-case `EvalResult` now carries a `tokens` value copied status-independently by `scenarioRunToResult`, and `EvalReport` exposes an aggregate sum computed by `buildReport`. This is the data-only increment that completes US1's capture path without touching report rendering (owned by US2).

## Spec debt & uncertainty
- SD-001 (inherited): stream-json usage placement may vary by Claude CLI version; extraction/dedup lives in Slice 1 and is unaffected by this data-threading slice.
- SD-002 (inherited): token envelope tolerance is not calibrated until the first token-aware baseline is captured (US3 concern; no envelopes touched here).
- SD-003 (inherited): the RFC touched-files matrix still omits token-threading surfaces; matrix amendment remains deferred to a later implementation PR.
- Assumption: a zero-token total means "no usable usage metadata observed," so `buildReport` sums plain `input`/`output` counts and empty reports expose `{input: 0, output: 0}`.
- Verification gap: could not run `build`/fixture tests — `dist/cli.js` is not present in this fresh worktree, so the 2 `fixture.test.ts` cases fail purely on the missing build artifact (unrelated to this diff).

## Validation
typecheck ✅ · test ✅ (report suite 58 passed; full evals unit 231 passed, 2 fixture failures are pre-existing missing-`dist/` build-artifact errors, not from this change) · build ⏭️ not run (no `dist/` in worktree)
