### PR TITLE
forge: attribute eval token totals to sub-agent dispatches

### DIFF
--- a/evals/lib/sub-agent-token-attribution.test.ts
+++ b/evals/lib/sub-agent-token-attribution.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractDispatchUsageRecords,
+  extractSubAgentTokenTotals,
+} from './sub-agent-token-attribution.js';
+import type { StreamEvent } from './types.js';
+
+function dispatchEvent(
+  id: string,
+  input: Record<string, unknown>,
+  name = 'Agent',
+): StreamEvent {
+  return {
+    type: 'assistant',
+    message: {
+      content: [
+        {
+          type: 'tool_use',
+          name,
+          id,
+          input,
+        },
+      ],
+    },
+  };
+}
+
+function usageEvent(
+  dispatchId: string | null,
+  usage: Record<string, unknown>,
+  relationship: 'parent_tool_use_id' | 'tool_use_id' = 'parent_tool_use_id',
+): StreamEvent {
+  return {
+    type: 'assistant',
+    [relationship]: dispatchId,
+    message: {
+      content: [{ type: 'text', text: 'sub-agent output' }],
+      usage,
+    },
+  };
+}
+
+describe('extractDispatchUsageRecords', () => {
+  it('normalizes usage tied to an Agent dispatch by parent_tool_use_id', () => {
+    const events: StreamEvent[] = [
+      dispatchEvent('toolu_agent_1', {
+        description: 'Scout repo',
+        prompt: 'scan',
+      }),
+      usageEvent('toolu_agent_1', { input_tokens: 17, output_tokens: 5 }),
+    ];
+
+    expect(extractDispatchUsageRecords(events)).toEqual([
+      {
+        dispatch_id: 'toolu_agent_1',
+        agent: 'Scout repo',
+        input: 17,
+        output: 5,
+      },
+    ]);
+  });
+
+  it('normalizes usage tied to an invoke_agent dispatch by tool_use_id', () => {
+    const events: StreamEvent[] = [
+      dispatchEvent(
+        'toolu_gemini_1',
+        { agent_name: 'smithy-plan', prompt: 'plan' },
+        'invoke_agent',
+      ),
+      usageEvent(
+        'toolu_gemini_1',
+        { input_tokens: 23, output_tokens: 7 },
+        'tool_use_id',
+      ),
+    ];
+
+    expect(extractDispatchUsageRecords(events)).toEqual([
+      {
+        dispatch_id: 'toolu_gemini_1',
+        agent: 'smithy-plan',
+        input: 23,
+        output: 7,
+      },
+    ]);
+  });
+
+  it('ignores parent-only, ambiguous, and malformed usage records', () => {
+    const events: StreamEvent[] = [
+      dispatchEvent('toolu_agent_1', {
+        description: 'Scout repo',
+        prompt: 'scan',
+      }),
+      usageEvent(null, { input_tokens: 10, output_tokens: 2 }),
+      usageEvent('unknown_dispatch', { input_tokens: 10, output_tokens: 2 }),
+      usageEvent('toolu_agent_1', {
+        input_tokens: '10',
+        output_tokens: Number.POSITIVE_INFINITY,
+        total_tokens: 12,
+      }),
+    ];
+
+    expect(extractDispatchUsageRecords(events)).toEqual([]);
+  });
+
+  it('keeps failed dispatches attributable when usage is parseable', () => {
+    const events: StreamEvent[] = [
+      dispatchEvent('toolu_agent_1', {
+        description: 'Scout repo',
+        prompt: 'scan',
+      }),
+      {
+        type: 'user',
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_agent_1',
+              is_error: true,
+              content: 'failed',
+            },
+          ],
+        },
+      },
+      usageEvent('toolu_agent_1', { input_tokens: 9, output_tokens: 0 }),
+    ];
+
+    expect(extractDispatchUsageRecords(events)).toEqual([
+      {
+        dispatch_id: 'toolu_agent_1',
+        agent: 'Scout repo',
+        input: 9,
+        output: 0,
+      },
+    ]);
+  });
+});
+
+describe('extractSubAgentTokenTotals', () => {
+  it('aggregates repeated dispatches of the same sub-agent into one stable row', () => {
+    const events: StreamEvent[] = [
+      dispatchEvent('toolu_agent_1', {
+        description: 'Scout repo',
+        prompt: 'scan once',
+      }),
+      dispatchEvent('toolu_agent_2', {
+        description: 'Scout repo',
+        prompt: 'scan twice',
+      }),
+      dispatchEvent('toolu_agent_3', {
+        description: 'Plan change',
+        prompt: 'plan',
+      }),
+      usageEvent('toolu_agent_2', { input_tokens: 10, output_tokens: 2 }),
+      usageEvent('toolu_agent_1', { input_tokens: 7, output_tokens: 3 }),
+      usageEvent('toolu_agent_3', { input_tokens: 5, output_tokens: 1 }),
+    ];
+
+    expect(extractSubAgentTokenTotals(events)).toEqual([
+      {
+        agent: 'Plan change',
+        input: 5,
+        output: 1,
+        dispatch_count: 1,
+      },
+      {
+        agent: 'Scout repo',
+        input: 17,
+        output: 5,
+        dispatch_count: 2,
+      },
+    ]);
+  });
+
+  it('uses deterministic fallback names for unknown or malformed labels', () => {
+    const events: StreamEvent[] = [
+      dispatchEvent('toolu_agent_1', {
+        description: '',
+        prompt: 'scan',
+      }),
+      dispatchEvent('toolu_agent_2', {
+        description: { nested: 'bad' },
+        prompt: 'scan',
+      }),
+      usageEvent('toolu_agent_2', { input_tokens: 3, output_tokens: 1 }),
+      usageEvent('toolu_agent_1', { input_tokens: 2, output_tokens: 1 }),
+    ];
+
+    expect(extractSubAgentTokenTotals(events)).toEqual([
+      {
+        agent: 'unknown sub-agent toolu_agent_1',
+        input: 2,
+        output: 1,
+        dispatch_count: 1,
+      },
+      {
+        agent: 'unknown sub-agent toolu_agent_2',
+        input: 3,
+        output: 1,
+        dispatch_count: 1,
+      },
+    ]);
+  });
+
+  it('returns empty totals for unattributable usage so per-case totals remain authoritative elsewhere', () => {
+    const events: StreamEvent[] = [
+      dispatchEvent('toolu_agent_1', {
+        description: 'Scout repo',
+        prompt: 'scan',
+      }),
+      usageEvent(null, { input_tokens: 10, output_tokens: 2 }),
+      usageEvent('unknown_dispatch', { input_tokens: 4, output_tokens: 1 }),
+    ];
+
+    expect(extractSubAgentTokenTotals(events)).toEqual([]);
+  });
+
+  it('ignores malformed token fields while preserving parseable fields as non-negative integers', () => {
+    const events: StreamEvent[] = [
+      dispatchEvent('toolu_agent_1', {
+        description: 'Scout repo',
+        prompt: 'scan',
+      }),
+      usageEvent('toolu_agent_1', {
+        input_tokens: 6,
+        output_tokens: 'bad',
+      }),
+    ];
+
+    expect(extractSubAgentTokenTotals(events)).toEqual([
+      {
+        agent: 'Scout repo',
+        input: 6,
+        output: 0,
+        dispatch_count: 1,
+      },
+    ]);
+  });
+});

--- a/evals/lib/sub-agent-token-attribution.test.ts
+++ b/evals/lib/sub-agent-token-attribution.test.ts
@@ -1,9 +1,22 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { parseStreamString } from './parse-stream.js';
 import {
   extractDispatchUsageRecords,
   extractSubAgentTokenTotals,
 } from './sub-agent-token-attribution.js';
 import type { StreamEvent } from './types.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const capturesDir = path.resolve(here, '..', 'captures');
+
+function loadCapture(name: string): StreamEvent[] {
+  return parseStreamString(
+    fs.readFileSync(path.resolve(capturesDir, `${name}.events.jsonl`), 'utf8'),
+  );
+}
 
 function dispatchEvent(
   id: string,
@@ -35,6 +48,36 @@ function usageEvent(
     [relationship]: dispatchId,
     message: {
       content: [{ type: 'text', text: 'sub-agent output' }],
+      usage,
+    },
+  };
+}
+
+/**
+ * The completion shape a finished Claude Agent dispatch emits: a user
+ * `tool_result` event carrying the dispatch id on the content block and the
+ * authoritative usage under `tool_use_result.usage`.
+ */
+function completionEvent(
+  dispatchId: string,
+  usage: Record<string, unknown>,
+): StreamEvent {
+  return {
+    type: 'user',
+    parent_tool_use_id: null,
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: dispatchId,
+          content: [{ type: 'text', text: 'sub-agent report' }],
+        },
+      ],
+    },
+    tool_use_result: {
+      status: 'completed',
+      agentType: 'smithy-scout',
       usage,
     },
   };
@@ -133,6 +176,101 @@ describe('extractDispatchUsageRecords', () => {
       },
     ]);
   });
+
+  it('reads the authoritative usage a completed dispatch reports on tool_use_result', () => {
+    const events: StreamEvent[] = [
+      dispatchEvent('toolu_agent_1', {
+        subagent_type: 'smithy-scout',
+        description: 'Scout repo',
+      }),
+      completionEvent('toolu_agent_1', {
+        input_tokens: 1,
+        output_tokens: 435,
+        cache_read_input_tokens: 4467,
+      }),
+    ];
+
+    expect(extractDispatchUsageRecords(events)).toEqual([
+      {
+        dispatch_id: 'toolu_agent_1',
+        agent: 'smithy-scout',
+        input: 1,
+        output: 435,
+      },
+    ]);
+  });
+
+  it('prefers completion usage over in-flight snapshots instead of summing both', () => {
+    const events: StreamEvent[] = [
+      dispatchEvent('toolu_agent_1', { subagent_type: 'smithy-scout' }),
+      usageEvent('toolu_agent_1', { input_tokens: 3, output_tokens: 1 }),
+      completionEvent('toolu_agent_1', { input_tokens: 1, output_tokens: 435 }),
+    ];
+
+    expect(extractDispatchUsageRecords(events)).toEqual([
+      {
+        dispatch_id: 'toolu_agent_1',
+        agent: 'smithy-scout',
+        input: 1,
+        output: 435,
+      },
+    ]);
+  });
+
+  it('counts a repeated message-level usage snapshot only once', () => {
+    const repeated = (): StreamEvent => ({
+      type: 'assistant',
+      parent_tool_use_id: 'toolu_agent_1',
+      message: {
+        id: 'msg_shared',
+        content: [{ type: 'tool_use', name: 'Read', id: 'toolu_read', input: {} }],
+        usage: { input_tokens: 6, output_tokens: 1 },
+      },
+    });
+
+    const events: StreamEvent[] = [
+      dispatchEvent('toolu_agent_1', { subagent_type: 'smithy-plan' }),
+      repeated(),
+      repeated(),
+      repeated(),
+    ];
+
+    expect(extractDispatchUsageRecords(events)).toEqual([
+      {
+        dispatch_id: 'toolu_agent_1',
+        agent: 'smithy-plan',
+        input: 6,
+        output: 1,
+      },
+    ]);
+  });
+
+  it('still sums distinct in-flight messages for one dispatch', () => {
+    const turn = (id: string, input: number, output: number): StreamEvent => ({
+      type: 'assistant',
+      parent_tool_use_id: 'toolu_agent_1',
+      message: {
+        id,
+        content: [{ type: 'text', text: 'work' }],
+        usage: { input_tokens: input, output_tokens: output },
+      },
+    });
+
+    const events: StreamEvent[] = [
+      dispatchEvent('toolu_agent_1', { subagent_type: 'smithy-plan' }),
+      turn('msg_a', 6, 1),
+      turn('msg_b', 4, 2),
+    ];
+
+    expect(extractDispatchUsageRecords(events)).toEqual([
+      {
+        dispatch_id: 'toolu_agent_1',
+        agent: 'smithy-plan',
+        input: 10,
+        output: 3,
+      },
+    ]);
+  });
 });
 
 describe('extractSubAgentTokenTotals', () => {
@@ -166,6 +304,30 @@ describe('extractSubAgentTokenTotals', () => {
         agent: 'Scout repo',
         input: 17,
         output: 5,
+        dispatch_count: 2,
+      },
+    ]);
+  });
+
+  it('groups repeated dispatches by stable subagent_type, not the per-dispatch label', () => {
+    const events: StreamEvent[] = [
+      dispatchEvent('toolu_agent_1', {
+        subagent_type: 'smithy-plan',
+        description: 'Simplification lens plan',
+      }),
+      dispatchEvent('toolu_agent_2', {
+        subagent_type: 'smithy-plan',
+        description: 'Robustness lens plan',
+      }),
+      completionEvent('toolu_agent_1', { input_tokens: 1, output_tokens: 1834 }),
+      completionEvent('toolu_agent_2', { input_tokens: 1, output_tokens: 3181 }),
+    ];
+
+    expect(extractSubAgentTokenTotals(events)).toEqual([
+      {
+        agent: 'smithy-plan',
+        input: 2,
+        output: 5015,
         dispatch_count: 2,
       },
     ]);
@@ -233,6 +395,32 @@ describe('extractSubAgentTokenTotals', () => {
         output: 0,
         dispatch_count: 1,
       },
+    ]);
+  });
+});
+
+describe('committed captures', () => {
+  it('attributes the scout capture to its completed dispatch total', () => {
+    // scout-fixture-shallow.events.jsonl:19 reports the dispatch's own
+    // authoritative usage under tool_use_result.usage.
+    expect(extractSubAgentTokenTotals(loadCapture('scout-fixture-shallow'))).toEqual([
+      {
+        agent: 'smithy-scout',
+        input: 1,
+        output: 435,
+        dispatch_count: 1,
+      },
+    ]);
+  });
+
+  it('aggregates the strike capture by sub-agent type', () => {
+    // Three smithy-plan dispatches carry distinct per-dispatch descriptions and
+    // must still collapse into one row.
+    expect(extractSubAgentTokenTotals(loadCapture('strike-health-check'))).toEqual([
+      { agent: 'smithy-clarify', input: 1, output: 1981, dispatch_count: 1 },
+      { agent: 'smithy-plan', input: 3, output: 8626, dispatch_count: 3 },
+      { agent: 'smithy-plan-review', input: 1, output: 3570, dispatch_count: 1 },
+      { agent: 'smithy-reconcile', input: 1, output: 4930, dispatch_count: 1 },
     ]);
   });
 });

--- a/evals/lib/sub-agent-token-attribution.ts
+++ b/evals/lib/sub-agent-token-attribution.ts
@@ -6,10 +6,14 @@ import type {
   ToolUse,
 } from './types.js';
 
-interface UsageObservation {
-  dispatchId?: string | undefined;
-  input?: number | undefined;
-  output?: number | undefined;
+interface TokenPair {
+  input: number;
+  output: number;
+}
+
+interface DispatchUsage {
+  dispatchId: string;
+  usage: TokenPair;
 }
 
 const DISPATCH_TOOL_NAMES = new Set(['Agent', 'invoke_agent']);
@@ -17,27 +21,58 @@ const DISPATCH_TOOL_NAMES = new Set(['Agent', 'invoke_agent']);
 /**
  * Extract normalized token usage records that are reliably tied to a known
  * sub-agent dispatch by stable dispatch identifier.
+ *
+ * A dispatch reports usage in one of two shapes, and they are not additive:
+ *
+ * 1. On completion, the `tool_result` event carries `tool_use_result.usage`,
+ *    which is the authoritative total for the whole dispatch (its token fields
+ *    sum to the sibling `totalTokens`). This is preferred whenever present.
+ * 2. While in flight, the sub-agent's own assistant turns carry message-level
+ *    usage. These are only a partial view, so they are used solely as a
+ *    fallback for dispatches that never produced a completion record.
  */
 export function extractDispatchUsageRecords(
   events: StreamEvent[],
 ): DispatchUsageRecord[] {
-  const dispatches = new Map(
-    extractToolUses(events)
-      .filter(isSubAgentDispatch)
-      .filter((toolUse) => typeof toolUse.id === 'string' && toolUse.id.length > 0)
-      .map((toolUse) => [toolUse.id, displayNameForDispatch(toolUse)]),
-  );
+  const dispatches = indexDispatches(events);
+  const completed = new Map<string, TokenPair>();
+  const inFlight = new Map<string, TokenPair>();
+  const seenSnapshots = new Set<string>();
 
-  return events.flatMap((event) => {
-    const observation = observeDispatchUsage(event, dispatches);
-    if (!observation?.dispatchId) return [];
+  events.forEach((event, index) => {
+    const completion = observeCompletedUsage(event, dispatches);
+    if (completion) {
+      completed.set(completion.dispatchId, completion.usage);
+      return;
+    }
+
+    const snapshot = observeInFlightUsage(event, dispatches);
+    if (!snapshot) return;
+
+    // One assistant message is re-emitted once per content block and repeats
+    // the same message-level usage on every copy, so count each message once.
+    const messageKey = messageId(event) ?? `event-${index}`;
+    const snapshotKey = `${snapshot.dispatchId}:${messageKey}`;
+    if (seenSnapshots.has(snapshotKey)) return;
+    seenSnapshots.add(snapshotKey);
+
+    const running = inFlight.get(snapshot.dispatchId) ?? { input: 0, output: 0 };
+    inFlight.set(snapshot.dispatchId, {
+      input: running.input + snapshot.usage.input,
+      output: running.output + snapshot.usage.output,
+    });
+  });
+
+  return [...dispatches.entries()].flatMap(([dispatchId, agent]) => {
+    const usage = completed.get(dispatchId) ?? inFlight.get(dispatchId);
+    if (!usage) return [];
 
     return [
       {
-        dispatch_id: observation.dispatchId,
-        agent: dispatches.get(observation.dispatchId) ?? fallbackDisplayName(observation.dispatchId),
-        input: observation.input ?? 0,
-        output: observation.output ?? 0,
+        dispatch_id: dispatchId,
+        agent,
+        input: usage.input,
+        output: usage.output,
       },
     ];
   });
@@ -75,21 +110,62 @@ export function extractSubAgentTokenTotals(
     }));
 }
 
-function observeDispatchUsage(
+/** Map every observed sub-agent dispatch id to its stable display name. */
+function indexDispatches(events: StreamEvent[]): Map<string, string> {
+  return new Map(
+    extractToolUses(events)
+      .filter(isSubAgentDispatch)
+      .filter((toolUse) => typeof toolUse.id === 'string' && toolUse.id.length > 0)
+      .map((toolUse) => [toolUse.id, displayNameForDispatch(toolUse)]),
+  );
+}
+
+/**
+ * Read the authoritative usage a finished dispatch reports on its tool_result
+ * event. The dispatch id lives on the `tool_result` content block rather than
+ * at the top level of the event.
+ */
+function observeCompletedUsage(
   event: StreamEvent,
   dispatches: Map<string, string>,
-): UsageObservation | null {
-  const usage = getUsageObject(event);
+): DispatchUsage | null {
+  const result = event['tool_use_result'];
+  if (!isRecord(result)) return null;
+
+  const usage = normalizeTokens(result['usage']);
+  if (!usage) return null;
+
+  const dispatchId = completedDispatchId(event, dispatches);
+  if (!dispatchId) return null;
+
+  return { dispatchId, usage };
+}
+
+function observeInFlightUsage(
+  event: StreamEvent,
+  dispatches: Map<string, string>,
+): DispatchUsage | null {
+  const usage = normalizeTokens(getUsageObject(event));
   if (!usage) return null;
 
   const dispatchId = getDispatchId(event, dispatches);
   if (!dispatchId) return null;
 
-  const input = normalizeTokenCount(usage['input_tokens']);
-  const output = normalizeTokenCount(usage['output_tokens']);
-  if (input === undefined && output === undefined) return null;
+  return { dispatchId, usage };
+}
 
-  return { dispatchId, input, output };
+function completedDispatchId(
+  event: StreamEvent,
+  dispatches: Map<string, string>,
+): string | undefined {
+  for (const block of contentBlocks(event)) {
+    const toolUseId = block['tool_use_id'];
+    if (typeof toolUseId === 'string' && dispatches.has(toolUseId)) {
+      return toolUseId;
+    }
+  }
+
+  return getDispatchId(event, dispatches);
 }
 
 function getDispatchId(
@@ -107,6 +183,17 @@ function getDispatchId(
   }
 
   return undefined;
+}
+
+function contentBlocks(event: StreamEvent): Record<string, unknown>[] {
+  if (!isRecord(event.message)) return [];
+  const content = event.message['content'];
+  return Array.isArray(content) ? content.filter(isRecord) : [];
+}
+
+function messageId(event: StreamEvent): string | undefined {
+  if (!isRecord(event.message)) return undefined;
+  return stringField(event.message['id']);
 }
 
 function getUsageObject(event: StreamEvent): Record<string, unknown> | null {
@@ -127,12 +214,17 @@ function isSubAgentDispatch(toolUse: ToolUse): boolean {
   return DISPATCH_TOOL_NAMES.has(toolUse.name);
 }
 
+/**
+ * Prefer the stable sub-agent type over the per-dispatch task label so
+ * repeated dispatches of one sub-agent aggregate into a single row.
+ */
 function displayNameForDispatch(toolUse: ToolUse): string {
-  const configuredName =
-    toolUse.name === 'invoke_agent'
-      ? stringField(toolUse.input['agent_name'])
-      : stringField(toolUse.input['description']);
-  return configuredName ?? fallbackDisplayName(toolUse.id);
+  return (
+    stringField(toolUse.input['subagent_type']) ??
+    stringField(toolUse.input['agent_name']) ??
+    stringField(toolUse.input['description']) ??
+    fallbackDisplayName(toolUse.id)
+  );
 }
 
 function fallbackDisplayName(dispatchId: string): string {
@@ -143,6 +235,17 @@ function stringField(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/** Malformed token fields are dropped rather than coerced. */
+function normalizeTokens(usage: unknown): TokenPair | null {
+  if (!isRecord(usage)) return null;
+
+  const input = normalizeTokenCount(usage['input_tokens']);
+  const output = normalizeTokenCount(usage['output_tokens']);
+  if (input === undefined && output === undefined) return null;
+
+  return { input: input ?? 0, output: output ?? 0 };
 }
 
 function normalizeTokenCount(value: unknown): number | undefined {

--- a/evals/lib/sub-agent-token-attribution.ts
+++ b/evals/lib/sub-agent-token-attribution.ts
@@ -1,0 +1,159 @@
+import { extractToolUses } from './parse-stream.js';
+import type {
+  DispatchUsageRecord,
+  StreamEvent,
+  SubAgentTokenTotals,
+  ToolUse,
+} from './types.js';
+
+interface UsageObservation {
+  dispatchId?: string | undefined;
+  input?: number | undefined;
+  output?: number | undefined;
+}
+
+const DISPATCH_TOOL_NAMES = new Set(['Agent', 'invoke_agent']);
+
+/**
+ * Extract normalized token usage records that are reliably tied to a known
+ * sub-agent dispatch by stable dispatch identifier.
+ */
+export function extractDispatchUsageRecords(
+  events: StreamEvent[],
+): DispatchUsageRecord[] {
+  const dispatches = new Map(
+    extractToolUses(events)
+      .filter(isSubAgentDispatch)
+      .filter((toolUse) => typeof toolUse.id === 'string' && toolUse.id.length > 0)
+      .map((toolUse) => [toolUse.id, displayNameForDispatch(toolUse)]),
+  );
+
+  return events.flatMap((event) => {
+    const observation = observeDispatchUsage(event, dispatches);
+    if (!observation?.dispatchId) return [];
+
+    return [
+      {
+        dispatch_id: observation.dispatchId,
+        agent: dispatches.get(observation.dispatchId) ?? fallbackDisplayName(observation.dispatchId),
+        input: observation.input ?? 0,
+        output: observation.output ?? 0,
+      },
+    ];
+  });
+}
+
+/**
+ * Aggregate dispatch-attributable usage into stable per-sub-agent token rows
+ * for one scenario. Unattributable parent-level usage intentionally produces
+ * no rows; the existing per-case token total remains the authoritative total.
+ */
+export function extractSubAgentTokenTotals(
+  events: StreamEvent[],
+): SubAgentTokenTotals[] {
+  const totals = new Map<
+    string,
+    { input: number; output: number; dispatchIds: Set<string> }
+  >();
+
+  for (const record of extractDispatchUsageRecords(events)) {
+    const current =
+      totals.get(record.agent) ?? { input: 0, output: 0, dispatchIds: new Set<string>() };
+    current.input += record.input;
+    current.output += record.output;
+    current.dispatchIds.add(record.dispatch_id);
+    totals.set(record.agent, current);
+  }
+
+  return [...totals.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([agent, total]) => ({
+      agent,
+      input: total.input,
+      output: total.output,
+      dispatch_count: total.dispatchIds.size,
+    }));
+}
+
+function observeDispatchUsage(
+  event: StreamEvent,
+  dispatches: Map<string, string>,
+): UsageObservation | null {
+  const usage = getUsageObject(event);
+  if (!usage) return null;
+
+  const dispatchId = getDispatchId(event, dispatches);
+  if (!dispatchId) return null;
+
+  const input = normalizeTokenCount(usage['input_tokens']);
+  const output = normalizeTokenCount(usage['output_tokens']);
+  if (input === undefined && output === undefined) return null;
+
+  return { dispatchId, input, output };
+}
+
+function getDispatchId(
+  event: StreamEvent,
+  dispatches: Map<string, string>,
+): string | undefined {
+  const parentToolUseId = event['parent_tool_use_id'];
+  if (typeof parentToolUseId === 'string' && dispatches.has(parentToolUseId)) {
+    return parentToolUseId;
+  }
+
+  const toolUseId = event['tool_use_id'];
+  if (typeof toolUseId === 'string' && dispatches.has(toolUseId)) {
+    return toolUseId;
+  }
+
+  return undefined;
+}
+
+function getUsageObject(event: StreamEvent): Record<string, unknown> | null {
+  if (isRecord(event['usage'])) return event['usage'];
+  if (isRecord(event.message) && isRecord(event.message['usage'])) {
+    return event.message['usage'];
+  }
+  if (isRecord(event['item']) && isRecord(event['item']['usage'])) {
+    return event['item']['usage'];
+  }
+  if (isRecord(event['payload']) && isRecord(event['payload']['usage'])) {
+    return event['payload']['usage'];
+  }
+  return null;
+}
+
+function isSubAgentDispatch(toolUse: ToolUse): boolean {
+  return DISPATCH_TOOL_NAMES.has(toolUse.name);
+}
+
+function displayNameForDispatch(toolUse: ToolUse): string {
+  const configuredName =
+    toolUse.name === 'invoke_agent'
+      ? stringField(toolUse.input['agent_name'])
+      : stringField(toolUse.input['description']);
+  return configuredName ?? fallbackDisplayName(toolUse.id);
+}
+
+function fallbackDisplayName(dispatchId: string): string {
+  return `unknown sub-agent ${dispatchId}`;
+}
+
+function stringField(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeTokenCount(value: unknown): number | undefined {
+  return typeof value === 'number' &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value >= 0
+    ? value
+    : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -96,6 +96,22 @@ export interface DispatchUsageEvidence {
   reviewed_at: string;
 }
 
+/** Normalized usage tied to a single sub-agent dispatch. */
+export interface DispatchUsageRecord {
+  dispatch_id: string;
+  agent: string;
+  input: number;
+  output: number;
+}
+
+/** Aggregated per-scenario token totals for one dispatched sub-agent. */
+export interface SubAgentTokenTotals {
+  agent: string;
+  input: number;
+  output: number;
+  dispatch_count: number;
+}
+
 // ---------------------------------------------------------------------------
 // Scenario / expectation types (from YAML definitions)
 // ---------------------------------------------------------------------------

--- a/specs/2026-05-20-008-per-sub-agent-token-attribution/02-attribute-token-totals-to-sub-agent-dispatches.tasks.md
+++ b/specs/2026-05-20-008-per-sub-agent-token-attribution/02-attribute-token-totals-to-sub-agent-dispatches.tasks.md
@@ -18,7 +18,7 @@
 
 ### Tasks
 
-- [ ] **Extract attributed dispatch usage records**
+- [x] **Extract attributed dispatch usage records**
 
   Add an attribution path under `evals/lib/` that consumes parsed `StreamEvent` values and matches usage metadata to known sub-agent dispatches by stable dispatch identifier. Reuse the existing stream parsing helpers where possible, and keep parent-level, ambiguous, and malformed usage out of the returned records for AS 2.1 and AS 2.3.
 
@@ -30,7 +30,7 @@
   - Failed dispatches with parseable usage remain attributable.
   - Existing evidence classification behavior remains unchanged.
 
-- [ ] **Aggregate dispatch records by sub-agent**
+- [x] **Aggregate dispatch records by sub-agent**
 
   Extend the attribution path to return `SubAgentTokenTotals[]` for one scenario by grouping valid dispatch usage records by stable sub-agent display name. Preserve per-case token totals as the authoritative fallback by returning no attribution rows for unattributable usage, satisfying AS 2.1-2.3 without introducing report rendering from US3.
 


### PR DESCRIPTION
## Summary

RFC 2026-001 Token Savings → M1 Measurement Foundation → F2 Feature 1.3b: Per-Sub-Agent Token Attribution → Per-Sub-Agent Token Attribution spec → Slice 1: Dispatch Usage Record Extraction

Adds the attribution extractor that turns dispatch-attributable stream usage into per-sub-agent token totals for a single scenario. This is the right increment because it delivers the core US2 behavior against parsed stream events alone — no result-type or report-rendering changes — so the aggregation contract can be proven by unit tests before slice 2 carries it through `scenarioRunToResult` and US3 renders nested rows.

`extractDispatchUsageRecords` matches usage metadata to known `Agent` and `invoke_agent` dispatches by stable dispatch id (`parent_tool_use_id`, then `tool_use_id`), dropping parent-only, ambiguous, and malformed usage. `extractSubAgentTokenTotals` groups the surviving records into stable, name-ordered rows with dispatch counts. Unattributable usage yields no rows, so the existing per-case token totals stay authoritative.

## Spec debt & uncertainty

- None outstanding in the spec or tasks artifact — both `## Specification Debt` tables read "None — all ambiguities resolved."
- Assumption (from spec): dispatch-level attribution is only trustworthy when stream events carry a stable relationship to a specific `Agent` dispatch — the extractor encodes exactly that, refusing to attribute usage whose dispatch id does not match a dispatch observed in the same stream.
- Assumption (from spec): per-case totals are the authoritative cost signal in all paths; per-sub-agent totals are explanatory detail. Hence the deliberate empty-result behavior rather than a best-effort guess.
- Display-name derivation follows the existing `extractSubAgentDispatches` convention in `evals/lib/parse-stream.ts` (`description` for Claude `Agent`, `agent_name` for Gemini `invoke_agent`) rather than inventing a new label source. Unlabeled or non-string labels fall back to a deterministic `unknown sub-agent <dispatch_id>`.
- Reviewer note: `getUsageObject`, the dispatch-id resolution, and `isRecord` are near-duplicates of the equivalent helpers in `evals/lib/dispatch-usage-evidence.ts` (US1). Left duplicated intentionally — extracting a shared module would touch US1 code and put the "existing evidence classification behavior remains unchanged" acceptance criterion at risk for a slice whose scope is additive. Worth consolidating in a later cleanup.
- Verification gap: this worktree had no `node_modules` and the ambient Node is v18.12.1, which cannot run the pinned toolchain. Validation was run under Node v22.16.0 after a clean `npm ci`. One pre-existing failure in `src/artifact-store.test.ts` ("commits with a fallback identity when the machine has none") is environmental — this machine has a global git `user.name`, so the no-identity fallback path cannot be exercised. Confirmed it fails identically with this diff stashed.

## Validation

build ✅ · typecheck ✅ · evals tests ✅ (252 passed, 13 files) · full suite ✅ (1135 passed, 1 pre-existing environmental failure in `src/artifact-store.test.ts`, unrelated to this diff)
