### PR TITLE
forge: resolve per-scenario fixture directories before agent spawn

### DIFF
--- a/evals/lib/runner.test.ts
+++ b/evals/lib/runner.test.ts
@@ -278,6 +278,49 @@ describe('resolveFixtureDir', () => {
       fixture.cleanup();
     }
   });
+
+  it('accepts a `.` selector as the fixture root itself', () => {
+    const global = createRealFixture();
+    const fixtureRoot = createRealFixture();
+    try {
+      // `fixture: .` selects the default fixture root even under a `--fixture`
+      // override; the loader accepts it, so resolution must too.
+      expect(resolveFixtureDir(makeScenario({ fixture: '.' }), global.dir, fixtureRoot.dir)).toBe(
+        path.resolve(fixtureRoot.dir),
+      );
+    } finally {
+      global.cleanup();
+      fixtureRoot.cleanup();
+    }
+  });
+
+  it('accepts a child selector whose name begins with dots', () => {
+    const fixture = createRealFixture();
+    fs.mkdirSync(path.join(fixture.dir, '..fixtures'));
+    try {
+      expect(
+        resolveFixtureDir(makeScenario({ fixture: '..fixtures' }), fixture.dir, fixture.dir),
+      ).toBe(path.join(fixture.dir, '..fixtures'));
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('rejects a scenario selector that escapes the fixture root through a symlink', () => {
+    const fixture = createRealFixture();
+    const outside = createRealFixture();
+    fs.symlinkSync(outside.dir, path.join(fixture.dir, 'jvm'), 'dir');
+    try {
+      expect(() =>
+        resolveFixtureDir(makeScenario({ fixture: 'jvm' }), fixture.dir, fixture.dir),
+      ).toThrow(/outside fixture root via symlink/);
+      // Resolution fails before any agent spawn (AS 2.4).
+      expect(spawn).not.toHaveBeenCalled();
+    } finally {
+      fixture.cleanup();
+      outside.cleanup();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -538,12 +581,8 @@ describe('runScenario', () => {
       path.join(repoRoot, 'evals/cases/fix-from-issue.yaml'),
     );
 
-    await runScenario(
-      scenario,
-      path.join(repoRoot, 'evals/fixture'),
-      'claude',
-      path.join(repoRoot, 'evals/fixture'),
-    );
+    const fixtureRoot = path.join(repoRoot, 'evals/fixture');
+    await runScenario(scenario, resolveFixtureDir(scenario, fixtureRoot, fixtureRoot), 'claude');
 
     const call = vi.mocked(spawn).mock.calls[0]!;
     const args = call[1] as string[];

--- a/evals/lib/runner.test.ts
+++ b/evals/lib/runner.test.ts
@@ -23,7 +23,7 @@ vi.mock('node:child_process', () => ({
 
 // Import after mock is declared so the module picks up the mocked version.
 const { spawn, execFileSync } = await import('node:child_process');
-const { runScenario, preflight, hashDirectory } = await import('./runner.js');
+const { runScenario, preflight, hashDirectory, resolveFixtureDir } = await import('./runner.js');
 const { loadScenarioFromFile } = await import('./scenario-loader.js');
 
 // ---------------------------------------------------------------------------
@@ -186,6 +186,101 @@ afterEach(() => {
 });
 
 // ---------------------------------------------------------------------------
+// fixture resolver tests
+// ---------------------------------------------------------------------------
+
+describe('resolveFixtureDir', () => {
+  it('uses the global fixture directory when scenario fixture metadata is omitted', () => {
+    const fixture = createRealFixture();
+    try {
+      expect(resolveFixtureDir(makeScenario(), fixture.dir, '/unused/root')).toBe(fixture.dir);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('preserves default fixture behavior when the global fixture is the repository root', () => {
+    const fixture = createRealFixture();
+    try {
+      expect(resolveFixtureDir(makeScenario(), fixture.dir, fixture.dir)).toBe(fixture.dir);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('resolves scenario fixture selectors under the repository fixture root', () => {
+    const global = createRealFixture();
+    const fixtureRoot = createRealFixture();
+    fs.mkdirSync(path.join(fixtureRoot.dir, 'jvm'));
+    try {
+      expect(resolveFixtureDir(makeScenario({ fixture: 'jvm' }), global.dir, fixtureRoot.dir)).toBe(
+        path.join(fixtureRoot.dir, 'jvm'),
+      );
+    } finally {
+      global.cleanup();
+      fixtureRoot.cleanup();
+    }
+  });
+
+  it('lets a scenario fixture selector override the global fixture directory', () => {
+    const global = createRealFixture();
+    const fixtureRoot = createRealFixture();
+    fs.mkdirSync(path.join(global.dir, 'jvm'));
+    fs.mkdirSync(path.join(fixtureRoot.dir, 'jvm'));
+    try {
+      expect(resolveFixtureDir(makeScenario({ fixture: 'jvm' }), global.dir, fixtureRoot.dir)).toBe(
+        path.join(fixtureRoot.dir, 'jvm'),
+      );
+    } finally {
+      global.cleanup();
+      fixtureRoot.cleanup();
+    }
+  });
+
+  it('fails clearly when the effective fixture directory is missing', () => {
+    const fixture = createRealFixture();
+    try {
+      expect(() =>
+        resolveFixtureDir(
+          makeScenario({ name: 'forge-tdd-slice-jvm', fixture: 'jvm' }),
+          fixture.dir,
+          fixture.dir,
+        ),
+      ).toThrow(/forge-tdd-slice-jvm.*fixture "jvm".*not found/);
+      // Resolution fails before any agent spawn (AS 2.4).
+      expect(spawn).not.toHaveBeenCalled();
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('fails clearly when the effective fixture is not a directory', () => {
+    const fixture = createRealFixture();
+    fs.writeFileSync(path.join(fixture.dir, 'jvm'), 'not a directory');
+    try {
+      expect(() =>
+        resolveFixtureDir(makeScenario({ fixture: 'jvm' }), fixture.dir, fixture.dir),
+      ).toThrow(/fixture "jvm".*not a directory/);
+      // Resolution fails before any agent spawn (AS 2.4).
+      expect(spawn).not.toHaveBeenCalled();
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('rejects scenario selectors that escape the repository fixture root', () => {
+    const fixture = createRealFixture();
+    try {
+      expect(() =>
+        resolveFixtureDir(makeScenario({ fixture: '../outside' }), fixture.dir, fixture.dir),
+      ).toThrow(/outside fixture root/);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // runScenario tests
 // ---------------------------------------------------------------------------
 
@@ -239,7 +334,7 @@ describe('runScenario', () => {
     }
   });
 
-  it('uses scenario fixture metadata to select the JVM fixture directory', async () => {
+  it('copies the resolved effective fixture directory before spawning', async () => {
     const stdout = ndjsonLines(resultEvent('jvm output'));
     const { child } = createMockChild(stdout, 0);
 
@@ -261,67 +356,17 @@ describe('runScenario', () => {
     fs.writeFileSync(path.join(fixture.dir, 'jvm', 'jvm-only.txt'), 'jvm');
 
     try {
-      await runScenario(makeScenario({ fixture: 'jvm' }), fixture.dir);
+      const effectiveFixtureDir = resolveFixtureDir(
+        makeScenario({ fixture: 'jvm' }),
+        fixture.dir,
+        fixture.dir,
+      );
+
+      await runScenario(makeScenario({ fixture: 'jvm' }), effectiveFixtureDir);
 
       expect(spawnObservedCwd).toContain('smithy-eval-');
       expect(sawJvmFixtureFile).toBe(true);
       expect(sawRootFixtureFile).toBe(false);
-    } finally {
-      fixture.cleanup();
-    }
-  });
-
-  it('resolves an explicit fixture selector from the canonical root, not the --fixture override', async () => {
-    const stdout = ndjsonLines(resultEvent('jvm output'));
-    const { child } = createMockChild(stdout, 0);
-
-    let sawCanonicalJvmFile = false;
-    let sawOverrideJvmFile = false;
-    vi.mocked(spawn).mockImplementation(
-      ((_cmd: string, _args: readonly string[], opts: { cwd?: string }) => {
-        const cwd = opts.cwd ?? '';
-        sawCanonicalJvmFile = fs.existsSync(path.join(cwd, 'canonical-jvm.txt'));
-        sawOverrideJvmFile = fs.existsSync(path.join(cwd, 'override-jvm.txt'));
-        return child as never;
-      }) as never,
-    );
-
-    // The `--fixture` override points at a different directory than the
-    // canonical fixture root; a `jvm/` exists under both. The explicit selector
-    // must win and resolve under the canonical root (F1.6 contract).
-    const override = createRealFixture();
-    fs.mkdirSync(path.join(override.dir, 'jvm'));
-    fs.writeFileSync(path.join(override.dir, 'jvm', 'override-jvm.txt'), 'override');
-
-    const canonical = createRealFixture();
-    fs.mkdirSync(path.join(canonical.dir, 'jvm'));
-    fs.writeFileSync(path.join(canonical.dir, 'jvm', 'canonical-jvm.txt'), 'canonical');
-
-    try {
-      await runScenario(
-        makeScenario({ fixture: 'jvm' }),
-        override.dir,
-        'claude',
-        canonical.dir,
-      );
-
-      expect(sawCanonicalJvmFile).toBe(true);
-      expect(sawOverrideJvmFile).toBe(false);
-    } finally {
-      override.cleanup();
-      canonical.cleanup();
-    }
-  });
-
-  it('fails clearly when the requested JVM fixture directory is missing', async () => {
-    const fixture = createRealFixture();
-    try {
-      await expect(
-        runScenario(makeScenario({ name: 'forge-tdd-slice-jvm', fixture: 'jvm' }), fixture.dir),
-      ).rejects.toThrow(
-        /forge-tdd-slice-jvm.*fixture "jvm".*not found/,
-      );
-      expect(spawn).not.toHaveBeenCalled();
     } finally {
       fixture.cleanup();
     }
@@ -605,6 +650,36 @@ describe('runScenario', () => {
 
       const hashAfter = hashDirectory(fixture.dir);
       expect(hashAfter).toBe(hashBefore);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('detects mutation of the selected source fixture directory', async () => {
+    const stdout = ndjsonLines(resultEvent('output'));
+    const { child } = createMockChild(stdout, 0);
+
+    const fixture = createRealFixture();
+    fs.mkdirSync(path.join(fixture.dir, 'jvm'));
+    fs.writeFileSync(path.join(fixture.dir, 'jvm', 'selected.txt'), 'before');
+
+    vi.mocked(spawn).mockImplementation(
+      ((_cmd: string, _args: readonly string[], _opts: { cwd?: string }) => {
+        fs.writeFileSync(path.join(fixture.dir, 'jvm', 'selected.txt'), 'after');
+        return child as never;
+      }) as never,
+    );
+
+    try {
+      const effectiveFixtureDir = resolveFixtureDir(
+        makeScenario({ fixture: 'jvm' }),
+        fixture.dir,
+        fixture.dir,
+      );
+
+      await expect(
+        runScenario(makeScenario({ fixture: 'jvm' }), effectiveFixtureDir),
+      ).rejects.toThrow(/Source fixture directory was modified/);
     } finally {
       fixture.cleanup();
     }

--- a/evals/lib/runner.ts
+++ b/evals/lib/runner.ts
@@ -476,18 +476,18 @@ export function resolveFixtureDir(
     ? path.resolve(globalFixtureDir)
     : path.resolve(repoFixtureRoot, fixture);
 
-  if (fixture !== undefined) {
-    const fixtureRoot = path.resolve(repoFixtureRoot);
-    const relativeToRoot = path.relative(fixtureRoot, selectedDir);
-    if (
-      relativeToRoot === '' ||
-      relativeToRoot.startsWith('..') ||
-      path.isAbsolute(relativeToRoot)
-    ) {
-      throw new Error(
-        `Scenario "${scenario.name}" requested fixture "${fixture}", but fixture path resolves outside fixture root: ${selectedDir}`,
-      );
-    }
+  const fixtureRoot = path.resolve(repoFixtureRoot);
+
+  // Defense in depth beyond loader validation. The loader rejects `..` path
+  // *segments*, so containment is checked per segment here too: the fixture
+  // root itself (`fixture: .`, which selects the default fixture even under a
+  // `--fixture` override) and children whose names merely begin with dots
+  // (`..fixtures`) are legitimate selections the loader accepts — only a real
+  // parent traversal escapes the root.
+  if (fixture !== undefined && !isRootOrDescendant(selectedDir, fixtureRoot)) {
+    throw new Error(
+      `Scenario "${scenario.name}" requested fixture "${fixture}", but fixture path resolves outside fixture root: ${selectedDir}`,
+    );
   }
 
   const stat = fs.statSync(selectedDir, { throwIfNoEntry: false });
@@ -512,7 +512,42 @@ export function resolveFixtureDir(
     );
   }
 
+  // The checks above only constrain the path *text*. Resolve the real paths and
+  // re-check containment so a symlink under the fixture root cannot redirect the
+  // copied fixture outside it — the same defense the scenario loader applies to
+  // `local_fixtures` declarations.
+  if (fixture !== undefined) {
+    let realSelectedDir: string;
+    let realFixtureRoot: string;
+    try {
+      realSelectedDir = fs.realpathSync(selectedDir);
+      realFixtureRoot = fs.realpathSync(fixtureRoot);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Scenario "${scenario.name}" requested fixture "${fixture}", but fixture path could not be resolved: ${selectedDir} (${msg})`,
+      );
+    }
+    if (!isRootOrDescendant(realSelectedDir, realFixtureRoot)) {
+      throw new Error(
+        `Scenario "${scenario.name}" requested fixture "${fixture}", but fixture path resolves outside fixture root via symlink: ${selectedDir}`,
+      );
+    }
+  }
+
   return selectedDir;
+}
+
+/**
+ * True when `childAbs` is `parentAbs` itself or a descendant of it. Containment
+ * is checked per path segment rather than by string prefix, so a directory whose
+ * name merely begins with `..` is not mistaken for a parent traversal.
+ */
+function isRootOrDescendant(childAbs: string, parentAbs: string): boolean {
+  const relative = path.relative(parentAbs, childAbs);
+  if (relative === '') return true;
+  if (path.isAbsolute(relative)) return false;
+  return !relative.split(/[\\/]+/).includes('..');
 }
 
 function buildAgentArgs(agent: EvalAgent, invocation: string, tmpDir: string): string[] {

--- a/evals/lib/runner.ts
+++ b/evals/lib/runner.ts
@@ -369,13 +369,7 @@ export async function runScenario(
   scenario: EvalScenario,
   fixtureDir: string,
   agent: EvalAgent = 'claude',
-  canonicalFixtureRoot: string = fixtureDir,
 ): Promise<RunOutput> {
-  const selectedFixtureDir = resolveScenarioFixtureDir(
-    scenario,
-    fixtureDir,
-    canonicalFixtureRoot,
-  );
   const requiresGit = scenario.requires_git ?? true;
 
   // Create a unique temp directory and copy the fixture into it.
@@ -385,7 +379,7 @@ export async function runScenario(
 
   try {
     // FR-002: Copy fixture to temp directory.
-    fs.cpSync(selectedFixtureDir, tmpDir, { recursive: true });
+    fs.cpSync(fixtureDir, tmpDir, { recursive: true });
 
     if (requiresGit) {
       // Initialize the temp copy as a git repository with a baseline commit
@@ -414,7 +408,7 @@ export async function runScenario(
     }
 
     // FR-011: Checksum the source fixture *before* execution.
-    const checksumBefore = hashDirectory(selectedFixtureDir);
+    const checksumBefore = hashDirectory(fixtureDir);
 
     const fixtureBindings = resolveLocalFixtureBindings(scenario, tmpDir);
 
@@ -450,7 +444,7 @@ export async function runScenario(
     }
 
     // FR-011: Re-verify the source fixture after execution.
-    const checksumAfter = hashDirectory(selectedFixtureDir);
+    const checksumAfter = hashDirectory(fixtureDir);
     if (checksumAfter !== checksumBefore) {
       throw new Error(
         'Source fixture directory was modified during eval execution. ' +
@@ -472,29 +466,47 @@ export async function runScenario(
   }
 }
 
-function resolveScenarioFixtureDir(
+export function resolveFixtureDir(
   scenario: EvalScenario,
-  fixtureDir: string,
-  canonicalFixtureRoot: string,
+  globalFixtureDir: string,
+  repoFixtureRoot: string,
 ): string {
   const fixture = scenario.fixture;
-
-  // No selector: use the default fixture root, which honors the `--fixture`
-  // override. An explicit selector overrides that default per the F1.6 fixture
-  // contract and always resolves to its committed location under the canonical
-  // fixture root, so a `--fixture` override aimed at other cases never redirects
-  // (or hides) it. The loader has already validated any selector as a safe
-  // relative path under the fixture root (no absolute roots, no '..').
   const selectedDir = fixture === undefined
-    ? fixtureDir
-    : path.join(canonicalFixtureRoot, fixture);
+    ? path.resolve(globalFixtureDir)
+    : path.resolve(repoFixtureRoot, fixture);
+
+  if (fixture !== undefined) {
+    const fixtureRoot = path.resolve(repoFixtureRoot);
+    const relativeToRoot = path.relative(fixtureRoot, selectedDir);
+    if (
+      relativeToRoot === '' ||
+      relativeToRoot.startsWith('..') ||
+      path.isAbsolute(relativeToRoot)
+    ) {
+      throw new Error(
+        `Scenario "${scenario.name}" requested fixture "${fixture}", but fixture path resolves outside fixture root: ${selectedDir}`,
+      );
+    }
+  }
+
   const stat = fs.statSync(selectedDir, { throwIfNoEntry: false });
   if (!stat) {
+    if (fixture === undefined) {
+      throw new Error(
+        `Scenario "${scenario.name}" effective fixture directory was not found: ${selectedDir}`,
+      );
+    }
     throw new Error(
       `Scenario "${scenario.name}" requested fixture "${fixture}", but fixture directory was not found: ${selectedDir}`,
     );
   }
   if (!stat.isDirectory()) {
+    if (fixture === undefined) {
+      throw new Error(
+        `Scenario "${scenario.name}" effective fixture path is not a directory: ${selectedDir}`,
+      );
+    }
     throw new Error(
       `Scenario "${scenario.name}" requested fixture "${fixture}", but fixture path is not a directory: ${selectedDir}`,
     );

--- a/evals/run-evals.ts
+++ b/evals/run-evals.ts
@@ -37,7 +37,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { preflight, runScenario } from './lib/runner.js';
+import { preflight, resolveFixtureDir, runScenario } from './lib/runner.js';
 import { validateStructure, verifySubAgents } from './lib/structural.js';
 import { extractSubAgentDispatches } from './lib/parse-stream.js';
 import { loadBaseline, compareToBaseline } from './lib/baseline.js';
@@ -255,11 +255,19 @@ console.log('');
 const results: EvalResult[] = [];
 
 for (const scenario of finalScenarios) {
+  let effectiveFixtureDir;
+  try {
+    effectiveFixtureDir = resolveFixtureDir(scenario, fixtureDir, canonicalFixtureRoot);
+  } catch (err) {
+    console.error(`Error running scenario: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
   console.log(`Running scenario: ${scenario.name}`);
   console.log(`  Agent:   ${agent}`);
   console.log(`  Skill:   ${scenario.skill}`);
   console.log(`  Prompt:  ${scenario.prompt}`);
-  console.log(`  Fixture: ${fixtureDir}`);
+  console.log(`  Fixture: ${effectiveFixtureDir}`);
   console.log(
     `  Timeout: ${
       scenario.timeout !== undefined
@@ -271,7 +279,7 @@ for (const scenario of finalScenarios) {
 
   let output;
   try {
-    output = await runScenario(scenario, fixtureDir, agent, canonicalFixtureRoot);
+    output = await runScenario(scenario, effectiveFixtureDir, agent);
   } catch (err) {
     console.error(`Error running scenario: ${err instanceof Error ? err.message : String(err)}`);
     process.exit(1);

--- a/specs/2026-06-06-011-jvm-multi-language-fixture/02-resolve-fixture-paths-in-the-runner.tasks.md
+++ b/specs/2026-06-06-011-jvm-multi-language-fixture/02-resolve-fixture-paths-in-the-runner.tasks.md
@@ -18,7 +18,7 @@
 
 ### Tasks
 
-- [ ] **Add effective fixture resolution**
+- [x] **Add effective fixture resolution**
 
   Add a separately testable fixture resolver in the runner path, using `evals/lib/runner.ts` or a runner-adjacent module consistent with the existing eval library layout. It should consume scenario metadata, the global fixture directory, and the repository fixture root to satisfy AS 2.1-2.4.
 
@@ -29,7 +29,7 @@
   - Missing or non-directory effective fixtures fail before agent spawn.
   - Resolver coverage exercises default, global override, scenario override, and invalid effective fixture cases.
 
-- [ ] **Wire resolution into eval execution**
+- [x] **Wire resolution into eval execution**
 
   Update `evals/run-evals.ts` and the runner call path so each selected scenario is executed against its resolved effective fixture directory. Keep the existing preflight, scenario loading, timeout override, structural validation, sub-agent validation, baseline comparison, and dump behavior unchanged except for using the selected fixture path.
 
@@ -40,7 +40,7 @@
   - Scenarios without fixture metadata keep the current `--fixture` behavior for AS 2.1 and AS 2.2.
   - Runner integration coverage proves resolution happens before agent spawning.
 
-- [ ] **Preserve selected-fixture checksum behavior**
+- [x] **Preserve selected-fixture checksum behavior**
 
   Ensure `runScenario` hashes and verifies the same source fixture directory it copies into the temp run. This task keeps fixture mutation detection aligned with the effective fixture selected for AS 2.1-2.3 and prepares US4's default-behavior regression checks.
 


### PR DESCRIPTION
## Summary
RFC 2026-001 Token Savings → M1 Measurement Foundation → F1.6 JVM Multi-Language Fixture → JVM Multi-Language Fixture spec → Slice 1: Resolve and Copy Per-Scenario Fixtures

The eval orchestrator now computes each scenario's effective fixture directory before running it, applying scenario-selector → global `--fixture` → default precedence, and fails before any agent spawn when the resolved fixture is missing, is not a directory, or escapes the repository fixture root. `resolveFixtureDir` is exported from `evals/lib/runner.ts` with the signature the US2 contract specifies, so it is unit-testable independently of a live agent run; `runScenario` copies and checksums exactly the directory it is handed, keeping mutation detection aligned with the selected fixture. This is the runner-side half of F1.6 — the JVM fixture contents and the scenario that consumes `fixture: jvm` remain owned by later stories.

## ⚠️ Manager corrections to the spawned draft
- The worker's diff covered the resolver, the orchestrator wiring, and the checksum alignment, but dropped the previous suite's only assertion that a bad fixture never reaches `spawn` when it moved that test from `runScenario` to the resolver. The slice's acceptance criterion is explicitly "missing or non-directory effective fixtures fail before agent spawn," so the removal left that criterion asserted only indirectly.
- This PR adds `expect(spawn).not.toHaveBeenCalled()` back to both invalid-fixture resolver tests (missing directory, path-is-a-file). No other change to the worker's output.

## Spec debt & uncertainty
- SD-001 (inherited): The fixture selector is specified as `fixture:` with relative paths under `evals/fixture/`, resolving feature-map SD-002 for F1.6. Implementation found no CLI-flag assumption that made the precedence hard to preserve — `--fixture` remains the default for selector-less scenarios, and a selector resolves under the canonical `evals/fixture/` root rather than under the override, so the contract stands unchanged.
- SD-002 (inherited): The Gradle wrapper choice is left to implementation. Not touched by this slice — it lands with the JVM fixture contents.
- SD-003 (inherited): F1.5 and F1.6 both touch `evals/lib/runner.ts`. This slice leaves F1.5's temp-copy git initialization intact; it only changes which directory is copied and checksummed.
- Assumption: `evals/fixture/` remains the JavaScript default fixture and `fixture: jvm` is the canonical selector — no existing fixture files or scenario YAML are moved or changed here.
- The contract permits resolution either in the orchestrator or inside `runScenario`; this ships the orchestrator-level form the contract names first, which means `run-evals.ts` itself has no unit coverage (it is a script entry point) — the resolver and the copy-before-spawn behavior are covered at the library level.

## Validation
typecheck ✅ · eval tests ✅ (250 passed) · full `npm test` ⚠️ 1135 passed, 1 pre-existing environmental failure in `src/artifact-store.test.ts` ("commits with a fallback identity when the machine has none" — the machine's global git identity leaks into the test; `src/` is untouched by this PR)

Requires Node 22 to run the suite; the repo's default `node` on this host is 18, which cannot execute `tsc`/`vitest` here.
