### PR TITLE
cut: decompose token-total report rendering into a slice

### DIFF
--- a/specs/2026-05-18-007-per-case-token-totals-in-evalreport/02-render-token-totals-in-eval-reports.tasks.md
+++ b/specs/2026-05-18-007-per-case-token-totals-in-evalreport/02-render-token-totals-in-eval-reports.tasks.md
@@ -1,0 +1,82 @@
+# Tasks: Render Token Totals in Eval Reports
+
+**Source**: `specs/2026-05-18-007-per-case-token-totals-in-evalreport/per-case-token-totals-in-evalreport.spec.md` — User Story 2
+**Data Model**: `specs/2026-05-18-007-per-case-token-totals-in-evalreport/per-case-token-totals-in-evalreport.data-model.md`
+**Contracts**: `specs/2026-05-18-007-per-case-token-totals-in-evalreport/per-case-token-totals-in-evalreport.contracts.md`
+**Story Number**: 02
+
+---
+
+## Slice 1: Render Per-Case Token Totals in Reports
+<!-- audience: builder; mode: how-to; length: 5-15 steps; diagram: optional; examples: forbidden -->
+
+**Goal**: Display each scenario's measured input and output token totals on the formatted eval report case line. After this PR, contributors can see per-case token cost in stdout for passing, failing, timeout, and error cases without changing aggregate pass/fail summary semantics.
+
+**Justification**: User Story 1 already carries token totals through `EvalResult` and `EvalReport`. Rendering is the remaining user-facing report surface, and it can land as one focused slice in `formatReport` plus report documentation because it does not require revisiting stream extraction, result assembly, or baseline comparison.
+
+**Addresses**: FR-007, FR-008, FR-009, FR-015; Acceptance Scenarios 2.1, 2.2, 2.3
+
+### Tasks
+
+- [ ] **Render token totals on every case line**
+
+  Update `evals/lib/report.ts` so `formatReport` includes each result's token totals on every per-case line in the contract shape `input: <N>, output: <N>`. Preserve the existing status token, scenario name, duration, final elapsed line, and final result line behavior for AS 2.1 and AS 2.2.
+
+  _Acceptance criteria:_
+  - Passing case lines display their input and output token counts.
+  - Failing, timeout, and error case lines display token counts without changing their status tokens.
+  - The aggregate `Total elapsed:` and `Result:` lines remain unchanged.
+  - Empty reports remain well formed and do not invent case lines.
+  - Unit coverage verifies per-case token rendering for pass, fail, timeout, and error results.
+
+- [ ] **Keep baseline markers visible with token totals**
+
+  Extend the report-formatting coverage for baseline-enabled reports so token totals and baseline markers both appear on the relevant case lines. Keep the existing rule that baseline markers render for all cases only when at least one result carries baseline checks.
+
+  _Acceptance criteria:_
+  - Token totals render for cases with passing baseline checks.
+  - Token totals render for cases with failing baseline checks.
+  - Token totals render for no-baseline cases when another case enables baseline marker rendering.
+  - Existing `baseline: PASS`, `baseline: FAIL`, and `baseline: n/a` marker semantics remain unchanged.
+  - Unit coverage verifies AS 2.3 without depending on token-aware baseline envelopes from User Story 3.
+
+- [ ] **Refresh eval report documentation examples**
+
+  Update `evals/README.md` report examples and surrounding prose so contributors see the token-total line shape when reading the eval workflow documentation. Keep the documentation scoped to formatted report output; do not document token envelopes or token-delta workflows owned by other stories.
+
+  _Acceptance criteria:_
+  - README report examples include `input: <N>, output: <N>` on per-case lines.
+  - Documentation still explains the existing status tokens and baseline marker behavior.
+  - Documentation does not imply aggregate summary status or baseline comparison behavior changed in this slice.
+
+**PR Outcome**: Formatted eval reports expose per-case input and output token totals alongside the existing duration and baseline marker fields, with status and summary rendering protected by focused tests.
+
+---
+
+## Specification Debt
+<!-- audience: reviewer; mode: reference; length: tables only; diagram: optional; examples: discouraged -->
+
+| ID | Title | Source Category | Impact | Confidence | Origin |
+|----|-------|-----------------|--------|------------|--------|
+| SD-001 | Stream usage placement | Integration | High | Medium | spec:SD-001 |
+| SD-002 | Token envelope tolerance | Non-Functional Quality | Medium | Medium | spec:SD-002 |
+| SD-003 | RFC touched-files matrix | Integration | Medium | High | spec:SD-003 |
+
+---
+
+## Dependency Order
+<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: recommended; examples: discouraged -->
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| S1 | Render Per-Case Token Totals in Reports | — | — |
+
+### Cross-Story Dependencies
+
+| Dependency | Direction | Notes |
+|------------|-----------|-------|
+| User Story 1: Capture Per-Case Token Totals | depends on | US2 renders the per-case token totals already captured and carried through report data by US1. |
+| User Story 3: Extend Baselines with Token Envelopes | independent sibling | US2 preserves existing baseline marker visibility but does not implement token envelope loading or comparison. |
+| User Story 4: Refresh the Strike Baseline in the Token-Aware Schema | depended upon by | US4 expects report lines to show token totals after the strike baseline is refreshed. |

--- a/specs/2026-05-18-007-per-case-token-totals-in-evalreport/per-case-token-totals-in-evalreport.spec.md
+++ b/specs/2026-05-18-007-per-case-token-totals-in-evalreport/per-case-token-totals-in-evalreport.spec.md
@@ -101,7 +101,7 @@ Recommended implementation sequence:
 | ID | Title | Depends On | Artifact |
 |----|-------|------------|----------|
 | US1 | Capture Per-Case Token Totals | — | specs/2026-05-18-007-per-case-token-totals-in-evalreport/01-capture-per-case-token-totals.tasks.md |
-| US2 | Render Token Totals in Eval Reports | US1 | — |
+| US2 | Render Token Totals in Eval Reports | US1 | specs/2026-05-18-007-per-case-token-totals-in-evalreport/02-render-token-totals-in-eval-reports.tasks.md |
 | US3 | Extend Baselines with Token Envelopes | US1 | specs/2026-05-18-007-per-case-token-totals-in-evalreport/03-extend-baselines-with-token-envelopes.tasks.md |
 | US4 | Refresh the Strike Baseline in the Token-Aware Schema | US2, US3 | — |
 


### PR DESCRIPTION
## Summary

RFC 2026-001 Token Savings → M1 Measurement Foundation → F1.3a Per-Case Token Totals in EvalReport → Per-Case Token Totals in EvalReport spec → User Story 2: Render Token Totals in Eval Reports

Decomposes US2 into a single PR-sized slice and links the new tasks artifact from the spec's `## Dependency Order` table. US2 is deliberately one slice, not two: `formatReport` is the only rendering surface, and splitting "render the numbers" from "keep the baseline marker visible" would produce a first PR that ships a regression risk its own tests can't cover. The slice's three tasks — case-line rendering, baseline-marker coexistence, and the `evals/README.md` examples — all land against that one function and its test file.

Planning-only change — no code or template source is touched.

## Spec debt & uncertainty

- SD-001 (inherited from spec): Stream usage placement — the stream-json event carrying usage metadata varies by Claude CLI version. Not load-bearing for US2, which consumes totals already carried on `EvalResult`.
- SD-002 (inherited from spec): Token envelope tolerance is uncalibrated until the first token-aware strike baseline is captured (US4). The slice's baseline-marker task therefore asserts marker *visibility* only, and pins no envelope semantics.
- SD-003 (inherited from spec): The RFC touched-files matrix omits some token-threading surfaces owned by F1.3a; the amendment lands with the implementation PR.
- Assumption (from spec): per-case token reporting is additive — existing structural pass/fail behavior stays compatible. Every acceptance criterion in the slice carries an explicit "unchanged" clause for status tokens, summary lines, and baseline markers for that reason.
- Assumption I named while reviewing: a `smithy.cut` step has no pre-existing `[ ]` tasks row to flip. The rows it *authors* describe future implementation work and correctly stay unchecked; the durable "this cut is done" signal is the spec's `## Dependency Order` `Artifact` column, which this PR fills in for US2 — mirroring the already-cut US1 and US3 rows (#543).
- Verification gap: this worktree has no `node_modules` (`npm test` cannot run), and the `smithy` CLI is not on PATH, so neither the suite nor `smithy status` parsing was exercised here. The diff is markdown-only and no test reads this spec folder, so CI on this PR is the first meaningful execution.

## Validation

build ⏭️ · typecheck ⏭️ · test ⏭️ (docs-only diff; no deps installed in this worktree) · schema conformance vs the merged US3 tasks artifact ✅ (identical section order, audience tags, and `Title`/`Origin` spec-debt columns) · markdown table column counts consistent ✅ · US2 coverage complete: FR-007/008/009/015 and AS 2.1/2.2/2.3 each map to a named acceptance criterion ✅ · referenced surfaces verified present and token-free today — `formatReport` in `evals/lib/report.ts` renders status, name, duration, and baseline marker but no token totals, while `EvalResult` already carries `tokens.input`/`tokens.output` from the merged US1 work ✅
