### PR TITLE
cut: validate smithy.fix output structure and helper evidence

### DIFF
--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/03-validate-smithy-fix-output-structure-and-helper-evidence.tasks.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/03-validate-smithy-fix-output-structure-and-helper-evidence.tasks.md
@@ -1,0 +1,86 @@
+# Tasks: Validate smithy.fix Output Structure and Helper Evidence
+
+**Source**: `specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md` — User Story 3
+**Data Model**: `specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md`
+**Contracts**: `specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.contracts.md`
+**Story Number**: 03
+
+---
+
+## Slice 1: Calibrated smithy.fix Validation Checks
+<!-- audience: builder; mode: how-to; length: 5-15 steps; diagram: optional; examples: forbidden -->
+
+**Goal**: Strengthen the `fix-from-issue` eval so its report verifies diagnosis, fix, verification, and any observed helper-agent evidence from the offline smithy.fix path.
+
+**Justification**: US2 made the scenario runnable from local fixtures. This slice turns that run into a durable quality signal while avoiding brittle full-output snapshots and avoiding fabricated helper checks when the exercised path dispatches none.
+
+**Addresses**: FR-007, FR-008, FR-013; Acceptance Scenarios 3.1, 3.2, 3.3
+
+### Tasks
+
+- [ ] **Calibrate structural workflow markers**
+
+  Update the `fix-from-issue` scenario expectations so validation checks stable diagnosis, fix-action, and verification evidence produced by the offline run. Keep markers tied to workflow sections, labels, or fixture-specific evidence instead of a complete response snapshot.
+
+  _Acceptance criteria:_
+  - The scenario report can pass structural validation for AS 3.1.
+  - Required markers cover diagnosis, fix action, and verification result evidence.
+  - The checks remain resilient to wording changes that preserve the workflow for AS 3.3.
+  - Existing local fixture declaration and invocation behavior remains unchanged.
+
+- [ ] **Calibrate helper evidence from observed dispatches**
+
+  Run or inspect the offline `fix-from-issue` path and record helper evidence only for helpers that actually dispatch. If the current error-description path dispatches no helpers, leave helper evidence empty or omitted and document that choice on the scenario surface.
+
+  _Acceptance criteria:_
+  - Helper evidence validation passes for each observed helper for AS 3.2.
+  - A no-helper offline path does not fail because of fabricated expectations.
+  - Helper patterns use stable dispatch or result evidence rather than agent-name-only matches.
+  - The inherited helper-set uncertainty from spec SD-001 is resolved by observed behavior.
+
+- [ ] **Lock scenario validation coverage**
+
+  Add focused coverage that exercises the `fix-from-issue` structural expectations and the helper-evidence branch selected during calibration. The coverage should prove the report path emits the expected pass/fail checks without requiring live GitHub credentials.
+
+  _Acceptance criteria:_
+  - Unit or integration coverage exercises structural checks for AS 3.1.
+  - Coverage exercises helper evidence checks when helpers are declared, or the empty-helper path when none are declared.
+  - The scenario remains runnable without `GH_TOKEN`, `GITHUB_TOKEN`, or live GitHub CLI access.
+  - Baseline data remains out of scope for US4.
+
+**PR Outcome**: The `fix-from-issue` eval report carries calibrated structural checks and empirically grounded helper evidence for the offline smithy.fix workflow.
+
+---
+
+## Specification Debt
+<!-- audience: reviewer; mode: reference; length: index table + 1-3 sentences per item; diagram: optional; examples: discouraged -->
+
+_None — no specification debt was recorded._
+
+---
+
+## Open Implementation Questions
+<!-- audience: builder; mode: reference; length: one table row per question; diagram: optional; examples: discouraged -->
+
+| ID | Question | Slice | Settled By | Origin |
+|----|----------|-------|------------|--------|
+| IQ-001 | Which helper agents, if any, does the offline fix path dispatch? | S1 | testing | spec:SD-001 |
+
+---
+
+## Dependency Order
+<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: recommended; examples: discouraged -->
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| S1 | Calibrated smithy.fix Validation Checks | — | — |
+
+### Cross-Story Dependencies
+
+| Dependency | Direction | Notes |
+|------------|-----------|-------|
+| User Story 1: Provide Offline smithy.fix Fixtures | depends on | US3 validates output produced from the committed issue and CI-log fixture files authored by US1. |
+| User Story 2: Run smithy.fix Against Local Failure Evidence | depends on | US3 strengthens the `fix-from-issue` scenario and runner behavior delivered by US2. |
+| User Story 4: Commit the smithy.fix Token-Aware Baseline | depended upon by | US4 captures a token-aware baseline after US3's structural and helper checks are calibrated. |

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
@@ -102,7 +102,7 @@ Recommended implementation sequence:
 |----|-------|------------|----------|
 | US1 | Provide Offline smithy.fix Fixtures | — | — |
 | US2 | Run smithy.fix Against Local Failure Evidence | US1 | specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/02-run-smithy-fix-against-local-failure-evidence.tasks.md |
-| US3 | Validate smithy.fix Output Structure and Helper Evidence | US2 | — |
+| US3 | Validate smithy.fix Output Structure and Helper Evidence | US2 | specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/03-validate-smithy-fix-output-structure-and-helper-evidence.tasks.md |
 | US4 | Commit the smithy.fix Token-Aware Baseline | US3 | — |
 
 ## Requirements *(mandatory)*


### PR DESCRIPTION
## Summary

RFC 2026-001 Token Savings → M1 Measurement Foundation → F3 Feature 1.4: smithy.fix End-to-End Eval Scenario → smithy.fix End-to-End Eval Scenario spec → User Story 3: Validate smithy.fix Output Structure and Helper Evidence

Cuts US3 into `03-validate-smithy-fix-output-structure-and-helper-evidence.tasks.md` — one PR-sized slice covering structural marker calibration, empirically-grounded helper evidence, and validation coverage — and links it from the spec's `## Dependency Order` table. One slice is the right increment here: US2 already made `fix-from-issue` runnable offline, so US3 only turns that run into a quality signal, and the helper-evidence branch cannot be split from the structural markers because both are calibrated from the same observed run.

## ⚠️ Manager corrections to the spawned draft

- The worker's tasks file omitted the `<!-- audience: ... -->` voice tags that the cut scaffold (`src/templates/agent-skills/commands/smithy.cut.prompt`) emits on every slice and section heading, and that `smithy.audit`'s voice-tag lint enforces. The sibling `02-…tasks.md` in the same spec folder carries them.
- This PR adds the four canonical tags (Slice 1, Specification Debt, Open Implementation Questions, Dependency Order), copied verbatim from the scaffold and the `spec-debt-section` / `open-implementation-questions` snippets. No prose, task, or acceptance-criteria content was changed.

## Spec debt & uncertainty

- The tasks file records **no** specification debt. Spec `SD-001` (open) — the helper-agent evidence set for the offline smithy.fix path is unknown until the fixture is run — is *implementation*-kind under the cut gate: it is settled by running the fixture, not by a human choosing between named alternatives. It therefore carries down as `IQ-001` (Settled By: `testing`, Origin: `spec:SD-001`) rather than as inherited debt. Per the README's inheritance rule the spec's own row is left `open` — reclassification changes what the child carries, not what the parent records.
- Spec `SD-002` (open) — the smithy.fix token envelope cannot be calibrated until F1.3a's schema lands — is US4's concern (baseline commit) and is deliberately not inherited into US3.
- Assumption (from the spec): the expected helper-agent list is finalized from *observed* smithy.fix behavior at implementation time. US3's second task is written so a genuinely no-helper path leaves helper evidence empty rather than failing on fabricated expectations.
- Assumption I made: for a `smithy.cut` step there is no implementation checkbox to flip — the tasks inside the new file are `smithy.forge`'s work and must stay `[ ]`. The durable "this step is done" signal is the spec's `## Dependency Order` **Artifact** column for US3, flipped from `—` to the tasks path in this patch.
- Pre-existing drift, left alone as out of scope: the spec's US1 row still shows `Artifact: —` although `01-provide-offline-smithy-fix-fixtures.tasks.md` was committed in #477. `smithy status` discovers tasks files by scan rather than by that column, so the drift is cosmetic — worth a separate hygiene fix.

## Validation

docs-only change (no source touched) · build ✅ · `smithy status --format json` ✅ — parses the new tasks file as a real `tasks` record under spec row US3 (S1, `not-started`) with zero warnings; US4 correctly remains a virtual `not-started` record awaiting its own cut. Repo test suite not run: nothing under `src/` is touched and no test references `specs/`.
