### PR TITLE
forge: render per-case token totals in eval reports

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -131,16 +131,17 @@ Checks:
   [FAIL] smithy-reconcile evidence present — expected: dispatching.*smithy-reconcile, actual: no match found
 
 Eval Summary
-  [FAIL] strike-health-check (442502ms) baseline: FAIL
-  [FAIL] scout-fixture-shallow (27830ms) baseline: n/a
+  [FAIL] strike-health-check (442502ms) input: 14820, output: 3003 baseline: FAIL
+  [FAIL] scout-fixture-shallow (27830ms) input: 5201, output: 980 baseline: n/a
 
 Total elapsed: 471117ms
 Result: FAIL (0/2 passed, 2 total)
 ```
 
 Status tokens: `PASS`, `FAIL`, `TIMEOUT`, `ERROR` (FR-009, AS 9.3). The
-`baseline:` column appears only when at least one scenario has a baseline file
-(see [Baselines](#baselines)).
+per-case summary line also renders measured token totals as
+`input: <N>, output: <N>`. The `baseline:` marker appears only when at least
+one scenario has a baseline file (see [Baselines](#baselines)).
 
 ## Layout
 

--- a/evals/lib/report.test.ts
+++ b/evals/lib/report.test.ts
@@ -737,6 +737,101 @@ describe('formatReport', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Token rendering (US2)
+  // -----------------------------------------------------------------------
+  describe('token rendering', () => {
+    it('renders input and output token totals on a passing case line', () => {
+      const results: EvalResult[] = [
+        makeResult({
+          scenario_name: 'alpha',
+          tokens: { input: 123, output: 45 },
+          duration_ms: 111,
+        }),
+      ];
+      const report = buildReport(results, 111);
+      const out = formatReport(report);
+      const lines = out.split('\n');
+
+      const alphaLine = lines.find((l) => l.includes('alpha'));
+      expect(alphaLine).toBeDefined();
+      expect(alphaLine!).toBe(
+        '  [PASS] alpha (111ms) input: 123, output: 45',
+      );
+    });
+
+    it('renders token totals for fail, timeout, and error lines without changing status tokens', () => {
+      const results: EvalResult[] = [
+        makeResult({
+          scenario_name: 'fail-case',
+          status: 'fail',
+          tokens: { input: 200, output: 20 },
+          duration_ms: 2000,
+        }),
+        makeResult({
+          scenario_name: 'timeout-case',
+          status: 'timeout',
+          tokens: { input: 300, output: 30 },
+          duration_ms: 3000,
+          error: 'timed out',
+        }),
+        makeResult({
+          scenario_name: 'error-case',
+          status: 'error',
+          tokens: { input: 400, output: 40 },
+          duration_ms: 4000,
+          error: 'exit 1',
+        }),
+      ];
+      const report = buildReport(results, 9000);
+      const out = formatReport(report);
+      const lines = out.split('\n');
+
+      expect(lines.find((l) => l.includes('fail-case'))).toBe(
+        '  [FAIL] fail-case (2000ms) input: 200, output: 20',
+      );
+      expect(lines.find((l) => l.includes('timeout-case'))).toBe(
+        '  [TIMEOUT] timeout-case (3000ms) input: 300, output: 30',
+      );
+      expect(lines.find((l) => l.includes('error-case'))).toBe(
+        '  [ERROR] error-case (4000ms) input: 400, output: 40',
+      );
+    });
+
+    it('keeps Total elapsed: and Result: summary lines unchanged when token totals are present', () => {
+      const results: EvalResult[] = [
+        makeResult({
+          scenario_name: 'alpha',
+          tokens: { input: 12, output: 3 },
+        }),
+      ];
+      const report = buildReport(results, 750);
+      const out = formatReport(report);
+      const lines = out.split('\n');
+
+      expect(lines.find((l) => l.startsWith('Total elapsed:'))).toBe(
+        'Total elapsed: 750ms',
+      );
+      expect(lines[lines.length - 1]).toBe(
+        'Result: PASS (1/1 passed, 1 total)',
+      );
+    });
+
+    it('keeps empty reports well formed without inventing case lines', () => {
+      const report = buildReport([], 0);
+      const out = formatReport(report);
+
+      expect(out).toBe(
+        [
+          'Eval Summary',
+          '',
+          'Total elapsed: 0ms',
+          'Result: PASS (0/0 passed, 0 total)',
+        ].join('\n'),
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Determinism
   // -----------------------------------------------------------------------
   describe('determinism', () => {
@@ -958,7 +1053,7 @@ describe('baseline checks wiring', () => {
   // formatReport: no baseline present anywhere
   // -----------------------------------------------------------------------
   describe('formatReport with no baseline_checks anywhere', () => {
-    it('renders per-case lines byte-identical to pre-slice behavior', () => {
+    it('renders per-case lines without baseline markers', () => {
       const results: EvalResult[] = [
         makeResult({ scenario_name: 'alpha', duration_ms: 111 }),
         makeResult({ scenario_name: 'beta', duration_ms: 222, status: 'fail' }),
@@ -975,9 +1070,8 @@ describe('baseline checks wiring', () => {
       expect(alphaLine!).not.toContain('baseline:');
       expect(betaLine!).not.toContain('baseline:');
 
-      // Exact line shape preserved from US9.
-      expect(alphaLine!).toBe('  [PASS] alpha (111ms)');
-      expect(betaLine!).toBe('  [FAIL] beta (222ms)');
+      expect(alphaLine!).toBe('  [PASS] alpha (111ms) input: 0, output: 0');
+      expect(betaLine!).toBe('  [FAIL] beta (222ms) input: 0, output: 0');
     });
   });
 
@@ -989,6 +1083,7 @@ describe('baseline checks wiring', () => {
       const results: EvalResult[] = [
         makeResult({
           scenario_name: 'alpha',
+          tokens: { input: 101, output: 11 },
           baseline_checks: [passingBaselineCheck],
         }),
       ];
@@ -998,6 +1093,7 @@ describe('baseline checks wiring', () => {
 
       const alphaLine = lines.find((l) => l.includes('alpha'));
       expect(alphaLine).toBeDefined();
+      expect(alphaLine!).toContain('input: 101, output: 11');
       expect(alphaLine!).toContain('baseline: PASS');
       expect(alphaLine!).not.toContain('baseline: FAIL');
       expect(alphaLine!).not.toContain('baseline: n/a');
@@ -1008,6 +1104,7 @@ describe('baseline checks wiring', () => {
         makeResult({
           scenario_name: 'alpha',
           status: 'fail',
+          tokens: { input: 202, output: 22 },
           baseline_checks: [passingBaselineCheck, failingBaselineCheck],
         }),
       ];
@@ -1017,6 +1114,7 @@ describe('baseline checks wiring', () => {
 
       const alphaLine = lines.find((l) => l.includes('alpha'));
       expect(alphaLine).toBeDefined();
+      expect(alphaLine!).toContain('input: 202, output: 22');
       expect(alphaLine!).toContain('baseline: FAIL');
       expect(alphaLine!).not.toContain('baseline: PASS');
     });
@@ -1025,9 +1123,13 @@ describe('baseline checks wiring', () => {
       const results: EvalResult[] = [
         makeResult({
           scenario_name: 'alpha',
+          tokens: { input: 303, output: 33 },
           baseline_checks: [passingBaselineCheck],
         }),
-        makeResult({ scenario_name: 'beta' }),
+        makeResult({
+          scenario_name: 'beta',
+          tokens: { input: 404, output: 44 },
+        }),
       ];
       const report = buildReport(results, 500);
       const out = formatReport(report);
@@ -1039,16 +1141,22 @@ describe('baseline checks wiring', () => {
       expect(betaLine).toBeDefined();
 
       expect(alphaLine!).toContain('baseline: PASS');
+      expect(alphaLine!).toContain('input: 303, output: 33');
       expect(betaLine!).toContain('baseline: n/a');
+      expect(betaLine!).toContain('input: 404, output: 44');
     });
 
     it('keeps Total elapsed: and Result: summary lines unchanged when baseline markers are present', () => {
       const results: EvalResult[] = [
         makeResult({
           scenario_name: 'alpha',
+          tokens: { input: 10, output: 1 },
           baseline_checks: [passingBaselineCheck],
         }),
-        makeResult({ scenario_name: 'beta' }),
+        makeResult({
+          scenario_name: 'beta',
+          tokens: { input: 20, output: 2 },
+        }),
       ];
       const report = buildReport(results, 750);
       const out = formatReport(report);
@@ -1066,14 +1174,19 @@ describe('baseline checks wiring', () => {
       const results: EvalResult[] = [
         makeResult({
           scenario_name: 'alpha',
+          tokens: { input: 10, output: 1 },
           baseline_checks: [passingBaselineCheck],
         }),
         makeResult({
           scenario_name: 'beta',
           status: 'fail',
+          tokens: { input: 20, output: 2 },
           baseline_checks: [failingBaselineCheck],
         }),
-        makeResult({ scenario_name: 'gamma' }),
+        makeResult({
+          scenario_name: 'gamma',
+          tokens: { input: 30, output: 3 },
+        }),
       ];
       const report = buildReport(results, 1000);
       const out = formatReport(report);
@@ -1087,8 +1200,11 @@ describe('baseline checks wiring', () => {
       expect(gammaLine).toBeDefined();
 
       expect(alphaLine!).toContain('baseline: PASS');
+      expect(alphaLine!).toContain('input: 10, output: 1');
       expect(betaLine!).toContain('baseline: FAIL');
+      expect(betaLine!).toContain('input: 20, output: 2');
       expect(gammaLine!).toContain('baseline: n/a');
+      expect(gammaLine!).toContain('input: 30, output: 3');
     });
   });
 });

--- a/evals/lib/report.ts
+++ b/evals/lib/report.ts
@@ -158,24 +158,24 @@ function statusToken(status: EvalResult['status']): string {
  * Output shape:
  *
  *     Eval Summary
- *       [PASS] strike-health-check (1234ms)
- *       [FAIL] plan-standalone (5678ms)
- *       [TIMEOUT] scout-standalone (120000ms)
- *       [ERROR] clarify-standalone (42ms)
+ *       [PASS] strike-health-check (1234ms) input: 1200, output: 345
+ *       [FAIL] plan-standalone (5678ms) input: 2300, output: 456
+ *       [TIMEOUT] scout-standalone (120000ms) input: 3400, output: 567
+ *       [ERROR] clarify-standalone (42ms) input: 4500, output: 678
  *
  *     Total elapsed: 127000ms
  *     Result: FAIL (1/4 passed, 4 total)
  *
  * When at least one result in the report has populated `baseline_checks`,
  * each per-case line is extended with a compact `baseline: PASS`,
- * `baseline: FAIL`, or `baseline: n/a` marker (AS 10.3 — the marker only
- * appears when at least one case opts into baselines, so scenarios without
- * a baseline never pollute the default output):
+ * `baseline: FAIL`, or `baseline: n/a` marker after token totals (AS 10.3 —
+ * the marker only appears when at least one case opts into baselines, so
+ * scenarios without a baseline never pollute the default output):
  *
  *     Eval Summary
- *       [PASS] strike-health-check (1234ms) baseline: PASS
- *       [FAIL] plan-standalone (5678ms) baseline: FAIL
- *       [PASS] no-baseline-case (789ms) baseline: n/a
+ *       [PASS] strike-health-check (1234ms) input: 1200, output: 345 baseline: PASS
+ *       [FAIL] plan-standalone (5678ms) input: 2300, output: 456 baseline: FAIL
+ *       [PASS] no-baseline-case (789ms) input: 0, output: 0 baseline: n/a
  *
  *     Total elapsed: 127000ms
  *     Result: FAIL (1/3 passed, 3 total)
@@ -191,7 +191,7 @@ function statusToken(status: EvalResult['status']): string {
  * (US11 AS 11.2, FR-009). Durations render as integer milliseconds with
  * the `ms` suffix uniformly across per-case and total lines. The
  * `Total elapsed:` and `Result:` summary lines are unchanged regardless
- * of whether baseline markers appear (US10 Slice 2 — additions only).
+ * of whether token totals or baseline markers appear.
  */
 export function formatReport(report: EvalReport): string {
   const lines: string[] = ['Eval Summary'];
@@ -202,7 +202,7 @@ export function formatReport(report: EvalReport): string {
 
   for (const result of report.results) {
     const token = statusToken(result.status);
-    let line = `  [${token}] ${result.scenario_name} (${result.duration_ms}ms)`;
+    let line = `  [${token}] ${result.scenario_name} (${result.duration_ms}ms) input: ${result.tokens.input}, output: ${result.tokens.output}`;
     if (anyBaseline) {
       line += ` baseline: ${baselineMarker(result)}`;
     }

--- a/specs/2026-05-18-007-per-case-token-totals-in-evalreport/02-render-token-totals-in-eval-reports.tasks.md
+++ b/specs/2026-05-18-007-per-case-token-totals-in-evalreport/02-render-token-totals-in-eval-reports.tasks.md
@@ -18,7 +18,7 @@
 
 ### Tasks
 
-- [ ] **Render token totals on every case line**
+- [x] **Render token totals on every case line**
 
   Update `evals/lib/report.ts` so `formatReport` includes each result's token totals on every per-case line in the contract shape `input: <N>, output: <N>`. Preserve the existing status token, scenario name, duration, final elapsed line, and final result line behavior for AS 2.1 and AS 2.2.
 
@@ -29,7 +29,7 @@
   - Empty reports remain well formed and do not invent case lines.
   - Unit coverage verifies per-case token rendering for pass, fail, timeout, and error results.
 
-- [ ] **Keep baseline markers visible with token totals**
+- [x] **Keep baseline markers visible with token totals**
 
   Extend the report-formatting coverage for baseline-enabled reports so token totals and baseline markers both appear on the relevant case lines. Keep the existing rule that baseline markers render for all cases only when at least one result carries baseline checks.
 
@@ -40,7 +40,7 @@
   - Existing `baseline: PASS`, `baseline: FAIL`, and `baseline: n/a` marker semantics remain unchanged.
   - Unit coverage verifies AS 2.3 without depending on token-aware baseline envelopes from User Story 3.
 
-- [ ] **Refresh eval report documentation examples**
+- [x] **Refresh eval report documentation examples**
 
   Update `evals/README.md` report examples and surrounding prose so contributors see the token-total line shape when reading the eval workflow documentation. Keep the documentation scoped to formatted report output; do not document token envelopes or token-delta workflows owned by other stories.
 


### PR DESCRIPTION
## Summary

RFC 2026-001 Token Savings → M1 Measurement Foundation → F1.3a Per-Case Token Totals in EvalReport → Per-Case Token Totals in EvalReport (User Story 2) → Slice 1: Render Per-Case Token Totals in Reports

User Story 1 already captures token totals and threads them through `RunOutput`, `EvalResult`, and `EvalReport`; this slice renders them. `formatReport` now appends `input: <N>, output: <N>` to every per-case line — after the duration, before the optional baseline marker — so contributors see per-case token cost in `npm run eval` stdout without any change to aggregate pass/fail semantics.

## Spec debt & uncertainty

- SD-001 (open): stream-json usage-metadata event placement varies by Claude CLI version; the terminal `result` precedence / delta-sum fallback rule must be verified by the extraction work. Not touched here — this slice only renders totals that US1 already produced.
- SD-002 (open): token envelope tolerance is uncalibrated until the first token-aware strike baseline is captured (owned by US3/US4, not this slice).
- SD-003 (open): the RFC touched-files matrix omits some token-threading surfaces owned by F1.3a. This PR does not amend the matrix — the slice's task list scopes it to `evals/lib/report.ts` and `evals/README.md` only, so the amendment is left to the feature's remaining stories.
- Assumption: a zero-token total means "no usable usage metadata was observed," not "the scenario had no cost." The no-baseline test cases render `input: 0, output: 0` on that basis rather than suppressing the field.
- Decision I made while reviewing: token totals are placed *before* the baseline marker. The contracts document leaves placement open ("may follow the existing duration and baseline marker conventions"), so this is a judgment call — it keeps the optional marker last, where its presence/absence stays visually consistent across lines.
- Verification gap: the new rendering is covered by unit tests only. No live `npm run eval` was executed (it costs a full headless agent run), so the README's illustrative token numbers are representative, not captured from a real run.
- Pre-existing unrelated failure: `src/artifact-store.test.ts > commits with a fallback identity when the machine has none` fails in this worktree because the machine has a global git identity, so the fallback path is never exercised. It does not touch any file in this diff.

## Validation

build ✅ · typecheck ✅ · eval unit tests ✅ (248 passed, 12 files) · full `npm test` ⚠️ (1135 passed, 1 pre-existing environmental failure in `artifact-store.test.ts`, unrelated to this diff)
