### PR TITLE
forge: expose flow-lint as a fast CLI check

### DIFF
--- a/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/06-flow-lint-validates-the-screen-flow-test-graph-in-app-ci.tasks.md
+++ b/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/06-flow-lint-validates-the-screen-flow-test-graph-in-app-ci.tasks.md
@@ -68,7 +68,7 @@
 
 ### Tasks
 
-- [ ] **Register the flow-lint command**
+- [x] **Register the flow-lint command**
 
   Add `flow-lint` to the Smithy CLI alongside the existing subcommands. The command should accept an optional path argument or root option, default to the current working directory, and pass the resolved path to the validator without requiring a smithy manifest or forge run.
 
@@ -79,7 +79,7 @@
   - The command does not require initialized smithy artifacts
   - The command does not dispatch or mention agent work
 
-- [ ] **Return CI-friendly exit codes**
+- [x] **Return CI-friendly exit codes**
 
   Make the command return success only when the validator reports no graph findings, and failure when references, pairings, or uniqueness checks fail. Invalid input paths should use the CLI's existing invalid-argument failure pattern rather than being reported as graph findings.
 
@@ -90,7 +90,7 @@
   - Duplicate screen or flow IDs exit nonzero
   - Nonexistent input paths are reported as command input errors
 
-- [ ] **Print specific severed-reference diagnostics**
+- [x] **Print specific severed-reference diagnostics**
 
   Format validator findings so maintainers can identify exactly which artifact or path needs repair. Diagnostics should distinguish dangling screen references, missing paired test bodies, orphan test bodies, and duplicate IDs rather than collapsing all failures into a generic lint error.
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -39,6 +39,173 @@ describe('CLI init (interactive)', () => {
   }, 20_000);
 });
 
+describe('CLI flow-lint', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smithy-flow-lint-cli-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function write(relPath: string, contents: string): void {
+    const abs = path.join(tmpDir, relPath);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, contents);
+  }
+
+  function screen(id: string): string {
+    return `---
+id: ${id}
+component-path: src/${id}.tsx
+design_system: test-system
+---
+
+## Why this screen exists
+`;
+  }
+
+  function flow(id: string, screens: string[], testBodyPath: string): string {
+    return `---
+id: ${id}
+screens: [${screens.join(', ')}]
+test-body: ${testBodyPath}
+---
+
+## Intent
+`;
+  }
+
+  it('is available in CLI help output', () => {
+    const result = spawnSync('node', [CLI, '--help'], { encoding: 'utf-8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('flow-lint');
+    expect(result.stdout).toContain('Validate durable screen, flow, and paired');
+    expect(result.stdout).toContain('test-body artifacts');
+  });
+
+  it('runs against the current working directory by default and exits 0 for a resolved graph', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'maestro/flows/AddTitle.yaml'));
+    write('maestro/flows/AddTitle.yaml', '# flow\n');
+
+    const result = spawnSync('node', [CLI, 'flow-lint'], {
+      cwd: tmpDir,
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout + result.stderr).toBe('');
+  });
+
+  it('scopes the check to a supplied path argument', () => {
+    write('app/design/screens/Library.design.md', screen('Library'));
+    write('app/design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'maestro/flows/AddTitle.yaml'));
+    write('app/maestro/flows/AddTitle.yaml', '# flow\n');
+
+    const result = spawnSync('node', [CLI, 'flow-lint', path.join(tmpDir, 'app')], {
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout + result.stderr).toBe('');
+  });
+
+  it('scopes the check to --root', () => {
+    write('app/design/screens/Library.design.md', screen('Library'));
+    write('app/design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'maestro/flows/AddTitle.yaml'));
+    write('app/maestro/flows/AddTitle.yaml', '# flow\n');
+
+    const result = spawnSync('node', [CLI, 'flow-lint', '--root', path.join(tmpDir, 'app')], {
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout + result.stderr).toBe('');
+  });
+
+  it('exits nonzero and names dangling screen references', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library', 'AddTitleScreen'], 'maestro/flows/AddTitle.yaml'));
+    write('maestro/flows/AddTitle.yaml', '# flow\n');
+
+    const result = spawnSync('node', [CLI, 'flow-lint', tmpDir], {
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('missing screen');
+    expect(result.stderr).toContain('flow AddTitle');
+    expect(result.stderr).toContain('ScreenId AddTitleScreen');
+  });
+
+  it('exits nonzero and names missing test bodies', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'maestro/flows/AddTitle.yaml'));
+
+    const result = spawnSync('node', [CLI, 'flow-lint', tmpDir], {
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('missing test body');
+    expect(result.stderr).toContain('design/flows/AddTitle.flow.md');
+    expect(result.stderr).toContain('maestro/flows/AddTitle.yaml');
+  });
+
+  it('exits nonzero and names orphan test bodies in the scoped flow-test root', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'ui-flows/AddTitle.yaml'));
+    write('ui-flows/AddTitle.yaml', '# flow\n');
+    write('ui-flows/RemovedFlow.yaml', '# orphan\n');
+
+    const result = spawnSync(
+      'node',
+      [CLI, 'flow-lint', tmpDir, '--flow-test-root', 'ui-flows'],
+      { encoding: 'utf-8' },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('orphan test body');
+    expect(result.stderr).toContain('ui-flows/RemovedFlow.yaml');
+  });
+
+  it('exits nonzero and names duplicate screen and flow IDs', () => {
+    write('design/screens/Library.design.md', screen('Library'));
+    write('design/screens/LibraryCopy.design.md', screen('Library'));
+    write('design/flows/AddTitle.flow.md', flow('AddTitle', ['Library'], 'maestro/flows/AddTitle.yaml'));
+    write('design/flows/AddTitleCopy.flow.md', flow('AddTitle', ['Library'], 'maestro/flows/AddTitleCopy.yaml'));
+    write('maestro/flows/AddTitle.yaml', '# flow\n');
+    write('maestro/flows/AddTitleCopy.yaml', '# flow\n');
+
+    const result = spawnSync('node', [CLI, 'flow-lint', tmpDir], {
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('duplicate ScreenId Library');
+    expect(result.stderr).toContain('design/screens/Library.design.md');
+    expect(result.stderr).toContain('design/screens/LibraryCopy.design.md');
+    expect(result.stderr).toContain('duplicate FlowId AddTitle');
+    expect(result.stderr).toContain('design/flows/AddTitle.flow.md');
+    expect(result.stderr).toContain('design/flows/AddTitleCopy.flow.md');
+  });
+
+  it('reports nonexistent input paths as command input errors', () => {
+    const missing = path.join(tmpDir, 'does-not-exist');
+
+    const result = spawnSync('node', [CLI, 'flow-lint', missing], {
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain(`smithy flow-lint: path does not exist: ${missing}`);
+  });
+});
+
 describe('CLI init --yes (non-interactive)', () => {
   let tmpDir: string;
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -194,6 +194,31 @@ test-body: ${testBodyPath}
     expect(result.stderr).toContain('design/flows/AddTitleCopy.flow.md');
   });
 
+  it('reports an unscannable artifact tree as a command input error, not a graph finding', () => {
+    // Malformed YAML front matter makes the scan itself fail. That must not
+    // escape as an unhandled exception, and must not use exit 1 — CI reads
+    // exit 1 as "the graph has findings", which this is not.
+    write(
+      'design/screens/Library.design.md',
+      `---
+id: Library
+  bad: [unclosed
+---
+
+## Why this screen exists
+`,
+    );
+
+    const result = spawnSync('node', [CLI, 'flow-lint', tmpDir], {
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('smithy flow-lint: failed to scan UI artifacts under');
+    expect(result.stderr).toContain(tmpDir);
+    expect(result.stderr).not.toContain('YAMLParseError:');
+  });
+
   it('reports nonexistent input paths as command input errors', () => {
     const missing = path.join(tmpDir, 'does-not-exist');
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { toolchains, type LanguageToolchain } from './permissions.js';
 import { uninitAction } from './commands/uninit.js';
 import { updateAction, type UpdateOptions } from './commands/update.js';
 import { statusAction, type StatusOptions } from './commands/status.js';
+import { flowLintAction, type FlowLintOptions } from './commands/flow-lint.js';
 
 const require = createRequire(import.meta.url);
 const { version } = require('../package.json') as { version: string };
@@ -107,6 +108,16 @@ program
   .action((opts: Record<string, unknown>) => {
     const statusOpts: StatusOptions = { ...opts } as StatusOptions;
     return statusAction(statusOpts);
+  });
+
+program
+  .command('flow-lint')
+  .description('Validate durable screen, flow, and paired test-body artifacts')
+  .argument('[path]', 'Directory or subpath to scan (defaults to current working directory)')
+  .option('--root <path>', 'Directory or subpath to scan (defaults to current working directory)')
+  .option('--flow-test-root <path>', 'Repo-relative root used for orphan test-body detection')
+  .action((inputPath: string | undefined, opts: Record<string, unknown>) => {
+    return flowLintAction(inputPath, opts as FlowLintOptions);
   });
 
 program.parse(process.argv);

--- a/src/commands/flow-lint.ts
+++ b/src/commands/flow-lint.ts
@@ -47,7 +47,22 @@ export function flowLintAction(inputPath?: string, opts: FlowLintOptions = {}): 
 
   const lintOptions: { flowTestRoot?: string } = {};
   if (opts.flowTestRoot !== undefined) lintOptions.flowTestRoot = opts.flowTestRoot;
-  const { findings } = lintFlowGraph(resolvedRoot, lintOptions);
+
+  let findings: FlowLintFinding[];
+  try {
+    ({ findings } = lintFlowGraph(resolvedRoot, lintOptions));
+  } catch (error: unknown) {
+    // A malformed artifact or an unreadable directory means the scan could not
+    // run at all — that is a broken input tree, not a graph finding. Report it
+    // as a command input error so exit 1 stays unambiguously "graph findings"
+    // for CI and is never confused with "flow-lint could not read the repo".
+    const detail = error instanceof Error ? error.message : String(error);
+    process.stderr.write(
+      `smithy flow-lint: failed to scan UI artifacts under ${rawRoot}: ${detail}\n`,
+    );
+    process.exitCode = 2;
+    return;
+  }
 
   if (findings.length === 0) return;
 

--- a/src/commands/flow-lint.ts
+++ b/src/commands/flow-lint.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { lintFlowGraph, type FlowLintFinding } from '../flow-lint.js';
+
+export interface FlowLintOptions {
+  /** Directory or subpath to scan. Defaults to `process.cwd()`. */
+  root?: string;
+  /** Optional repo-relative root used for orphan test-body detection. */
+  flowTestRoot?: string;
+}
+
+export function flowLintAction(inputPath?: string, opts: FlowLintOptions = {}): void {
+  if (inputPath !== undefined && opts.root !== undefined) {
+    process.stderr.write(
+      'smithy flow-lint: pass either a path argument or --root, not both.\n',
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  const rawRoot = inputPath ?? opts.root ?? process.cwd();
+  const resolvedRoot = path.resolve(rawRoot);
+
+  try {
+    fs.statSync(resolvedRoot);
+  } catch (error: unknown) {
+    const errorCode =
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      typeof (error as { code?: unknown }).code === 'string'
+        ? (error as { code: string }).code
+        : undefined;
+
+    const message =
+      errorCode === 'ENOENT'
+        ? `smithy flow-lint: path does not exist: ${rawRoot}\n`
+        : errorCode === 'EACCES' || errorCode === 'EPERM'
+          ? `smithy flow-lint: cannot access path: ${rawRoot}\n`
+          : `smithy flow-lint: failed to inspect path: ${rawRoot}\n`;
+
+    process.stderr.write(message);
+    process.exitCode = 2;
+    return;
+  }
+
+  const lintOptions: { flowTestRoot?: string } = {};
+  if (opts.flowTestRoot !== undefined) lintOptions.flowTestRoot = opts.flowTestRoot;
+  const { findings } = lintFlowGraph(resolvedRoot, lintOptions);
+
+  if (findings.length === 0) return;
+
+  for (const finding of findings) {
+    process.stderr.write(`${formatFlowLintFinding(finding)}\n`);
+  }
+  process.exitCode = 1;
+}
+
+export function formatFlowLintFinding(finding: FlowLintFinding): string {
+  switch (finding.type) {
+    case 'missing-screen':
+      return `missing screen: flow ${finding.flowId} (${finding.flowPath}) references ScreenId ${finding.screenId}, but no matching screen annotation was found.`;
+    case 'missing-test-body':
+      return `missing test body: flow ${finding.flowId} (${finding.flowPath}) declares test-body ${finding.testBodyPath}, but the file does not exist.`;
+    case 'orphan-test-body':
+      return `orphan test body: ${finding.testBodyPath} exists under the flow-test root, but no flow definition declares it.`;
+    case 'duplicate-test-body':
+      return `duplicate test-body ${finding.testBodyPath}: ${finding.paths.join(', ')}`;
+    case 'duplicate-screen-id':
+      return `duplicate ScreenId ${finding.screenId}: ${finding.paths.join(', ')}`;
+    case 'duplicate-flow-id':
+      return `duplicate FlowId ${finding.flowId}: ${finding.paths.join(', ')}`;
+  }
+}


### PR DESCRIPTION
## Summary

EPIC #404 → Screens and Flows as UI Feature Kinds (spec) → User Story 6: Flow-lint validates the screen/flow/test graph in app CI → Slice 2: Expose `flow-lint` as a fast CLI check

Slice 1 (#516) landed the deterministic screen/flow/test graph resolver and validator; this slice turns it into an invocable command surface so app repositories can run `smithy flow-lint` directly in their own CI. It adds only the CLI layer — registration, exit-code contract, and per-kind diagnostic formatting — leaving CI adoption docs and helper-template alignment to Slice 3.

The command is stateless with respect to smithy: it needs no manifest, no `smithy init`, and no prior forge run, which is what makes it usable as a plain CI step in a target app repo.

Exit-code contract: `0` for a fully resolved graph, `1` for graph findings, `2` for invalid input paths — the last reusing the existing `status` command's `process.exitCode = 2` invalid-argument pattern rather than reporting a bad path as a graph finding. A clean run prints nothing at all, keeping CI logs quiet.

## Spec debt & uncertainty

- SD-010 (open): Fully driver-neutral enumeration of orphan test bodies is reliable only within the declared `test-body:` set or an explicitly supplied flow-test root; blind-scanning arbitrary driver layouts risks false positives on unrelated tests. A general convention or machine-readable stub marker for detecting stray test bodies anywhere in the repo is deferred. This slice inherits Slice 1's scoping — the CLI exposes `--flow-test-root` as the explicit opt-in, and orphan detection otherwise falls back to the conventional stub location or reports not-run.
- SD-005 (inherited): Fidelity of `import`-mode structure derivation. Owned by User Story 5; flow-lint validates the confirmed artifact graph after it exists.
- SD-006 (inherited): Whether `SC`/`FL` nodes are always atomic or can be sub-sliced. Owned by User Story 3; this story validates artifacts regardless of how the producing tasks were sliced.
- SD-007 (inherited): Build-phase coverage honesty — a build screen can be "done" with a missing brief state and no executable gate until its flows wire. Flow-lint checks graph integrity, not whether every intended brief state has executable coverage.
- SD-008 (inherited): Visual-intent honesty under the non-blocking gate. Owned by User Story 4; flow-lint does not validate visual-intent fulfillment.
- Assumption (spec): "Tool-agnostic" means the AI adapts to the project's existing stack; smithy ships no per-framework generators. Accordingly `flow-lint` treats `test-body` as an opaque driver-neutral repo-relative path and never parses or validates test-body contents — it only checks that the declared file exists.
- Assumption (spec): The `.claude/` snapshot and `.smithy/` manifest are not regenerated by source PRs. This PR honors that — it changes no `.claude/` or `.smithy/` file. Its non-`src/` change is the deliberate one: the three Slice 2 rows in `06-…-flow-lint-….tasks.md` flip `[ ]` → `[x]`, which is how a completed slice records itself.
- Uncertainty: `--flow-test-root` is new user-controlled input reaching Slice 1's `resolveScopedRoot`. I reviewed that path — it `realpathSync`es the candidate and confines it via `isWithinRoot`, so a traversal argument resolves to a not-run scan rather than escaping the artifact root. No new test was added for the escape case specifically, since the containment lives in already-merged Slice 1 code.
- Uncertainty: `flowLintAction` `statSync`s the path before handing it to `resolveArtifactRoot`, which itself `realpathSync`es. A delete racing between the two calls would surface as an uncaught exception rather than the exit-2 input error. Judged not worth guarding in a local lint CLI.

## Review follow-up

`035a736` addresses the Copilot review: `lintFlowGraph()` was called outside any try/catch, so malformed YAML front matter, an unreadable nested directory (`readdirSync` EACCES), or an unreadable artifact file crashed the CLI with a raw stack trace and **exit 1**. Since exit 1 is the documented "the graph has findings" signal, that made an unreadable repo indistinguishable from a real lint failure in CI. The scan is now wrapped and reports a command input error (exit 2), consistent with the nonexistent-path case, with a regression test.

Known gap, deliberately not fixed here: the error line names the root being scanned but not the specific offending artifact, because attributing the file would mean changing Slice 1's already-merged `readFrontmatter`. Worth a follow-up.

## Validation

build ✅ · typecheck ✅ · targeted tests ✅ (105 passed, `src/cli.test.ts` + `src/flow-lint.test.ts`) · full suite 1144/1145 — the one failure is `src/artifact-store.test.ts` asserting a git author of `Smithy CLI <smithy@localhost>` and instead picking up the local global git identity; neither `src/artifact-store.ts` nor its test is touched by this branch, so the failure is environmental and unrelated to this slice.

Note: dependencies had to be reinstalled under Node 22 in this worktree (`node_modules` was absent, and a first `npm ci` under the shell's default Node 18 resolved the wrong native rolldown binding).
