### PR TITLE
forge: surface typed UI ledger nodes in status and dependency graphs

### DIFF
--- a/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/07-ui-work-is-visible-to-status-dependency-and-audit-tooling.tasks.md
+++ b/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/07-ui-work-is-visible-to-status-dependency-and-audit-tooling.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Parse typed UI ledger rows for status**
+- [x] **Parse typed UI ledger rows for status**
 
   Extend the status artifact scanner so a spec `## Dependency Order` table with `ID`, `Kind`, `Title`, `Depends On`, `Design`, and `Artifact` columns is accepted as a UI ledger. Each `SC<N>`, `FL<N>`, and `US<N>` row should produce a distinct status record whose progress derives from its own `Artifact` task file when present and remains visible when no artifact exists.
 
@@ -28,7 +28,7 @@
   - `US<N>` rows inside UI ledgers continue to produce distinct status records
   - Rows with `Artifact` set to `—` are reported as unstarted rather than hidden
 
-- [ ] **Resolve UI dependency edges**
+- [x] **Resolve UI dependency edges**
 
   Update dependency graph reconstruction so typed UI ledger `Depends On` cells resolve same-table `SC`, `FL`, and `US` IDs. Preserve existing backend graph behavior while ensuring screen, flow, and story nodes participate in ordering and blocked/unblocked calculations for AS 7.2.
 
@@ -39,7 +39,7 @@
   - Dangling UI dependency IDs surface as graph warnings or failures consistent with existing dependency behavior
   - Backend-only dependency parsing remains unchanged
 
-- [ ] **Render per-node UI progress**
+- [x] **Render per-node UI progress**
 
   Update status output rendering so UI node identity is visible without relying on title inference. The human and JSON status surfaces should expose enough node metadata for developers and automation to distinguish screen-build, flow-wire, and backend-story progress for AS 7.1.
 

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -650,6 +650,27 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
     );
   }
 
+  function writeUiLedgerFixture(): void {
+    const uiHeader =
+      '| ID | Kind | Title (→ mark durable file) | Depends On | Design | Artifact |\n' +
+      '|----|------|-----------------------------|------------|--------|----------|';
+    write(
+      'specs/ui/ui.spec.md',
+      `# UI Spec\n\n## Dependency Order\n\n${uiHeader}\n` +
+        '| SC1 | screen | AddTitle screen | — | brief | specs/ui/sc-01-add-title.tasks.md |\n' +
+        '| FL1 | flow | AddTitle flow | SC1 | — | — |\n' +
+        '| US1 | story | Persist title | FL1 | — | specs/ui/01-persist-title.tasks.md |\n',
+    );
+    write(
+      'specs/ui/sc-01-add-title.tasks.md',
+      `# Tasks: AddTitle Screen\n\n## Slice 1: Build\n\n- [x] Done\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Build | — | — |\n`,
+    );
+    write(
+      'specs/ui/01-persist-title.tasks.md',
+      `# Tasks: Persist Title\n\n## Slice 1: Persist\n\n- [ ] Todo\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Persist | — | — |\n`,
+    );
+  }
+
   // --- AS 10.5: JSON graph populated unconditionally ---
 
   it('AS 10.5: JSON `graph` is populated from buildDependencyGraph (multi-row spec, --all reveals done nodes)', () => {
@@ -697,6 +718,39 @@ describe('statusAction --graph integration (US10 Slice 3)', () => {
       cycles: [],
       dangling_refs: [],
     });
+  });
+
+  it('surfaces typed UI node identity in JSON and human graph output', () => {
+    writeUiLedgerFixture();
+
+    statusAction({ root, format: 'json', all: true });
+    const payload = JSON.parse(captured()) as StatusJsonPayload;
+    expect(payload.graph.nodes['specs/ui/ui.spec.md#SC1']?.row.kind).toBe(
+      'screen',
+    );
+    expect(payload.graph.nodes['specs/ui/ui.spec.md#FL1']?.row.kind).toBe(
+      'flow',
+    );
+    expect(payload.graph.nodes['specs/ui/ui.spec.md#US1']?.row.kind).toBe(
+      'story',
+    );
+    expect(
+      payload.records.find(
+        (record) => record.path === 'specs/ui/fl-01-addtitle-flow.tasks.md',
+      ),
+    ).toMatchObject({
+      virtual: true,
+      status: 'not-started',
+      parent_row_id: 'FL1',
+      parent_row_kind: 'flow',
+    });
+
+    logSpy.mockClear();
+    statusAction({ root, graph: true, all: true });
+    const stdout = captured();
+    expect(stdout).toContain('SC1 screen AddTitle screen');
+    expect(stdout).toContain('FL1 flow AddTitle flow');
+    expect(stdout).toContain('US1 story Persist title');
   });
 
   it('JSON `graph` empty-repo shape under `--all` reports mode `all`', () => {

--- a/src/status/graph.test.ts
+++ b/src/status/graph.test.ts
@@ -142,6 +142,37 @@ describe('buildDependencyGraph — within-artifact topological layering (AS 10.1
   });
 });
 
+describe('buildDependencyGraph — typed UI ledger dependencies', () => {
+  it('resolves SC, FL, and US dependencies within the same spec ledger', () => {
+    const specPath = 'specs/ui/ui.spec.md';
+    const spec = makeRecord({
+      type: 'spec',
+      path: specPath,
+      status: 'in-progress',
+      dependency_order: {
+        id_prefix: 'US',
+        format: 'table',
+        rows: [
+          row('SC1', [], { kind: 'screen', title: 'Screen' }),
+          row('FL1', ['SC1'], { kind: 'flow', title: 'Flow' }),
+          row('US1', ['FL1'], { kind: 'story', title: 'Backend' }),
+        ],
+      },
+    });
+
+    const graph = buildDependencyGraph([spec]);
+
+    expect(graph.layers).toEqual([
+      { layer: 0, node_ids: [`${specPath}#SC1`] },
+      { layer: 1, node_ids: [`${specPath}#FL1`] },
+      { layer: 2, node_ids: [`${specPath}#US1`] },
+    ]);
+    expect(graph.nodes[`${specPath}#SC1`]?.row.kind).toBe('screen');
+    expect(graph.nodes[`${specPath}#FL1`]?.row.kind).toBe('flow');
+    expect(graph.nodes[`${specPath}#US1`]?.row.kind).toBe('story');
+  });
+});
+
 describe('buildDependencyGraph — determinism (SD-013)', () => {
   it('orders Layer 0 by record discovery order, then by row order within each table', () => {
     // Two records, each with two independent rows. Both records belong

--- a/src/status/parser.test.ts
+++ b/src/status/parser.test.ts
@@ -276,6 +276,46 @@ trailing content
     });
   });
 
+  it('accepts typed UI ledger columns and preserves screen, flow, and story row metadata', () => {
+    const markdown = `# UI Spec
+
+## Dependency Order
+
+| ID | Kind | Title (→ mark's durable file) | Depends On | Design | Artifact |
+|----|------|-------------------------------|------------|--------|----------|
+| SC1 | screen | AddTitle | — | brief | specs/ui/sc-01-add-title.tasks.md |
+| FL1 | flow | AddTitle flow | SC1 | — | — |
+| US1 | story | Persist title | FL1 | — | specs/ui/01-persist-title.tasks.md |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.warnings).toEqual([]);
+    expect(result.table.format).toBe('table');
+    expect(result.table.rows).toEqual([
+      {
+        id: 'SC1',
+        kind: 'screen',
+        title: 'AddTitle',
+        depends_on: [],
+        design: 'brief',
+        artifact_path: 'specs/ui/sc-01-add-title.tasks.md',
+      },
+      {
+        id: 'FL1',
+        kind: 'flow',
+        title: 'AddTitle flow',
+        depends_on: ['SC1'],
+        artifact_path: null,
+      },
+      {
+        id: 'US1',
+        kind: 'story',
+        title: 'Persist title',
+        depends_on: ['FL1'],
+        artifact_path: 'specs/ui/01-persist-title.tasks.md',
+      },
+    ]);
+  });
+
   it('coerces backtick-wrapped absolute Artifact paths to null with a warning', () => {
     // Backtick unwrapping must happen before the absolute-path check so
     // a backticked absolute path is still rejected instead of being

--- a/src/status/parser.test.ts
+++ b/src/status/parser.test.ts
@@ -337,18 +337,39 @@ trailing content
     expect(result.table.rows[0]?.design).toBeUndefined();
   });
 
-  it('names the full allowed prefix set when a spec row prefix is wrong', () => {
+  it('names the full allowed prefix set when a typed UI ledger row prefix is wrong', () => {
     const markdown = `# UI Spec
+
+## Dependency Order
+
+| ID | Kind | Title | Depends On | Design | Artifact |
+|----|------|-------|------------|--------|----------|
+| M1 | screen | Wrong prefix | — | — | — |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.warnings).toContain(
+      "dependency_order: row M1 has prefix 'M' but expected one of 'US', 'SC', 'FL' for artifact type 'spec'",
+    );
+  });
+
+  it('drops SC/FL IDs in a backend-only spec table as invalid, leaving parsing unchanged', () => {
+    // A backend spec keeps the canonical 4-column shape (no `Kind`
+    // column). `SC`/`FL` prefixes are UI-ledger-only, so an `SC1` typo
+    // here must be dropped as an invalid ID exactly as before typed UI
+    // ledgers existed — never scanned as a screen child.
+    const markdown = `# Backend Spec
 
 ## Dependency Order
 
 | ID | Title | Depends On | Artifact |
 |----|-------|------------|----------|
-| M1 | Wrong prefix | — | — |
+| US1 | Real story | — | — |
+| SC1 | Stray screen prefix | — | — |
 `;
     const result = parseDependencyTable(markdown, 'spec');
+    expect(result.table.rows.map((row) => row.id)).toEqual(['US1']);
     expect(result.warnings).toContain(
-      "dependency_order: row M1 has prefix 'M' but expected one of 'US', 'SC', 'FL' for artifact type 'spec'",
+      "dependency_order: row 2 has invalid ID 'SC1' — dropped",
     );
   });
 

--- a/src/status/parser.test.ts
+++ b/src/status/parser.test.ts
@@ -316,6 +316,42 @@ trailing content
     ]);
   });
 
+  it('warns on unrecognized Kind and Design values instead of silently dropping them', () => {
+    const markdown = `# UI Spec
+
+## Dependency Order
+
+| ID | Kind | Title | Depends On | Design | Artifact |
+|----|------|-------|------------|--------|----------|
+| SC1 | scren | AddTitle | — | breif | — |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.warnings).toContain(
+      "dependency_order: row SC1 has unrecognized Kind 'scren' — expected screen, flow, or story; ignored",
+    );
+    expect(result.warnings).toContain(
+      "dependency_order: row SC1 has unrecognized Design 'breif' — expected none, import, or brief; ignored",
+    );
+    // The bad cells are dropped from the row, not carried through.
+    expect(result.table.rows[0]?.kind).toBeUndefined();
+    expect(result.table.rows[0]?.design).toBeUndefined();
+  });
+
+  it('names the full allowed prefix set when a spec row prefix is wrong', () => {
+    const markdown = `# UI Spec
+
+## Dependency Order
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| M1 | Wrong prefix | — | — |
+`;
+    const result = parseDependencyTable(markdown, 'spec');
+    expect(result.warnings).toContain(
+      "dependency_order: row M1 has prefix 'M' but expected one of 'US', 'SC', 'FL' for artifact type 'spec'",
+    );
+  });
+
   it('coerces backtick-wrapped absolute Artifact paths to null with a warning', () => {
     // Backtick unwrapping must happen before the absolute-path check so
     // a backticked absolute path is still rejected instead of being

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -36,7 +36,12 @@ const ID_PREFIX_BY_TYPE: Record<ArtifactType, IdPrefix> = {
   tasks: 'S',
 };
 
-const ID_REGEX = /^(M|F|US|S|SC|FL)[1-9][0-9]*$/;
+// Backend-only tables keep the canonical prefix set. Only a typed UI
+// ledger (a spec table with a `Kind` column) additionally accepts the
+// `SC`/`FL` screen/flow prefixes — so an `SC1` typo in a backend spec is
+// still dropped as an invalid ID exactly as before UI ledgers existed.
+const ID_REGEX = /^(M|F|US|S)[1-9][0-9]*$/;
+const ID_REGEX_UI_LEDGER = /^(M|F|US|S|SC|FL)[1-9][0-9]*$/;
 const EM_DASH = '—';
 
 /**
@@ -108,6 +113,12 @@ export function parseDependencyTable(
 
   const { dataStart, columnIndex } = headerInfo;
 
+  // A spec table is a typed UI ledger only when it carries the `Kind`
+  // column. Backend-only spec tables keep the canonical 4-column shape
+  // and must reject `SC`/`FL` IDs (a typo there is a real error, not a
+  // silently-scanned screen/flow child).
+  const isUiLedger = columnIndex.kind !== undefined;
+
   // Parse data rows beginning after the separator line.
   const rows: DependencyRow[] = [];
   const rawRows: Array<{ cells: string[]; sourceIndex: number }> = [];
@@ -144,7 +155,8 @@ export function parseDependencyTable(
         ? ''
         : (cells[columnIndex.design] ?? '').trim();
 
-    if (!ID_REGEX.test(id)) {
+    const idRegex = isUiLedger ? ID_REGEX_UI_LEDGER : ID_REGEX;
+    if (!idRegex.test(id)) {
       warnings.push(
         `dependency_order: row ${sourceIndex} has invalid ID '${id}' — dropped`,
       );
@@ -166,9 +178,9 @@ export function parseDependencyTable(
           : id.startsWith('FL')
             ? 'FL'
             : (id[0] ?? '');
-    if (!isAllowedRowPrefix(artifactType, rowPrefix)) {
+    if (!isAllowedRowPrefix(artifactType, rowPrefix, isUiLedger)) {
       warnings.push(
-        `dependency_order: row ${id} has prefix '${rowPrefix}' but expected ${allowedRowPrefixLabel(artifactType)} for artifact type '${artifactType}'`,
+        `dependency_order: row ${id} has prefix '${rowPrefix}' but expected ${allowedRowPrefixLabel(artifactType, isUiLedger)} for artifact type '${artifactType}'`,
       );
     }
 
@@ -816,24 +828,32 @@ function findHeaderIndex(
 function isAllowedRowPrefix(
   artifactType: ArtifactType,
   rowPrefix: string,
+  isUiLedger: boolean,
 ): boolean {
-  return ALLOWED_ROW_PREFIXES[artifactType].includes(rowPrefix);
+  return allowedRowPrefixes(artifactType, isUiLedger).includes(rowPrefix);
 }
 
 /**
- * The row-ID prefixes a given artifact type may carry. `spec` accepts
- * the typed UI ledger prefixes (`SC`/`FL`) alongside `US`; every other
- * type is limited to its single canonical prefix.
+ * The row-ID prefixes a given table may carry. A spec table that is a
+ * typed UI ledger (has a `Kind` column) accepts `SC`/`FL` alongside
+ * `US`; a backend-only spec table and every other artifact type are
+ * limited to their single canonical prefix.
  */
-const ALLOWED_ROW_PREFIXES: Record<ArtifactType, readonly string[]> = {
-  rfc: [ID_PREFIX_BY_TYPE.rfc],
-  features: [ID_PREFIX_BY_TYPE.features],
-  spec: ['US', 'SC', 'FL'],
-  tasks: [ID_PREFIX_BY_TYPE.tasks],
-};
+function allowedRowPrefixes(
+  artifactType: ArtifactType,
+  isUiLedger: boolean,
+): readonly string[] {
+  if (artifactType === 'spec' && isUiLedger) {
+    return ['US', 'SC', 'FL'];
+  }
+  return [ID_PREFIX_BY_TYPE[artifactType]];
+}
 
-function allowedRowPrefixLabel(artifactType: ArtifactType): string {
-  const prefixes = ALLOWED_ROW_PREFIXES[artifactType];
+function allowedRowPrefixLabel(
+  artifactType: ArtifactType,
+  isUiLedger: boolean,
+): string {
+  const prefixes = allowedRowPrefixes(artifactType, isUiLedger);
   if (prefixes.length === 1) return `'${prefixes[0]}'`;
   return `one of ${prefixes.map((p) => `'${p}'`).join(', ')}`;
 }

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -36,7 +36,7 @@ const ID_PREFIX_BY_TYPE: Record<ArtifactType, IdPrefix> = {
   tasks: 'S',
 };
 
-const ID_REGEX = /^(M|F|US|S)[1-9][0-9]*$/;
+const ID_REGEX = /^(M|F|US|S|SC|FL)[1-9][0-9]*$/;
 const EM_DASH = '—';
 
 /**
@@ -51,9 +51,12 @@ const FORMAT_LEGACY_WARNING =
   'format_legacy: `## Dependency Order` uses checkbox list; expected 4-column table (ID | Title | Depends On | Artifact). ' +
   'Migrate this section to the canonical 4-column schema — see `src/templates/agent-skills/README.md`.';
 
-const EXPECTED_HEADERS = ['id', 'title', 'depends on', 'artifact'] as const;
-type ColumnName = (typeof EXPECTED_HEADERS)[number];
-type ColumnIndex = Record<ColumnName, number>;
+const REQUIRED_HEADERS = ['id', 'title', 'depends on', 'artifact'] as const;
+const OPTIONAL_HEADERS = ['kind', 'design'] as const;
+type RequiredColumnName = (typeof REQUIRED_HEADERS)[number];
+type OptionalColumnName = (typeof OPTIONAL_HEADERS)[number];
+type ColumnIndex = Record<RequiredColumnName, number> &
+  Partial<Record<OptionalColumnName, number>>;
 
 /**
  * Parse the `## Dependency Order` section of a Smithy artifact.
@@ -134,6 +137,12 @@ export function parseDependencyTable(
     const title = (cells[columnIndex.title] ?? '').trim();
     const dependsOnCell = (cells[columnIndex['depends on']] ?? '').trim();
     const artifactCell = (cells[columnIndex.artifact] ?? '').trim();
+    const kindCell =
+      columnIndex.kind === undefined ? '' : (cells[columnIndex.kind] ?? '').trim();
+    const designCell =
+      columnIndex.design === undefined
+        ? ''
+        : (cells[columnIndex.design] ?? '').trim();
 
     if (!ID_REGEX.test(id)) {
       warnings.push(
@@ -150,8 +159,14 @@ export function parseDependencyTable(
     }
     seenIds.add(id);
 
-    const rowPrefix = id.startsWith('US') ? 'US' : (id[0] as IdPrefix);
-    if (rowPrefix !== id_prefix) {
+    const rowPrefix = id.startsWith('US')
+      ? 'US'
+      : id.startsWith('SC')
+          ? 'SC'
+          : id.startsWith('FL')
+            ? 'FL'
+            : (id[0] ?? '');
+    if (!isAllowedRowPrefix(artifactType, rowPrefix)) {
       warnings.push(
         `dependency_order: row ${id} has prefix '${rowPrefix}' but expected '${id_prefix}' for artifact type '${artifactType}'`,
       );
@@ -184,8 +199,14 @@ export function parseDependencyTable(
       artifact_path = unwrappedArtifact;
     }
 
+    const row: DependencyRow = { id, title, depends_on: [], artifact_path };
+    const kind = parseUiKind(kindCell);
+    if (kind !== undefined) row.kind = kind;
+    const design = parseDesignMode(designCell);
+    if (design !== undefined) row.design = design;
+
     partials.push({
-      row: { id, title, depends_on: [], artifact_path },
+      row,
       rawDependsOn,
     });
   }
@@ -725,13 +746,24 @@ function findTableHeader(
     // causes the match to fail.
     const resolved: Partial<ColumnIndex> = {};
     let valid = true;
-    for (const label of EXPECTED_HEADERS) {
-      const first = cells.indexOf(label);
+    for (const label of REQUIRED_HEADERS) {
+      const first = findHeaderIndex(cells, label);
       if (first === -1) {
         valid = false;
         break;
       }
-      if (cells.indexOf(label, first + 1) !== -1) {
+      if (findHeaderIndex(cells, label, first + 1) !== -1) {
+        valid = false;
+        break;
+      }
+      resolved[label] = first;
+    }
+    if (!valid) continue;
+
+    for (const label of OPTIONAL_HEADERS) {
+      const first = findHeaderIndex(cells, label);
+      if (first === -1) continue;
+      if (findHeaderIndex(cells, label, first + 1) !== -1) {
         valid = false;
         break;
       }
@@ -750,6 +782,45 @@ function findTableHeader(
     };
   }
   return null;
+}
+
+function findHeaderIndex(
+  cells: string[],
+  label: RequiredColumnName | OptionalColumnName,
+  fromIndex = 0,
+): number {
+  for (let i = fromIndex; i < cells.length; i++) {
+    const cell = cells[i];
+    if (cell === undefined) continue;
+    if (label === 'title') {
+      if (cell === 'title' || cell.startsWith('title ')) return i;
+      continue;
+    }
+    if (cell === label) return i;
+  }
+  return -1;
+}
+
+function isAllowedRowPrefix(
+  artifactType: ArtifactType,
+  rowPrefix: string,
+): boolean {
+  if (artifactType === 'spec') {
+    return rowPrefix === 'US' || rowPrefix === 'SC' || rowPrefix === 'FL';
+  }
+  return rowPrefix === ID_PREFIX_BY_TYPE[artifactType];
+}
+
+function parseUiKind(value: string): DependencyRow['kind'] | undefined {
+  if (value === '' || value === EM_DASH) return undefined;
+  if (value === 'screen' || value === 'flow' || value === 'story') return value;
+  return undefined;
+}
+
+function parseDesignMode(value: string): DependencyRow['design'] | undefined {
+  if (value === '' || value === EM_DASH) return undefined;
+  if (value === 'none' || value === 'import' || value === 'brief') return value;
+  return undefined;
 }
 
 /**

--- a/src/status/parser.ts
+++ b/src/status/parser.ts
@@ -168,7 +168,7 @@ export function parseDependencyTable(
             : (id[0] ?? '');
     if (!isAllowedRowPrefix(artifactType, rowPrefix)) {
       warnings.push(
-        `dependency_order: row ${id} has prefix '${rowPrefix}' but expected '${id_prefix}' for artifact type '${artifactType}'`,
+        `dependency_order: row ${id} has prefix '${rowPrefix}' but expected ${allowedRowPrefixLabel(artifactType)} for artifact type '${artifactType}'`,
       );
     }
 
@@ -201,9 +201,21 @@ export function parseDependencyTable(
 
     const row: DependencyRow = { id, title, depends_on: [], artifact_path };
     const kind = parseUiKind(kindCell);
-    if (kind !== undefined) row.kind = kind;
+    if (kind !== undefined) {
+      row.kind = kind;
+    } else if (isMeaningfulCell(kindCell)) {
+      warnings.push(
+        `dependency_order: row ${id} has unrecognized Kind '${kindCell}' — expected screen, flow, or story; ignored`,
+      );
+    }
     const design = parseDesignMode(designCell);
-    if (design !== undefined) row.design = design;
+    if (design !== undefined) {
+      row.design = design;
+    } else if (isMeaningfulCell(designCell)) {
+      warnings.push(
+        `dependency_order: row ${id} has unrecognized Design '${designCell}' — expected none, import, or brief; ignored`,
+      );
+    }
 
     partials.push({
       row,
@@ -805,10 +817,33 @@ function isAllowedRowPrefix(
   artifactType: ArtifactType,
   rowPrefix: string,
 ): boolean {
-  if (artifactType === 'spec') {
-    return rowPrefix === 'US' || rowPrefix === 'SC' || rowPrefix === 'FL';
-  }
-  return rowPrefix === ID_PREFIX_BY_TYPE[artifactType];
+  return ALLOWED_ROW_PREFIXES[artifactType].includes(rowPrefix);
+}
+
+/**
+ * The row-ID prefixes a given artifact type may carry. `spec` accepts
+ * the typed UI ledger prefixes (`SC`/`FL`) alongside `US`; every other
+ * type is limited to its single canonical prefix.
+ */
+const ALLOWED_ROW_PREFIXES: Record<ArtifactType, readonly string[]> = {
+  rfc: [ID_PREFIX_BY_TYPE.rfc],
+  features: [ID_PREFIX_BY_TYPE.features],
+  spec: ['US', 'SC', 'FL'],
+  tasks: [ID_PREFIX_BY_TYPE.tasks],
+};
+
+function allowedRowPrefixLabel(artifactType: ArtifactType): string {
+  const prefixes = ALLOWED_ROW_PREFIXES[artifactType];
+  if (prefixes.length === 1) return `'${prefixes[0]}'`;
+  return `one of ${prefixes.map((p) => `'${p}'`).join(', ')}`;
+}
+
+/**
+ * True for a cell that carries an author-supplied value worth
+ * validating — non-empty and not the em-dash placeholder.
+ */
+function isMeaningfulCell(value: string): boolean {
+  return value !== '' && value !== EM_DASH;
 }
 
 function parseUiKind(value: string): DependencyRow['kind'] | undefined {

--- a/src/status/render.ts
+++ b/src/status/render.ts
@@ -286,7 +286,7 @@ function formatLine(
   }
 
   const marker = formatStatusMarker(record, node, theme);
-  const titleWithNumber = applyStoryNumber(record.title, record.parent_row_id);
+  const titleWithNumber = formatRecordTitle(record);
   const isBroken =
     record.parent_missing === true &&
     typeof record.parent_path === 'string' &&
@@ -309,13 +309,20 @@ function formatLine(
  * line is noise. Returns the title unchanged (minus any `Tasks: `
  * prefix) when `rowId` is missing or has no trailing digits.
  */
+function formatRecordTitle(record: ArtifactRecord): string {
+  const stripped = record.title.replace(/^Tasks:\s+/, '');
+  if (record.parent_row_kind !== undefined && record.parent_row_id !== undefined) {
+    return `${record.parent_row_id} ${record.parent_row_kind} ${stripped}`;
+  }
+  return applyStoryNumber(stripped, record.parent_row_id);
+}
+
 function applyStoryNumber(title: string, rowId: string | undefined): string {
-  const stripped = title.replace(/^Tasks:\s+/, '');
-  if (rowId === undefined) return stripped;
+  if (rowId === undefined) return title;
   const digits = rowId.match(/[0-9]+$/)?.[0];
-  if (digits === undefined) return stripped;
+  if (digits === undefined) return title;
   const nn = digits.padStart(2, '0');
-  return `${nn} ${stripped}`;
+  return `${nn} ${title}`;
 }
 
 /**

--- a/src/status/renderGraph.ts
+++ b/src/status/renderGraph.ts
@@ -536,6 +536,8 @@ function actionSignature(action: NextAction): string {
  * depth is added here.
  */
 function rowIdDepth(rowId: string): number | null {
+  if (rowId.startsWith('SC')) return 3;
+  if (rowId.startsWith('FL')) return 3;
   if (rowId.startsWith('US')) return 3;
   if (rowId.startsWith('S')) return 4;
   if (rowId.startsWith('F')) return 2;
@@ -691,8 +693,14 @@ function formatNodeLine(
   // replaces the FQ id, which would otherwise hide the row id
   // entirely for any actionable row). The id paints dim so the title
   // stays the dominant visual element.
-  const idPrefix = theme.paint.dim(`${node.row.id} `);
+  const idPrefix = theme.paint.dim(`${formatNodeIdentity(node)} `);
   return `${connector}${idPrefix}${node.row.title}  ${marker}  ${suffix}`;
+}
+
+function formatNodeIdentity(node: DependencyNode): string {
+  const kind = node.row.kind;
+  if (kind === undefined) return node.row.id;
+  return `${node.row.id} ${kind}`;
 }
 
 /**

--- a/src/status/scanner.test.ts
+++ b/src/status/scanner.test.ts
@@ -678,6 +678,57 @@ ${TABLE_HEADER}
     );
   });
 
+  it('accepts typed UI ledgers and emits distinct SC, FL, and US task records', () => {
+    const uiHeader =
+      '| ID | Kind | Title (→ mark durable file) | Depends On | Design | Artifact |\n' +
+      '|----|------|-----------------------------|------------|--------|----------|';
+    write(
+      'specs/ui/ui.spec.md',
+      `# UI Spec\n\n## Dependency Order\n\n${uiHeader}\n` +
+        '| SC1 | screen | AddTitle screen | — | brief | specs/ui/sc-01-add-title-screen.tasks.md |\n' +
+        '| FL1 | flow | AddTitle flow | SC1 | — | — |\n' +
+        '| US1 | story | Persist title | FL1 | — | specs/ui/01-persist-title.tasks.md |\n',
+    );
+    write(
+      'specs/ui/sc-01-add-title-screen.tasks.md',
+      `# Tasks: AddTitle Screen\n\n## Slice 1: Build\n\n- [x] Done\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Build | — | — |\n`,
+    );
+    write(
+      'specs/ui/01-persist-title.tasks.md',
+      `# Tasks: Persist Title\n\n## Slice 1: Persist\n\n- [ ] Todo\n\n## Dependency Order\n\n${TABLE_HEADER}\n| S1 | Persist | — | — |\n`,
+    );
+
+    const records = scan(root);
+    const screen = byPath(records, 'specs/ui/sc-01-add-title-screen.tasks.md');
+    const flow = byPath(records, 'specs/ui/fl-01-addtitle-flow.tasks.md');
+    const story = byPath(records, 'specs/ui/01-persist-title.tasks.md');
+
+    expect(screen).toMatchObject({
+      status: 'done',
+      parent_row_id: 'SC1',
+      parent_row_kind: 'screen',
+      parent_row_design: 'brief',
+    });
+    expect(flow).toMatchObject({
+      virtual: true,
+      status: 'not-started',
+      parent_row_id: 'FL1',
+      parent_row_kind: 'flow',
+    });
+    expect(story).toMatchObject({
+      status: 'not-started',
+      parent_row_id: 'US1',
+      parent_row_kind: 'story',
+    });
+    const spec = byPath(records, 'specs/ui/ui.spec.md');
+    expect(spec?.dependency_order.rows.map((row) => row.id)).toEqual([
+      'SC1',
+      'FL1',
+      'US1',
+    ]);
+    expect(spec?.status).toBe('in-progress');
+  });
+
   it('AS 9.3: feature-map row pointing at a real spec folder rolls up from that spec\'s status', () => {
     // Single-hop feature-map → spec rollup. The feature map's
     // `## Dependency Order` has exactly one row whose `Artifact` cell

--- a/src/status/scanner.ts
+++ b/src/status/scanner.ts
@@ -241,6 +241,8 @@ export function scan(root: string): ArtifactRecord[] {
         } else {
           child.parent_path = parent.path;
           child.parent_row_id = row.id;
+          if (row.kind !== undefined) child.parent_row_kind = row.kind;
+          if (row.design !== undefined) child.parent_row_design = row.design;
         }
       } else {
         child = makeVirtualRecord(resolution.path, resolution.type, row, parent);
@@ -610,6 +612,7 @@ function resolveChildForRow(
       const type: ArtifactType = 'tasks';
       const parentDir = repoDirname(parent.path);
       const nn = paddedNumberFromId(row.id);
+      const filePrefix = tasksFilenamePrefix(row.id, nn);
 
       if (row.artifact_path !== null) {
         const declared = normalizePath(row.artifact_path);
@@ -623,7 +626,7 @@ function resolveChildForRow(
         // the filename convention — a single `<NN>-*.tasks.md` under
         // the spec's folder is unambiguous and recovers linkage that
         // would otherwise produce a floating orphan.
-        const fallback = findTasksByStoryNumber(parentDir, nn, records);
+        const fallback = findTasksByRowId(parentDir, row.id, nn, records);
         if (fallback !== null) {
           return { path: fallback, type };
         }
@@ -639,12 +642,12 @@ function resolveChildForRow(
       // `<parentDir>/<NN>-*.tasks.md` should link to that real file,
       // not a virtual derived from the row title (the row title and
       // the on-disk slug routinely diverge in practice).
-      const fallback = findTasksByStoryNumber(parentDir, nn, records);
+      const fallback = findTasksByRowId(parentDir, row.id, nn, records);
       if (fallback !== null) {
         return { path: fallback, type };
       }
       return {
-        path: repoJoin(parentDir, `${nn}-${slugify(row.title)}.tasks.md`),
+        path: repoJoin(parentDir, `${filePrefix}-${slugify(row.title)}.tasks.md`),
         type,
       };
     }
@@ -666,17 +669,21 @@ function resolveChildForRow(
  * no match or more than one (ambiguous cases fall through to the
  * caller's virtual-placeholder path so a warning can surface).
  */
-function findTasksByStoryNumber(
+function findTasksByRowId(
   parentDir: string,
+  rowId: string,
   nn: string,
   records: Map<string, ArtifactRecord>,
 ): string | null {
-  const prefix = parentDir === '' ? `${nn}-` : `${parentDir}/${nn}-`;
+  const prefixes = tasksLookupPrefixes(rowId, nn).map((prefix) =>
+    parentDir === '' ? prefix : `${parentDir}/${prefix}`,
+  );
   let match: string | null = null;
   for (const [p, rec] of records) {
     if (rec.type !== 'tasks') continue;
     if (rec.virtual === true) continue;
-    if (!p.startsWith(prefix)) continue;
+    const prefix = prefixes.find((candidate) => p.startsWith(candidate));
+    if (prefix === undefined) continue;
     if (!p.endsWith('.tasks.md')) continue;
     // Reject nested sub-folder matches: only direct children of
     // `parentDir` count. A tasks file at `specs/a/b/01-foo.tasks.md`
@@ -759,7 +766,7 @@ function makeVirtualRecord(
   row: DependencyRow,
   parent: ArtifactRecord,
 ): ArtifactRecord {
-  return {
+  const record: ArtifactRecord = {
     type,
     path: p,
     title: row.title,
@@ -774,6 +781,9 @@ function makeVirtualRecord(
     },
     warnings: [],
   };
+  if (row.kind !== undefined) record.parent_row_kind = row.kind;
+  if (row.design !== undefined) record.parent_row_design = row.design;
+  return record;
 }
 
 // ---------------------------------------------------------------------------
@@ -873,6 +883,17 @@ function paddedNumberFromId(id: string): string {
   const digits = id.match(/[0-9]+$/)?.[0];
   if (digits === undefined) return id.toLowerCase();
   return digits.padStart(2, '0');
+}
+
+function tasksFilenamePrefix(rowId: string, nn: string): string {
+  if (rowId.startsWith('SC')) return `sc-${nn}`;
+  if (rowId.startsWith('FL')) return `fl-${nn}`;
+  return nn;
+}
+
+function tasksLookupPrefixes(rowId: string, nn: string): string[] {
+  const typed = tasksFilenamePrefix(rowId, nn);
+  return [`${typed}-`];
 }
 
 function idPrefixForType(type: ArtifactType): DependencyOrderTable['id_prefix'] {

--- a/src/status/suggester.test.ts
+++ b/src/status/suggester.test.ts
@@ -212,6 +212,28 @@ describe('suggestNextAction — tasks records', () => {
     expect(action!.arguments).toEqual(['specs/x', '3']);
   });
 
+  it('emits a folder-only cut hint for a virtual screen/flow node instead of targeting US<N>', () => {
+    // A screen (`SC<N>`) or flow (`FL<N>`) ledger node carries a numeric
+    // suffix, but `smithy.cut`'s digit argument selects a `US<N>` story.
+    // Passing the SC/FL digit would silently target the wrong row, so the
+    // hint must stay folder-only and name the actual ledger node.
+    const record = makeRecord({
+      type: 'tasks',
+      status: 'not-started',
+      virtual: true,
+      path: 'specs/ui/sc-01-add-title.tasks.md',
+      parent_path: 'specs/ui/ui.spec.md',
+      parent_row_id: 'SC1',
+      parent_row_kind: 'screen',
+    });
+    const action = suggestNextAction(record, [], false);
+    expect(action).not.toBeNull();
+    expect(action!.command).toBe('smithy.cut');
+    expect(action!.arguments).toEqual(['specs/ui']);
+    expect(action!.reason).toContain('ledger node SC1');
+    expect(action!.reason).not.toContain('user story');
+  });
+
   it('falls back to smithy.forge on a virtual tasks record missing parent fields', () => {
     // Defensive guard: if the scanner ever emits a virtual tasks
     // record without `parent_path`/`parent_row_id` (shouldn't happen

--- a/src/status/suggester.ts
+++ b/src/status/suggester.ts
@@ -84,16 +84,24 @@ function numericIdSuffix(id: string): string | undefined {
  */
 function cutTargetFromVirtualTasks(
   record: ArtifactRecord,
-): { folder: string; digits: string | undefined } | null {
+): { folder: string; digits: string | undefined; nodeId: string | undefined } | null {
   const parentPath = record.parent_path;
   if (typeof parentPath !== 'string' || parentPath.length === 0) {
     return null;
   }
   const folder = specFolderFromPath(parentPath);
-  const digits = record.parent_row_id !== undefined
-    ? numericIdSuffix(record.parent_row_id)
-    : undefined;
-  return { folder, digits };
+  // Screen (`SC<N>`) and flow (`FL<N>`) ledger nodes carry a numeric
+  // suffix too, but `smithy.cut`'s digit argument selects a `US<N>`
+  // story — passing an `SC`/`FL` digit would silently target the wrong
+  // row. Emit a folder-only hint for those kinds and let the reason name
+  // the actual node instead of a fabricated user story.
+  const kind = record.parent_row_kind;
+  const isTypedUiNode = kind === 'screen' || kind === 'flow';
+  const digits =
+    !isTypedUiNode && record.parent_row_id !== undefined
+      ? numericIdSuffix(record.parent_row_id)
+      : undefined;
+  return { folder, digits, nodeId: record.parent_row_id };
 }
 
 /**
@@ -416,9 +424,15 @@ export function suggestNextAction(
           args = cutTarget.digits !== undefined
             ? [cutTarget.folder, cutTarget.digits]
             : [cutTarget.folder];
-          reason = cutTarget.digits !== undefined
-            ? `Tasks file ${record.title} does not exist yet; run smithy.cut to create it from user story US${cutTarget.digits}.`
-            : `Tasks file ${record.title} does not exist yet; run smithy.cut to create it.`;
+          if (cutTarget.digits !== undefined) {
+            reason = `Tasks file ${record.title} does not exist yet; run smithy.cut to create it from user story US${cutTarget.digits}.`;
+          } else if (cutTarget.nodeId !== undefined) {
+            // Screen/flow node (or a row with no numeric suffix): name
+            // the ledger node rather than fabricating a US story number.
+            reason = `Tasks file ${record.title} does not exist yet; run smithy.cut to decompose ledger node ${cutTarget.nodeId}.`;
+          } else {
+            reason = `Tasks file ${record.title} does not exist yet; run smithy.cut to create it.`;
+          }
           break;
         }
         // Defensive fallback: scanner didn't populate parent fields.

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -61,6 +61,18 @@ export interface DependencyRow {
    * scanner emits a virtual not-started record for the expected path.
    */
   artifact_path: string | null;
+  /**
+   * Optional typed UI ledger kind from a spec-level `Kind` column.
+   * Present only for UI dependency ledgers (`screen`, `flow`, `story`);
+   * backend-only dependency tables omit it.
+   */
+  kind?: 'screen' | 'flow' | 'story';
+  /**
+   * Optional screen design mode from a spec-level `Design` column.
+   * Present for screen rows when authored; omitted for backend-only
+   * rows and for `—` design cells.
+   */
+  design?: 'none' | 'import' | 'brief';
 }
 
 /**
@@ -219,6 +231,17 @@ export interface ArtifactRecord {
    * number so the tree mirrors the parent's dep-order numbering.
    */
   parent_row_id?: string;
+  /**
+   * Optional typed UI ledger kind copied from the parent dependency row
+   * that claimed this record. Lets JSON consumers distinguish screen,
+   * flow, and backend-story nodes without inferring from the title.
+   */
+  parent_row_kind?: DependencyRow['kind'];
+  /**
+   * Optional design mode copied from the parent dependency row that
+   * claimed this record.
+   */
+  parent_row_design?: DependencyRow['design'];
   /**
    * True for not-started records inferred from a parent's parsed
    * `## Dependency Order` table but not yet present on disk. `virtual`


### PR DESCRIPTION
## Summary
EPIC #404 → Screens and Flows as UI Feature Kinds (spec) → User Story 7: UI work is visible to status, dependency, and audit tooling → Slice 1: Surface typed UI nodes in status and dependency graphs.

This slice makes typed UI ledgers first-class in the deterministic status tooling: the scanner/parser accept a spec `## Dependency Order` table carrying `Kind`/`Design` columns and `SC`/`FL` row IDs, the dependency graph resolves same-table screen/flow/story edges, and both the human and JSON status surfaces expose node kind so screen-build, flow-wire, and backend-story progress are distinguishable without title inference. It is the right first increment because status/dependency visibility is the shared foundation the audit and plan-review slices build on.

## Spec debt & uncertainty
- SD-005 (inherited): `import`-mode structure-derivation fidelity — owned by User Story 5; this tooling only consumes the resulting artifacts.
- SD-006 (inherited): whether `SC`/`FL` nodes are always atomic or can be sub-sliced — owned by User Story 3; status reports whatever task artifacts cut produces.
- SD-007 (inherited): build-phase coverage honesty (a build screen "done" with a missing brief state and no executable gate) — coverage semantics remain owned by forge/flow-lint.
- SD-008 (inherited): visual-intent honesty under the non-blocking gate — owned by User Story 4.
- Assumption: UI sequencing runs through a single typed ordering ledger (Critical Assumption, resolves SD-001) — screen (`SC`), flow (`FL`), and story (`US`) rows are interleaved first-class nodes each pointing at its own durable/task artifact.
- The "dangling UI dependency IDs surface as warnings" criterion is satisfied by the existing generic dependency-resolution path (SC/FL now being valid IDs), not a new UI-specific code path, so it inherits existing backend behavior rather than adding a dedicated test.

## Validation
build ✅ · typecheck ✅ · test ✅ (1039 passed)
