### PR TITLE
forge: surface brief-mode design intent in mark without blocking

### DIFF
--- a/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/04-a-non-blocking-visual-design-gate-with-import-brief-none-modes.tasks.md
+++ b/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/04-a-non-blocking-visual-design-gate-with-import-brief-none-modes.tasks.md
@@ -64,7 +64,7 @@
 
 ### Tasks
 
-- [ ] **Mark brief-mode intent explicitly**
+- [x] **Mark brief-mode intent explicitly**
 
   Extend the UI authoring path in `src/templates/agent-skills/commands/smithy.mark.prompt` so `brief` screen nodes are marked as intending a prototype while still writing self-sufficient `.design.md` and `.flow.md` intent. The durable artifacts should be usable as the prototyping brief without adding layout prose to the spec ledger.
 
@@ -75,7 +75,7 @@
   - `.design.md` and `.flow.md` remain mark-owned durable truth
   - Mark does not require a bundle before writing brief-mode artifacts
 
-- [ ] **Recommend gating for complex bundle-less screens**
+- [x] **Recommend gating for complex bundle-less screens**
 
   Add mark guidance for the mark-initiated `brief` case: when no bundle is supplied and the screen is complex enough to benefit from visual prototyping, mark authors the brief and recommends gating for a bundle. The recommendation should be visible to the developer but must not stop artifact generation.
 
@@ -86,7 +86,7 @@
   - The recommendation also leaves the developer free to pass through without a bundle
   - Artifact writing continues after the recommendation is recorded
 
-- [ ] **Preserve none-mode pass-through behavior**
+- [x] **Preserve none-mode pass-through behavior**
 
   Tighten mark guidance so `Design: none` remains valid for simple pass-through screens and does not trigger bundle, prototype, or brief ceremony. This keeps AS 4.1 from being implemented as a special case in forge only.
 

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -411,9 +411,10 @@ UI ledger rules:
     have entered at `render` and rides forward as downstream visual source
     context. Do not derive detailed prototype structure here.
   - `brief` means mark-authored intent for a visual tool; the durable
-    `.design.md` and `.flow.md` artifacts are self-sufficient briefs. Mark the
-    screen row `brief` when the developer requested a mark-first prototype or
-    when you initiate that path for a complex bundle-less screen.
+    `.design.md` and `.flow.md` artifacts are self-sufficient briefs. A bundle
+    is not a precondition for writing them.
+  - Copy the feature's declared `design` value into this cell verbatim. Choose a
+    mode yourself only when the input declares none.
 - `Artifact` is `—` for every row in mark's output. It holds the
   `cut`-produced `.tasks.md` path only after `smithy.cut` runs; mark never
   pre-fills a tasks path in this column.
@@ -455,26 +456,41 @@ verbatim:
 - `smithy.helper-flow-definition` — `.flow.md` front-matter schema, the
   intent-only body rules, and the paired executable test-body contract.
 
-Before writing any UI artifact, validate the feature's UI metadata and abort if
-it cannot be satisfied (per contracts C1):
+Before writing any UI artifact, validate the feature's **required** UI metadata.
+Each check below is fatal — abort before writing the spec or any durable UI
+artifact if it cannot be satisfied (per contracts C1):
 - Every screen node must resolve to a flat `ScreenId`. If a node has none, abort
   with a message naming the node.
-- The UI feature must name a non-empty `design_system`. If it is missing, abort
-  before writing the spec or any durable UI artifact.
+- The UI feature must name a non-empty `design_system`. If it is missing, abort.
+
+Design-mode and bundle handling is **not** part of that fatal set. None of the
+rules below abort; every one of them ends with mark continuing:
+- The feature-level `design` value is declared metadata, not a mark inference.
+  When the input declares a mode, copy it verbatim into the `Design` cell of
+  each of the feature's `SC<N>` rows. Never overwrite a declared `none` or
+  `import` with `brief`, even for a screen you judge complex — the parent
+  feature and the generated spec must agree on the mode.
+- Mark selects a mode itself only when the input declares none — for example a
+  raw feature description or an untyped legacy map. In that case pick the
+  honest mode for the screen: `brief` when it is complex enough to benefit from
+  a visual prototype and no `bundle` is present, `none` when it is simple
+  pass-through work.
 - If a `bundle` is present, treat it as an optional visual prototype boundary
   object from a visual tool such as Figma, Claude Design, or an equivalent
   export. The bundle wins layout and visual intent, while the committed
   design skill wins implementation dialect; a screen with a bundle still
   requires `design_system`.
-- If no `bundle` is present and a screen is complex enough to benefit from a
-  visual prototype, choose `Design: brief`, write the self-sufficient durable
-  brief artifacts, and record a non-blocking design-gate recommendation for the
-  developer-facing summary. The recommendation must say the developer may
-  attach a bundle and re-run or pass through without one; it must not stop spec,
-  `.design.md`, `.flow.md`, or stub test-body generation.
-- If a screen is simple pass-through work, keep `Design: none` valid without a
-  bundle, prototype expectation, or recommendation. Author the same ordinary
-  durable screen intent and continue.
+- Whenever a screen ends up with no `bundle` and is complex enough to benefit
+  from a visual prototype, record a non-blocking design-gate recommendation for
+  the developer-facing summary — whether the mode is a declared `none` /
+  `import` or a mark-selected `brief`. The recommendation must say the developer
+  may attach a bundle and re-run or pass through without one; it must not stop
+  spec, `.design.md`, `.flow.md`, or stub test-body generation.
+- For `brief`, write the self-sufficient durable brief artifacts; a bundle is
+  never a precondition for them.
+- For simple pass-through work, `Design: none` stands without a bundle,
+  prototype expectation, or recommendation. Author the same ordinary durable
+  screen intent and continue.
 
 Then write, matching the ledger pointers:
 - One `design/screens/<ScreenId>.design.md` per `SC<N>` row, per
@@ -496,10 +512,10 @@ The mark output set for `kind: ui` is:
   map.
 
 For `kind: ui`, include a short design-gate note in the developer-facing
-summary when you selected `brief` without a bundle. The note is informational:
-the durable artifacts are already usable as the prototyping brief and the
-pipeline has continued. Do not emit a design-gate note for `Design: none`
-pass-through screens.
+summary for any bundle-less screen that earned a gate recommendation above. The
+note is informational: the durable artifacts are already usable as the
+prototyping brief and the pipeline has continued. Do not emit a design-gate note
+for simple pass-through screens.
 
 ---
 

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -405,12 +405,15 @@ UI ledger rules:
 - `Design` is required for `screen` rows and is one of `none`, `import`, or
   `brief`; use `—` for `flow` and `story` rows.
   - `none` means no visual loop; no bundle or prototype recommendation is
-    required for a simple pass-through screen.
+    required for a simple pass-through screen. It still produces the ordinary
+    mark-owned `.design.md` intent, but no visual-tool ceremony is added.
   - `import` means prototype-first; a visual prototype boundary object may
     have entered at `render` and rides forward as downstream visual source
     context. Do not derive detailed prototype structure here.
   - `brief` means mark-authored intent for a visual tool; the durable
-    `.design.md` and `.flow.md` artifacts are self-sufficient briefs.
+    `.design.md` and `.flow.md` artifacts are self-sufficient briefs. Mark the
+    screen row `brief` when the developer requested a mark-first prototype or
+    when you initiate that path for a complex bundle-less screen.
 - `Artifact` is `—` for every row in mark's output. It holds the
   `cut`-produced `.tasks.md` path only after `smithy.cut` runs; mark never
   pre-fills a tasks path in this column.
@@ -425,6 +428,10 @@ UI ledger rules:
 - Direct all screen and flow intent into the durable artifacts described by the
   UI Spec Ledger and Screen/Flow node entities in the data model. Do not
   duplicate the screen or flow artifact body schemas in the spec ledger.
+- Keep the ledger pointer-only even for `brief`: the `Design` cell records that
+  the screen intends a prototype, while the durable `.design.md` and `.flow.md`
+  files carry the brief content. Do not add layout prose, visual-tool notes, or
+  gate recommendations to ledger cells.
 - If the feature has no internal ordering, emit the smallest honest typed graph.
   A single pass-through screen with no flows or backend work may be one `SC<N>`
   row, but it must still use the full UI ledger column set.
@@ -459,6 +466,15 @@ it cannot be satisfied (per contracts C1):
   export. The bundle wins layout and visual intent, while the committed
   design skill wins implementation dialect; a screen with a bundle still
   requires `design_system`.
+- If no `bundle` is present and a screen is complex enough to benefit from a
+  visual prototype, choose `Design: brief`, write the self-sufficient durable
+  brief artifacts, and record a non-blocking design-gate recommendation for the
+  developer-facing summary. The recommendation must say the developer may
+  attach a bundle and re-run or pass through without one; it must not stop spec,
+  `.design.md`, `.flow.md`, or stub test-body generation.
+- If a screen is simple pass-through work, keep `Design: none` valid without a
+  bundle, prototype expectation, or recommendation. Author the same ordinary
+  durable screen intent and continue.
 
 Then write, matching the ledger pointers:
 - One `design/screens/<ScreenId>.design.md` per `SC<N>` row, per
@@ -478,6 +494,12 @@ The mark output set for `kind: ui` is:
 - one paired stub test body at each `.flow.md` `test-body` path;
 - the `.features.md` dependency-order write-back when the input was a feature
   map.
+
+For `kind: ui`, include a short design-gate note in the developer-facing
+summary when you selected `brief` without a bundle. The note is informational:
+the durable artifacts are already usable as the prototyping brief and the
+pipeline has continued. Do not emit a design-gate note for `Design: none`
+pass-through screens.
 
 ---
 


### PR DESCRIPTION
## Summary

EPIC #404 → Screens and Flows as UI Feature Kinds (spec) → User Story 4: A non-blocking visual-design gate with import / brief / none modes → Slice 2: Surface Brief Mode Without Blocking Mark

This slice teaches `smithy.mark` to author `brief`-mode screen intent honestly: it marks the screen row as intending a prototype, writes self-sufficient `.design.md`/`.flow.md` briefs with no bundle required, and — for a complex bundle-less screen — records a *non-blocking* design-gate recommendation in the developer-facing summary rather than a hard stop. It also pins `Design: none` as valid pass-through that incurs no bundle, prototype, or brief ceremony, so AS 4.1 is not left to be special-cased in forge alone. Slice 1 established the shared mode/bundle vocabulary; this is the first slice where a command actually behaves differently per mode, and it deliberately stops short of forge's build routing (Slice 3).

This slice satisfies AS 4.3 and AS 4.6; the forge-side halves (AS 4.4, AS 4.5) remain Slice 3.

## Spec debt & uncertainty

- SD-005 (inherited): fidelity of `import`-mode structure derivation from a prototype/bundle, and how much human confirmation the derived structure needs — owned by User Story 5, untouched here.
- SD-006 (inherited): whether `SC`/`FL` nodes are always atomic or can be sub-sliced — owned by User Story 3.
- SD-007 (inherited): build-phase coverage honesty for a screen "done" with a missing brief state — owned by User Stories 3 and 6.
- SD-008 (inherited, owned by this story): how a `brief`-mode node that never received a bundle surfaces its unrealized prototype rather than silently shipping skill-only. This slice contributes the mark-side half (the design-gate note in mark's summary); the build-side surfacing is Slice 3's job and is *not* in this PR.
- Assumption (from the spec): smithy never performs visual iteration inline; the `bundle` is the only object crossing the terminal↔visual boundary. All new guidance is prompt prose that keeps pixels out of the terminal.
- Assumption (from the spec): `.claude/` is NOT regenerated for source-template PRs. This PR edits `src/templates/` only, per CLAUDE.md.
- Uncertainty: the two new non-blocking bullets sit inside mark's "validate UI metadata and abort if it cannot be satisfied (per contracts C1)" list, which is otherwise abort-framed. Both bullets state explicitly that they must not stop generation, and the pre-existing bundle-present bullet is likewise non-aborting, so the placement is consistent — but a reviewer may prefer these split into their own non-blocking subsection.
- Verification gap: this is agent-prompt text with no direct unit coverage, so correctness is reviewed by reading, not asserted by a test. Behavioral confirmation would need a Tier-3 eval run (`npm run eval`), which was not exercised here.

## Validation

build ✅ · typecheck ✅ · test ⚠️ 1135 passed / 1 failed — the single failure is `src/artifact-store.test.ts > commits with a fallback identity when the machine has none`, a pre-existing environment failure (this machine has a global git `user.name`/`user.email`, so the fallback identity never engages). It touches no file in this diff.
