### PR TITLE
forge: project reused personas and cold-draft only gaps in ignite

### DIFF
--- a/specs/2026-06-05-011-smithy-persona-command/04-ignite-reuses-existing-persona-files-before-generating-new-ones.tasks.md
+++ b/specs/2026-06-05-011-smithy-persona-command/04-ignite-reuses-existing-persona-files-before-generating-new-ones.tasks.md
@@ -51,7 +51,7 @@
 
 ### Tasks
 
-- [ ] **Project covered personas into the RFC**
+- [x] **Project covered personas into the RFC**
 
   Update Sub-phase 3b instructions so each covered persona file is read and projected into the RFC `## Personas` section as how this RFC benefits that durable persona. The projection should preserve the durable persona's role, context, and friction while tailoring the final benefit language to the current RFC.
 
@@ -61,7 +61,7 @@
   - Projection keeps durable persona content as the source context while allowing RFC-specific benefit framing.
   - The resulting section still passes ignite's existing non-empty Personas verification.
 
-- [ ] **Cold-draft only uncovered persona gaps**
+- [x] **Cold-draft only uncovered persona gaps**
 
   Amend the `smithy-prose` dispatch in Sub-phase 3b so cold drafting is limited to personas not covered by existing files, then combine any cold-drafted gap content with the file-sourced projections into one valid `## Personas` section.
 
@@ -71,7 +71,7 @@
   - The final RFC contains one `## Personas` section that includes both reused and newly drafted personas when both are present.
   - If all needed personas are covered by files, Sub-phase 3b does not perform an unnecessary cold Personas dispatch.
 
-- [ ] **Protect reuse behavior with template tests**
+- [x] **Protect reuse behavior with template tests**
 
   Update template coverage around `smithy.ignite.prompt` so the reuse-before-generate behavior is protected without regenerating deployed snapshots. Focus the checks on discovery-before-dispatch, slug-based coverage, projection from files, and gap-only cold drafting.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -716,6 +716,31 @@ describe('getComposedTemplates', () => {
     expect(subphase3bBlock).toContain('`<slug>.persona.md` covers');
     expect(subphase3bBlock).toMatch(/Avoid fuzzy\s+matching/);
     expect(subphase3bBlock).toContain('If no `.persona.md` files exist');
+    expect(subphase3bBlock).not.toContain('coverage detection only');
+    expect(subphase3bBlock).not.toContain('regardless of the match results');
+  });
+
+  it('smithy.ignite projects reusable personas and cold-drafts only uncovered gaps', () => {
+    const ignite = claudeComposed.commands.get('smithy.ignite.md')!;
+    const subphase3bIdx = ignite.indexOf('Sub-phase 3b: Personas');
+    const subphase3cIdx = ignite.indexOf('Sub-phase 3c: Goals + Out of Scope');
+    expect(subphase3bIdx).toBeGreaterThan(-1);
+    expect(subphase3cIdx).toBeGreaterThan(subphase3bIdx);
+    const subphase3bBlock = ignite.slice(subphase3bIdx, subphase3cIdx);
+
+    const discoveryIdx = subphase3bBlock.indexOf('Before drafting Personas cold');
+    const projectionIdx = subphase3bBlock.indexOf('For each covered persona, read the matching `.persona.md` file');
+    const dispatchIdx = subphase3bBlock.indexOf('dispatch **smithy-prose** for only those gaps');
+    expect(projectionIdx).toBeGreaterThan(discoveryIdx);
+    expect(dispatchIdx).toBeGreaterThan(projectionIdx);
+    expect(subphase3bBlock).toMatch(/preserve the\s+persona's role, context, and friction/);
+    expect(subphase3bBlock).toContain('project it into the RFC-specific');
+    expect(subphase3bBlock).toContain('narrowed to the uncovered persona names or roles');
+    expect(subphase3bBlock).toContain('Do not regenerate personas covered by existing `.persona.md` files');
+    expect(subphase3bBlock).toContain('If every needed persona is covered');
+    expect(subphase3bBlock).toMatch(/do not\s+dispatch smithy-prose for Personas/);
+    expect(subphase3bBlock).toContain('Combine the file-sourced projections and any cold-drafted uncovered gap content');
+    expect(subphase3bBlock).toContain('exactly one `## Personas` section');
   });
 
   it('smithy.pr-review scripts start with bash shebang', () => {

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -731,6 +731,9 @@ describe('getComposedTemplates', () => {
     const discoveryIdx = subphase3bBlock.indexOf('Before drafting Personas cold');
     const projectionIdx = subphase3bBlock.indexOf('For each covered persona, read the matching `.persona.md` file');
     const dispatchIdx = subphase3bBlock.indexOf('dispatch **smithy-prose** for only those gaps');
+    expect(discoveryIdx).toBeGreaterThan(-1);
+    expect(projectionIdx).toBeGreaterThan(-1);
+    expect(dispatchIdx).toBeGreaterThan(-1);
     expect(projectionIdx).toBeGreaterThan(discoveryIdx);
     expect(dispatchIdx).toBeGreaterThan(projectionIdx);
     expect(subphase3bBlock).toMatch(/preserve the\s+persona's role, context, and friction/);

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -538,27 +538,38 @@ Before drafting Personas cold, discover reusable durable personas:
    persona. A needed slug with no matching file remains uncovered. Avoid fuzzy
    matching, semantic similarity, interactive selection, or any new registry.
 
-This slice adds coverage detection only — it does not yet change how the
-`## Personas` section is drafted. Record which needed personas are covered by a
-matching `<slug>.persona.md` file and which remain uncovered as informational
-notes for the projection and gap-only drafting that a later slice introduces.
-If no `.persona.md` files exist, there is simply nothing to reuse. Then,
-**regardless of the match results** (no files, some covered, or all covered),
-follow the existing cold-draft path and dispatch **smithy-prose** with:
+For each covered persona, read the matching `.persona.md` file before drafting
+the RFC section. Treat that durable file as source context: preserve the
+persona's role, context, and friction, but project it into the RFC-specific
+`## Personas` section by explaining how this RFC benefits that persona. The RFC
+projection is not a byte-for-byte copy of the durable file; it is a tailored
+benefit framing grounded in the durable file's narrative.
+
+For each uncovered needed persona, keep it in an uncovered-persona gaps list.
+If no `.persona.md` files exist, every needed persona is uncovered and there is
+simply nothing to reuse. If the uncovered-persona gaps list is non-empty,
+dispatch **smithy-prose** for only those gaps with:
 
 - **section_assignment**: "Personas"
 - **idea_description**: the user's idea description or PRD content from intake
-- **clarify_output**: the Q&A and assumptions from Phase 2 clarification
+- **clarify_output**: the Q&A and assumptions from Phase 2 clarification, narrowed to the uncovered persona names or roles so covered personas are not regenerated cold
 - **rfc_file_path**: the path to the accumulating `<slug>.rfc.md` (which at this point contains the header plus Summary and Motivation)
-- **tone_directives**: "Personas named or described during Phase 2 clarification are mandatory — every persona surfaced there MUST appear in the drafted `## Personas` section with a role and a description of how this RFC benefits them. Do not return placeholder or empty content."
+- **tone_directives**: "Draft only the uncovered personas listed in clarify_output. Do not regenerate personas covered by existing `.persona.md` files. Every uncovered persona is mandatory and MUST appear with a role and a description of how this RFC benefits them. Do not return placeholder or empty content."
 
-After smithy-prose returns, verify that the returned content contains a
-non-empty `## Personas` section with at least one named persona. If the
-sub-agent returns empty output, placeholder content (e.g., the template's
-`<Persona 1 ...>` literal), or a response missing the `## Personas` heading,
-**halt the pipeline** with a diagnostic that points at the Phase 2
-clarification record so the user can confirm which personas were identified
-before retrying. Otherwise, append the returned content to the RFC file.
+If every needed persona is covered by matching `.persona.md` files, do not
+dispatch smithy-prose for Personas. Build the `## Personas` section entirely
+from the file-sourced projections.
+
+Combine the file-sourced projections and any cold-drafted uncovered gap content
+into exactly one `## Personas` section. If both sources are present, include
+both in that single section; do not append a second `## Personas` heading.
+Verify that the combined content contains a non-empty `## Personas` section with
+at least one named persona. If the combined result is empty, placeholder content
+(e.g., the template's `<Persona 1 ...>` literal), or missing the `## Personas`
+heading, **halt the pipeline** with a diagnostic that points at the Phase 2
+clarification record and the reusable persona coverage record so the user can
+confirm which personas were identified before retrying. Otherwise, append the
+combined `## Personas` section to the RFC file.
 
 ### Sub-phase 3c: Goals + Out of Scope
 

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -552,7 +552,7 @@ dispatch **smithy-prose** for only those gaps with:
 
 - **section_assignment**: "Personas"
 - **idea_description**: the user's idea description or PRD content from intake
-- **clarify_output**: the Q&A and assumptions from Phase 2 clarification, narrowed to the uncovered persona names or roles so covered personas are not regenerated cold
+- **clarify_output**: the Q&A and assumptions from Phase 2 clarification, narrowed to the uncovered persona names or roles so covered personas are not regenerated cold (include only the clarification context for the uncovered personas; exclude the names, roles, and context of any persona already covered by a matching `.persona.md` file)
 - **rfc_file_path**: the path to the accumulating `<slug>.rfc.md` (which at this point contains the header plus Summary and Motivation)
 - **tone_directives**: "Draft only the uncovered personas listed in clarify_output. Do not regenerate personas covered by existing `.persona.md` files. Every uncovered persona is mandatory and MUST appear with a role and a description of how this RFC benefits them. Do not return placeholder or empty content."
 

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -427,7 +427,12 @@ Before drafting orchestrator-inline RFC prose in this phase, load
 source for directly authored RFC sections such as Decisions and coherence
 repairs. Keep Summary, Motivation / Problem Statement, and Personas delegated
 to `smithy-prose` where those sub-phases already own the narrative drafting,
-and do not inline the helper's taxonomy here.
+and do not inline the helper's taxonomy here. Sub-phase 3b is the sole
+Personas exception to this delegation rule: covered personas are projected
+inline by the orchestrator from their `.persona.md` files, and only the
+uncovered-persona gaps are delegated to `smithy-prose` — so when every needed
+persona is covered, no `smithy-prose` Personas dispatch occurs at all. See
+Sub-phase 3b for the full projection-and-gap procedure.
 
 {{#ifAgent}}
 ### RFC File Creation


### PR DESCRIPTION
## Summary
smithy.persona-command spec → User Story 4: Ignite Reuses Existing Persona Files → Slice 2: Project Reused Personas and Draft Only Gaps
Ignite Sub-phase 3b now reads each covered `.persona.md` file and projects it into the RFC `## Personas` section as RFC-specific benefit framing, and narrows the `smithy-prose` cold draft to only the uncovered persona gaps — the user-visible US4 payoff on top of Slice 1's coverage-detection decision point. When every needed persona is covered, no cold dispatch runs at all; both sources are combined into exactly one `## Personas` section before the existing non-empty verification.

## Spec debt & uncertainty
- SD-003 (inherited): how ignite feeds an existing `.persona.md`'s content to smithy-prose given no matching input parameter — bound by this slice: ignite reads covered files inline and supplies their content as projection source context rather than adding a new smithy-prose parameter.
- SD-004 (inherited, unresolved): how Sub-phase 3g detects file-sourced `## Personas` provenance on resume — out of scope here; owned by the downstream US5 non-clobber slice.
- Assumption: personas are matched by deterministic filename-slug identity derived from Phase 2 clarification names/roles (bound by Slice 1); this slice inherits that contract for the covered-vs-gap split.
- The prompt change is instructional (LLM-executed at ignite runtime); validation is limited to template composition/coverage tests, not an end-to-end ignite run.

## Validation
build ✅ · typecheck ✅ · test ✅ (src/templates.test.ts, 234 passed incl. 2 new persona-reuse checks)
