### PR TITLE
forge: audit screen and flow durable artifacts

### DIFF
--- a/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/07-ui-work-is-visible-to-status-dependency-and-audit-tooling.tasks.md
+++ b/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/07-ui-work-is-visible-to-status-dependency-and-audit-tooling.tasks.md
@@ -64,7 +64,7 @@
 
 ### Tasks
 
-- [ ] **Add screen artifact audit support**
+- [x] **Add screen artifact audit support**
 
   Extend audit artifact classification and guidance so `design/screens/<ScreenId>.design.md` files are valid audit targets. The audit should apply the `smithy.helper-screen-design` review checklist and keep screen bodies rationale-only rather than evaluating visual fidelity.
 
@@ -75,7 +75,7 @@
   - Missing or invalid `design_system` is reported
   - Layout prose and state inventories are flagged as out of contract
 
-- [ ] **Add flow artifact audit support**
+- [x] **Add flow artifact audit support**
 
   Extend audit artifact classification and guidance so `design/flows/<FlowId>.flow.md` files are valid audit targets. The audit should apply the `smithy.helper-flow-definition` checklist, including driver-neutral `test-body`, screen references, and intent-only body constraints for AS 7.3.
 
@@ -86,7 +86,7 @@
   - Missing or invalid `test-body` is reported
   - Step lists and executable behavior inside `.flow.md` are flagged as out of contract
 
-- [ ] **Document UI audit routing**
+- [x] **Document UI audit routing**
 
   Update source-template documentation adjacent to `smithy.audit` and the helper skills so maintainers can see which checker owns screen and flow artifact review. Keep the guidance self-contained in deployable templates and avoid source-tree-only path references.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -549,6 +549,49 @@ describe('feature-kinds snippet', () => {
   });
 });
 
+describe('smithy.audit UI artifact routing', () => {
+  let composed: ComposedTemplates;
+  let audit: string;
+
+  beforeAll(async () => {
+    composed = await getComposedTemplates();
+    audit = composed.commands.get('smithy.audit.md')!;
+  });
+
+  it('recognizes screen and flow durable artifacts as file-argument targets', () => {
+    expect(audit).toContain('`.design.md` under `design/screens/`');
+    expect(audit).toContain('Screen Design Annotation');
+    expect(audit).toContain('`.flow.md` under `design/flows/`');
+    expect(audit).toContain('Flow Definition');
+  });
+
+  it('routes UI artifact audits to the helper-skill contracts', () => {
+    expect(audit).toContain('smithy.helper-screen-design');
+    expect(audit).toContain('smithy.helper-flow-definition');
+    expect(audit).toContain('review against its "Review checklist" section');
+  });
+
+  it('checks required screen contract fields and rationale-only body scope', () => {
+    expect(audit).toContain('`component-path`');
+    expect(audit).toContain('`design_system`');
+    expect(audit).toContain('state inventories');
+    expect(audit).toContain('do not judge visual fidelity');
+  });
+
+  it('checks required flow contract fields and excludes executable behavior', () => {
+    expect(audit).toContain('`screens`');
+    expect(audit).toContain('`test-body`');
+    expect(audit).toContain('no matching `design/screens/<ScreenId>.design.md` annotation');
+    expect(audit).toContain('ordered executable behavior');
+  });
+
+  it('keeps deployed audit guidance self-contained', () => {
+    expect(audit).not.toContain('src/templates/');
+    expect(audit).not.toContain('agent-skills/README.md');
+    expect(audit).not.toContain('snippets/README.md');
+  });
+});
+
 describe('getTemplateFilesByCategory', () => {
   it('returns the correct number of files per category', () => {
     const byCategory = getTemplateFilesByCategory();

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -520,6 +520,11 @@ template, a worked `Library.design.md` example, naming decisions, and a review c
 annotation; this README intentionally does not duplicate the schema so the two
 cannot drift.
 
+`smithy.audit` routes `design/screens/<ScreenId>.design.md` targets to that
+helper's review checklist. The audit is structural: it checks the front-matter
+contract, including `component-path` and `design_system`, and the rationale-only
+body rule. Visual fidelity stays out of scope for audit.
+
 ## Flow Definitions
 
 Each `FlowId` listed under a UI feature's `flows:` field resolves — in the
@@ -543,6 +548,11 @@ Maestro, naming decisions, the audio-service coverage caveat, and a review check
 via `Skill("smithy.helper-flow-definition")` when authoring or auditing a
 flow definition (typically at a UI feature's `wire` phase); this README
 intentionally does not duplicate the schema so the two cannot drift.
+
+`smithy.audit` routes `design/flows/<FlowId>.flow.md` targets to that helper's
+review checklist. The audit checks the `screens` references, `test-body` path,
+and intent-only body rule; executable path consistency across the full app tree
+remains the job of `flow-lint`.
 
 ## Sub-Agent Model Tiers
 

--- a/src/templates/agent-skills/commands/smithy.audit.prompt
+++ b/src/templates/agent-skills/commands/smithy.audit.prompt
@@ -35,6 +35,8 @@ When a file path is provided, detect the artifact type by its file extension:
 | `.spec.md` | Feature Spec | smithy.mark |
 | `.tasks.md` | Tasks / Slices | smithy.cut |
 | `.strike.md` | Strike Plan | smithy.strike |
+| `.design.md` under `design/screens/` | Screen Design Annotation | smithy.mark |
+| `.flow.md` under `design/flows/` | Flow Definition | smithy.mark |
 
 1. Read the file at the given path.
 2. Identify its extension from the table above.
@@ -47,6 +49,8 @@ When a file path is provided, detect the artifact type by its file extension:
    | `.spec.md` | The `.data-model.md` and `.contracts.md` in the same spec folder (`{{artifactsRoot}}specs/<YYYY-MM-DD-NNN-slug>/`), to verify cross-document consistency |
    | `.tasks.md` | The `.spec.md`, `.data-model.md`, and `.contracts.md` in the same spec folder, to verify FR traceability and slice-to-requirement mapping |
    | `.strike.md` | None — strike files are self-contained (data model and contracts are inline sections) |
+   | `.design.md` under `design/screens/` | The component named by front-matter `component-path`, when present, to verify the path contract resolves |
+   | `.flow.md` under `design/flows/` | The screen annotations named by front-matter `screens` and the executable body named by `test-body`, when present, to verify flow references resolve |
 
    If a context document is missing, note it as a finding rather than skipping the check.
 
@@ -94,6 +98,53 @@ Use the checklist matching the artifact's extension. Each checklist defines what
 {{>audit-checklist-tasks}}
 
 {{>audit-checklist-strike}}
+
+### Audit Checklist (.design.md screen artifacts)
+
+Use this checklist when the target is a `design/screens/<ScreenId>.design.md`
+artifact. The owning contract is `smithy.helper-screen-design`; load that skill
+and review against its "Review checklist" section. The audit is structural and
+contractual only: do not judge visual fidelity, pixel polish, layout quality, or
+whether the eventual component visually matches a mockup.
+
+Flag at least the following:
+
+- Missing or malformed YAML front-matter.
+- Missing required front-matter keys: `id`, `component-path`, and
+  `design_system`.
+- `component-path` is empty, absolute, escapes the repo, names a framework
+  symbol instead of a repo-relative path, or does not resolve to a file.
+- `design_system` is empty or names a bundle/prototype rather than the
+  committed design-system skill.
+- `bundle` is present without a `design_system`, or names a path that does not
+  resolve when a concrete bundle path is provided.
+- Body sections or prose that move beyond rationale-only intent, especially
+  `## Layout`, `## States`, `## Flow`, `## Steps`, `## Walkthrough`, visual
+  fidelity critique, state inventories, or implementation instructions.
+
+### Audit Checklist (.flow.md flow artifacts)
+
+Use this checklist when the target is a `design/flows/<FlowId>.flow.md`
+artifact. The owning contract is `smithy.helper-flow-definition`; load that
+skill and review against its "Review checklist" section. The audit checks the
+intent annotation and its declared executable test-body pair. Graph-level
+screen/flow/test consistency remains appropriate for `flow-lint`, but direct
+audit should still report unresolved references visible from this file.
+
+Flag at least the following:
+
+- Missing or malformed YAML front-matter.
+- Missing required front-matter keys: `id`, `screens`, and `test-body`.
+- `screens` is empty, not a list, contains non-string values, or names a
+  `ScreenId` with no matching `design/screens/<ScreenId>.design.md` annotation.
+- `test-body` is empty, absolute, escapes the repo, or does not resolve to the
+  paired executable test body.
+- Body sections or prose that move beyond rationale-only intent, especially
+  `## Steps`, `## Walkthrough`, `## Flow`, `## Path`, click/tap sequences,
+  ordered executable behavior, selectors, assertions, or driver-specific test
+  code inside the `.flow.md` itself.
+- Executable behavior that belongs in the test body is duplicated in the
+  `.flow.md`; the `.flow.md` owns why, guards, entry/exit, and coverage caveats.
 
 ---
 

--- a/src/templates/agent-skills/commands/smithy.audit.prompt
+++ b/src/templates/agent-skills/commands/smithy.audit.prompt
@@ -52,10 +52,10 @@ and, for the durable UI artifacts, by the directory it sits in as well:
    | `.spec.md` | The `.data-model.md` and `.contracts.md` in the same spec folder (`{{artifactsRoot}}specs/<YYYY-MM-DD-NNN-slug>/`), to verify cross-document consistency |
    | `.tasks.md` | The `.spec.md`, `.data-model.md`, and `.contracts.md` in the same spec folder, to verify FR traceability and slice-to-requirement mapping |
    | `.strike.md` | None — strike files are self-contained (data model and contracts are inline sections) |
-   | `.design.md` under `design/screens/` | The component named by front-matter `component-path`, when present, to verify the path contract resolves |
-   | `.flow.md` under `design/flows/` | The screen annotations named by front-matter `screens` and the executable body named by `test-body`, when present, to verify flow references resolve |
+   | `.design.md` under `design/screens/` | The component named by front-matter `component-path`, when present, to verify the path contract resolves; plus the owning spec's typed `## Dependency Order` ledger when it is discoverable, to resolve the matching `SC<N>` row |
+   | `.flow.md` under `design/flows/` | The screen annotations named by front-matter `screens` and the executable body named by `test-body`, when present, to verify flow references resolve; plus the owning spec's typed `## Dependency Order` ledger when it is discoverable, to resolve the matching `FL<N>` row |
 
-   If a context document is missing, note it as a finding rather than skipping the check.
+   If a context document is missing, note it as a finding rather than skipping the check. The one exception is a context entry marked "when it is discoverable" — a durable UI artifact carries no back-pointer to its owning spec, so an unreachable ledger is not itself a finding.
 
 4. Use the matching **Artifact-Type Checklist** below, reviewing against both the target file and any context documents gathered.
 5. If the target matches no row, fall back to a general review using all checklists.
@@ -110,6 +110,13 @@ and review against its "Review checklist" section. The audit is structural and
 contractual only: do not judge visual fidelity, pixel polish, layout quality, or
 whether the eventual component visually matches a mockup.
 
+**One carve-out from that checklist.** Its `id` bullet checks membership against
+a feature-level `screens:` list. Features no longer carry one — screens are
+first-class `SC<N>` rows in the owning spec's typed `## Dependency Order`
+ledger. Resolve `id` against that ledger row instead, and only when the owning
+spec is reachable from the target. When it is not, skip the membership check —
+do **not** report a finding for a missing `screens:` list.
+
 Flag at least the following:
 
 - Missing or malformed YAML front-matter.
@@ -133,6 +140,13 @@ skill and review against its "Review checklist" section. The audit checks the
 intent annotation and its declared executable test-body pair. Graph-level
 screen/flow/test consistency remains appropriate for `flow-lint`, but direct
 audit should still report unresolved references visible from this file.
+
+**One carve-out from that checklist.** Its `id` bullet checks membership against
+a feature-level `flows:` list. Features no longer carry one — flows are
+first-class `FL<N>` rows in the owning spec's typed `## Dependency Order`
+ledger. Resolve `id` against that ledger row instead, and only when the owning
+spec is reachable from the target. When it is not, skip the membership check —
+do **not** report a finding for a missing `flows:` list.
 
 Flag at least the following:
 

--- a/src/templates/agent-skills/commands/smithy.audit.prompt
+++ b/src/templates/agent-skills/commands/smithy.audit.prompt
@@ -26,10 +26,11 @@ If no input is provided above, check whether you are on a **forge branch** (see 
 
 ### File Argument Mode
 
-When a file path is provided, detect the artifact type by its file extension:
+When a file path is provided, detect the artifact type by its file extension —
+and, for the durable UI artifacts, by the directory it sits in as well:
 
-| Extension | Artifact Type | Producing Command |
-|-----------|--------------|-------------------|
+| Target | Artifact Type | Producing Command |
+|--------|--------------|-------------------|
 | `.rfc.md` | RFC | smithy.ignite |
 | `.features.md` | Feature Map | smithy.render |
 | `.spec.md` | Feature Spec | smithy.mark |
@@ -39,11 +40,13 @@ When a file path is provided, detect the artifact type by its file extension:
 | `.flow.md` under `design/flows/` | Flow Definition | smithy.mark |
 
 1. Read the file at the given path.
-2. Identify its extension from the table above.
+2. Match it against the table above. The two UI rows match only when the file
+   also sits under the named directory — a `.design.md` or `.flow.md` elsewhere
+   in the repo is **not** a screen or flow artifact and falls through to step 5.
 3. **Gather context documents** — many checklists require cross-document checks. Before running the checklist, discover and read the related files for the artifact type:
 
-   | Target extension | Context to gather |
-   |-----------------|-------------------|
+   | Target | Context to gather |
+   |--------|-------------------|
    | `.rfc.md` | Any `.features.md` files in the same RFC folder (`{{artifactsRoot}}docs/rfcs/<YYYY-NNN-slug>/`) |
    | `.features.md` | The `.rfc.md` in the same RFC folder, to verify RFC alignment |
    | `.spec.md` | The `.data-model.md` and `.contracts.md` in the same spec folder (`{{artifactsRoot}}specs/<YYYY-MM-DD-NNN-slug>/`), to verify cross-document consistency |
@@ -54,8 +57,8 @@ When a file path is provided, detect the artifact type by its file extension:
 
    If a context document is missing, note it as a finding rather than skipping the check.
 
-4. Use the matching **Extension-Specific Checklist** below, reviewing against both the target file and any context documents gathered.
-5. If the extension is not recognized, fall back to a general review using all checklists.
+4. Use the matching **Artifact-Type Checklist** below, reviewing against both the target file and any context documents gathered.
+5. If the target matches no row, fall back to a general review using all checklists.
 
 ### Forge-Branch Mode
 
@@ -85,9 +88,9 @@ When no file argument is provided and the current branch matches the forge branc
 
 ---
 
-## Extension-Specific Checklists
+## Artifact-Type Checklists
 
-Use the checklist matching the artifact's extension. Each checklist defines what "good" looks like for that artifact type.
+Use the checklist matching the artifact type resolved in **Mode Detection**. Each checklist defines what "good" looks like for that artifact type.
 
 {{>audit-checklist-rfc}}
 

--- a/src/templates/agent-skills/skills/smithy.helper-flow-definition/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.helper-flow-definition/SKILL.prompt
@@ -362,9 +362,14 @@ When auditing an existing flow pair, flag any of the following:
 - [ ] `test-body:` path does not resolve to an existing file in the repo.
 - [ ] `id` does not match the originating feature's `flows:` list, or is
       reused across flows.
-- [ ] `screens:` references a `ScreenId` that no feature declares.
+- [ ] `screens:` is empty, not a list, contains non-string values, or
+      references a `ScreenId` with no matching
+      `design/screens/<ScreenId>.design.md` annotation.
 - [ ] `.flow.md` body contains a `## Steps`, `## Walkthrough`, `## Flow`,
       or `## Path` section.
+- [ ] `.flow.md` body contains click/tap sequences, selectors, assertions,
+      driver-specific test code, or other executable behavior that belongs in
+      the paired test body.
 - [ ] `## Guards` lists invariants the test body does **not** assert.
 - [ ] `## Coverage Caveat` is missing on a flow whose screen touches an
       audio-service surface.

--- a/src/templates/agent-skills/skills/smithy.helper-flow-definition/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.helper-flow-definition/SKILL.prompt
@@ -364,7 +364,10 @@ When auditing an existing flow pair, flag any of the following:
       reused across flows.
 - [ ] `screens:` is empty, not a list, contains non-string values, or
       references a `ScreenId` with no matching
-      `design/screens/<ScreenId>.design.md` annotation.
+      `design/screens/<ScreenId>.design.md` annotation. A direct review of
+      this pair checks only that each referenced annotation file **exists**;
+      whether that `ScreenId` is declared by some feature — and the rest of
+      the screen/flow/test graph — stays with `flow-lint` (#409).
 - [ ] `.flow.md` body contains a `## Steps`, `## Walkthrough`, `## Flow`,
       or `## Path` section.
 - [ ] `.flow.md` body contains click/tap sequences, selectors, assertions,

--- a/src/templates/agent-skills/skills/smithy.helper-screen-design/SKILL.prompt
+++ b/src/templates/agent-skills/skills/smithy.helper-screen-design/SKILL.prompt
@@ -195,6 +195,8 @@ following:
       skill is invalid — skill is source of truth).
 - [ ] Body contains a `## Layout`, `## States`, `## Flow`, `## Steps`, or
       `## Walkthrough` section.
+- [ ] Body contains a state inventory or visual-fidelity critique instead of
+      rationale-only intent.
 - [ ] "Deliberate choices" describes what the screen looks like instead of
       why the choice was made.
 - [ ] "Deferred" lists items that belong to a different screen or


### PR DESCRIPTION
## Summary

EPIC #404 → Screens and Flows as UI Feature Kinds (spec) → User Story 7: UI work is visible to status, dependency, and audit tooling → Slice 2: Audit screen and flow durable artifacts

`smithy.audit` can now be pointed straight at the durable UI artifacts that `smithy.mark` authors — `design/screens/<ScreenId>.design.md` and `design/flows/<FlowId>.flow.md` — and routes each to the helper skill that owns its contract. This is the right increment because audit operates on durable design files rather than the planning graph, so it is cleanly separable from Slice 1's status/dependency work and closes the standalone "check my UI intent" path outside `forge`.

## Spec debt & uncertainty

- SD-005 (inherited): fidelity of `import`-mode structure derivation from a prototype/bundle, and how much human confirmation the derived structure needs. Owned by User Story 5; audit consumes the resulting artifacts.
- SD-006 (inherited): whether `SC`/`FL` nodes are always atomic or can be sub-sliced (and whether `flow-scaffold` #410 is in scope). Owned by User Story 3.
- SD-007 (inherited): build-phase coverage honesty — a build screen can be "done" with a missing brief state and no executable gate until its flows wire.
- SD-008 (inherited): visual-intent honesty under the non-blocking gate — how a `brief`-mode node that never received a bundle surfaces its unrealized prototype.
- Assumption (spec): the reviewer never judges pixels. That assumption is what makes the screen checklist explicitly contract-only — it flags a missing/unresolvable `component-path` or `design_system` and rationale-violating body prose, and says in so many words not to judge visual fidelity.
- Boundary drawn here: flow audit reports references it can resolve from the `.flow.md` itself (`screens:` entries with no matching `.design.md`, an unresolvable `test-body`). Whole-graph screen/flow/test consistency stays `flow-lint`'s job, per the cross-story dependency on User Story 6. If review prefers audit to stay silent on cross-file references entirely, that is a one-line trim to the flow checklist.
- Verification gap: this slice ships prompt/template text plus composition assertions. The tests confirm the deployed `smithy.audit` command contains the routing, the required-field checks, and no source-only path references — they cannot confirm an agent given a malformed `.design.md` actually emits the finding. That behavior belongs to the Tier-3 evals, which are not wired into default CI.
- Per repo policy, the committed `.claude/` snapshot is deliberately **not** regenerated in this PR; only `src/templates/` changed.

## Validation

build ✅ · typecheck ✅ · test ✅ (1140 passed, 5 new) — one pre-existing failure in `src/artifact-store.test.ts` ("commits with a fallback identity when the machine has none") reproduces on this machine independent of these changes and touches no file in this diff.
