### PR TITLE
forge: import-mode prototype ingestion in the render feature map

### DIFF
--- a/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/05-render-is-a-clean-ui-aware-entry-point-with-prototype-ingestion.tasks.md
+++ b/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/05-render-is-a-clean-ui-aware-entry-point-with-prototype-ingestion.tasks.md
@@ -53,7 +53,7 @@
 
 ### Tasks
 
-- [ ] **Route supplied bundles through render**
+- [x] **Route supplied bundles through render**
 
   Update render intake and drafting guidance so a supplied import-mode bundle is treated as a boundary object available to the feature map. Render should record the bundle reference in the relevant UI feature metadata without implying that smithy calls the visual tool inline or that the bundle replaces the committed design skill.
 
@@ -64,7 +64,7 @@
   - Render does not describe inline visual-tool calls as part of the workflow
   - No-bundle render runs keep the existing non-import path
 
-- [ ] **Derive candidate screens and flows from the bundle**
+- [x] **Derive candidate screens and flows from the bundle**
 
   Add import-mode drafting instructions so render uses the supplied prototype to propose candidate `ScreenId` and `FlowId` entries for the feature metadata. The output should frame those candidates as confirmable structure that `mark` will later turn into the typed ledger and durable files, not as authoritative implementation detail.
 

--- a/src/templates/agent-skills/commands/smithy.render.prompt
+++ b/src/templates/agent-skills/commands/smithy.render.prompt
@@ -13,14 +13,18 @@ together deliver the milestone's goals.
 
 ## Input
 
-The user's RFC path and optional milestone number: $ARGUMENTS
+The user's RFC path, optional milestone number, and optional `--bundle <path>`:
+$ARGUMENTS
 
 This may be:
 - An **RFC file path** (`.rfc.md`) — auto-selects the next unprocessed milestone.
 - An **RFC file path + milestone number** — targets that specific milestone.
-- An **RFC file path + milestone number + import bundle path** — targets that
-  milestone and treats the bundle as prototype-first UI context for any
-  `design: import` features the map emits.
+- **Either of the above plus `--bundle <path>`** — treats the named bundle as
+  prototype-first UI context for any `design: import` features the map emits.
+  `--bundle` is a named argument, so it never competes with the optional
+  milestone number: `<rfc> --bundle <path>` keeps auto-selection, while
+  `<rfc> 3 --bundle <path>` targets milestone 3. A bare path that is not
+  preceded by `--bundle` is never treated as a bundle.
 - An **existing `.features.md` path** — enters the review loop (Phase 0).
 - Empty — ask the user for a path.
 
@@ -191,8 +195,10 @@ Parse the input and prepare the target:
 
 ### Import Bundle Intake
 
-If the input includes an import bundle path, treat it as a boundary object
-available while drafting the feature map:
+If the input includes a `--bundle <path>` argument, treat that path as a
+boundary object available while drafting the feature map. Read the bundle path
+from `--bundle` only — never from a bare positional argument, so auto-selected
+and explicitly numbered milestone runs accept a bundle identically:
 
 - Record the exact repo-relative bundle path in every relevant `kind: ui`,
   `design: import` feature's metadata.
@@ -211,7 +217,7 @@ available while drafting the feature map:
 - Do not author `.design.md`, `.flow.md`, or executable test-body files during
   render. Those durable artifacts remain owned by downstream `smithy.mark`.
 
-If no import bundle path is supplied, keep the existing no-bundle path: omit
+If no `--bundle` argument is supplied, keep the existing no-bundle path: omit
 `bundle`, choose `design` from the milestone/RFC context, and derive only the
 screen/flow identifiers supported by the written milestone intent.
 
@@ -357,7 +363,7 @@ kind: ui
 phase: build
 design_system: <committed design skill, e.g. story-spider-design>
 design: <none|import|brief>
-bundle: <repo-relative path to supplied prototype bundle when design is import; omit when absent>
+bundle: <repo-relative path to a visual prototype boundary object — supplied via --bundle at render for `design: import`, or attached later for `design: brief`; omit the key when no bundle exists yet>
 flag: <feature-flag name gating this screen>
 screens: [<candidate ScreenId derived from milestone or import bundle>]
 flows: [<candidate FlowId derived from milestone or import bundle>]
@@ -549,7 +555,9 @@ here, by render.
   write its repo-relative path to `bundle` on relevant `kind: ui`,
   `design: import` features, keep `design_system` as the committed dialect
   source, and derive candidate `ScreenId`/`FlowId` metadata from the prototype
-  for human confirmation.
+  for human confirmation. `bundle` itself is not import-only — a `design: brief`
+  feature may gain one later, after the visual tool answers mark's brief — so
+  omit the key at render rather than treating its absence as a mode signal.
 - **DO** route ambiguous import derivation to specification debt. The feature
   map should say what is unclear rather than pretending the candidate screen or
   flow structure is authoritative.

--- a/src/templates/agent-skills/commands/smithy.render.prompt
+++ b/src/templates/agent-skills/commands/smithy.render.prompt
@@ -18,6 +18,9 @@ The user's RFC path and optional milestone number: $ARGUMENTS
 This may be:
 - An **RFC file path** (`.rfc.md`) — auto-selects the next unprocessed milestone.
 - An **RFC file path + milestone number** — targets that specific milestone.
+- An **RFC file path + milestone number + import bundle path** — targets that
+  milestone and treats the bundle as prototype-first UI context for any
+  `design: import` features the map emits.
 - An **existing `.features.md` path** — enters the review loop (Phase 0).
 - Empty — ask the user for a path.
 
@@ -184,6 +187,33 @@ Parse the input and prepare the target:
    - RFC path
    - Milestone number and title
    - Derived filename
+   - Import bundle path, if supplied
+
+### Import Bundle Intake
+
+If the input includes an import bundle path, treat it as a boundary object
+available while drafting the feature map:
+
+- Record the exact repo-relative bundle path in every relevant `kind: ui`,
+  `design: import` feature's metadata.
+- Keep `design_system` as the committed implementation dialect source even
+  when a bundle is present. A bundle supplements visual/structural context; it
+  does not replace the design skill.
+- Use the supplied prototype/bundle to derive candidate `ScreenId` and `FlowId`
+  values for the feature metadata (`screens:` and `flows:`). These IDs are a
+  human-confirmable starting point that `smithy.mark` later turns into the typed
+  ledger and durable artifacts.
+- Surface unclear prototype structure as specification debt instead of hiding
+  it. Examples: multiple plausible screen boundaries, unnamed alternate paths,
+  or flows whose entry/exit/guard cannot be inferred confidently.
+- Do not call a visual design/prototyping tool inline. Render only ingests the
+  supplied bundle reference and records/derives feature-map structure from it.
+- Do not author `.design.md`, `.flow.md`, or executable test-body files during
+  render. Those durable artifacts remain owned by downstream `smithy.mark`.
+
+If no import bundle path is supplied, keep the existing no-bundle path: omit
+`bundle`, choose `design` from the milestone/RFC context, and derive only the
+screen/flow identifiers supported by the written milestone intent.
 
 ---
 
@@ -327,13 +357,15 @@ kind: ui
 phase: build
 design_system: <committed design skill, e.g. story-spider-design>
 design: <none|import|brief>
-bundle: <optional repo-relative path to a visual prototype boundary object, or omit the key>
+bundle: <repo-relative path to supplied prototype bundle when design is import; omit when absent>
 flag: <feature-flag name gating this screen>
-screens: [<ScreenId>]
-flows: [<FlowId>]
+screens: [<candidate ScreenId derived from milestone or import bundle>]
+flows: [<candidate FlowId derived from milestone or import bundle>]
 ```
 
-**Description**: <What this screen delivers, built against a mock behind the flag.>
+**Description**: <What this screen delivers, built against a mock behind the flag. If
+`design: import`, name the supplied bundle as context and state that the screen/flow
+IDs are candidate structure for human confirmation.>
 
 **User-Facing Value**: <Why a user cares about this feature.>
 
@@ -513,6 +545,20 @@ here, by render.
   `screens`/`flows` name the candidate identifiers that downstream `mark` will
   turn into the typed ledger and durable artifacts. Do not rely on feature
   titles to communicate any of those facts.
+- **DO** accept a supplied import bundle as feature-map context when present:
+  write its repo-relative path to `bundle` on relevant `kind: ui`,
+  `design: import` features, keep `design_system` as the committed dialect
+  source, and derive candidate `ScreenId`/`FlowId` metadata from the prototype
+  for human confirmation.
+- **DO** route ambiguous import derivation to specification debt. The feature
+  map should say what is unclear rather than pretending the candidate screen or
+  flow structure is authoritative.
+- **DO NOT** call visual design tools inline or describe inline visual-tool calls
+  as part of render. Render records a supplied bundle reference; it does not
+  create, modify, or round-trip a prototype.
+- **DO NOT** author `.design.md`, `.flow.md`, or executable test-body files from
+  render. Candidate `screens`/`flows` metadata is the handoff to `smithy.mark`,
+  which owns the durable files.
 - **DO** keep backend features visibly backend: emit only `kind: backend` in the
   metadata block, and do not add `phase`, `design_system`, `design`, `bundle`,
   `flag`, `screens`, or `flows` to backend feature metadata. Missing `kind` on

--- a/src/templates/agent-skills/snippets/feature-kinds.md
+++ b/src/templates/agent-skills/snippets/feature-kinds.md
@@ -20,7 +20,7 @@ durable design truth.
 | `phase` | ui | Yes | `build` or `wire` (feature-level). |
 | `design_system` | ui | Yes | Committed design-skill ref (for example `story-spider-design`); source of truth even when a bundle is present. A screen with a `bundle` still requires `design_system`. |
 | `design` | ui | Yes | Screen-node design mode: `none`, `import`, or `brief`, shared by every `ScreenId` the feature lists. Render must set this explicitly; downstream `mark` copies it into the `Design` cell of each of the feature's `SC<N>` ledger rows instead of inferring from the title. Screens needing distinct modes go in separate features. |
-| `bundle` | ui | No | Repo-relative path to a visual prototype boundary object (for example a Figma export, Claude Design export, or equivalent visual-tool bundle) — a visual/structural reference, not a drop-in. Bundle wins on layout/visual intent; the skill wins on implementation dialect. |
+| `bundle` | ui | No | Repo-relative path to a visual prototype boundary object supplied to render or attached later (for example a Figma export, Claude Design export, or equivalent visual-tool bundle) — a visual/structural reference, not a drop-in. Bundle wins on layout/visual intent; the skill wins on implementation dialect. |
 | `flag` | ui | Yes (flag-gated) | Feature-flag name; the shared contract joining a `build` feature to its `wire` feature. |
 | `screens` | ui | Yes | List of `ScreenId`, e.g. `[AddTitle]`. |
 | `flows` | ui | No (build) / Yes (wire) | List of `FlowId` the screen participates in. Build features may list mock-satisfiable candidate flows; wire features must list the flows they connect to real data. |
@@ -53,8 +53,18 @@ one-screen-per-build model already favors. `mark` copies the value into the
 | Mode | Meaning | Bundle behavior |
 |------|---------|-----------------|
 | `none` | No visual loop. Build from the committed design skill with no bundle ceremony. | Omit `bundle`. |
-| `import` | Prototype-first: a visual prototype already exists. `render` may carry the supplied bundle forward for downstream honoring. | Bundle enters at `render` and rides to `forge` as visual source context; downstream prompts do not derive detailed prototype-to-screen/flow structure. |
+| `import` | Prototype-first: a visual prototype already exists. `render` carries the supplied bundle forward and may derive candidate screen/flow structure from it. | Bundle enters at `render`, is recorded in UI feature metadata, and rides to `forge` as visual source context; derived `screens`/`flows` are confirmable candidates for `mark`, not durable design truth. |
 | `brief` | Mark-authored intent for a visual tool: the `.design.md`/`.flow.md` artifacts are the brief. | Bundle may be attached later; if present, downstream build honors it under the conflict rule. |
+
+**Import-mode derivation.** When render receives an import bundle, it treats the
+bundle as feature-map context: record the exact bundle reference on relevant
+`design: import` UI features, keep `design_system` as the committed
+implementation dialect, and use the prototype to propose candidate `ScreenId`
+and `FlowId` values in `screens:` and `flows:`. Those identifiers are a
+human-confirmable starting point that downstream `mark` turns into the typed
+ledger plus durable `.design.md`/`.flow.md` artifacts. Render does not call a
+visual tool inline, author durable screen/flow files, or hide ambiguous
+prototype interpretation; unresolved ambiguity belongs in specification debt.
 
 **Phase semantics.** `build` implements the screen component against a mock
 behind `flag` (rendering every brief state with design-system tokens only);


### PR DESCRIPTION
## Summary
EPIC [#404](https://github.com/Balexda/SmithyCLI/issues/404) → Screens and Flows as UI Feature Kinds (spec) → User Story 5: render is a clean, UI-aware entry point with prototype ingestion → Slice 2: Add Import-Mode Prototype Ingestion

Teaches `smithy.render` to accept a supplied import-mode prototype bundle as feature-map context: it records the repo-relative bundle path on the relevant `kind: ui` / `design: import` features and derives candidate `ScreenId`/`FlowId` values from the prototype as human-confirmable structure. This is the right increment after Slice 1 tightened baseline UI metadata — import ingestion only applies when a bundle is supplied, so the no-bundle path stays exactly as it was, and durable `.design.md`/`.flow.md` ownership stays with downstream `mark`.

## Spec debt & uncertainty
- SD-005 (inherited, open): Fidelity of `import`-mode structure derivation — how reliably `render` can extract screens/flows/behavior from a prototype/bundle, and how much human confirmation the derived structure needs. **This slice is its named owner**: the change labels all derived structure as confirmable candidates and routes unresolved ambiguity to specification debt, but does not close the underlying fidelity question.
- SD-006 (inherited, open): Whether `SC`/`FL` nodes are always atomic or can be sub-sliced. Untouched here — render only emits feature-map metadata and does not decide node slice granularity.
- SD-007 (inherited, open): Build-phase coverage honesty. Untouched — render only preserves the build/wire seam.
- SD-008 (inherited, open): Visual-intent honesty for a `brief`-mode node that never receives a bundle. Untouched — this slice covers `import` recording only.
- Assumption (spec): Smithy never performs visual iteration inline; the `bundle` is the only object crossing the terminal↔visual boundary. The prompt now states this as an explicit **DO NOT** so render cannot drift into describing inline visual-tool calls.
- Assumption (spec): `.claude/` is **not** regenerated for source-template PRs. This PR edits `src/templates/` only; the deployed snapshot is intentionally left stale per `CLAUDE.md`.
- Uncertainty: the intake section describes the bundle as an optional third input token but does not pin a strict argument grammar (flag vs. positional). That matches the prompt's existing loose `$ARGUMENTS` parsing style, but a stricter contract may be wanted when Slice 3's audit checks land.
- Verification gap: this slice changes prompt/snippet prose only, so there is no behavioral test asserting import-mode output — correctness rests on the template-composition tests plus review of the rendered guidance.

## Validation
build ✅ · typecheck ✅ · test ⚠️ 1135 passed / 1 failed — the single failure is `src/artifact-store.test.ts > commits with a fallback identity when the machine has none`, which asserts a no-git-identity fallback and fails because this machine has a global git identity configured. Pre-existing and unrelated to the touched templates. Node 22 was required locally (repo tooling fails under the ambient Node 18).
