### PR TITLE
forge: load optional token envelopes from eval baselines

### DIFF
--- a/evals/lib/baseline.test.ts
+++ b/evals/lib/baseline.test.ts
@@ -226,6 +226,28 @@ describe('loadBaseline', () => {
         input: { min: 10, max: 20 },
       });
     });
+
+    it.each([
+      ['is empty', {}],
+      ['declares only unsupported ranges', { cache: { min: 1, max: 2 } }],
+    ])(
+      'omits the token envelope when it %s',
+      (_label, tokenEnvelope) => {
+        writeBaselineFile(tmp.dir, 'no-supported-ranges', {
+          scenario_name: 'no-supported-ranges',
+          captured_at: '2026-04-17T00:00:00Z',
+          headings: ['## A'],
+          tables: [],
+          token_envelope: tokenEnvelope,
+        });
+
+        const result = loadBaseline('no-supported-ranges', tmp.dir);
+        expect(result!.token_envelope).toBeUndefined();
+        expect(result as unknown as Record<string, unknown>).not.toHaveProperty(
+          'token_envelope',
+        );
+      },
+    );
   });
 
   // -----------------------------------------------------------------------

--- a/evals/lib/baseline.test.ts
+++ b/evals/lib/baseline.test.ts
@@ -101,6 +101,79 @@ describe('loadBaseline', () => {
       expect(result).toEqual(payload);
     });
 
+    it('loads structural-only baselines without a token envelope', () => {
+      writeBaselineFile(tmp.dir, 'structural-only', {
+        scenario_name: 'structural-only',
+        captured_at: '2026-04-17T00:00:00Z',
+        headings: ['## Summary'],
+        tables: [],
+      });
+
+      const result = loadBaseline('structural-only', tmp.dir);
+      expect(result).toEqual({
+        scenario_name: 'structural-only',
+        captured_at: '2026-04-17T00:00:00Z',
+        headings: ['## Summary'],
+        tables: [],
+      });
+      expect(result as unknown as Record<string, unknown>).not.toHaveProperty(
+        'token_envelope',
+      );
+    });
+
+    it('loads a valid input-only token envelope', () => {
+      writeBaselineFile(tmp.dir, 'input-envelope', {
+        scenario_name: 'input-envelope',
+        captured_at: '2026-04-17T00:00:00Z',
+        headings: ['## A'],
+        tables: [],
+        token_envelope: {
+          input: { min: 10, max: 20 },
+        },
+      });
+
+      const result = loadBaseline('input-envelope', tmp.dir);
+      expect(result!.token_envelope).toEqual({
+        input: { min: 10, max: 20 },
+      });
+    });
+
+    it('loads a valid output-only token envelope', () => {
+      writeBaselineFile(tmp.dir, 'output-envelope', {
+        scenario_name: 'output-envelope',
+        captured_at: '2026-04-17T00:00:00Z',
+        headings: ['## A'],
+        tables: [],
+        token_envelope: {
+          output: { min: 5, max: 15 },
+        },
+      });
+
+      const result = loadBaseline('output-envelope', tmp.dir);
+      expect(result!.token_envelope).toEqual({
+        output: { min: 5, max: 15 },
+      });
+    });
+
+    it('loads a valid input-plus-output token envelope', () => {
+      writeBaselineFile(tmp.dir, 'full-envelope', {
+        scenario_name: 'full-envelope',
+        captured_at: '2026-04-17T00:00:00Z',
+        headings: ['## A'],
+        tables: [],
+        token_envelope: {
+          input: { min: 10, max: 20 },
+          output: { min: 5, max: 15 },
+        },
+      });
+
+      const result = loadBaseline('full-envelope', tmp.dir);
+      expect(result!.token_envelope).toEqual({
+        input: { min: 10, max: 20 },
+        output: { min: 5, max: 15 },
+      });
+    });
+
     it('defaults missing `tables` field to empty array', () => {
       writeBaselineFile(tmp.dir, 'no-tables', {
         scenario_name: 'no-tables',
@@ -134,6 +207,24 @@ describe('loadBaseline', () => {
       expect(result as unknown as Record<string, unknown>).not.toHaveProperty(
         'future_field',
       );
+    });
+
+    it('ignores unsupported token envelope fields', () => {
+      writeBaselineFile(tmp.dir, 'envelope-extras', {
+        scenario_name: 'envelope-extras',
+        captured_at: '2026-04-17T00:00:00Z',
+        headings: ['## A'],
+        tables: [],
+        token_envelope: {
+          input: { min: 10, max: 20, midpoint: 15 },
+          cache: { min: 1, max: 2 },
+        },
+      });
+
+      const result = loadBaseline('envelope-extras', tmp.dir);
+      expect(result!.token_envelope).toEqual({
+        input: { min: 10, max: 20 },
+      });
     });
   });
 
@@ -235,6 +326,76 @@ describe('loadBaseline', () => {
 
       expect(() => loadBaseline('asked-for-this', tmp.dir)).toThrow(
         /scenario_name.*must match.*asked-for-this/,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Token envelope validation
+  // -----------------------------------------------------------------------
+  describe('token envelope validation', () => {
+    function writeTokenEnvelope(
+      name: string,
+      tokenEnvelope: unknown,
+    ): void {
+      writeBaselineFile(tmp.dir, name, {
+        scenario_name: name,
+        captured_at: '2026-04-17T00:00:00Z',
+        headings: ['## A'],
+        tables: [],
+        token_envelope: tokenEnvelope,
+      });
+    }
+
+    it.each([
+      ['missing min', { input: { max: 10 } }],
+      ['missing max', { input: { min: 1 } }],
+      ['string min', { input: { min: '1', max: 10 } }],
+      ['fractional max', { input: { min: 1, max: 10.5 } }],
+      ['negative min', { input: { min: -1, max: 10 } }],
+      ['inverted bounds', { input: { min: 10, max: 1 } }],
+      ['output missing min', { output: { max: 10 } }],
+      ['output inverted bounds', { output: { min: 10, max: 1 } }],
+    ])('throws when token envelope has %s', (_label, tokenEnvelope) => {
+      writeTokenEnvelope('bad-token-envelope', tokenEnvelope);
+
+      expect(() => loadBaseline('bad-token-envelope', tmp.dir)).toThrow(
+        /token_envelope/,
+      );
+    });
+
+    it('throws when token envelope has a non-finite bound', () => {
+      writeBaselineFile(
+        tmp.dir,
+        'non-finite-token-envelope',
+        [
+          '{',
+          '  "scenario_name": "non-finite-token-envelope",',
+          '  "captured_at": "2026-04-17T00:00:00Z",',
+          '  "headings": ["## A"],',
+          '  "tables": [],',
+          '  "token_envelope": {',
+          '    "input": { "min": 1, "max": 1e309 }',
+          '  }',
+          '}',
+        ].join('\n'),
+      );
+
+      expect(() =>
+        loadBaseline('non-finite-token-envelope', tmp.dir),
+      ).toThrow(/token_envelope/);
+    });
+
+    it.each([
+      ['null envelope', null],
+      ['array envelope', []],
+      ['null input range', { input: null }],
+      ['array output range', { output: [] }],
+    ])('throws when token envelope has %s', (_label, tokenEnvelope) => {
+      writeTokenEnvelope('bad-token-shape', tokenEnvelope);
+
+      expect(() => loadBaseline('bad-token-shape', tmp.dir)).toThrow(
+        /token_envelope/,
       );
     });
   });

--- a/evals/lib/baseline.ts
+++ b/evals/lib/baseline.ts
@@ -15,10 +15,76 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import type { Baseline, CheckResult } from './types.js';
+import type { Baseline, CheckResult, TokenEnvelope } from './types.js';
 
 /** Default directory (relative to cwd) where baselines are looked up. */
 const DEFAULT_BASELINES_DIR = 'evals/baselines';
+
+function validateTokenBound(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value >= 0
+  );
+}
+
+function validateTokenRange(
+  filePath: string,
+  rangeName: 'input' | 'output',
+  value: unknown,
+): { min: number; max: number } {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(
+      `Invalid baseline file ${filePath}: token_envelope.${rangeName} must be an object with "min" and "max" bounds`,
+    );
+  }
+
+  const record = value as Record<string, unknown>;
+  const min = record['min'];
+  const max = record['max'];
+  if (!validateTokenBound(min)) {
+    throw new Error(
+      `Invalid baseline file ${filePath}: token_envelope.${rangeName}.min must be a finite non-negative integer`,
+    );
+  }
+  if (!validateTokenBound(max)) {
+    throw new Error(
+      `Invalid baseline file ${filePath}: token_envelope.${rangeName}.max must be a finite non-negative integer`,
+    );
+  }
+  if (max < min) {
+    throw new Error(
+      `Invalid baseline file ${filePath}: token_envelope.${rangeName}.max must be greater than or equal to token_envelope.${rangeName}.min`,
+    );
+  }
+
+  return {
+    min,
+    max,
+  };
+}
+
+function validateTokenEnvelope(
+  filePath: string,
+  value: unknown,
+): TokenEnvelope {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(
+      `Invalid baseline file ${filePath}: field "token_envelope" must be an object when present`,
+    );
+  }
+
+  const record = value as Record<string, unknown>;
+  const envelope: TokenEnvelope = {};
+  if (record['input'] !== undefined) {
+    envelope.input = validateTokenRange(filePath, 'input', record['input']);
+  }
+  if (record['output'] !== undefined) {
+    envelope.output = validateTokenRange(filePath, 'output', record['output']);
+  }
+  return envelope;
+}
 
 /**
  * Load a baseline snapshot for the given scenario name.
@@ -146,14 +212,23 @@ export function loadBaseline(
     });
   }
 
+  const tokenEnvelope =
+    record['token_envelope'] === undefined
+      ? undefined
+      : validateTokenEnvelope(filePath, record['token_envelope']);
+
   // Construct the Baseline explicitly so unknown extra fields do not leak
   // through. This keeps the returned shape exactly matching the interface.
-  return {
+  const baseline: Baseline = {
     scenario_name: record['scenario_name'],
     captured_at: record['captured_at'],
     headings: (record['headings'] as string[]).slice(),
     tables,
   };
+  if (tokenEnvelope !== undefined) {
+    baseline.token_envelope = tokenEnvelope;
+  }
+  return baseline;
 }
 
 /**

--- a/evals/lib/baseline.ts
+++ b/evals/lib/baseline.ts
@@ -68,7 +68,7 @@ function validateTokenRange(
 function validateTokenEnvelope(
   filePath: string,
   value: unknown,
-): TokenEnvelope {
+): TokenEnvelope | undefined {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error(
       `Invalid baseline file ${filePath}: field "token_envelope" must be an object when present`,
@@ -82,6 +82,13 @@ function validateTokenEnvelope(
   }
   if (record['output'] !== undefined) {
     envelope.output = validateTokenRange(filePath, 'output', record['output']);
+  }
+
+  // An envelope that declares no supported range carries no bounds at all.
+  // Report it as absent rather than as an empty object, so comparison code
+  // cannot read "envelope present" as "this baseline has token bounds".
+  if (envelope.input === undefined && envelope.output === undefined) {
+    return undefined;
   }
   return envelope;
 }

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -121,6 +121,22 @@ export interface LocalFixtureSet {
 }
 
 /**
+ * Inclusive token bounds recorded in a committed baseline.
+ */
+export interface TokenRange {
+  min: number;
+  max: number;
+}
+
+/**
+ * Optional accepted token ranges for a committed baseline.
+ */
+export interface TokenEnvelope {
+  input?: TokenRange | undefined;
+  output?: TokenRange | undefined;
+}
+
+/**
  * Persisted baseline snapshot of a known-good skill output.
  * Loaded from `evals/baselines/<scenario_name>.json`; used by
  * `compareToBaseline` to detect structural regressions.
@@ -130,6 +146,7 @@ export interface Baseline {
   captured_at: string;
   headings: string[];
   tables: { columns: string[] }[];
+  token_envelope?: TokenEnvelope | undefined;
 }
 
 /** A single eval scenario loaded from YAML. */

--- a/specs/2026-05-18-007-per-case-token-totals-in-evalreport/03-extend-baselines-with-token-envelopes.tasks.md
+++ b/specs/2026-05-18-007-per-case-token-totals-in-evalreport/03-extend-baselines-with-token-envelopes.tasks.md
@@ -18,7 +18,7 @@
 
 ### Tasks
 
-- [ ] **Declare token envelope baseline types**
+- [x] **Declare token envelope baseline types**
 
   Extend the eval baseline model in `evals/lib/types.ts` with the optional token envelope shape from the data model. Reuse the existing token-total terminology so live results and committed bounds describe the same input and output dimensions.
 
@@ -28,7 +28,7 @@
   - `Baseline` accepts an optional token envelope without requiring it.
   - Existing type exports remain import-compatible for current eval modules.
 
-- [ ] **Validate token envelopes during baseline loading**
+- [x] **Validate token envelopes during baseline loading**
 
   Update `loadBaseline` in `evals/lib/baseline.ts` so structural-only baselines still load, valid token envelopes are preserved, and malformed token bounds reject the baseline instead of producing misleading drift checks.
 


### PR DESCRIPTION
## Summary

RFC 2026-001 Token Savings → M1 Measurement Foundation → F1.3a Per-Case Token Totals in EvalReport → Per-Case Token Totals in EvalReport → Slice 1: Load Optional Token Envelopes from Baselines

Extends the eval baseline schema with an optional `token_envelope` so committed baselines can declare accepted input/output token ranges, and teaches `loadBaseline` to validate it. This is the right first increment because baseline loading owns schema compatibility: landing the optional envelope first keeps every existing structural-only baseline valid while giving the next slice's comparison code a typed, already-validated contract to consume.

## Spec debt & uncertainty

- SD-001 (open): stream-json usage metadata placement varies by Claude CLI version; implementers must apply the contracts document's dedup rule. Not exercised by this slice — it lands with the stream-parsing work in US1.
- SD-002 (open): token envelope tolerance is uncalibrated until the first token-aware strike baseline is captured. This slice only defines and validates the envelope shape; no envelope values are committed here, so calibration remains open for US4.
- SD-003 (open): the RFC touched-files matrix omits some token-threading surfaces (`evals/lib/types.ts`, `evals/lib/baseline.ts` among them). Not amended in this PR — deferred to the slice that closes SD-003 rather than partially amended here.
- Assumption (from the spec): structural-only baseline compatibility is required during M1, since later features add baselines after F1.3a lands. This drove the "absent `token_envelope` still loads" behavior and its dedicated regression test.
- Decision I made while reviewing: unrecognized keys *inside* `token_envelope` (e.g. a `cache` range, or a `midpoint` alongside `min`/`max`) are silently ignored rather than rejected, mirroring the loader's existing treatment of unknown top-level baseline fields. The task's acceptance criteria only require unknown fields to be ignored "outside the supported schema" — reading that as also covering the envelope's interior is my call, and it is now pinned by a test. Malformed *known* bounds still hard-fail the baseline as specified.
- Verification gap: `src/artifact-store.test.ts > commits with a fallback identity when the machine has none` fails in this worktree. It is pre-existing and environmental — the test asserts a fallback git identity that cannot trigger on a machine with a global `user.name`/`user.email` set. Confirmed failing on a clean stashed tree before this change.

## Validation

typecheck ✅ · eval unit tests ✅ (262 passed) · full suite ⚠️ 1135 passed, 1 pre-existing environmental failure unrelated to this diff (see above)
