### PR TITLE
forge: build screen nodes from mark-owned design intent

### DIFF
--- a/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/03-render-mark-cut-forge-is-identical-for-ui-and-backend-nodes.tasks.md
+++ b/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/03-render-mark-cut-forge-is-identical-for-ui-and-backend-nodes.tasks.md
@@ -64,7 +64,7 @@
 
 ### Tasks
 
-- [ ] **Add the screen-build forge profile**
+- [x] **Add the screen-build forge profile**
 
   Update `src/templates/agent-skills/commands/smithy.forge.prompt` so tasks produced for an `SC` node preload the referenced `.design.md` and committed design skill, then build the component behind the feature `flag` against mock data. The profile must consume the mark-owned artifact and refuse to create durable `.design.md` truth downstream.
 
@@ -75,7 +75,7 @@
   - Generated screen work is gated behind the feature `flag`
   - Forge does not author a new `.design.md` from scratch
 
-- [ ] **Require token-only brief-state rendering**
+- [x] **Require token-only brief-state rendering**
 
   Strengthen the screen-build profile so every brief state named by the durable screen intent is represented in the implementation using the project's design-system tokens and reusable components. Keep data mocked at this stage so backend availability does not block screen construction.
 
@@ -86,7 +86,7 @@
   - Screen-build work can run with mock data
   - Backend story implementation is not required for the screen-build slice
 
-- [ ] **Honor bundles without blocking**
+- [x] **Honor bundles without blocking**
 
   Add bundle handling to the screen-build profile so an attached bundle is translated into the project framework under the conflict rule, while a bundle-less `brief` or `none` screen still builds from the design skill. Keep the design skill loaded as implementation dialect context in all modes.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -104,7 +104,7 @@ describe('resolveSnippets', () => {
 describe('loadSnippets', () => {
   it('loads all snippet files', () => {
     const snippets = loadSnippets();
-    expect(snippets.size).toBe(23);
+    expect(snippets.size).toBe(24);
 
     const expectedFiles = [
       'audit-checklist-rfc.md',
@@ -130,6 +130,7 @@ describe('loadSnippets', () => {
       'engraved-recall-degraded.md',
       'spec-debt-section.md',
       'open-implementation-questions.md',
+      'typed-ui-build-profiles.md',
     ];
     for (const file of expectedFiles) {
       expect(snippets.has(file)).toBe(true);
@@ -2371,10 +2372,10 @@ describe('getComposedTemplates', () => {
   it('forge template defines the screen-build profile for typed UI nodes', () => {
     const forge = composed.commands.get('smithy.forge.md')!;
     expect(forge).toContain('### Typed UI Node Build Profiles');
-    expect(forge).toContain('**`SC<N>` / `screen-build` tasks** select the screen-build forge profile');
+    expect(forge).toContain('**`SC<N>` / `screen-build` tasks** select the screen-build profile');
     expect(forge).toContain('Read the referenced `design/screens/<ScreenId>.design.md` before editing');
     expect(forge).toContain('the committed design skill named by the screen artifact');
-    expect(forge).toContain('behind the feature `flag`');
+    expect(forge).toContain('behind the resolved feature `flag`');
     expect(forge).toContain('Use mock data for screen-build work');
     expect(forge).toContain('Represent every brief state named by the screen intent');
     expect(forge).toContain('design-system');
@@ -2383,6 +2384,23 @@ describe('getComposedTemplates', () => {
     expect(forge).toContain('`brief`');
     expect(forge).toContain('mode without a bundle and `none` mode are non-blocking');
     expect(forge).toContain('Refuse to author a new `.design.md` from scratch');
+  });
+
+  it('screen-build profile resolves the gating feature flag or stops', () => {
+    const forge = composed.commands.get('smithy.forge.md')!;
+    expect(forge).toContain('Resolve the gating feature `flag` before writing code');
+    expect(forge).toContain('`**Design Metadata**` line first');
+    expect(forge).toContain("`**Source Feature Map**` pointer");
+    expect(forge).toContain('never');
+    expect(forge).toContain('ship an ungated screen');
+  });
+
+  it('smithy-implement carries the same typed UI build profile as forge', () => {
+    const implement = composed.agents.get('smithy.implement.md')!;
+    expect(implement).toBeDefined();
+    expect(implement).toContain('**`SC<N>` / `screen-build` tasks** select the screen-build profile');
+    expect(implement).toContain('Resolve the gating feature `flag` before writing code');
+    expect(implement).toContain('Refuse to author a new `.design.md` from scratch');
   });
 
   it('strike template contains ## Specification Debt between ## Decisions and ## Single Slice', () => {

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -2368,6 +2368,23 @@ describe('getComposedTemplates', () => {
     expect(forge).toContain('Implementation repo mismatch');
   });
 
+  it('forge template defines the screen-build profile for typed UI nodes', () => {
+    const forge = composed.commands.get('smithy.forge.md')!;
+    expect(forge).toContain('### Typed UI Node Build Profiles');
+    expect(forge).toContain('**`SC<N>` / `screen-build` tasks** select the screen-build forge profile');
+    expect(forge).toContain('Read the referenced `design/screens/<ScreenId>.design.md` before editing');
+    expect(forge).toContain('the committed design skill named by the screen artifact');
+    expect(forge).toContain('behind the feature `flag`');
+    expect(forge).toContain('Use mock data for screen-build work');
+    expect(forge).toContain('Represent every brief state named by the screen intent');
+    expect(forge).toContain('design-system');
+    expect(forge).toContain('tokens and reusable project components');
+    expect(forge).toContain('Honor an attached `bundle` for layout and visual intent');
+    expect(forge).toContain('`brief`');
+    expect(forge).toContain('mode without a bundle and `none` mode are non-blocking');
+    expect(forge).toContain('Refuse to author a new `.design.md` from scratch');
+  });
+
   it('strike template contains ## Specification Debt between ## Decisions and ## Single Slice', () => {
     const strike = composed.commands.get('smithy.strike.md')!;
     expect(strike).toBeDefined();

--- a/src/templates/agent-skills/agents/smithy.implement.prompt
+++ b/src/templates/agent-skills/agents/smithy.implement.prompt
@@ -55,6 +55,12 @@ implementation.
 
 ---
 
+## Typed UI Node Build Profiles
+
+{{>typed-ui-build-profiles}}
+
+---
+
 {{>tdd-protocol}}
 
 ---

--- a/src/templates/agent-skills/commands/smithy.forge.prompt
+++ b/src/templates/agent-skills/commands/smithy.forge.prompt
@@ -176,40 +176,7 @@ Store this value for later.
 
 ### Typed UI Node Build Profiles
 
-When the target `.tasks.md` file carries a `**Node Kind**:` metadata line from
-a typed UI ledger, select the build profile before executing the slice tasks.
-This routing changes the implementation profile only; branch handling, review,
-documentation, validation, and PR creation stay the same as ordinary forge work.
-
-- **`SC<N>` / `screen-build` tasks** select the screen-build forge profile.
-  Read the referenced `design/screens/<ScreenId>.design.md` before editing any
-  implementation files and treat it as mark-owned durable screen intent. Preload
-  the committed design skill named by the screen artifact's `design_system`
-  metadata as implementation dialect context. If the screen artifact is missing
-  or does not name a design skill, stop instead of inventing downstream design
-  truth.
-- Build the screen component at the artifact's `component-path`, or the
-  project-equivalent path named by the task plan, using the target project's
-  existing UI framework and component conventions. Gate generated screen work
-  behind the feature `flag` carried by the task plan or design metadata.
-- Use mock data for screen-build work. Backend story implementation is not
-  required for a screen-build slice, even when later flow-wire work will connect
-  real data.
-- Represent every brief state named by the screen intent. Use design-system
-  tokens and reusable project components for styling; do not introduce hardcoded
-  colors or one-off style constants when a project token or component convention
-  exists.
-- Honor an attached `bundle` for layout and visual intent under the conflict
-  rule: bundle wins layout/visual intent, while the design skill remains
-  authoritative for implementation dialect and project conventions. `brief`
-  mode without a bundle and `none` mode are non-blocking; build from the design
-  skill and the `.design.md` intent without waiting for a prototype.
-- Refuse to author a new `.design.md` from scratch, and do not modify
-  `.design.md` or `.flow.md` files as part of screen-build work. Those durable
-  artifacts originate at `mark`; `forge` consumes them.
-
-For non-screen node kinds, follow the selected task plan and existing forge
-mechanics; do not apply screen-build rules to `FL<N>` or `US<N>` work.
+{{>typed-ui-build-profiles}}
 
 Execute each task from the slice's checklist **in order**:
 
@@ -223,6 +190,10 @@ For each task, use the **smithy-implement** sub-agent. Pass it:
 - **Slice goal**: The slice's stated goal
 - **File paths**: The spec, contracts, data-model, and tasks/strike file paths
 - **Branch**: The current branch name
+
+The sub-agent carries the same typed UI build profiles as this prompt and reads
+the node metadata from the tasks file you pass it, so a dispatched screen-build
+task applies the profile itself — you do not need to restate it in the task text.
 
 After the sub-agent returns:
 

--- a/src/templates/agent-skills/commands/smithy.forge.prompt
+++ b/src/templates/agent-skills/commands/smithy.forge.prompt
@@ -174,6 +174,43 @@ Store this value for later.
 
 ## Implementation
 
+### Typed UI Node Build Profiles
+
+When the target `.tasks.md` file carries a `**Node Kind**:` metadata line from
+a typed UI ledger, select the build profile before executing the slice tasks.
+This routing changes the implementation profile only; branch handling, review,
+documentation, validation, and PR creation stay the same as ordinary forge work.
+
+- **`SC<N>` / `screen-build` tasks** select the screen-build forge profile.
+  Read the referenced `design/screens/<ScreenId>.design.md` before editing any
+  implementation files and treat it as mark-owned durable screen intent. Preload
+  the committed design skill named by the screen artifact's `design_system`
+  metadata as implementation dialect context. If the screen artifact is missing
+  or does not name a design skill, stop instead of inventing downstream design
+  truth.
+- Build the screen component at the artifact's `component-path`, or the
+  project-equivalent path named by the task plan, using the target project's
+  existing UI framework and component conventions. Gate generated screen work
+  behind the feature `flag` carried by the task plan or design metadata.
+- Use mock data for screen-build work. Backend story implementation is not
+  required for a screen-build slice, even when later flow-wire work will connect
+  real data.
+- Represent every brief state named by the screen intent. Use design-system
+  tokens and reusable project components for styling; do not introduce hardcoded
+  colors or one-off style constants when a project token or component convention
+  exists.
+- Honor an attached `bundle` for layout and visual intent under the conflict
+  rule: bundle wins layout/visual intent, while the design skill remains
+  authoritative for implementation dialect and project conventions. `brief`
+  mode without a bundle and `none` mode are non-blocking; build from the design
+  skill and the `.design.md` intent without waiting for a prototype.
+- Refuse to author a new `.design.md` from scratch, and do not modify
+  `.design.md` or `.flow.md` files as part of screen-build work. Those durable
+  artifacts originate at `mark`; `forge` consumes them.
+
+For non-screen node kinds, follow the selected task plan and existing forge
+mechanics; do not apply screen-build rules to `FL<N>` or `US<N>` work.
+
 Execute each task from the slice's checklist **in order**:
 
 {{#ifAgent}}

--- a/src/templates/agent-skills/snippets/typed-ui-build-profiles.md
+++ b/src/templates/agent-skills/snippets/typed-ui-build-profiles.md
@@ -1,0 +1,43 @@
+When the slice's `.tasks.md` file carries a `**Node Kind**:` metadata line from
+a typed UI ledger, apply the matching build profile. A profile changes only how
+the implementation itself is carried out — branch handling, review,
+documentation, validation, and PR creation stay the same as ordinary work.
+
+- **`SC<N>` / `screen-build` tasks** select the screen-build profile. Every rule
+  below is scoped to that profile:
+  - Read the referenced `design/screens/<ScreenId>.design.md` before editing any
+    implementation files, and treat it as mark-owned durable screen intent.
+  - Preload the committed design skill named by the screen artifact's
+    `design_system` metadata as implementation dialect context. If the screen
+    artifact is missing or does not name a design skill, stop instead of
+    inventing downstream design truth.
+  - Resolve the gating feature `flag` before writing code. Read the task plan's
+    `**Design Metadata**` line first; if it does not name a flag, follow the
+    spec's `**Source Feature Map**` pointer and read the `flag:` field of the
+    owning feature in that `.features.md`. The screen artifact schema carries no
+    `flag`, so an absent metadata pointer is not evidence that the feature is
+    ungated. If no flag resolves from either source, stop and report it — never
+    ship an ungated screen.
+  - Build the screen component at the artifact's `component-path`, or the
+    project-equivalent path named by the task plan, using the target project's
+    existing UI framework and component conventions. Gate the generated screen
+    work behind the resolved feature `flag`.
+  - Use mock data for screen-build work. Backend story implementation is not
+    required for a screen-build slice, even when later flow-wire work will
+    connect real data.
+  - Represent every brief state named by the screen intent. Use design-system
+    tokens and reusable project components for styling; do not introduce
+    hardcoded colors or one-off style constants when a project token or
+    component convention exists.
+  - Honor an attached `bundle` for layout and visual intent under the conflict
+    rule: bundle wins layout/visual intent, while the design skill remains
+    authoritative for implementation dialect and project conventions. `brief`
+    mode without a bundle and `none` mode are non-blocking; build from the
+    design skill and the `.design.md` intent without waiting for a prototype.
+  - Refuse to author a new `.design.md` from scratch, and do not modify
+    `.design.md` or `.flow.md` files as part of screen-build work. Those durable
+    artifacts originate at `mark`; `forge` consumes them.
+
+For non-screen node kinds, follow the selected task plan and the existing
+implementation mechanics; do not apply screen-build rules to `FL<N>` or `US<N>`
+work.


### PR DESCRIPTION
## Summary
EPIC #404 → Screens and Flows as UI Feature Kinds (spec) → User Story 3: `render → mark → cut → forge` is identical for UI and backend nodes → Slice 2: Build screen nodes through forge

Adds the screen-build forge profile so an `SC<N>` task plan is implemented from mark-owned screen intent rather than from anything forge invents: forge reads the referenced `design/screens/<ScreenId>.design.md`, preloads the committed design skill named by its `design_system`, builds the component behind the feature `flag` against mock data, renders every brief state with design-system tokens and reusable project components, and honors an attached `bundle` under the conflict rule (bundle wins layout/visual intent, skill wins implementation dialect) while `brief`-without-bundle and `none` stay non-blocking. This is the right first UI forge profile because flow-wire work (Slice 3) depends on built screens, and a flagged mock-data screen is independently reviewable without any backend story landing first.

## Spec debt & uncertainty
- SD-005 (inherited): fidelity of `import`-mode structure derivation from a prototype/bundle — owned by User Story 5; this slice only consumes bundles once they exist.
- SD-007 (inherited): build-phase coverage honesty — a screen can be "done" with a missing brief state and no executable gate until its flows wire. Partially mitigated here by the brief-state rule; executable coverage stays with Slice 3 / User Story 6.
- SD-008 (inherited): visual-intent honesty for a `brief`-mode node that never received a bundle — owned by User Story 4; this slice only guarantees forge does not block on a missing bundle.
- Assumption: Smithy templates stay tool-agnostic — the profile names no framework and defers to the target project's existing UI framework, component conventions, and design tokens.
- Assumption: the profile keys off the `**Node Kind**:` metadata line that `smithy.cut` writes (Slice 1, `smithy.cut.prompt`), and uses the `design_system` / `component-path` / `bundle` field names from `smithy.helper-screen-design`. Both were verified against those sources in this checkout.
- Verification gap: this is prompt-template text, so coverage is a `getComposedTemplates` string-assertion test — there is no execution-level (eval) check that an agent actually follows the screen-build profile. Per CLAUDE.md the `.claude/` snapshot was deliberately not regenerated.

## Validation
build ✅ · typecheck ✅ · test ✅ (1136 passed) — one pre-existing environmental failure in `src/artifact-store.test.ts` ("commits with a fallback identity when the machine has none"), which asserts the fallback git identity and fails on a machine that has a global one; untouched by this diff.
