### PR TITLE
feat: cross-repo artifact stores, backed by git

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,42 @@ You can also set it non-interactively with `--artifacts-location repo|external` 
 
 ### External layout
 
-External artifacts are stored under a fixed, repo-keyed root:
+Where an external store lands depends on whether you ran `smithy init` inside a git repo:
 
 ```
-~/.smithy/repos/<repoKey>/        # then docs/rfcs/, docs/prds/, specs/, specs/strikes/ underneath
+~/.smithy/repos/<repoKey>/        # inside a repo — one store per repo
+~/.smithy/projects/default/       # outside one — the shared cross-repo store
+                                  # then docs/rfcs/, docs/prds/, specs/, specs/strikes/ underneath
 ```
 
-- `repos/` is a fixed grouping segment that isolates per-repo stores from Smithy's own files in `~/.smithy/` (`templates/`, `smithy-manifest.json`, `config.yml`). It's collision-proof: a repo literally named `templates` resolves to `~/.smithy/repos/templates/`, never clobbering `~/.smithy/templates/`.
+- `repos/` and `projects/` are fixed grouping segments that isolate stores from Smithy's own files in `~/.smithy/` (`templates/`, `smithy-manifest.json`). It's collision-proof: a repo literally named `templates` resolves to `~/.smithy/repos/templates/`, never clobbering `~/.smithy/templates/`.
 - `<repoKey>` is **worktree-stable**. It's derived from git's shared git-common-dir (`git rev-parse --git-common-dir`) rather than the working-directory name, so every linked worktree of a repo *and* its main checkout resolve to the same key and share one store. `smithy status` therefore reports identical, repo-keyed paths no matter which worktree you run it from. When git can't identify the repo, Smithy falls back to the `origin` remote name, then the directory name. The key is always sanitized to a single filesystem-safe path segment.
+- `projects/default/` is the store for planning that isn't anchored to a single repo — an RFC spanning several services, or work started from a scratch directory. A repo-keyed store can't serve that case: outside a repo the key would fall back to whatever folder you happened to be standing in, and the store would move the moment you changed directories.
+
+### Discovery
+
+`smithy status` finds artifacts by trying each store in turn and keeping the first that has any:
+
+| Where you run it | Order tried |
+|---|---|
+| Inside a repo, `artifactsLocation: repo` | the repo |
+| Inside a repo, `artifactsLocation: external` | the repo → `~/.smithy/repos/<repoKey>/` → `~/.smithy/projects/default/` |
+| Outside a repo | `~/.smithy/projects/default/` → the working directory |
+
+Passing `--root <path>` skips the cascade entirely and scans exactly that path. When discovery lands anywhere other than the working directory, `smithy status` prints the store it used, and `--format json` reports it as `scan_root`.
+
+### External stores are git repositories
+
+`smithy init` runs `git init` on the store it creates and makes one initial commit. That history is the only record these artifacts have — nothing else tracks them — so if an agent overwrites or deletes one, `git restore` brings it back. Re-running `init` or `update` never touches an existing store's history.
+
+Nothing is pushed anywhere. To sync a store between machines, attach a remote yourself:
+
+```bash
+git -C ~/.smithy/repos/<repoKey> remote add origin <your-remote-url>
+git -C ~/.smithy/repos/<repoKey> push -u origin main
+```
+
+The deployed prompts tell your AI assistant to commit artifacts to the store as it writes them, and the deployed permissions auto-allow `git -C ~/.smithy/... add`/`commit` (but never `push` — that stays yours). If git is unavailable, `smithy init` warns and continues: you still get a working install, just without the history.
 
 ## Workflow Industrial Pipeline
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Where an external store lands depends on whether you ran `smithy init` inside a 
 - `<repoKey>` is **worktree-stable**. It's derived from git's shared git-common-dir (`git rev-parse --git-common-dir`) rather than the working-directory name, so every linked worktree of a repo *and* its main checkout resolve to the same key and share one store. `smithy status` therefore reports identical, repo-keyed paths no matter which worktree you run it from. When git can't identify the repo, Smithy falls back to the `origin` remote name, then the directory name. The key is always sanitized to a single filesystem-safe path segment.
 - `projects/default/` is the store for planning that isn't anchored to a single repo — an RFC spanning several services, or work started from a scratch directory. A repo-keyed store can't serve that case: outside a repo the key would fall back to whatever folder you happened to be standing in, and the store would move the moment you changed directories.
 
+> **Known limitation.** Running Smithy from outside a git repo, artifact authoring and `smithy status` work against `projects/default/`, but the commands that finish by opening a pull request — `smithy.strike` and `smithy.ignite` — will fail at that step, because they commit, push, and open the PR against a repo that isn't there. Use them from inside a member repo for now.
+
 ### Discovery
 
 `smithy status` finds artifacts by trying each store in turn and keeping the first that has any:

--- a/src/agents/codex.test.ts
+++ b/src/agents/codex.test.ts
@@ -63,6 +63,67 @@ describe('deploy', () => {
     expect(fs.existsSync(rulesPath)).toBe(false);
   });
 
+  describe('external artifact store rules', () => {
+    const rules = async (artifactsRoot: string): Promise<string> => {
+      await deploy(tmpDir, true, artifactsRoot);
+      return fs.readFileSync(
+        path.join(tmpDir, '.codex', 'rules', 'default.rules'),
+        'utf8',
+      );
+    };
+
+    it('grants the resolved store path, not a wildcard', async () => {
+      // Codex prefix rules have no wildcard segment — `buildPrefixPattern`
+      // strips a trailing `*` and then tokens match exactly. Emitting the
+      // Claude-style `~/.smithy/repos/*` would collapse to the literal token
+      // `~/.smithy/repos/`, which matches no real command. The deployer
+      // already knows the store, so it grants that path directly.
+      const content = await rules('~/.smithy/repos/widget/');
+      expect(content).toContain(
+        'prefix_rule(pattern=["git","-C","~/.smithy/repos/widget/","add","-A"], decision="allow")',
+      );
+      expect(content).toContain(
+        'prefix_rule(pattern=["git","-C","~/.smithy/repos/widget/","commit","--no-gpg-sign","-m"], decision="allow")',
+      );
+    });
+
+    it('emits no rule carrying a bare store-namespace token', async () => {
+      // The mangled shape this exists to prevent: a rule that looks like it
+      // grants store access but can never match.
+      const content = await rules('~/.smithy/repos/widget/');
+      expect(content).not.toContain('"~/.smithy/repos/"');
+      expect(content).not.toContain('"~/.smithy/projects/"');
+    });
+
+    it('grants the shared project store when that is the resolved root', async () => {
+      const content = await rules('~/.smithy/projects/default/');
+      expect(content).toContain(
+        'prefix_rule(pattern=["git","-C","~/.smithy/projects/default/","add","-A"], decision="allow")',
+      );
+    });
+
+    it('emits no store rules in repo mode', async () => {
+      // Nothing to grant: artifacts live in the repo and ride its history.
+      const content = await rules('');
+      expect(content).not.toContain('~/.smithy/');
+      expect(content).not.toContain('"-C"');
+    });
+
+    it('never grants push, reset, clean, or checkout against the store', async () => {
+      const content = await rules('~/.smithy/repos/widget/');
+      const storeRules = content
+        .split('\n')
+        .filter((line) => line.includes('"-C"'));
+      expect(storeRules.length).toBeGreaterThan(0);
+      for (const line of storeRules) {
+        expect(line).not.toContain('"push"');
+        expect(line).not.toContain('"reset"');
+        expect(line).not.toContain('"clean"');
+        expect(line).not.toContain('"checkout"');
+      }
+    });
+  });
+
   it('returns deployed file paths', async () => {
     const files = await deploy(tmpDir, false);
     expect(files.length).toBeGreaterThan(0);

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import picocolors from 'picocolors';
 import { getComposedTemplates, getTemplateFilesByCategory, stripFrontmatter, parseFrontmatterName } from '../templates.js';
 import { toCodexAgentToml } from '../agent-models.js';
-import { permissions } from '../permissions.js';
+import { permissions, STORE_GIT_ARGS } from '../permissions.js';
 import { removeIfExists } from '../utils.js';
 
 const SMITHY_CODEX_RULES_BEGIN = '# BEGIN SMITHY CODEX RULES';
@@ -104,7 +104,7 @@ export async function deploy(
   }
 
   if (initPermissions) {
-    writePermissions(targetDir);
+    writePermissions(targetDir, artifactsRoot);
   }
 
   return deployedFiles;
@@ -145,7 +145,7 @@ export function removeLegacy(targetDir: string): number {
   return removedCount;
 }
 
-function writePermissions(targetDir: string): void {
+function writePermissions(targetDir: string, artifactsRoot: string = ''): void {
   const codexDir = path.join(targetDir, '.codex');
   if (!fs.existsSync(codexDir)) fs.mkdirSync(codexDir, { recursive: true });
 
@@ -160,7 +160,7 @@ function writePermissions(targetDir: string): void {
   const rulesPath = path.join(rulesDir, 'default.rules');
   const rulesBlock = [
     SMITHY_CODEX_RULES_BEGIN,
-    ...buildCodexRules().map(formatPrefixRule),
+    ...buildCodexRules(artifactsRoot).map(formatPrefixRule),
     SMITHY_CODEX_RULES_END,
     '',
   ].join('\n');
@@ -173,7 +173,40 @@ function writePermissions(targetDir: string): void {
   console.log(picocolors.blue(`  Added default permissions to ${rulesPath}`));
 }
 
-function buildCodexRules(): string[][] {
+/**
+ * The `git` sub-key whose values encode an external artifact store path with
+ * a wildcard segment (`~/.smithy/repos/* add -A`). Skipped by the generic
+ * rule builder and handled by {@link buildStoreRules} instead — see there for
+ * why the generic path cannot represent it.
+ */
+const GIT_STORE_PERMISSION_KEY = '-C';
+
+/**
+ * Prefix rules for the external artifact store, built from the *resolved*
+ * store path rather than a wildcard.
+ *
+ * Codex rules have no wildcard segment: `buildPrefixPattern` strips a
+ * trailing `*` from each token and `prefix_rule` then matches tokens
+ * exactly, so the Claude-style `~/.smithy/repos/*` collapses to the literal
+ * token `~/.smithy/repos/` and never matches a real
+ * `~/.smithy/repos/widget/`. The result would be a rule that looks like it
+ * grants something and grants nothing.
+ *
+ * The deployer doesn't need a wildcard, though — it already knows which
+ * store this install uses. `artifactsRoot` is the tilde form
+ * (`~/.smithy/repos/widget/`, trailing slash included, exactly as the
+ * prompts emit it), so the token matches literally, and no absolute home
+ * directory is written into the committed rules file.
+ *
+ * Returns nothing in repo mode, where `artifactsRoot` is empty and there is
+ * no store to grant access to.
+ */
+function buildStoreRules(artifactsRoot: string): string[][] {
+  if (artifactsRoot.length === 0) return [];
+  return STORE_GIT_ARGS.map(arg => buildPrefixPattern('git', '-C', artifactsRoot, arg));
+}
+
+function buildCodexRules(artifactsRoot: string): string[][] {
   const patterns = SMITHY_SKILL_SCRIPT_RULES.map(script => [script]);
 
   for (const [cmd, value] of Object.entries(permissions)) {
@@ -182,11 +215,16 @@ function buildCodexRules(): string[][] {
       for (const arg of value) patterns.push(buildPrefixPattern(cmd, arg));
     } else {
       for (const [sub, args] of Object.entries(value)) {
+        // The store entries carry a wildcard path segment the prefix-rule
+        // format cannot express; `buildStoreRules` emits the resolved form.
+        if (cmd === 'git' && sub === GIT_STORE_PERMISSION_KEY) continue;
         if (args.length === 0) patterns.push(buildPrefixPattern(cmd, sub));
         for (const arg of args) patterns.push(buildPrefixPattern(cmd, sub, arg));
       }
     }
   }
+
+  patterns.push(...buildStoreRules(artifactsRoot));
 
   const seen = new Set<string>();
   return patterns.filter(pattern => {

--- a/src/artifact-store.test.ts
+++ b/src/artifact-store.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+import { ensureArtifactStore } from './artifact-store.js';
+
+/** Read the store's commit subjects, newest first. */
+function gitLog(root: string): string[] {
+  return execFileSync('git', ['log', '--format=%s'], {
+    cwd: root,
+    encoding: 'utf-8',
+  })
+    .trim()
+    .split('\n')
+    .filter((l) => l.length > 0);
+}
+
+describe('ensureArtifactStore', () => {
+  let workdir: string;
+  let fakeHome: string;
+
+  beforeEach(() => {
+    workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-store-work-'));
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-store-home-'));
+    vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(workdir, { recursive: true, force: true });
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  it('does nothing in repo mode', () => {
+    expect(ensureArtifactStore(workdir, 'repo')).toBeNull();
+    expect(fs.existsSync(path.join(fakeHome, '.smithy'))).toBe(false);
+  });
+
+  it('creates the store as a git repository with a seeded initial commit', () => {
+    const result = ensureArtifactStore(workdir, 'external');
+
+    expect(result).not.toBeNull();
+    expect(result!.warning).toBeUndefined();
+    expect(result!.createdDir).toBe(true);
+    expect(result!.gitInitialized).toBe(true);
+    expect(fs.existsSync(path.join(result!.root, '.git'))).toBe(true);
+    expect(gitLog(result!.root)).toEqual(['smithy: initialize artifact store']);
+
+    // The README explains what the directory is and how to attach a remote —
+    // this store shows up in someone's home directory unannounced.
+    const readme = fs.readFileSync(path.join(result!.root, 'README.md'), 'utf8');
+    expect(readme).toContain('Smithy artifact store');
+    expect(readme).toContain('remote add origin');
+  });
+
+  it('lands in projects/default outside a repo and repos/<key> inside one', () => {
+    const loose = ensureArtifactStore(workdir, 'external');
+    expect(loose!.root).toBe(
+      path.join(fakeHome, '.smithy', 'projects', 'default'),
+    );
+
+    const repoDir = path.join(workdir, 'widget');
+    fs.mkdirSync(repoDir);
+    execFileSync('git', ['init', '-q'], { cwd: repoDir, stdio: 'ignore' });
+    const keyed = ensureArtifactStore(repoDir, 'external');
+    expect(keyed!.root).toBe(
+      path.join(fakeHome, '.smithy', 'repos', 'widget'),
+    );
+  });
+
+  it('is a no-op on re-run and never rewrites history', () => {
+    const first = ensureArtifactStore(workdir, 'external');
+    const root = first!.root;
+    const headBefore = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: root,
+      encoding: 'utf-8',
+    }).trim();
+
+    // A user artifact written between runs must survive untouched — `update`
+    // is routine and must not commit, stash, or clobber work in progress.
+    fs.mkdirSync(path.join(root, 'specs'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'specs', 'wip.spec.md'), '# WIP\n');
+
+    const second = ensureArtifactStore(workdir, 'external');
+    expect(second!.gitInitialized).toBe(false);
+    expect(second!.createdDir).toBe(false);
+    expect(second!.warning).toBeUndefined();
+    expect(
+      execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf-8' }).trim(),
+    ).toBe(headBefore);
+    expect(gitLog(root)).toEqual(['smithy: initialize artifact store']);
+    expect(fs.readFileSync(path.join(root, 'specs', 'wip.spec.md'), 'utf8')).toBe(
+      '# WIP\n',
+    );
+  });
+
+  it('commits with a fallback identity when the machine has none', () => {
+    // Point git at empty global/system config so no `user.email` resolves.
+    // Without the fallback the very first commit fails and the store is left
+    // historyless on exactly the machines least likely to notice.
+    vi.stubEnv('GIT_CONFIG_GLOBAL', '/dev/null');
+    vi.stubEnv('GIT_CONFIG_SYSTEM', '/dev/null');
+    try {
+      const result = ensureArtifactStore(workdir, 'external');
+      expect(result!.warning).toBeUndefined();
+      expect(result!.gitInitialized).toBe(true);
+
+      const author = execFileSync('git', ['log', '-1', '--format=%an <%ae>'], {
+        cwd: result!.root,
+        encoding: 'utf-8',
+      }).trim();
+      expect(author).toBe('Smithy CLI <smithy@localhost>');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("uses the user's own git identity when one is configured", () => {
+    // These are the user's commits, not Smithy's — inheriting their identity
+    // keeps `git log` in the store readable alongside their other work.
+    vi.stubEnv('GIT_CONFIG_GLOBAL', '/dev/null');
+    vi.stubEnv('GIT_CONFIG_SYSTEM', '/dev/null');
+    vi.stubEnv('GIT_AUTHOR_NAME', 'Ada');
+    vi.stubEnv('GIT_AUTHOR_EMAIL', 'ada@example.com');
+    vi.stubEnv('GIT_COMMITTER_NAME', 'Ada');
+    vi.stubEnv('GIT_COMMITTER_EMAIL', 'ada@example.com');
+    try {
+      const result = ensureArtifactStore(workdir, 'external');
+      const author = execFileSync('git', ['log', '-1', '--format=%an <%ae>'], {
+        cwd: result!.root,
+        encoding: 'utf-8',
+      }).trim();
+      expect(author).toBe('Ada <ada@example.com>');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('still creates the directory, with a warning, when git is unavailable', () => {
+    // Empty PATH → `git` cannot be spawned. The install must survive: only
+    // the history is lost, not the ability to write artifacts.
+    vi.stubEnv('PATH', '');
+    try {
+      const result = ensureArtifactStore(workdir, 'external');
+      expect(result!.gitInitialized).toBe(false);
+      expect(result!.warning).toBeDefined();
+      expect(fs.existsSync(result!.root)).toBe(true);
+      expect(fs.existsSync(path.join(result!.root, '.git'))).toBe(false);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+});

--- a/src/artifact-store.ts
+++ b/src/artifact-store.ts
@@ -1,0 +1,166 @@
+import fs from 'fs';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import type { ArtifactsLocation } from './interactive.js';
+import { resolveArtifactsRoot } from './manifest.js';
+
+/**
+ * Git-backed external artifact stores.
+ *
+ * When planning artifacts live outside the code repo they have no history of
+ * their own: an agent that overwrites or deletes a spec leaves nothing to
+ * recover from, and there is no way to move the store between machines.
+ * Making each store a git repository fixes both — `git restore` becomes the
+ * undo button, and the user can attach a remote whenever they want the store
+ * to follow them.
+ *
+ * One repository per store. Stores are independent projects; a single
+ * repository spanning `~/.smithy/` would couple unrelated work onto one
+ * history and one remote, and would nest badly the moment a user cloned an
+ * existing store into place.
+ */
+
+const INIT_COMMIT_MESSAGE = 'smithy: initialize artifact store';
+
+/** Identity used only when the machine has no global git identity at all. */
+const FALLBACK_USER_NAME = 'Smithy CLI';
+const FALLBACK_USER_EMAIL = 'smithy@localhost';
+
+export interface EnsureArtifactStoreResult {
+  /** Absolute path to the store. */
+  root: string;
+  /** Whether this call created the store directory. */
+  createdDir: boolean;
+  /** Whether this call ran `git init` (false if the store was already a repo). */
+  gitInitialized: boolean;
+  /**
+   * Set when git-backing could not be established. The store directory still
+   * exists and is usable — only the history is missing.
+   */
+  warning?: string;
+}
+
+/** Run a git command in `cwd`, letting failures throw for the caller to catch. */
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+/**
+ * Whether git can already attribute a commit made in `cwd` — i.e. `user.name`
+ * and `user.email` resolve from any scope (global, system, or an existing
+ * repo-local config).
+ */
+function hasGitIdentity(cwd: string): boolean {
+  for (const key of ['user.name', 'user.email']) {
+    try {
+      if (git(cwd, ['config', '--get', key]).trim().length === 0) return false;
+    } catch {
+      // `git config --get` exits non-zero when the key is unset.
+      return false;
+    }
+  }
+  return true;
+}
+
+function storeReadme(root: string): string {
+  return `# Smithy artifact store
+
+Smithy planning artifacts (RFCs, feature maps, specs, tasks, strikes, PRDs)
+for an install configured with \`artifactsLocation: external\`. Smithy created
+this directory and initialized it as a git repository so the artifacts have a
+history — if an agent overwrites or deletes one, \`git restore\` brings it
+back.
+
+    ${root}
+
+Artifacts land under \`docs/\` and \`specs/\` here, using the same layout they
+would have in-tree.
+
+## Syncing between machines
+
+Nothing is pushed anywhere by default. To carry this store between machines,
+attach a remote yourself:
+
+    git -C ${root} remote add origin <your-remote-url>
+    git -C ${root} push -u origin main
+
+Smithy will not push on your behalf.
+`;
+}
+
+/**
+ * Ensure the external artifact store for `targetDir` exists and is a git
+ * repository. Returns `null` for `'repo'` mode, where artifacts live in the
+ * code repo and already have its history.
+ *
+ * Idempotent: a store that is already a git repository is left completely
+ * alone, so re-running `smithy init` or `smithy update` never rewrites
+ * history or adds empty commits.
+ *
+ * Never throws. Creating the store is a side benefit of `init`, not its
+ * purpose — a machine without git, or one where the commit is rejected by a
+ * hook, should still get a working Smithy install. Failures come back as
+ * `warning` for the caller to surface.
+ */
+export function ensureArtifactStore(
+  targetDir: string,
+  location: ArtifactsLocation,
+): EnsureArtifactStoreResult | null {
+  if (location !== 'external') return null;
+
+  const root = resolveArtifactsRoot(targetDir, 'external');
+
+  let createdDir = false;
+  try {
+    createdDir = !fs.existsSync(root);
+    fs.mkdirSync(root, { recursive: true });
+  } catch (err) {
+    return {
+      root,
+      createdDir: false,
+      gitInitialized: false,
+      warning: `could not create ${root}: ${(err as Error).message}`,
+    };
+  }
+
+  if (fs.existsSync(path.join(root, '.git'))) {
+    return { root, createdDir, gitInitialized: false };
+  }
+
+  try {
+    // `-c init.defaultBranch=main` pins the branch name regardless of the
+    // user's git defaults and silences the "using 'master'" advice.
+    git(root, ['-c', 'init.defaultBranch=main', 'init']);
+
+    // These are the user's own commits, so inherit their identity. Only fall
+    // back to a local placeholder when the machine has none — otherwise the
+    // very first commit would fail on a fresh install.
+    if (!hasGitIdentity(root)) {
+      git(root, ['config', '--local', 'user.name', FALLBACK_USER_NAME]);
+      git(root, ['config', '--local', 'user.email', FALLBACK_USER_EMAIL]);
+    }
+
+    const readmePath = path.join(root, 'README.md');
+    if (!fs.existsSync(readmePath)) {
+      fs.writeFileSync(readmePath, storeReadme(root));
+    }
+
+    git(root, ['add', '-A']);
+    // `--no-gpg-sign` matters: a global `commit.gpgsign = true` would
+    // otherwise block on a passphrase prompt in a non-interactive run.
+    git(root, ['commit', '--no-gpg-sign', '-m', INIT_COMMIT_MESSAGE]);
+
+    return { root, createdDir, gitInitialized: true };
+  } catch (err) {
+    return {
+      root,
+      createdDir,
+      gitInitialized: false,
+      warning: `could not git-init ${root}: ${(err as Error).message.trim()}`,
+    };
+  }
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -125,6 +125,35 @@ describe('CLI init --yes (non-interactive)', () => {
   });
 
   describe('--artifacts-location', () => {
+    // External mode creates a git-backed store under `~/.smithy/`, so every
+    // invocation below runs against a throwaway HOME. Without this the suite
+    // would write into (and commit inside) the developer's real home
+    // directory, and `smithy status` assertions would see whatever stores
+    // happen to exist on the machine.
+    let fakeHome: string;
+
+    beforeEach(() => {
+      fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-home-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    });
+
+    /** Run the built CLI in `tmpDir` with HOME pointed at the throwaway. */
+    function runCli(args: string[]): string {
+      return execFileSync('node', [CLI, ...args], {
+        encoding: 'utf-8',
+        cwd: tmpDir,
+        env: { ...process.env, HOME: fakeHome, USERPROFILE: fakeHome },
+      });
+    }
+
+    /** Make `tmpDir` a real git repo so the store resolves to repos/<key>/. */
+    function initGitRepo(): void {
+      execFileSync('git', ['init', '-q'], { cwd: tmpDir, stdio: 'ignore' });
+    }
+
     it('defaults to repo mode — no artifactsLocation field in the manifest, no tilde prefix in deployed prompts', () => {
       execFileSync('node', [CLI, 'init', '-a', 'claude', '-y'], {
         encoding: 'utf-8',
@@ -150,11 +179,8 @@ describe('CLI init --yes (non-interactive)', () => {
     });
 
     it('--artifacts-location external persists in the manifest and bakes ~/.smithy/repos/<repo>/ into deployed prompts', () => {
-      execFileSync(
-        'node',
-        [CLI, 'init', '-a', 'claude', '-y', '--artifacts-location', 'external'],
-        { encoding: 'utf-8', cwd: tmpDir },
-      );
+      initGitRepo();
+      runCli(['init', '-a', 'claude', '-y', '--artifacts-location', 'external']);
       const manifestPath = path.join(tmpDir, '.smithy', 'smithy-manifest.json');
       const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
       expect(manifest.artifactsLocation).toBe('external');
@@ -169,16 +195,24 @@ describe('CLI init --yes (non-interactive)', () => {
       expect(strike).not.toContain('{{artifactsRoot}}');
     });
 
-    it('update round-trips the artifactsLocation field — no flag required', () => {
-      execFileSync(
-        'node',
-        [CLI, 'init', '-a', 'claude', '-y', '--artifacts-location', 'external'],
-        { encoding: 'utf-8', cwd: tmpDir },
+    it('bakes ~/.smithy/projects/default/ into deployed prompts outside a git repo', () => {
+      // `tmpDir` is deliberately left as a plain directory. `repoKey` would
+      // still yield its basename, but a store keyed that way is unfindable
+      // from anywhere else — cross-repo work goes to the fixed project store.
+      runCli(['init', '-a', 'claude', '-y', '--artifacts-location', 'external']);
+
+      const strike = fs.readFileSync(
+        path.join(tmpDir, '.claude', 'commands', 'smithy.strike.md'),
+        'utf8',
       );
-      execFileSync('node', [CLI, 'update', '-y'], {
-        encoding: 'utf-8',
-        cwd: tmpDir,
-      });
+      expect(strike).toContain('~/.smithy/projects/default/specs/strikes/');
+      expect(strike).not.toContain(`~/.smithy/repos/${path.basename(tmpDir)}/`);
+    });
+
+    it('update round-trips the artifactsLocation field — no flag required', () => {
+      initGitRepo();
+      runCli(['init', '-a', 'claude', '-y', '--artifacts-location', 'external']);
+      runCli(['update', '-y']);
       const manifestPath = path.join(tmpDir, '.smithy', 'smithy-manifest.json');
       const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
       expect(manifest.artifactsLocation).toBe('external');
@@ -192,16 +226,9 @@ describe('CLI init --yes (non-interactive)', () => {
     });
 
     it('update --artifacts-location repo migrates an external manifest back to in-repo paths', () => {
-      execFileSync(
-        'node',
-        [CLI, 'init', '-a', 'claude', '-y', '--artifacts-location', 'external'],
-        { encoding: 'utf-8', cwd: tmpDir },
-      );
-      execFileSync(
-        'node',
-        [CLI, 'update', '-y', '--artifacts-location', 'repo'],
-        { encoding: 'utf-8', cwd: tmpDir },
-      );
+      initGitRepo();
+      runCli(['init', '-a', 'claude', '-y', '--artifacts-location', 'external']);
+      runCli(['update', '-y', '--artifacts-location', 'repo']);
 
       const manifestPath = path.join(tmpDir, '.smithy', 'smithy-manifest.json');
       const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -24,6 +24,7 @@ import {
   writeManifest,
 } from '../manifest.js';
 import { ORDERS_TEMPLATE_TYPES, provisionOrdersTemplates } from '../orders-templates.js';
+import { ensureArtifactStore, type EnsureArtifactStoreResult } from '../artifact-store.js';
 import * as gemini from '../agents/gemini.js';
 import * as claude from '../agents/claude.js';
 import * as codex from '../agents/codex.js';
@@ -60,6 +61,29 @@ export interface InitOptions {
   yes?: boolean;
   /** When true, suppresses the welcome banner and uses "Upgrade" in the completion message. */
   quiet?: boolean;
+}
+
+/**
+ * Print a one-line report for the external artifact store. Silent in repo
+ * mode (`result` is `null`) and for a store that was already git-backed on a
+ * re-run, so a routine `smithy update` stays quiet — the interesting cases
+ * are "just created it" and "couldn't".
+ */
+function reportArtifactStore(result: EnsureArtifactStoreResult | null): void {
+  if (result === null) return;
+  if (result.warning !== undefined) {
+    console.log(
+      picocolors.yellow(
+        `  Artifact store: ${result.warning} — artifacts will still be written, but without history`,
+      ),
+    );
+    return;
+  }
+  if (result.gitInitialized) {
+    console.log(
+      picocolors.dim(`  Artifact store: ${result.root} (git repository initialized)`),
+    );
+  }
 }
 
 export async function initAction(opts: InitOptions = {}): Promise<void> {
@@ -143,6 +167,11 @@ export async function initAction(opts: InitOptions = {}): Promise<void> {
     artifactsLocation = await promptArtifactsLocation();
   }
   const artifactsRoot = templateArtifactsPrefix(targetDir, artifactsLocation);
+
+  // Create the external store and give it a git history, so an agent that
+  // clobbers an artifact leaves something to restore from. No-op in repo
+  // mode, where artifacts already ride the repo's own history.
+  reportArtifactStore(ensureArtifactStore(targetDir, artifactsLocation));
 
   // 5d. Orders templates — write canonical default bodies to
   // <manifestDir>/templates/orders/. Provisioning runs BEFORE the manifest-write

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -15,6 +15,7 @@ import {
 } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
 
 import {
   formatSummaryHeader,
@@ -444,6 +445,7 @@ describe('StatusJsonPayload.graph type wiring', () => {
       },
       records: [],
       graph: populated,
+      scan_root: '/repo',
     };
     expect(payload.graph.nodes[fqId]?.record_path).toBe(
       'specs/sample/sample.spec.md',
@@ -489,6 +491,7 @@ describe('StatusJsonPayload.graph type wiring', () => {
       },
       records: [],
       graph: populated,
+      scan_root: '/repo',
     };
     const firstLayer = payload.graph.layers[0]!;
     expect(firstLayer.mode).toBe('all');
@@ -516,6 +519,7 @@ describe('StatusJsonPayload.graph type wiring', () => {
       },
       records: [],
       graph: stub,
+      scan_root: '/repo',
     };
     expect(payload.graph.mode).toBe('pending-only');
     expect(payload.graph.nodes).toEqual({});
@@ -1469,16 +1473,20 @@ describe('statusAction — pending-graph view + layer-filter flags', () => {
 });
 
 describe('statusAction artifacts-location integration', () => {
-  // The scanner is taught to read `.smithy/smithy-manifest.json` (or
-  // `~/.smithy/smithy-manifest.json`) and redirect its scan root to
-  // `~/.smithy/repos/<repoKey>/` when `artifactsLocation === 'external'`. These
-  // tests exercise that wiring end-to-end via real on-disk files.
+  // The scanner reads `.smithy/smithy-manifest.json` (or
+  // `~/.smithy/smithy-manifest.json`) and, when `artifactsLocation ===
+  // 'external'`, cascades over the repo, `~/.smithy/repos/<repoKey>/`, and
+  // `~/.smithy/projects/default/`. These tests exercise that wiring
+  // end-to-end via real on-disk files.
   //
-  // The redirect only fires when `opts.root` is `undefined` (the scanner
+  // The cascade only fires when `opts.root` is `undefined` (the scanner
   // falls back to `process.cwd()` then), so the cases that actually hit
-  // the new branch stub both `process.cwd` and `process.env.HOME` —
-  // tests that pass `root` explicitly intentionally bypass the redirect
-  // and document the "explicit --root always wins" rule.
+  // it stub both `process.cwd` and `process.env.HOME` — tests that pass
+  // `root` explicitly intentionally bypass the cascade and document the
+  // "explicit --root always wins" rule.
+  //
+  // `workdir` is a real git repo so the store resolves to the repo-keyed
+  // branch; the outside-a-repo branch has its own describe block below.
 
   let workdir: string;
   let fakeHome: string;
@@ -1488,6 +1496,7 @@ describe('statusAction artifacts-location integration', () => {
   beforeEach(() => {
     workdir = mkdtempSync(join(tmpdir(), 'smithy-status-workdir-'));
     fakeHome = mkdtempSync(join(tmpdir(), 'smithy-status-home-'));
+    execFileSync('git', ['init', '-q'], { cwd: workdir, stdio: 'ignore' });
     cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(workdir);
     vi.stubEnv('HOME', fakeHome);
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -1585,6 +1594,51 @@ describe('statusAction artifacts-location integration', () => {
     expect(payload.records).toEqual([]);
   });
 
+  it('prefers in-repo artifacts over the external store when both have some', () => {
+    // First step of the cascade. A repo that kept artifacts in-tree (from
+    // before the flip to external mode) must still see them — silently
+    // showing only the external store would make that work look lost.
+    writeManifest(workdir, 'external');
+    writeTasksFixture(workdir);
+    const externalRoot = resolveArtifactsRoot(workdir, 'external');
+    mkdirSync(join(externalRoot, 'specs', 'other'), { recursive: true });
+    writeFileSync(
+      join(externalRoot, 'specs', 'other', '99-other.tasks.md'),
+      '# Other\n\n## Slice 1: Only\n\n- [ ] One\n\n## Dependency Order\n\n| ID | Title | Depends On | Artifact |\n|----|-------|------------|----------|\n| S1 | Only | — | — |\n',
+    );
+
+    statusAction({ format: 'json' });
+    const payload = JSON.parse(captured()) as StatusJsonPayload;
+    expect(payload.records[0]!.path).toBe('specs/sample/01-first.tasks.md');
+    expect(payload.scan_root).toBe(workdir);
+  });
+
+  it('falls back to ~/.smithy/projects/default/ when the repo and its keyed store are both empty', () => {
+    // Third step of the cascade: a cross-repo artifact authored outside any
+    // repo is still reachable from a member repo.
+    writeManifest(workdir, 'external');
+    const projectRoot = join(fakeHome, '.smithy', 'projects', 'default');
+    writeTasksFixture(projectRoot);
+
+    statusAction({ format: 'json' });
+    const payload = JSON.parse(captured()) as StatusJsonPayload;
+    expect(payload.records.length).toBeGreaterThan(0);
+    expect(payload.records[0]!.path).toBe(
+      '~/.smithy/projects/default/specs/sample/01-first.tasks.md',
+    );
+    expect(payload.scan_root).toBe('~/.smithy/projects/default/');
+  });
+
+  it('reports the winning scan root in the JSON payload', () => {
+    writeManifest(workdir, 'external');
+    const externalRoot = resolveArtifactsRoot(workdir, 'external');
+    writeTasksFixture(externalRoot);
+
+    statusAction({ format: 'json' });
+    const payload = JSON.parse(captured()) as StatusJsonPayload;
+    expect(payload.scan_root).toBe(templateArtifactsPrefix(workdir, 'external'));
+  });
+
   it('explicit --root always wins, even when the manifest declares external', () => {
     writeManifest(workdir, 'external');
     // Pre-create both locations with different fixtures so the test can tell
@@ -1603,5 +1657,71 @@ describe('statusAction artifacts-location integration', () => {
     for (const r of payload.records) {
       expect(r.path.startsWith('~/.smithy/')).toBe(false);
     }
+  });
+});
+
+describe('statusAction discovery outside a git repo', () => {
+  // Standing in a plain directory there is no repo-keyed store to consult,
+  // so discovery leads with the shared project store — that is where
+  // cross-repo planning lands. The working directory stays as a trailing
+  // candidate so a folder full of artifacts still scans.
+
+  let workdir: string;
+  let fakeHome: string;
+  let cwdSpy: MockInstance<() => string>;
+  let logSpy: MockInstance<(...args: unknown[]) => void>;
+
+  beforeEach(() => {
+    workdir = mkdtempSync(join(tmpdir(), 'smithy-status-loose-'));
+    fakeHome = mkdtempSync(join(tmpdir(), 'smithy-status-home-'));
+    // Deliberately NOT a git repo.
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(workdir);
+    vi.stubEnv('HOME', fakeHome);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cwdSpy.mockRestore();
+    vi.unstubAllEnvs();
+    logSpy.mockRestore();
+    if (workdir) rmSync(workdir, { recursive: true, force: true });
+    if (fakeHome) rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  function captured(): string {
+    return logSpy.mock.calls.map((args) => args.join(' ')).join('\n');
+  }
+
+  function writeTasksFixture(root: string): void {
+    const dir = join(root, 'specs', 'sample');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, '01-first.tasks.md'),
+      '# US1 Tasks\n\n## Slice 1: Only\n\n- [ ] One\n\n## Dependency Order\n\n| ID | Title | Depends On | Artifact |\n|----|-------|------------|----------|\n| S1 | Only | — | — |\n',
+    );
+  }
+
+  it('reads ~/.smithy/projects/default/ ahead of the working directory', () => {
+    writeTasksFixture(join(fakeHome, '.smithy', 'projects', 'default'));
+    writeTasksFixture(workdir);
+
+    statusAction({ format: 'json' });
+    const payload = JSON.parse(captured()) as StatusJsonPayload;
+    expect(payload.records[0]!.path).toBe(
+      '~/.smithy/projects/default/specs/sample/01-first.tasks.md',
+    );
+    expect(payload.scan_root).toBe('~/.smithy/projects/default/');
+  });
+
+  it('still scans the working directory when the project store is empty', () => {
+    // Without this fallback the result would depend on whether the user
+    // happens to have a project store — a plain directory of artifacts
+    // would silently report nothing.
+    writeTasksFixture(workdir);
+
+    statusAction({ format: 'json' });
+    const payload = JSON.parse(captured()) as StatusJsonPayload;
+    expect(payload.records[0]!.path).toBe('specs/sample/01-first.tasks.md');
+    expect(payload.scan_root).toBe(workdir);
   });
 });

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -57,7 +57,6 @@
  */
 
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
 import {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -57,9 +57,17 @@
  */
 
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
-import { readManifest, resolveArtifactsRoot, templateArtifactsPrefix } from '../manifest.js';
+import {
+  isInsideGitRepo,
+  projectStorePrefix,
+  projectStoreRoot,
+  readManifest,
+  resolveArtifactsRoot,
+  templateArtifactsPrefix,
+} from '../manifest.js';
 import {
   buildDependencyGraph,
   buildTree,
@@ -224,6 +232,14 @@ export interface StatusJsonPayload {
   summary: ScanSummary;
   records: ArtifactRecord[];
   graph: SerializedGraph;
+  /**
+   * The root discovery settled on — the working directory, or the tilde form
+   * of an external store (`~/.smithy/repos/<repoKey>/`,
+   * `~/.smithy/projects/default/`). Additive field: it tells a consumer which
+   * of the cascade's candidates won, so "why is this empty?" is answerable
+   * without re-deriving the resolution rules.
+   */
+  scan_root: string;
 }
 
 /**
@@ -412,27 +428,18 @@ export function statusAction(opts: StatusOptions = {}): void {
     return;
   }
 
-  // If the user didn't pass `--root` explicitly and the working directory has
-  // a smithy manifest declaring `artifactsLocation: 'external'`, redirect the
-  // scan to `~/.smithy/repos/<repoKey>/` so artifacts written off-tree are still found.
-  // Explicit `--root` always wins so power users can scan an arbitrary path.
-  const externalScanRoot =
-    opts.root === undefined ? resolveExternalArtifactsRoot(resolvedRoot) : null;
-  const scanRoot = externalScanRoot ?? resolvedRoot;
-  const records = scan(scanRoot);
-  // The scanner returns paths relative to `scanRoot`. When we redirected, those
-  // paths read like `specs/foo/01.tasks.md` but the actual files live at
-  // `~/.smithy/repos/<repoKey>/specs/foo/01.tasks.md`. Re-prepend the tilde
-  // prefix so the rendered tree, JSON records, and `Next: smithy.forge <path>
-  // <N>` hints all point at the real on-disk location. We reuse
-  // `templateArtifactsPrefix` (rather than rebuilding the prefix inline) so the
-  // displayed paths are guaranteed to match where the artifacts are actually
-  // stored — both go through the same worktree-stable `repoKey`. Skipped in the
-  // in-repo case (the cheap common path) where `externalScanRoot` is `null`.
-  if (externalScanRoot !== null) {
-    const externalPrefix = templateArtifactsPrefix(resolvedRoot, 'external');
-    applyExternalPrefix(records, externalPrefix);
-  }
+  // Without an explicit `--root`, discovery cascades over the places an
+  // install's artifacts can live (see `artifactScanCandidates`) and keeps the
+  // first root that actually has any. The cascade also re-prefixes the
+  // records it returns, so rendered paths, JSON records, and
+  // `Next: smithy.forge <path> <N>` hints all name the real on-disk location
+  // rather than a store-relative path the user can't act on.
+  //
+  // Explicit `--root` always wins, so power users can scan an arbitrary path.
+  const { records, scanRoot } =
+    opts.root === undefined
+      ? scanWithCascade(resolvedRoot)
+      : { records: scan(resolvedRoot), scanRoot: resolvedRoot };
   // US6: apply the `--status` / `--type` filters to the classified
   // record set before it reaches `buildTree` / the JSON emitter.
   // Ancestor retention inside `filterRecords` preserves AS 6.1 / AS
@@ -488,6 +495,7 @@ export function statusAction(opts: StatusOptions = {}): void {
         all: opts.all === true,
         ...(layerSelection !== undefined ? { layerSelection } : {}),
       }),
+      scan_root: scanRoot,
     };
     console.log(JSON.stringify(payload, null, 2));
     return;
@@ -505,6 +513,14 @@ export function statusAction(opts: StatusOptions = {}): void {
     noColor: opts.color === false,
     ascii: opts.ascii === true,
   });
+
+  // Name the store whenever discovery landed somewhere other than the working
+  // directory. Every path below is then prefixed with that store, so without
+  // this line the cascade is invisible and "these aren't my repo's artifacts"
+  // has no explanation on screen.
+  if (scanRoot !== resolvedRoot) {
+    console.log(theme.paint.dim(`Artifacts: ${scanRoot}`));
+  }
 
   // US10 Slice 3: `--graph` swaps the tree pipeline for the layered
   // view from `renderGraph`. The summary header still prints first so
@@ -833,26 +849,84 @@ function applyExternalPrefix(records: ArtifactRecord[], externalPrefix: string):
 }
 
 /**
- * If `<resolvedRoot>` has a smithy manifest declaring `artifactsLocation:
- * 'external'`, return the absolute path to `~/.smithy/repos/<repoKey>/` so the
- * scanner finds artifacts that were written off-tree. Returns `null` for
- * the in-repo case (the caller falls back to `resolvedRoot`). Either
- * manifest location ('repo' deploy at `.smithy/...`, 'user' deploy at
- * `~/.smithy/...`) is consulted — `artifactsLocation` is an orthogonal
- * setting on the manifest itself, not on the manifest's own location.
- *
- * If the external root doesn't exist on disk yet (the user just flipped
- * the flag and hasn't written any artifacts there), fall through to the
- * default so the scanner reports the same friendly "no artifacts found"
- * hint instead of bailing with a `stat` error.
+ * One place the scanner may find artifacts, paired with the display prefix
+ * to apply if it wins. `prefix` is `''` when the root *is* the working
+ * directory (paths already read correctly) and the tilde form of an
+ * external store otherwise, so rendered paths and `Next:` commands point at
+ * the real on-disk location.
  */
-function resolveExternalArtifactsRoot(resolvedRoot: string): string | null {
+interface ScanCandidate {
+  root: string;
+  prefix: string;
+}
+
+/**
+ * The ordered list of roots `smithy status` will try, most specific first.
+ * The caller scans each in turn and keeps the first that actually yields
+ * artifacts.
+ *
+ * A cascade rather than a single root because an external install has its
+ * artifacts in one of three places and the user shouldn't have to know
+ * which: the repo itself (artifacts predating the flip to external mode, or
+ * a repo that keeps some in-tree), the repo-keyed store, or the shared
+ * project store used for cross-repo work.
+ *
+ * Outside a git repo there is no in-tree store worth preferring, so the
+ * project store leads. `resolvedRoot` still trails it as a last resort —
+ * scanning a plain directory full of artifacts remains useful, and dropping
+ * it would make the result depend on whether `~/.smithy/projects/default/`
+ * happens to exist.
+ *
+ * Either manifest location is consulted ('repo' deploy at `.smithy/...`,
+ * 'user' deploy at `~/.smithy/...`) — `artifactsLocation` is an orthogonal
+ * setting on the manifest itself, not on the manifest's own location.
+ */
+function artifactScanCandidates(resolvedRoot: string): ScanCandidate[] {
+  const projects: ScanCandidate = {
+    root: projectStoreRoot(),
+    prefix: projectStorePrefix(),
+  };
+
+  if (!isInsideGitRepo(resolvedRoot)) {
+    return [projects, { root: resolvedRoot, prefix: '' }];
+  }
+
   const manifest =
     readManifest(resolvedRoot, 'repo') ?? readManifest(resolvedRoot, 'user');
-  if (!manifest || manifest.artifactsLocation !== 'external') return null;
-  const externalRoot = resolveArtifactsRoot(resolvedRoot, 'external');
-  if (!fs.existsSync(externalRoot)) return null;
-  return externalRoot;
+  if ((manifest?.artifactsLocation ?? 'repo') !== 'external') {
+    return [{ root: resolvedRoot, prefix: '' }];
+  }
+
+  return [
+    { root: resolvedRoot, prefix: '' },
+    {
+      root: resolveArtifactsRoot(resolvedRoot, 'external'),
+      prefix: templateArtifactsPrefix(resolvedRoot, 'external'),
+    },
+    projects,
+  ];
+}
+
+/**
+ * Walk {@link artifactScanCandidates} and return the first root that exists
+ * and yields at least one artifact, with its records already re-prefixed.
+ *
+ * When nothing matches, returns an empty record set anchored at
+ * `resolvedRoot` so the caller still prints the friendly "no artifacts
+ * found" hint rather than reporting a store the user has never used.
+ */
+function scanWithCascade(resolvedRoot: string): {
+  records: ArtifactRecord[];
+  scanRoot: string;
+} {
+  for (const candidate of artifactScanCandidates(resolvedRoot)) {
+    if (!fs.existsSync(candidate.root)) continue;
+    const records = scan(candidate.root);
+    if (records.length === 0) continue;
+    if (candidate.prefix.length > 0) applyExternalPrefix(records, candidate.prefix);
+    return { records, scanRoot: candidate.prefix || candidate.root };
+  }
+  return { records: [], scanRoot: resolvedRoot };
 }
 
 /**

--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -22,9 +22,12 @@ vi.mock('child_process', async (importOriginal) => {
 });
 
 const { execFileSync } = await import('child_process');
-const { repoKey, resolveArtifactsRoot, templateArtifactsPrefix } = await import(
-  './manifest.js'
-);
+const {
+  isInsideGitRepo,
+  repoKey,
+  resolveArtifactsRoot,
+  templateArtifactsPrefix,
+} = await import('./manifest.js');
 
 // Run a real git command for fixture setup, bypassing the mock entirely.
 function git(args: string[], cwd: string): void {
@@ -166,13 +169,43 @@ describe('repoKey', () => {
   });
 });
 
+describe('isInsideGitRepo', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(execFileSync).mockReset();
+  });
+
+  it('is true inside a git checkout and false in a plain directory', () => {
+    passGitThrough();
+
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-inrepo-'));
+    try {
+      const repoDir = path.join(parent, 'repo');
+      const plainDir = path.join(parent, 'plain');
+      fs.mkdirSync(repoDir);
+      fs.mkdirSync(plainDir);
+      git(['init', '-q'], repoDir);
+
+      expect(isInsideGitRepo(repoDir)).toBe(true);
+      // `parent` lives under the OS temp dir, which is not itself a repo.
+      expect(isInsideGitRepo(plainDir)).toBe(false);
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('reports false when the git binary is unavailable', () => {
+    vi.mocked(execFileSync).mockImplementation((() => {
+      throw new Error('spawn git ENOENT');
+    }) as never);
+
+    expect(isInsideGitRepo('/work/widget')).toBe(false);
+  });
+});
+
 describe('resolveArtifactsRoot', () => {
   beforeEach(() => {
     vi.spyOn(os, 'homedir').mockReturnValue('/fake/home');
-    // Non-git target → repoKey resolves to basename.
-    vi.mocked(execFileSync).mockImplementation((() => {
-      throw new Error('not a git repository');
-    }) as never);
   });
 
   afterEach(() => {
@@ -180,39 +213,110 @@ describe('resolveArtifactsRoot', () => {
     vi.mocked(execFileSync).mockReset();
   });
 
-  it('returns the repo-keyed external root under ~/.smithy/repos/', () => {
+  it('returns the repo-keyed external root under ~/.smithy/repos/ inside a repo', () => {
+    passGitThrough();
+
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-extroot-'));
+    try {
+      const repoDir = path.join(parent, 'widget');
+      fs.mkdirSync(repoDir);
+      git(['init', '-q'], repoDir);
+
+      expect(resolveArtifactsRoot(repoDir, 'external')).toBe(
+        path.join('/fake/home', '.smithy', 'repos', 'widget'),
+      );
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to ~/.smithy/projects/default/ outside a repo', () => {
+    // Not a git repo — `repoKey` would still return `widget`, but a store
+    // keyed on a directory basename is unfindable from anywhere else, so
+    // cross-repo work goes to the fixed project store instead.
+    vi.mocked(execFileSync).mockImplementation((() => {
+      throw new Error('not a git repository');
+    }) as never);
+
     expect(resolveArtifactsRoot('/work/widget', 'external')).toBe(
-      path.join('/fake/home', '.smithy', 'repos', 'widget'),
+      path.join('/fake/home', '.smithy', 'projects', 'default'),
     );
   });
 
   it('returns targetDir unchanged for repo mode', () => {
+    vi.mocked(execFileSync).mockImplementation((() => {
+      throw new Error('not a git repository');
+    }) as never);
+
     expect(resolveArtifactsRoot('/work/widget', 'repo')).toBe('/work/widget');
     expect(resolveArtifactsRoot('/work/widget')).toBe('/work/widget');
   });
 });
 
 describe('templateArtifactsPrefix', () => {
-  beforeEach(() => {
-    vi.mocked(execFileSync).mockImplementation((() => {
-      throw new Error('not a git repository');
-    }) as never);
-  });
-
   afterEach(() => {
     vi.restoreAllMocks();
     vi.mocked(execFileSync).mockReset();
   });
 
-  it('returns the repo-keyed tilde prefix for external mode', () => {
+  it('returns the repo-keyed tilde prefix inside a repo', () => {
+    passGitThrough();
+
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-extpx-'));
+    try {
+      const repoDir = path.join(parent, 'widget');
+      fs.mkdirSync(repoDir);
+      git(['init', '-q'], repoDir);
+
+      expect(templateArtifactsPrefix(repoDir, 'external')).toBe(
+        '~/.smithy/repos/widget/',
+      );
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it('returns the project-store tilde prefix outside a repo', () => {
+    vi.mocked(execFileSync).mockImplementation((() => {
+      throw new Error('not a git repository');
+    }) as never);
+
     expect(templateArtifactsPrefix('/work/widget', 'external')).toBe(
-      '~/.smithy/repos/widget/',
+      '~/.smithy/projects/default/',
     );
   });
 
   it('returns an empty prefix for repo mode', () => {
+    vi.mocked(execFileSync).mockImplementation((() => {
+      throw new Error('not a git repository');
+    }) as never);
+
     expect(templateArtifactsPrefix('/work/widget', 'repo')).toBe('');
     expect(templateArtifactsPrefix('/work/widget')).toBe('');
+  });
+
+  it('names the same store as resolveArtifactsRoot in both branches', () => {
+    // The prompt-facing tilde form and the on-disk absolute form must always
+    // point at one store — otherwise agents write where status cannot look.
+    vi.spyOn(os, 'homedir').mockReturnValue('/fake/home');
+    passGitThrough();
+
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-parity-'));
+    try {
+      const repoDir = path.join(parent, 'widget');
+      const plainDir = path.join(parent, 'loose');
+      fs.mkdirSync(repoDir);
+      fs.mkdirSync(plainDir);
+      git(['init', '-q'], repoDir);
+
+      for (const dir of [repoDir, plainDir]) {
+        const tilde = templateArtifactsPrefix(dir, 'external');
+        const absolute = resolveArtifactsRoot(dir, 'external');
+        expect(tilde.replace(/^~/, '/fake/home').replace(/\/$/, '')).toBe(absolute);
+      }
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true });
+    }
   });
 
   it('renders identical prefixes from the main checkout and a worktree (display matches storage)', () => {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -21,6 +21,23 @@ const MANIFEST_FILENAME = 'smithy-manifest.json';
  */
 const REPOS_DIR = 'repos';
 
+/**
+ * Sibling grouping segment to {@link REPOS_DIR} for work that is *not*
+ * anchored to a single repository — planning done from a scratch directory,
+ * or an RFC that spans several repos. `repoKey` cannot serve that case: it
+ * always resolves to *something* (falling back to the directory basename),
+ * so a cross-repo store keyed that way would move every time the user
+ * changed directories and could never be found again.
+ */
+const PROJECTS_DIR = 'projects';
+
+/**
+ * The single project store used outside a repo. Fixed for now — there is
+ * deliberately no configurable slug and no config file, so the "where did my
+ * artifacts go?" answer stays a constant.
+ */
+const DEFAULT_PROJECT = 'default';
+
 export interface SmithyManifest {
   version: 1;
   smithyVersion: string;
@@ -152,11 +169,63 @@ export function repoKey(targetDir: string): string {
 }
 
 /**
+ * Absolute path to the shared project store, `~/.smithy/projects/default/`.
+ *
+ * {@link resolveArtifactsRoot} already returns this for a target outside a
+ * repo, but `smithy status` needs it as a *fallback* while standing inside
+ * one — a cross-repo RFC lives here no matter which member repo you ask
+ * from. Exported so that lookup doesn't have to rebuild the path by hand.
+ */
+export function projectStoreRoot(): string {
+  return path.join(os.homedir(), '.smithy', PROJECTS_DIR, DEFAULT_PROJECT);
+}
+
+/** Tilde form of {@link projectStoreRoot}, for display and prompt paths. */
+export function projectStorePrefix(): string {
+  return `~/.smithy/${PROJECTS_DIR}/${DEFAULT_PROJECT}/`;
+}
+
+/**
+ * Whether `dir` sits inside a git working tree — including a linked
+ * worktree, a submodule, or any subdirectory of one.
+ *
+ * This is the signal {@link repoKey} deliberately cannot give: `repoKey`
+ * always returns a usable key, falling back to the directory basename for
+ * non-git directories, so callers that need to distinguish "this is a repo"
+ * from "this is just a folder" have to ask separately. Uses the same
+ * `--git-common-dir` probe as `repoKey` so the two agree about what counts
+ * as a repo, and inherits `gitCapture`'s quiet failure: a missing git binary
+ * reads the same as "not a repo", which is the right answer for both.
+ */
+export function isInsideGitRepo(dir: string): boolean {
+  return gitCapture(dir, ['rev-parse', '--git-common-dir']) !== null;
+}
+
+/**
+ * The path segments under `~/.smithy/` naming the external artifact store
+ * that serves `targetDir`:
+ *   - inside a git repo → `repos/<repoKey(targetDir)>`
+ *   - outside one       → `projects/default`
+ *
+ * Single source of truth for {@link resolveArtifactsRoot} and
+ * {@link templateArtifactsPrefix}. Those two must always name the same
+ * store — one as an absolute filesystem path, the other as the tilde form
+ * baked into deployed prompts — and routing both through this helper is what
+ * stops them drifting apart.
+ */
+function externalStoreSegments(targetDir: string): string[] {
+  return isInsideGitRepo(targetDir)
+    ? [REPOS_DIR, repoKey(targetDir)]
+    : [PROJECTS_DIR, DEFAULT_PROJECT];
+}
+
+/**
  * Resolve the absolute directory under which planning artifacts (RFCs,
  * specs, tasks, strikes, PRDs) are written:
  *   - 'repo'     → `<targetDir>` (paths land at `docs/rfcs/...`, `specs/...`)
- *   - 'external' → `~/.smithy/repos/<repoKey(targetDir)>/` (paths land at
- *     `~/.smithy/repos/<repo>/docs/rfcs/...`, `~/.smithy/repos/<repo>/specs/...`)
+ *   - 'external' → `~/.smithy/repos/<repoKey(targetDir)>/` when `targetDir`
+ *     is inside a git repo, else `~/.smithy/projects/default/` (paths land
+ *     at `<store>/docs/rfcs/...`, `<store>/specs/...`)
  *
  * The `<repoKey>` segment is worktree-stable (see {@link repoKey}), so every
  * worktree of a repo shares one external store.
@@ -172,7 +241,7 @@ export function resolveArtifactsRoot(
   location: ArtifactsLocation = 'repo',
 ): string {
   if (location === 'external') {
-    return path.join(os.homedir(), '.smithy', REPOS_DIR, repoKey(targetDir));
+    return path.join(os.homedir(), '.smithy', ...externalStoreSegments(targetDir));
   }
   return targetDir;
 }
@@ -180,9 +249,10 @@ export function resolveArtifactsRoot(
 /**
  * The prefix that gets substituted into deployed prompts via the
  * `{{artifactsRoot}}` template variable. Returns `""` for in-repo mode
- * so paths render unchanged (`docs/rfcs/...`), or the tilde form
- * `~/.smithy/repos/<repoKey>/` for external mode so paths render as
- * `~/.smithy/repos/<repo>/docs/rfcs/...`.
+ * so paths render unchanged (`docs/rfcs/...`), or the tilde form of the
+ * external store — `~/.smithy/repos/<repoKey>/` inside a repo,
+ * `~/.smithy/projects/default/` outside one — so paths render as
+ * `<store>/docs/rfcs/...`.
  *
  * Tilde-form (not home-expanded) so committed deployed prompts stay
  * portable across team members. Agents (Claude Code, Gemini CLI, Codex)
@@ -193,7 +263,7 @@ export function templateArtifactsPrefix(
   location: ArtifactsLocation = 'repo',
 ): string {
   if (location === 'external') {
-    return `~/.smithy/${REPOS_DIR}/${repoKey(targetDir)}/`;
+    return `~/.smithy/${externalStoreSegments(targetDir).join('/')}/`;
   }
   return '';
 }

--- a/src/permissions.test.ts
+++ b/src/permissions.test.ts
@@ -413,3 +413,43 @@ describe('flattenPermissions — regression guard for existing install auto-allo
     expect(all).toContain('nodenv install *');
   });
 });
+
+describe('external artifact store permissions', () => {
+  const result = flattenPermissions();
+
+  it('allows committing to a repo-keyed store via git -C', () => {
+    // `git -C <store> commit` is how agents record artifact changes in
+    // external mode. Permission matching is prefix-based on the whole
+    // command string, so these need their own entries — the bare
+    // `git commit -m *` never matches a `-C`-prefixed invocation.
+    expect(result).toContain('git -C ~/.smithy/repos/* add -A');
+    expect(result).toContain('git -C ~/.smithy/repos/* commit -m *');
+  });
+
+  it('allows committing to the shared project store', () => {
+    expect(result).toContain('git -C ~/.smithy/projects/* add -A');
+    expect(result).toContain('git -C ~/.smithy/projects/* commit -m *');
+  });
+
+  it('uses tilde paths so no developer home directory is committed', () => {
+    // These strings land in a shared .claude/settings.json.
+    for (const entry of result) {
+      if (entry.startsWith('git -C ')) {
+        expect(entry).toMatch(/^git -C ~\/\.smithy\//);
+      }
+    }
+  });
+
+  it('does not auto-allow pushing or destructive commands against a store', () => {
+    // Syncing a store to a remote is the user's decision, and history is the
+    // whole point of the store — an agent must not be able to reset it.
+    const storeEntries = result.filter((e) => e.startsWith('git -C '));
+    expect(storeEntries.length).toBeGreaterThan(0);
+    for (const entry of storeEntries) {
+      expect(entry).not.toContain(' push');
+      expect(entry).not.toContain(' reset');
+      expect(entry).not.toContain(' clean');
+      expect(entry).not.toContain(' checkout');
+    }
+  });
+});

--- a/src/permissions.test.ts
+++ b/src/permissions.test.ts
@@ -431,6 +431,26 @@ describe('external artifact store permissions', () => {
     expect(result).toContain('git -C ~/.smithy/projects/* commit -m *');
   });
 
+  it('covers the trailing-slash path the prompts actually emit', () => {
+    // `{{artifactsRoot}}` always ends in `/`, so agents emit
+    // `git -C ~/.smithy/repos/<key>/ add -A`. Matching that against the bare
+    // `~/.smithy/repos/* …` form would need `*` to swallow the separator,
+    // which permission wildcards do not reliably do — so the `*/` form has
+    // to be listed too or every commit hits an approval prompt.
+    expect(result).toContain('git -C ~/.smithy/repos/*/ add -A');
+    expect(result).toContain('git -C ~/.smithy/repos/*/ commit -m *');
+    expect(result).toContain('git -C ~/.smithy/projects/*/ add -A');
+    expect(result).toContain('git -C ~/.smithy/projects/*/ commit -m *');
+  });
+
+  it('covers the --no-gpg-sign commit form the prompts specify', () => {
+    // The prompt tells agents to pass --no-gpg-sign so a machine with
+    // `commit.gpgsign` set doesn't block on a passphrase. That flag form is
+    // a different command string, so it needs its own entry.
+    expect(result).toContain('git -C ~/.smithy/repos/*/ commit --no-gpg-sign -m *');
+    expect(result).toContain('git -C ~/.smithy/projects/*/ commit --no-gpg-sign -m *');
+  });
+
   it('uses tilde paths so no developer home directory is committed', () => {
     // These strings land in a shared .claude/settings.json.
     for (const entry of result) {

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -22,6 +22,33 @@ export const platforms: Record<PlatformPackageManager, { label: string; permissi
   linux: { label: 'apt/dpkg (Linux)', permissionKeys: ['apt', 'apt-cache', 'dpkg'], osPlatforms: ['linux'] },
 };
 
+/**
+ * The `git -C <store>` argument forms auto-allowed against an external
+ * artifact store, generated for both the trailing-slash and bare spellings of
+ * `<base>/<store-name>`. See the `-C` entry under `git` below for why both
+ * are needed.
+ *
+ * Deliberately read-and-commit only. `push`, `reset`, `clean`, and `checkout`
+ * are absent: the store's history is the whole point of git-backing it, and
+ * whether it syncs to a remote is the user's decision.
+ */
+function storeGitPermissions(base: string): string[] {
+  const args = [
+    'add -A',
+    'add *',
+    'commit -m *',
+    'commit --no-gpg-sign -m *',
+    'status',
+    'status -s',
+    'log --oneline *',
+    'diff *',
+    'show *',
+  ];
+  return [`${base}/*`, `${base}/*/`].flatMap((prefix) =>
+    args.map((arg) => `${prefix} ${arg}`),
+  );
+}
+
 export const permissions: Record<string, PermissionEntry> = {
   // --- Git ---
   // Flag variants are listed explicitly because Gemini CLI's wildcard
@@ -109,23 +136,22 @@ export const permissions: Record<string, PermissionEntry> = {
     //
     // Read and commit only: no `push`, no `reset`, no `clean`. Syncing a
     // store to a remote is the user's call, not an agent's.
+    //
+    // Both a trailing-slash and a bare form of each store path are listed.
+    // `{{artifactsRoot}}` always ends in `/` (so `{{artifactsRoot}}specs/...`
+    // concatenates), which means agents emit
+    // `git -C ~/.smithy/repos/<key>/ add -A` — matching that against
+    // `~/.smithy/repos/* add -A` would require `*` to swallow the trailing
+    // separator, which permission wildcards do not reliably do. The `*/`
+    // form matches it without spanning a `/` at all; the bare form is kept
+    // for hand-typed commands that omit the slash.
+    //
+    // `commit --no-gpg-sign -m *` mirrors what the prompt tells agents to
+    // run (and what `ensureArtifactStore` runs itself) so a machine with
+    // `commit.gpgsign` set doesn't hit an approval prompt on the flag form.
     "-C": [
-      "~/.smithy/repos/* add -A",
-      "~/.smithy/repos/* add *",
-      "~/.smithy/repos/* commit -m *",
-      "~/.smithy/repos/* status",
-      "~/.smithy/repos/* status -s",
-      "~/.smithy/repos/* log --oneline *",
-      "~/.smithy/repos/* diff *",
-      "~/.smithy/repos/* show *",
-      "~/.smithy/projects/* add -A",
-      "~/.smithy/projects/* add *",
-      "~/.smithy/projects/* commit -m *",
-      "~/.smithy/projects/* status",
-      "~/.smithy/projects/* status -s",
-      "~/.smithy/projects/* log --oneline *",
-      "~/.smithy/projects/* diff *",
-      "~/.smithy/projects/* show *",
+      ...storeGitPermissions("~/.smithy/repos"),
+      ...storeGitPermissions("~/.smithy/projects"),
     ],
   },
 

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -94,6 +94,39 @@ export const permissions: Record<string, PermissionEntry> = {
     "push origin": ["*"],
     "push --force-with-lease": [""],
     "push --force-with-lease origin": ["*"],
+
+    // External artifact stores (`artifactsLocation: external`) are git repos
+    // under `~/.smithy/`, and agents commit to them there via `git -C <store>`.
+    // That form needs its own entries: permission matching is prefix-based on
+    // the whole command string, so `git -C ~/x commit -m "y"` does not match
+    // the bare `git commit -m *` above.
+    //
+    // Scoped to the two store namespaces rather than granting `git -C *`, and
+    // written in tilde form on purpose — these strings land in a committed
+    // `.claude/settings.json`, so an expanded `/home/<user>/...` path would
+    // leak one developer's home directory to the whole team. The prompts tell
+    // agents the tilde path is authoritative, so that is the form they emit.
+    //
+    // Read and commit only: no `push`, no `reset`, no `clean`. Syncing a
+    // store to a remote is the user's call, not an agent's.
+    "-C": [
+      "~/.smithy/repos/* add -A",
+      "~/.smithy/repos/* add *",
+      "~/.smithy/repos/* commit -m *",
+      "~/.smithy/repos/* status",
+      "~/.smithy/repos/* status -s",
+      "~/.smithy/repos/* log --oneline *",
+      "~/.smithy/repos/* diff *",
+      "~/.smithy/repos/* show *",
+      "~/.smithy/projects/* add -A",
+      "~/.smithy/projects/* add *",
+      "~/.smithy/projects/* commit -m *",
+      "~/.smithy/projects/* status",
+      "~/.smithy/projects/* status -s",
+      "~/.smithy/projects/* log --oneline *",
+      "~/.smithy/projects/* diff *",
+      "~/.smithy/projects/* show *",
+    ],
   },
 
   // --- Filesystem (read + create, no delete) ---

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -23,29 +23,39 @@ export const platforms: Record<PlatformPackageManager, { label: string; permissi
 };
 
 /**
- * The `git -C <store>` argument forms auto-allowed against an external
- * artifact store, generated for both the trailing-slash and bare spellings of
- * `<base>/<store-name>`. See the `-C` entry under `git` below for why both
- * are needed.
+ * The git operations auto-allowed against an external artifact store, as
+ * argument strings following `git -C <store>`.
  *
  * Deliberately read-and-commit only. `push`, `reset`, `clean`, and `checkout`
  * are absent: the store's history is the whole point of git-backing it, and
  * whether it syncs to a remote is the user's decision.
+ *
+ * Shared across agents on purpose. Claude and Codex express these very
+ * differently — Claude takes wildcard command strings, while Codex needs
+ * exact token prefixes built from the resolved store path (see
+ * `buildStoreRules` in `./agents/codex.ts`) — and the one thing that must
+ * not diverge between them is *which* operations an agent may run unattended.
+ */
+export const STORE_GIT_ARGS = [
+  'add -A',
+  'add *',
+  'commit -m *',
+  'commit --no-gpg-sign -m *',
+  'status',
+  'status -s',
+  'log --oneline *',
+  'diff *',
+  'show *',
+] as const;
+
+/**
+ * The `git -C <store>` permission strings for one store namespace, generated
+ * for both the trailing-slash and bare spellings of `<base>/<store-name>`.
+ * See the `-C` entry under `git` below for why both are needed.
  */
 function storeGitPermissions(base: string): string[] {
-  const args = [
-    'add -A',
-    'add *',
-    'commit -m *',
-    'commit --no-gpg-sign -m *',
-    'status',
-    'status -s',
-    'log --oneline *',
-    'diff *',
-    'show *',
-  ];
   return [`${base}/*`, `${base}/*/`].flatMap((prefix) =>
-    args.map((arg) => `${prefix} ${arg}`),
+    STORE_GIT_ARGS.map((arg) => `${prefix} ${arg}`),
   );
 }
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -3764,4 +3764,30 @@ describe('getComposedTemplates artifactsRoot', () => {
     expect(strike).toContain('~/.smithy/x/specs/strikes/');
     expect(strike).not.toContain('{{artifactsRoot}}');
   });
+
+  it('includes the store commit protocol only in external mode', async () => {
+    // In repo mode the same instructions would tell the agent to commit the
+    // *code* repo mid-plan, so the block has to be genuinely absent — not
+    // merely prefaced with a condition the agent is trusted to evaluate.
+    const external = await getComposedTemplates('claude', '~/.smithy/myrepo/');
+    const strike = external.commands.get('smithy.strike.md')!;
+    expect(strike).toContain('### Committing artifacts to the store');
+    expect(strike).toContain('git -C ~/.smithy/myrepo/ add -A');
+    expect(strike).toContain('git -C ~/.smithy/myrepo/ commit -m');
+    expect(strike).not.toContain('{{#ifExternalArtifacts}}');
+
+    const inRepo = await getComposedTemplates('claude');
+    const repoStrike = inRepo.commands.get('smithy.strike.md')!;
+    expect(repoStrike).not.toContain('### Committing artifacts to the store');
+    expect(repoStrike).not.toContain('git -C ');
+    expect(repoStrike).not.toContain('{{#ifExternalArtifacts}}');
+  });
+
+  it('tells agents not to push the store', async () => {
+    // The store may have a remote the user controls; pushing it is their
+    // call, and a stray push could publish planning they kept off the repo.
+    const c = await getComposedTemplates('claude', '~/.smithy/myrepo/');
+    const strike = c.commands.get('smithy.strike.md')!;
+    expect(strike).toContain('Do not `git push`');
+  });
 });

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -3773,7 +3773,10 @@ describe('getComposedTemplates artifactsRoot', () => {
     const strike = external.commands.get('smithy.strike.md')!;
     expect(strike).toContain('### Committing artifacts to the store');
     expect(strike).toContain('git -C ~/.smithy/myrepo/ add -A');
-    expect(strike).toContain('git -C ~/.smithy/myrepo/ commit -m');
+    // --no-gpg-sign must be in the instruction, matching what
+    // `ensureArtifactStore` runs — otherwise a machine with `commit.gpgsign`
+    // set blocks the agent on a passphrase prompt.
+    expect(strike).toContain('git -C ~/.smithy/myrepo/ commit --no-gpg-sign -m');
     expect(strike).not.toContain('{{#ifExternalArtifacts}}');
 
     const inRepo = await getComposedTemplates('claude');
@@ -3781,6 +3784,16 @@ describe('getComposedTemplates artifactsRoot', () => {
     expect(repoStrike).not.toContain('### Committing artifacts to the store');
     expect(repoStrike).not.toContain('git -C ');
     expect(repoStrike).not.toContain('{{#ifExternalArtifacts}}');
+  });
+
+  it('lets agents skip the commit when the store has no git repository', async () => {
+    // `ensureArtifactStore` degrades to a warning when git is unavailable, so
+    // a historyless store is a supported state. The prompt must not turn that
+    // into a guaranteed failure at the end of every artifact-writing run.
+    const c = await getComposedTemplates('claude', '~/.smithy/myrepo/');
+    const strike = c.commands.get('smithy.strike.md')!;
+    expect(strike).toContain('skip this step entirely and carry');
+    expect(strike).toContain('not run `git init` yourself');
   });
 
   it('tells agents not to push the store', async () => {

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -262,6 +262,22 @@ export async function getComposedTemplates(
     return artifactsRoot;
   });
 
+  // Block helper gating content on external-artifacts mode. Needed as a
+  // helper for the same reason as `ifAgent`: dotprompt runs with
+  // `knownHelpersOnly`, so a plain `{{#if artifactsRoot}}` will not resolve.
+  //
+  // Some instructions only make sense when artifacts live in a separate
+  // git-backed store — telling an agent to commit the store is actively
+  // wrong in repo mode, where the same words would have it commit the code
+  // repo mid-plan. Rendering them unconditionally is not a harmless extra.
+  renderer.defineHelper('ifExternalArtifacts', function (this: unknown, ...args: unknown[]) {
+    const options = args[args.length - 1] as {
+      fn: (ctx: unknown) => string;
+      inverse: (ctx: unknown) => string;
+    };
+    return artifactsRoot.length > 0 ? options.fn(this) : options.inverse(this);
+  });
+
   const resolve = async (dir: string): Promise<Map<string, string>> => {
     const raw = readTemplateDir(dir, variant);
     const entries = await Promise.all(

--- a/src/templates/agent-skills/snippets/artifact-location-policy.md
+++ b/src/templates/agent-skills/snippets/artifact-location-policy.md
@@ -11,12 +11,16 @@ prefix.
 - When `{{artifactsRoot}}` is empty, artifacts live **in the repo**:
   `docs/rfcs/...`, `docs/prds/...`, `docs/personas/...`, `specs/...`,
   `specs/strikes/...`.
-- When `{{artifactsRoot}}` is `~/.smithy/repos/<repoKey>/`, artifacts live **outside
-  the repo, in the user's home directory**: `~/.smithy/repos/<repoKey>/docs/rfcs/...`,
-  `~/.smithy/repos/<repoKey>/docs/personas/...`, `~/.smithy/repos/<repoKey>/specs/...`, etc.
-  Treat the resolved path as authoritative — agents (Claude Code, Gemini CLI,
-  Codex) expand `~` at tool-call time, so the path is portable across team
-  members even when this prompt is committed to source control.
+- When `{{artifactsRoot}}` is `~/.smithy/repos/<repoKey>/` or
+  `~/.smithy/projects/default/`, artifacts live **outside the repo, in the
+  user's home directory**: `{{artifactsRoot}}docs/rfcs/...`,
+  `{{artifactsRoot}}docs/personas/...`, `{{artifactsRoot}}specs/...`, etc.
+  The repo-keyed form is used when Smithy was set up inside a git repo; the
+  `projects/default` form is the shared store for cross-repo work set up
+  outside one. Treat the resolved path as authoritative — agents (Claude
+  Code, Gemini CLI, Codex) expand `~` at tool-call time, so the path is
+  portable across team members even when this prompt is committed to source
+  control.
 
 ### Scope of the policy
 
@@ -39,3 +43,26 @@ When you scan for existing artifacts (e.g. "list folders in
 `{{artifactsRoot}}docs/rfcs/`"), use the prefixed path. The `smithy status`
 CLI already reads the manifest and looks in the right place, so its output
 will be consistent with the paths in this prompt.
+{{#ifExternalArtifacts}}
+
+### Committing artifacts to the store
+
+`{{artifactsRoot}}` is a **git repository** that Smithy initialized. It is
+the only history these artifacts have: nothing else tracks them, and an
+uncommitted file you overwrite is gone. Commit your work there.
+
+After you finish writing or updating artifacts — once the artifact is
+complete, not after every partial write:
+
+```bash
+git -C {{artifactsRoot}} add -A
+git -C {{artifactsRoot}} commit -m "<command>: <what changed>"
+```
+
+- If the commit reports nothing to commit, that is fine — carry on rather
+  than treating it as a failure.
+- **Do not `git push`** the store. Any remote on it belongs to the user, who
+  decides when it syncs.
+- This is **separate from, and never a substitute for**, the code commits you
+  make in the target repo on the working branch. Committing the store does
+  not put anything in the user's pull request.{{/ifExternalArtifacts}}

--- a/src/templates/agent-skills/snippets/artifact-location-policy.md
+++ b/src/templates/agent-skills/snippets/artifact-location-policy.md
@@ -47,22 +47,31 @@ will be consistent with the paths in this prompt.
 
 ### Committing artifacts to the store
 
-`{{artifactsRoot}}` is a **git repository** that Smithy initialized. It is
-the only history these artifacts have: nothing else tracks them, and an
-uncommitted file you overwrite is gone. Commit your work there.
+`smithy init` initializes `{{artifactsRoot}}` as a **git repository**. When it
+succeeded, that history is the only record these artifacts have — nothing
+else tracks them, and an uncommitted file you overwrite is gone. So commit
+your work there.
 
 After you finish writing or updating artifacts — once the artifact is
 complete, not after every partial write:
 
 ```bash
 git -C {{artifactsRoot}} add -A
-git -C {{artifactsRoot}} commit -m "<command>: <what changed>"
+git -C {{artifactsRoot}} commit --no-gpg-sign -m "<command>: <what changed>"
 ```
 
+- `--no-gpg-sign` keeps the commit from blocking on a signing passphrase
+  prompt on machines that set `commit.gpgsign`.
 - If the commit reports nothing to commit, that is fine — carry on rather
   than treating it as a failure.
+- **If the store is not a git repository, skip this step entirely and carry
+  on.** `smithy init` warns and continues when git is unavailable, so a
+  historyless store is a supported state — not a reason to fail the run. Do
+  not run `git init` yourself to work around it.
 - **Do not `git push`** the store. Any remote on it belongs to the user, who
   decides when it syncs.
 - This is **separate from, and never a substitute for**, the code commits you
   make in the target repo on the working branch. Committing the store does
-  not put anything in the user's pull request.{{/ifExternalArtifacts}}
+  not put anything in the user's pull request.
+
+{{/ifExternalArtifacts}}


### PR DESCRIPTION
## Summary
- Primary outcome: external artifact stores now work for planning that isn't anchored to a single repo, and every store is a git repository so artifacts have a history.
- Notable behaviour changes:
  - `artifactsLocation: external` outside a git repo resolves to a new fixed `~/.smithy/projects/default/` instead of a store keyed on the current directory's name.
  - `smithy status` discovery is a fallback cascade rather than a single root, and reports the root it settled on (text line + `scan_root` in JSON).
  - `smithy init` / `smithy update` `git init` the external store and make one initial commit.
  - Deployed prompts (external mode only) instruct agents to commit artifacts to the store; permissions auto-allow the store's `git` add/commit forms for both Claude and Codex.
- Follow-up work deferred: `smithy.strike` / `smithy.ignite` can't complete outside a repo (#530). The cascade picks one winning root rather than merging across roots. Monorepo sub-path stores (#263) still unaddressed.

## Context
Two gaps followed from the external-store design added in #469:

1. **Nothing worked outside a repo.** `repoKey()` always returns *something* — outside a git checkout it silently fell back to `basename(targetDir)`. Planning that spans repos, or that starts from a scratch directory, got a store keyed on whatever folder the user happened to be standing in, and discovery could never find it again from anywhere else.
2. **The store had no history.** It was a plain directory in `$HOME`. An agent that overwrote or deleted an artifact left nothing to recover from — no `git diff`, no `git restore` — and there was no way to sync it between machines without building that yourself.

This unlocks authoring a cross-repo RFC from outside any single repo and still finding it via `smithy status` from each member repo, and makes an agent's mistake in the store recoverable.

## Implementation Notes
**Store resolution** (`src/manifest.ts`) — new `isInsideGitRepo()` exposes the signal `repoKey()` deliberately cannot give (it always returns a usable key). A private `externalStoreSegments()` picks the `repos/<repoKey>` or `projects/default` branch, and both `resolveArtifactsRoot()` and `templateArtifactsPrefix()` route through it — they must always name the same store, one as an absolute path and one as the tilde form baked into prompts, and a shared helper is what stops them drifting. A parity test asserts it.

**Discovery** (`src/commands/status.ts`) — `resolveExternalArtifactsRoot()` is replaced by `artifactScanCandidates()` + `scanWithCascade()`. Each candidate pairs a real root with the display prefix to apply if it wins, so path re-prefixing stays correct whichever root is used. Outside a repo the project store leads but the working directory *trails* it rather than being dropped: without that, results would depend on whether `~/.smithy/projects/default/` happens to exist on the machine. Trade-off accepted: repo-mode `status` now shells out to git once (~5ms) where it previously didn't.

**Git-backed store** (new `src/artifact-store.ts`) — modelled on the hardened `initGitInTempCopy` in `evals/lib/runner.ts`, but deliberately *not* copying its `GIT_CONFIG_GLOBAL=/dev/null` / `core.hooksPath=/dev/null` neutralization: the evals want determinism, this store wants the user's real git config, because these are their commits. Falls back to a local placeholder identity only when the machine has none, so a fresh install's first commit can't fail. `--no-gpg-sign` avoids blocking on a passphrase prompt under a global `commit.gpgsign`. One repository per store rather than one spanning `~/.smithy/` — separate stores are separate projects, and a single repo would couple them onto one history and nest badly if a store were ever cloned into place.

**Prompts** (`src/templates.ts`, `snippets/artifact-location-policy.md`) — the commit protocol is gated behind a new `ifExternalArtifacts` block helper. It needs to be a helper because dotprompt runs `knownHelpersOnly`, and it needs to be *conditional* because in repo mode the same words would tell an agent to commit the code repo mid-plan. Alternative considered: prose-branching like the rest of the snippet — rejected, since a dead instruction is harmless for explanation but not for an imperative. The protocol tolerates a store with no git repository, matching `ensureArtifactStore`'s degrade-to-warning behaviour.

**Permissions** — the two agents need different shapes for the same grant, so both derive from one exported `STORE_GIT_ARGS` list and can't drift on *which* operations run unattended:
- **Claude** (`src/permissions.ts`): wildcard command strings. `git -C <path> …` doesn't match `Bash(git commit -m *)` — matching is prefix-based on the whole string. Both a `*/` and a bare form are listed because `{{artifactsRoot}}` ends in `/`, and matching the emitted `~/.smithy/repos/<key>/` against `~/.smithy/repos/*` would need the wildcard to swallow a separator. Tilde form only: these strings land in a committed `.claude/settings.json`, where an expanded `/home/<user>/…` path would leak a developer's home directory.
- **Codex** (`src/agents/codex.ts`): prefix rules have no wildcard segment — `buildPrefixPattern` strips a trailing `*` and then tokens match exactly, so a wildcard path collapses to the literal token `~/.smithy/repos/` and matches nothing. The deployer already receives `artifactsRoot` and was dropping it, so it now emits rules against the *resolved* store path. Still tilde-form, so nothing user-specific reaches the committed rules file.

Read and commit only in both: no push, reset, clean, or checkout.

Impacted boundaries: manifest resolution, the status scanner's root selection, `init`/`update` (via `initAction`, which `update` already routes through), the shared artifact-location snippet consumed by 13 prompts, and the generated permission sets for Claude and Codex.

Per `CLAUDE.md`, the committed `.claude/` snapshot and `.smithy/smithy-manifest.json` are **not** regenerated here.

## Risks & Mitigations
- Risk: `isInsideGitRepo` returning false reroutes discovery to `~/.smithy/projects/default/`, so tests running in non-git temp dirs could depend on the developer's real `$HOME` — green in CI, red locally. | Mitigation: the working directory remains a trailing candidate, and the affected suites stub `HOME`/`USERPROFILE` to a throwaway directory.
- Risk: existing external installs resolving to a different store after upgrade. | Mitigation: `repoKey()` is untouched and the in-repo branch is unchanged, so every existing store keeps its path. Only the outside-a-repo case (previously unusable) moves.
- Risk: `git init` failing on a machine without git, or a commit rejected by a global hook. | Mitigation: `ensureArtifactStore` never throws — it returns a warning, `init` prints it and continues, and the prompts tell agents to skip the commit when the store isn't a repository.
- Risk: an agent pushing a store that has a user-owned remote, publishing planning kept off the repo. | Mitigation: `push` is excluded from both agents' allowlists and the prompt explicitly says not to; tests assert no `push`/`reset`/`clean`/`checkout` reaches either.
- Risk (known, not mitigated): `smithy.strike` / `smithy.ignite` fail outside a repo — see #530 and the README note.

## Rollback Plan
Revert the commits. No data migration to undo: existing `~/.smithy/repos/<repoKey>/` stores are untouched by this change, and any `~/.smithy/projects/default/` store created under it remains a valid git repository on disk that the user can keep or delete. Reverting restores the previous single-root discovery; artifacts written to the project store would simply stop being found by `smithy status` until manually moved.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npm run typecheck`)
- [x] CLI `init` smoke test — exercised end-to-end against a throwaway `HOME` for both the in-repo and outside-a-repo branches

Full suite: **1067 passing across 30 files**. New coverage — `src/artifact-store.test.ts` (creation, layout in both branches, re-run idempotency preserving an uncommitted work-in-progress file, both git-identity paths, git-unavailable degradation); cascade and `scan_root` cases in `src/commands/status.test.ts`; in-repo vs outside-a-repo resolution and resolver parity in `src/manifest.test.ts`; conditional commit-block rendering in `src/templates.test.ts`; store allowlist shape in `src/permissions.test.ts`; resolved-path store rules in `src/agents/codex.test.ts`.

Manual end-to-end run confirmed: store git-initialized with one commit; prompts carry the right prefix per branch; `status` walks repo → keyed store → project store with the correct re-prefixed paths and `scan_root`; `smithy update` leaves store `HEAD` unchanged; the emitted `git -C` command matches a deployed allowlist entry for Claude, and the Codex rules carry the resolved store path with no mangled tokens.

### Template Generation
- [x] Claude Prompts: `.claude/commands/` — prefix substitution and the conditional commit block verified in both modes
- [x] Gemini Skills: covered by the existing `getComposedTemplates('gemini', …)` assertions, extended for the new helper
- [x] Codex Prompts: same composed-template path; no Codex-specific branch in the prompt text
- [ ] GitHub Issue Templates: not touched by this change

### Permissions & Configuration
- [x] Claude Config: `.claude/settings.json` correctly formed — store `git -C` entries present in both slash forms, asserted tilde-only
- [x] Codex Config: `.codex/rules/default.rules` now emits store rules against the resolved path; asserted no bare-namespace token survives, and none in repo mode
- [ ] Gemini Config: unchanged — Gemini gets no store rules (entries flow through the same `flattenPermissions()` output, no config-format change)

### Manual Test Cases
- [ ] `tests/Agent.tests.md` / `tests/Manual.tests.md` — **not yet re-run.** `init`/`update` flows changed (store creation is a new side effect), so the init/uninit cases there should be walked before merge. Flagging rather than checking a box I haven't earned.

One behaviour unit tests can't prove: that the store commit runs without an approval prompt in a live Claude Code or Codex session. Worth a manual pass before merge.

## Issue
Related to #263 (monorepo sub-path stores) and #530 (strike/ignite outside a repo) — neither is closed by this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dkPKRLJiBvqPW7doNy319