### PR TITLE
forge: add minimal JVM Gradle fixture with deterministic failure

### DIFF
--- a/evals/fixture.test.ts
+++ b/evals/fixture.test.ts
@@ -108,10 +108,22 @@ describe('evals/fixture deployment', () => {
       expect(fs.existsSync(path.join(JVM_FIXTURE_DIR, file))).toBe(true);
     }
 
-    expect(fs.existsSync(path.join(JVM_FIXTURE_DIR, 'gradlew'))).toBe(false);
-    expect(fs.existsSync(path.join(JVM_FIXTURE_DIR, 'gradlew.bat'))).toBe(false);
-    expect(fs.existsSync(path.join(JVM_FIXTURE_DIR, 'build'))).toBe(false);
-    expect(fs.existsSync(path.join(JVM_FIXTURE_DIR, '.gradle'))).toBe(false);
+    // Assert on committed (git-tracked) contents rather than the working
+    // tree: running `gradle` locally creates the ignored build/ and .gradle/
+    // directories, which must not make this test fail for contributors.
+    const trackedFiles = execFileSync('git', ['ls-files'], {
+      cwd: JVM_FIXTURE_DIR,
+      encoding: 'utf-8',
+    })
+      .split('\n')
+      .filter(Boolean);
+
+    // No Gradle wrapper is committed (system Gradle is documented instead).
+    expect(trackedFiles).not.toContain('gradlew');
+    expect(trackedFiles).not.toContain('gradlew.bat');
+    // No generated Gradle output is committed.
+    expect(trackedFiles.some((file) => file.startsWith('build/'))).toBe(false);
+    expect(trackedFiles.some((file) => file.startsWith('.gradle/'))).toBe(false);
 
     const buildFile = fs.readFileSync(path.join(JVM_FIXTURE_DIR, 'build.gradle'), 'utf-8');
     expect(buildFile).toContain("id 'java'");

--- a/evals/fixture.test.ts
+++ b/evals/fixture.test.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 
 const CLI = path.resolve('dist/cli.js');
 const FIXTURE_DIR = path.resolve('evals/fixture');
+const JVM_FIXTURE_DIR = path.join(FIXTURE_DIR, 'jvm');
 
 function hashDirectory(dirPath: string): string {
   const hash = crypto.createHash('sha256');
@@ -91,5 +92,47 @@ describe('evals/fixture deployment', () => {
     const hashAfter = hashDirectory(FIXTURE_DIR);
 
     expect(hashAfter).toBe(hashBefore);
+  });
+
+  it('commits a minimal JVM Gradle fixture shape (FR-009 through FR-014)', () => {
+    const expectedFiles = [
+      '.gitignore',
+      'README.md',
+      'settings.gradle',
+      'build.gradle',
+      'src/main/java/dev/smithy/fixture/GreetingService.java',
+      'src/test/java/dev/smithy/fixture/GreetingServiceTest.java',
+    ];
+
+    for (const file of expectedFiles) {
+      expect(fs.existsSync(path.join(JVM_FIXTURE_DIR, file))).toBe(true);
+    }
+
+    expect(fs.existsSync(path.join(JVM_FIXTURE_DIR, 'gradlew'))).toBe(false);
+    expect(fs.existsSync(path.join(JVM_FIXTURE_DIR, 'gradlew.bat'))).toBe(false);
+    expect(fs.existsSync(path.join(JVM_FIXTURE_DIR, 'build'))).toBe(false);
+    expect(fs.existsSync(path.join(JVM_FIXTURE_DIR, '.gradle'))).toBe(false);
+
+    const buildFile = fs.readFileSync(path.join(JVM_FIXTURE_DIR, 'build.gradle'), 'utf-8');
+    expect(buildFile).toContain("id 'java'");
+    expect(buildFile).toContain("tasks.register('fixtureTest', JavaExec)");
+    expect(buildFile).toContain('dependsOn fixtureTest');
+
+    const readme = fs.readFileSync(path.join(JVM_FIXTURE_DIR, 'README.md'), 'utf-8');
+    expect(readme).toContain('does not commit a Gradle wrapper');
+    expect(readme).toContain('gradle compileJava');
+    expect(readme).toContain('gradle check');
+    expect(readme).toContain('fails by design');
+
+    const source = fs.readFileSync(
+      path.join(JVM_FIXTURE_DIR, 'src/main/java/dev/smithy/fixture/GreetingService.java'),
+      'utf-8',
+    );
+    const test = fs.readFileSync(
+      path.join(JVM_FIXTURE_DIR, 'src/test/java/dev/smithy/fixture/GreetingServiceTest.java'),
+      'utf-8',
+    );
+    expect(source).toContain('return value;');
+    expect(test).toContain('assertEquals("yhtimS", service.reverse("Smithy"))');
   });
 });

--- a/evals/fixture/jvm/.gitignore
+++ b/evals/fixture/jvm/.gitignore
@@ -1,0 +1,3 @@
+build/
+.gradle/
+out/

--- a/evals/fixture/jvm/README.md
+++ b/evals/fixture/jvm/README.md
@@ -1,0 +1,37 @@
+# JVM Gradle Fixture
+
+This directory is a minimal Java Gradle project used by future Smithy eval scenarios that need a non-JavaScript fixture.
+
+## Tooling
+
+This fixture intentionally does not commit a Gradle wrapper. Use a local JDK and system Gradle from `PATH`.
+
+Required tools:
+
+- JDK 17 or newer
+- Gradle 8 or newer
+
+No external Java dependencies are declared, so the fixture build does not need network access beyond any local Gradle distribution setup.
+
+## Commands
+
+From `evals/fixture/jvm/`:
+
+```bash
+gradle compileJava
+gradle check
+```
+
+`gradle compileJava` should compile the fixture. `gradle check` compiles source and test classes, then runs `fixtureTest`, which currently fails by design.
+
+## Intentional Failure
+
+`src/main/java/dev/smithy/fixture/GreetingService.java` returns the input string unchanged from `reverse(String)`.
+
+`src/test/java/dev/smithy/fixture/GreetingServiceTest.java` expects that method to return the reversed string. This deterministic failure is the repair target for a future `smithy.forge` JVM slice. The failure is isolated to this fixture and does not require scenario YAML or eval baseline support.
+
+## Maintenance Boundaries
+
+Files under `evals/fixture/jvm/` are owned by the JVM fixture. The existing JavaScript fixture at `evals/fixture/` remains the default eval fixture and should not be moved or changed when maintaining this project.
+
+Generated Gradle directories such as `build/`, `.gradle/`, and `out/` are ignored locally and must not be committed.

--- a/evals/fixture/jvm/build.gradle
+++ b/evals/fixture/jvm/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'java'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.register('fixtureTest', JavaExec) {
+    group = 'verification'
+    description = 'Runs the fixture-local deterministic Java test.'
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass = 'dev.smithy.fixture.GreetingServiceTest'
+    dependsOn testClasses
+}
+
+tasks.named('test') {
+    enabled = false
+}
+
+tasks.named('check') {
+    dependsOn fixtureTest
+}

--- a/evals/fixture/jvm/settings.gradle
+++ b/evals/fixture/jvm/settings.gradle
@@ -1,0 +1,11 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+}
+
+rootProject.name = 'smithy-jvm-fixture'

--- a/evals/fixture/jvm/src/main/java/dev/smithy/fixture/GreetingService.java
+++ b/evals/fixture/jvm/src/main/java/dev/smithy/fixture/GreetingService.java
@@ -1,0 +1,11 @@
+package dev.smithy.fixture;
+
+public final class GreetingService {
+    public String greet(String name) {
+        return "Hello, " + name + "!";
+    }
+
+    public String reverse(String value) {
+        return value;
+    }
+}

--- a/evals/fixture/jvm/src/test/java/dev/smithy/fixture/GreetingServiceTest.java
+++ b/evals/fixture/jvm/src/test/java/dev/smithy/fixture/GreetingServiceTest.java
@@ -1,0 +1,18 @@
+package dev.smithy.fixture;
+
+public final class GreetingServiceTest {
+    public static void main(String[] args) {
+        GreetingService service = new GreetingService();
+
+        assertEquals("Hello, Smithy!", service.greet("Smithy"));
+        assertEquals("yhtimS", service.reverse("Smithy"));
+    }
+
+    private static void assertEquals(String expected, String actual) {
+        if (!expected.equals(actual)) {
+            throw new AssertionError(
+                "expected <" + expected + "> but was <" + actual + ">"
+            );
+        }
+    }
+}

--- a/specs/2026-06-06-011-jvm-multi-language-fixture/03-provide-a-minimal-jvm-gradle-fixture.tasks.md
+++ b/specs/2026-06-06-011-jvm-multi-language-fixture/03-provide-a-minimal-jvm-gradle-fixture.tasks.md
@@ -18,7 +18,7 @@
 
 ### Tasks
 
-- [ ] **Add the minimal Gradle project**
+- [x] **Add the minimal Gradle project**
 
   Create the JVM fixture under `evals/fixture/jvm/` with Gradle settings, build configuration, Java source, and Java test source. Keep the project intentionally small and aligned with the JVM Fixture Layout contract so future eval agents can inspect it quickly.
 
@@ -29,7 +29,7 @@
   - Existing JavaScript fixture files remain unmoved and semantically unchanged.
   - Fixture presence coverage verifies the committed JVM project shape.
 
-- [ ] **Plant the deterministic forge failure**
+- [x] **Plant the deterministic forge failure**
 
   Add a simple source behavior and corresponding test in the JVM fixture so the test suite has one intentional, deterministic failure. The failure must be suitable for a future `smithy.forge` slice to repair without requiring runner or scenario changes in this story.
 
@@ -39,7 +39,7 @@
   - The fixture still compiles before the planted failing assertion runs.
   - No JVM scenario YAML or baseline file is added.
 
-- [ ] **Document fixture operation and boundaries**
+- [x] **Document fixture operation and boundaries**
 
   Add `evals/fixture/jvm/README.md` and any fixture-local ignore rules needed to match the committed Gradle approach. Document how maintainers run the build and tests, which failure is intentional, required local tooling or first-run dependency resolution, and which files are fixture-owned.
 


### PR DESCRIPTION
## Summary
RFC 2026-001-token-savings → M1 measurement-foundation → F1.6 JVM Multi-Language Fixture → JVM Multi-Language Fixture spec → Slice 1: Add the JVM Gradle Fixture

Adds a documented minimal Gradle Java project at `evals/fixture/jvm/` with a deterministic, forge-ready failing test (`GreetingService.reverse` returns its input unchanged while the test expects the reversed string), plus fixture-shape coverage in `evals/fixture.test.ts`. This is substrate only — no scenario YAML or baseline — which is the correct increment since F1.7 owns the first scenario that consumes `fixture: jvm`.

## Spec debt & uncertainty
- SD-001 (open): fixture selector `fixture:` precedence under `evals/fixture/` — not exercised by this filesystem-only slice; owned by the runner-resolution story.
- SD-002 (open): Gradle wrapper choice was left to implementation. Resolved for this fixture — no wrapper is committed; the README documents system JDK 17+ / Gradle 8+ as prerequisites.
- SD-003 (open): `evals/lib/runner.ts` shared-ownership rebase note — not touched by this slice.
- Assumption: a small plain-Java project is sufficient (Kotlin/Spring/Android/multi-module out of scope), and the JS fixture at `evals/fixture/` stays the default and is left unmoved.
- Verification note: the fixture presence test runs under CI's Node toolchain; the repo's system Node was too old for vitest, so I validated under Node 22 via nvm. Gradle itself was not run (build tool absent), but the Java sources were compiled with `javac` and the planted test executed to confirm the deterministic `AssertionError`.

## Validation
build ✅ · fixture test ✅ (3 passed, incl. new JVM shape test) · javac compile ✅ · planted test fails deterministically as designed ✅ (`expected <yhtimS> but was <Smithy>`)
