### PR TITLE
forge: offline fix-from-issue eval scenario

### DIFF
--- a/evals/cases/fix-from-issue.yaml
+++ b/evals/cases/fix-from-issue.yaml
@@ -1,0 +1,33 @@
+# smithy.fix end-to-end eval scenario -- exercises `/smithy.fix` against
+# committed offline issue and CI-log evidence.
+#
+# Spec:       specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
+# Data model: specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md
+# Contracts:  specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.contracts.md
+# Tasks:      specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/02-run-smithy-fix-against-local-failure-evidence.tasks.md
+#
+# This case intentionally stops at local fixture declaration and invocation.
+# Stable output marker and helper-evidence calibration belongs to the later
+# structural-validation story.
+
+name: fix-from-issue
+skill: /smithy.fix
+prompt: |
+  Diagnose and fix the failure using only the repository-local evidence below.
+  Issue fixture: {{issue_path}}
+  CI log fixture: {{ci_log_path}}
+
+  Read those files from this temp fixture copy, identify the root cause, make the smallest code change, and run the relevant local verification.
+local_fixtures:
+  issue: evals/fixture/issues/fix-from-issue-health-check.md
+  ci_log: evals/fixture/ci-logs/fix-from-issue-health-check.log
+structural_expectations:
+  required_headings:
+    - '## Diagnosis'
+  required_patterns:
+    - 'health'
+    - 'src/index\.ts|/health|verification'
+  forbidden_patterns:
+    - "I'd be happy to help"
+    - "Sure, here's"
+    - '^---\r?\n'

--- a/evals/cases/fix-from-issue.yaml
+++ b/evals/cases/fix-from-issue.yaml
@@ -18,13 +18,29 @@ prompt: |
   CI log fixture: {{ci_log_path}}
 
   Read those files from this temp fixture copy, identify the root cause, make the smallest code change, and run the relevant local verification.
+
+  Begin your response with a `## Diagnosis` heading on a line by itself, then give the diagnosis.
 local_fixtures:
   issue: evals/fixture/issues/fix-from-issue-health-check.md
   ci_log: evals/fixture/ci-logs/fix-from-issue-health-check.log
 structural_expectations:
   required_headings:
+    # `validateStructure` requires this array to be non-empty and matches
+    # whole lines. The smithy.fix template mandates no ATX heading at all --
+    # its Step 1 contract is "Present a brief diagnosis:" followed by
+    # `- **Error**/- **Cause**/- **Fix**` bullets -- so no heading emitted by
+    # the template alone is safe to require here. This scenario's own prompt
+    # therefore asks for `## Diagnosis` explicitly, which makes the marker
+    # scenario-guaranteed rather than assumed. `smithy.fix.prompt` is
+    # deliberately not touched (spec Out of Scope).
     - '## Diagnosis'
   required_patterns:
+    # Template-guaranteed diagnosis labels (smithy.fix.prompt Step 1). These
+    # are bullet lines with trailing descriptions, so whole-line equality
+    # never matches -- they belong here rather than in `required_headings`.
+    - '\*\*Error\*\*'
+    - '\*\*Cause\*\*'
+    - '\*\*Fix\*\*'
     - 'health'
     - 'src/index\.ts|/health|verification'
   forbidden_patterns:

--- a/evals/lib/runner.test.ts
+++ b/evals/lib/runner.test.ts
@@ -508,6 +508,11 @@ describe('runScenario', () => {
     expect(invocation).toContain('Issue fixture: issues/fix-from-issue-health-check.md');
     expect(invocation).toContain('CI log fixture: ci-logs/fix-from-issue-health-check.log');
     expect(invocation).toContain('using only the repository-local evidence');
+    // The scenario's own prompt is what guarantees the `## Diagnosis` heading
+    // that `structural_expectations.required_headings` matches on whole-line
+    // equality -- the smithy.fix template mandates no ATX heading.
+    expect(invocation).toContain('`## Diagnosis` heading');
+    expect(scenario.structural_expectations.required_headings).toContain('## Diagnosis');
     expect(invocation).not.toContain('{{issue_path}}');
     expect(invocation).not.toContain('{{ci_log_path}}');
     expect(invocation).not.toMatch(/\bGH_TOKEN\b|\bGITHUB_TOKEN\b|gh issue|gh run|GitHub Actions/i);

--- a/evals/lib/runner.test.ts
+++ b/evals/lib/runner.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { EventEmitter } from 'node:events';
+import { fileURLToPath } from 'node:url';
 
 import type { EvalScenario, StreamEvent } from './types.js';
 
@@ -23,6 +24,7 @@ vi.mock('node:child_process', () => ({
 // Import after mock is declared so the module picks up the mocked version.
 const { spawn, execFileSync } = await import('node:child_process');
 const { runScenario, preflight, hashDirectory } = await import('./runner.js');
+const { loadScenarioFromFile } = await import('./scenario-loader.js');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -165,6 +167,9 @@ function createFixtureWithLocalEvidence(): { dir: string; cleanup: () => void } 
   );
   return fixture;
 }
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..');
 
 // ---------------------------------------------------------------------------
 // Test setup
@@ -477,6 +482,35 @@ describe('runScenario', () => {
     } finally {
       fixture.cleanup();
     }
+  });
+
+  it('renders the real fix-from-issue scenario from local evidence without credential requirements', async () => {
+    const stdout = ndjsonLines(resultEvent('output'));
+    const { child } = createMockChild(stdout, 0);
+    vi.mocked(spawn).mockReturnValue(child as never);
+
+    const scenario = loadScenarioFromFile(
+      path.join(repoRoot, 'evals/cases/fix-from-issue.yaml'),
+    );
+
+    await runScenario(
+      scenario,
+      path.join(repoRoot, 'evals/fixture'),
+      'claude',
+      path.join(repoRoot, 'evals/fixture'),
+    );
+
+    const call = vi.mocked(spawn).mock.calls[0]!;
+    const args = call[1] as string[];
+    const invocation = args[6]!;
+
+    expect(invocation).toContain('/smithy.fix ');
+    expect(invocation).toContain('Issue fixture: issues/fix-from-issue-health-check.md');
+    expect(invocation).toContain('CI log fixture: ci-logs/fix-from-issue-health-check.log');
+    expect(invocation).toContain('using only the repository-local evidence');
+    expect(invocation).not.toContain('{{issue_path}}');
+    expect(invocation).not.toContain('{{ci_log_path}}');
+    expect(invocation).not.toMatch(/\bGH_TOKEN\b|\bGITHUB_TOKEN\b|gh issue|gh run|GitHub Actions/i);
   });
 
   it('fails before spawning when a declared local fixture is missing from the temp copy', async () => {

--- a/evals/lib/scenario-loader.test.ts
+++ b/evals/lib/scenario-loader.test.ts
@@ -100,6 +100,21 @@ describe('loadScenarios', () => {
       ]);
     });
 
+    it('loads and can select the offline smithy.fix fixture scenario by name', () => {
+      const scenarios = loadScenarios(realCasesDir);
+      const matches = scenarios.filter((s) => s.name === 'fix-from-issue');
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]!.skill).toBe('/smithy.fix');
+      expect(matches[0]!.local_fixtures).toEqual({
+        issue: validIssueFixture,
+        ci_log: validCiLogFixture,
+      });
+      expect(matches[0]!.prompt).toContain('{{issue_path}}');
+      expect(matches[0]!.prompt).toContain('{{ci_log_path}}');
+      expect(matches[0]!.prompt).not.toMatch(/fetch live|gh issue|gh run|GitHub Actions/i);
+    });
+
     it('preserves a boolean requires_git flag when present', () => {
       const dir = mkdir();
       const content = [

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/02-run-smithy-fix-against-local-failure-evidence.tasks.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/02-run-smithy-fix-against-local-failure-evidence.tasks.md
@@ -91,7 +91,7 @@
 
 ### Tasks
 
-- [ ] **Declare and exercise the smithy.fix fixture scenario**
+- [x] **Declare and exercise the smithy.fix fixture scenario**
 
   Add the `fix-from-issue` YAML case under `evals/cases/` using the issue and CI-log fixtures provided by US1. The prompt should reference the injected local fixture bindings and direct smithy.fix to diagnose from committed evidence, with focused coverage for loading, case selection, and invocation rendering while leaving structural marker refinement to US3.
 


### PR DESCRIPTION
## Summary
RFC 2026-001 token-savings → M1 deterministic smithy.fix end-to-end eval coverage → F1.4 smithy.fix End-to-End Eval Scenario → smithy-fix-end-to-end-eval-scenario spec → Slice 3: Offline smithy.fix Scenario Invocation

Adds the `fix-from-issue` eval case that invokes `/smithy.fix` against the committed issue and CI-log fixtures via the `local_fixtures` bindings delivered by slices 1–2. This is the increment that makes the US2 behavior user-visible: the eval runner can now execute the smithy.fix workflow end to end from repository-local failure evidence, on a machine with no GitHub credentials.

## Spec debt & uncertainty
- SD-001 (inherited): the exact helper-agent evidence set for the offline smithy.fix path is unknown until the fixture is run against current smithy.fix behavior — the error-description path may dispatch no helpers at all. This slice deliberately declares no `sub_agent_evidence` rather than fabricating patterns; US3 owns recording the observed path.
- SD-002 (inherited): the initial token envelope cannot be calibrated until F1.3a's token-aware baseline schema exists and the scenario has a clean captured run. No baseline file is added here — US4 owns it.
- Assumption (spec): prompt-level local fixture references are enough to exercise smithy.fix's error-description path without editing `smithy.fix.prompt`, which M3 owns.
- Verification gap: the case's correctness was verified through the loader and runner unit paths (scenario loads, is selectable by name, renders both fixture bindings into the invocation, and requires no `GH_TOKEN`/`GITHUB_TOKEN`/`gh` access). A live `npm run eval -- --case fix-from-issue` against a real agent was not run — that captured run is what US3/US4 need in order to close SD-001 and SD-002.
- The `structural_expectations` block is intentionally minimal (the loader requires `required_headings`, so the case cannot load without one). Stable output-marker calibration stays with US3.
- Manager change to the worker's draft: switched the new test's repo-root derivation from `new URL(import.meta.url).pathname` to `fileURLToPath(import.meta.url)`, matching every other eval test file — `.pathname` leaves percent-encoding intact and would break on a checkout path containing spaces.

## Validation
build ✅ · typecheck ✅ · evals suite ✅ (246 passed, 12 files) · full `npm test` ✅ except one pre-existing environment-dependent failure in `src/artifact-store.test.ts` ("commits with a fallback identity when the machine has none"), which fails identically on the unmodified tree because this machine has a global git identity configured.
