### PR TITLE
forge: route .rfc.md inputs into smithy.persona RFC mode

### DIFF
--- a/specs/2026-06-05-011-smithy-persona-command/03-generate-persona-files-from-an-rfcs-personas-section.tasks.md
+++ b/specs/2026-06-05-011-smithy-persona-command/03-generate-persona-files-from-an-rfcs-personas-section.tasks.md
@@ -17,7 +17,7 @@
 
 ### Tasks
 
-- [ ] **Add RFC-mode routing**
+- [x] **Add RFC-mode routing**
 
   Update `src/templates/agent-skills/commands/smithy.persona.prompt` so a resolved input path ending in `.rfc.md` routes to RFC mode instead of free-text mode. Preserve the existing ask-fallback and free-text behavior from US2 for non-RFC inputs.
 
@@ -27,7 +27,7 @@
   - Empty or unclear input still engages the existing ask-fallback.
   - RFC-mode routing does not draft or overwrite persona files before extraction succeeds.
 
-- [ ] **Extract RFC persona candidates**
+- [x] **Extract RFC persona candidates**
 
   Add RFC-mode instructions that read the target RFC and extract one persona candidate per named persona in the `## Personas` section. Keep this v1 extraction focused on clearly named personas, with US6 still owning narrative-prose robustness and empty-section placeholder handling.
 
@@ -37,7 +37,7 @@
   - The extracted candidate set is used as the source for subsequent persona-file creation.
   - Narrative-only robustness and empty/placeholder diagnostics remain reserved for US6 unless already present.
 
-- [ ] **Cover RFC-mode routing and extraction**
+- [x] **Cover RFC-mode routing and extraction**
 
   Update template coverage around `smithy.persona.prompt` so the RFC-mode branch is protected without regenerating deployed snapshots. Focus the checks on `.rfc.md` routing, preservation of free-text routing, and extraction from the RFC `## Personas` section.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -727,7 +727,8 @@ describe('getComposedTemplates', () => {
     expect(persona).toContain('command-argument placeholder');
     expect(persona).toContain('use it as the effective command input for');
     expect(persona).toContain('what persona to generate');
-    expect(persona).toContain('continue directly through free-text mode');
+    expect(persona).toContain('continue directly through the two');
+    expect(persona).toContain('mode-selection rules below');
     expect(persona).toContain('do not add an approval STOP');
     expect(persona).toContain('If the input ends in `.rfc.md`, select **RFC mode**');
     expect(persona).toContain('If the input is non-empty and does **not** end in `.rfc.md`, select');
@@ -756,6 +757,13 @@ describe('getComposedTemplates', () => {
 
     expect(routingIdx).toBeGreaterThan(-1);
     expect(freeTextRoutingIdx).toBeGreaterThan(routingIdx);
+
+    // The ask-fallback is the primary entry path on agents that leave
+    // $ARGUMENTS literal, so a clarified answer must reach RFC mode too.
+    expect(persona).toContain('Route the clarified answer by the same `.rfc.md`');
+    expect(persona).toContain('an answer ending in `.rfc.md`');
+    expect(persona).toContain('selects RFC mode, and any other clear answer selects free-text mode');
+
     expect(rfcModeIdx).toBeGreaterThan(freeTextRoutingIdx);
     expect(freeTextModeIdx).toBeGreaterThan(rfcModeIdx);
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -729,6 +729,7 @@ describe('getComposedTemplates', () => {
     expect(persona).toContain('what persona to generate');
     expect(persona).toContain('continue directly through free-text mode');
     expect(persona).toContain('do not add an approval STOP');
+    expect(persona).toContain('If the input ends in `.rfc.md`, select **RFC mode**');
     expect(persona).toContain('If the input is non-empty and does **not** end in `.rfc.md`, select');
     expect(persona).toContain('**free-text mode**');
     expect(persona).toContain('Dispatch **smithy-prose** with:');
@@ -742,6 +743,38 @@ describe('getComposedTemplates', () => {
     expect(persona).toContain('written from free text with no intermediate approval gates');
     expect(persona).toContain('target persona slug already exists');
     expect(persona).toContain('written and skipped persona paths as explicit result fields');
+  });
+
+  it('smithy.persona renders RFC-mode routing and named persona extraction', () => {
+    const persona = claudeComposed.commands.get('smithy.persona.md')!;
+    const routingIdx = persona.indexOf('If the input ends in `.rfc.md`, select **RFC mode**');
+    const freeTextRoutingIdx = persona.indexOf(
+      'If the input is non-empty and does **not** end in `.rfc.md`, select',
+    );
+    const rfcModeIdx = persona.indexOf('## RFC Mode');
+    const freeTextModeIdx = persona.indexOf('## Free-Text Mode');
+
+    expect(routingIdx).toBeGreaterThan(-1);
+    expect(freeTextRoutingIdx).toBeGreaterThan(routingIdx);
+    expect(rfcModeIdx).toBeGreaterThan(freeTextRoutingIdx);
+    expect(freeTextModeIdx).toBeGreaterThan(rfcModeIdx);
+
+    const rfcMode = persona.slice(rfcModeIdx, freeTextModeIdx);
+    expect(rfcMode).toContain('Read the input RFC file before drafting, writing');
+    expect(rfcMode).toContain("Locate the RFC's `## Personas` section");
+    expect(rfcMode).toContain('after that heading up to the next H2 heading');
+    expect(rfcMode).toContain('Extract one persona candidate for each clearly named persona');
+    expect(rfcMode).toContain('explicit');
+    expect(rfcMode).toContain('bullet/list item, bold lead-in, or subheading');
+    expect(rfcMode).toContain('Keep the extracted candidate set as a structured list');
+    expect(rfcMode).toContain('as its source of truth');
+    expect(rfcMode).toContain('completes after reporting the candidate set');
+    expect(rfcMode).toContain('Do not draft with');
+    expect(rfcMode).toContain('smithy-prose');
+    expect(rfcMode).toContain('write files, or overwrite artifacts');
+    expect(rfcMode).toContain('Do not infer personas from');
+    expect(rfcMode).toContain('narrative-only prose');
+    expect(rfcMode).toContain('emit empty-section diagnostics');
   });
 
   it('smithy.persona renders shared persona convention and artifact policy snippets across agents', async () => {

--- a/src/templates/agent-skills/commands/smithy.persona.prompt
+++ b/src/templates/agent-skills/commands/smithy.persona.prompt
@@ -23,8 +23,11 @@ persona input** for the rest of this run.
   token), or otherwise does not contain a usable persona description or RFC
   path, ask the user what persona to generate. Replace the resolved persona
   input with the user's answer and use it as the effective command input for
-  the remainder of the run, then continue directly through free-text mode. This
-  is the only ask-fallback: do not add an approval STOP after the input is
+  the remainder of the run, then continue directly through the two
+  mode-selection rules below. Route the clarified answer by the same `.rfc.md`
+  suffix test as a directly supplied input: an answer ending in `.rfc.md`
+  selects RFC mode, and any other clear answer selects free-text mode. This is
+  the only ask-fallback: do not add an approval STOP after the input is
   clarified.
 - If the input ends in `.rfc.md`, select **RFC mode**.
 - If the input is non-empty and does **not** end in `.rfc.md`, select

--- a/src/templates/agent-skills/commands/smithy.persona.prompt
+++ b/src/templates/agent-skills/commands/smithy.persona.prompt
@@ -26,14 +26,42 @@ persona input** for the rest of this run.
   the remainder of the run, then continue directly through free-text mode. This
   is the only ask-fallback: do not add an approval STOP after the input is
   clarified.
+- If the input ends in `.rfc.md`, select **RFC mode**.
 - If the input is non-empty and does **not** end in `.rfc.md`, select
   **free-text mode**.
-- If the input ends in `.rfc.md`, RFC extraction is not implemented yet
-  (reserved for a later user story). Stop and tell the user that RFC-mode
-  persona extraction is not available yet — do not fall through to free-text
-  mode or any undefined path.
 - Do not parse RFC `## Personas` sections in free-text mode. RFC extraction is
   a separate route from this writer.
+
+## RFC Mode
+
+Given a resolved input path ending in `.rfc.md`, identify the durable persona
+candidates that should seed `.persona.md` file creation.
+
+1. Read the input RFC file before drafting, writing, or checking any persona
+   artifact target paths.
+2. Locate the RFC's `## Personas` section. Treat the section body as the text
+   after that heading up to the next H2 heading or the end of the file.
+3. Extract one persona candidate for each clearly named persona in that section.
+   For this v1 pass, "clearly named" means the persona is named by an explicit
+   bullet/list item, bold lead-in, or subheading such as:
+   - `- Release Manager: ...`
+   - `- **Support Engineer** — ...`
+   - `### Compliance Reviewer`
+4. For each extracted candidate, preserve:
+   - the human-readable persona name or role;
+   - the source excerpt or bullet/paragraph that describes that persona;
+   - the RFC path the candidate came from.
+5. Keep the extracted candidate set as a structured list named **RFC persona
+   candidates**. Any persona-file creation in this mode must consume this list
+   as its source of truth rather than rereading unrelated input.
+6. This RFC mode completes after reporting the candidate set. Do not draft with
+   smithy-prose, derive target paths, check collisions, create directories,
+   write files, or overwrite artifacts in RFC mode.
+
+Keep this RFC-mode parser intentionally narrow. Do not infer personas from
+narrative-only prose, emit empty-section diagnostics, suppress placeholders
+beyond the explicit named extraction above, or apply richer parsing for
+ambiguous prose.
 
 ## Free-Text Mode
 


### PR DESCRIPTION
## Summary

smithy.persona Command and Ignite Persona Reuse (spec `2026-06-05-011-smithy-persona-command`) → User Story 3: Generate Persona Files from an RFC's `## Personas` Section → Slice 1: Route RFC Inputs and Extract Named Personas

_(The spec's `**Input**:` is a raw feature description, not an RFC/feature-map lineage, so there is no RFC → milestone → feature breadcrumb to walk above the spec.)_

Adds the RFC-mode entry point to `smithy.persona`: a resolved input path ending in `.rfc.md` now selects **RFC mode**, which reads the RFC, scopes its `## Personas` section body, and extracts one persona candidate per clearly named persona. The slice deliberately stops at the candidate set — RFC mode is instructed not to draft via `smithy-prose`, derive target paths, check collisions, or write files — so the extraction boundary lands and is test-protected before Slice 2 adds multi-persona writes and collision skip-and-report. Free-text routing, the ask-fallback, and the existing writer are untouched.

## Spec debt & uncertainty

- SD-001 (inherited): unresolved rule by which ignite Sub-phase 3b decides a pre-existing `.persona.md` "covers" a needed RFC persona (exact match vs. fuzzy/semantic vs. user-confirmed).
- SD-002 (inherited): whether `.persona.md` carries a machine-readable identity field vs. relying on filename-slug identity — recorded in this artifact as resolved by US1's README convention (filename-slug identity, no separate key), which this slice's extraction respects by carrying name/role + source excerpt only.
- SD-003 (inherited): how an existing `.persona.md`'s content reaches `smithy-prose`, whose input contract has no existing-persona parameter. Not exercised here (this slice never dispatches prose) but it constrains Slice 2.
- SD-004 (inherited): how ignite Sub-phase 3g detects that on-disk `## Personas` content is file-sourced.
- Assumption (from spec, Critical): RFC mode ultimately emits one file per persona tolerating both bulleted and narrative-prose forms, with empty/placeholder sections yielding zero files plus a diagnostic. This slice scopes v1 extraction to **explicitly named** personas only (bullet, bold lead-in, or subheading) and leaves narrative-prose robustness and empty-section diagnostics to US6, per the slice's own acceptance criteria and the tasks file's Cross-Story Dependencies row.
- ~~Uncertainty I hit while reviewing: the pre-existing ask-fallback bullet says the clarified input "continue[s] directly through free-text mode", so a user who answers the ask with an `.rfc.md` path would land on the free-text path rather than the new RFC branch.~~ **Resolved in a27ee93.** Both automated reviewers independently flagged this, and the Codex reviewer supplied the consequence that settled it: because Gemini and Codex leave `$ARGUMENTS` literal, the ask-fallback is the *primary* entry path on those agents, so the old wording made RFC mode effectively unreachable cross-agent and would have drafted a single persona named after the RFC path. The ask-fallback now routes its clarified answer through the same `.rfc.md` suffix test as a directly supplied input; no approval STOP was added, so the one-shot contract holds. Preserving the ask-fallback's *existence* — which the slice does require — turned out not to mean preserving its terminal-mode wording.
- Verification gap: this is a prompt-template change, so coverage is composition-level string/ordering assertions in `src/templates.test.ts`. No end-to-end eval exercises an agent actually parsing an RFC's `## Personas` section; Tier-3 behavior is unverified. Per CLAUDE.md, no `.claude/` / `.gemini/` / `.agents/` / `.codex/` / manifest snapshots were regenerated.

## Validation

build ✅ · typecheck ✅ · `npm test -- src/templates.test.ts` ✅ (268 passed, re-run after the a27ee93 review fix) · full `npm test` 1136 passed / 1 failed — `src/artifact-store.test.ts > commits with a fallback identity when the machine has none`, which is a pre-existing environment failure (this machine has a global git identity, so the fallback author is never used); confirmed failing identically at the parent commit `ec98644` with this branch's `src/` reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
