### PR TITLE
forge: re-project file-sourced personas during ignite harmonize repair

### DIFF
--- a/specs/2026-06-05-011-smithy-persona-command/05-harmonize-preserves-file-sourced-persona-content.tasks.md
+++ b/specs/2026-06-05-011-smithy-persona-command/05-harmonize-preserves-file-sourced-persona-content.tasks.md
@@ -51,7 +51,7 @@
 
 ### Tasks
 
-- [ ] **Repair file-sourced personas from durable files**
+- [x] **Repair file-sourced personas from durable files**
 
   Update the Personas repair branch so any persona classified as file-sourced is rebuilt from its matching `.persona.md` file, preserving the durable persona's role, context, and friction while re-projecting the RFC-specific benefit language.
 
@@ -61,7 +61,7 @@
   - Repaired content remains an RFC-specific projection rather than copying the durable file verbatim.
   - Position or formatting normalization may occur without changing the source basis of the persona content.
 
-- [ ] **Keep cold repair limited to uncovered gaps**
+- [x] **Keep cold repair limited to uncovered gaps**
 
   Amend the Sub-phase 3g smithy-prose dispatch so it is used only for personas not covered by durable files, then combine any file re-projections with cold repaired gaps into one valid `## Personas` section.
 
@@ -71,7 +71,7 @@
   - The repaired RFC contains exactly one `## Personas` section.
   - If every persona is file-sourced and well-formed, harmonize does not perform an unnecessary cold Personas repair dispatch.
 
-- [ ] **Protect harmonize non-clobber behavior with template tests**
+- [x] **Protect harmonize non-clobber behavior with template tests**
 
   Update template coverage around `smithy.ignite.prompt` so the Sub-phase 3g behavior is protected without regenerating deployed snapshots. Focus the checks on repair-time re-discovery, slug-based file-sourced classification, re-projection from files, and gap-only cold repair.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1002,6 +1002,49 @@ describe('getComposedTemplates', () => {
     expect(subphase3gBlock).toContain('projected from durable `.persona.md` files');
   });
 
+  it('smithy.ignite re-projects file-sourced personas during harmonize repair', () => {
+    const ignite = claudeComposed.commands.get('smithy.ignite.md')!;
+    const subphase3gIdx = ignite.indexOf('Sub-phase 3g: Harmonize');
+    const phase4Idx = ignite.indexOf('## Phase 4', subphase3gIdx);
+    expect(subphase3gIdx).toBeGreaterThan(-1);
+    expect(phase4Idx).toBeGreaterThan(subphase3gIdx);
+    const subphase3gBlock = ignite.slice(subphase3gIdx, phase4Idx);
+
+    const repairIdx = subphase3gBlock.indexOf('3. **Personas repair.**');
+    const fileRepairIdx = subphase3gBlock.indexOf('For every persona recorded as file-sourced');
+    const coldDispatchIdx = subphase3gBlock.indexOf('re-dispatch **smithy-prose** for only those gaps');
+    expect(repairIdx).toBeGreaterThan(-1);
+    expect(fileRepairIdx).toBeGreaterThan(repairIdx);
+    expect(coldDispatchIdx).toBeGreaterThan(fileRepairIdx);
+    expect(subphase3gBlock).toContain('read the matching `.persona.md` file again');
+    expect(subphase3gBlock).toMatch(/Preserve the durable\s+persona's role, context, and friction/);
+    expect(subphase3gBlock).toContain('re-projecting the');
+    expect(subphase3gBlock).toContain('RFC-specific benefit language');
+    expect(subphase3gBlock).toContain('not a byte-for-byte copy');
+    expect(subphase3gBlock).toContain('must not be regenerated from clarify output');
+    expect(subphase3gBlock).toMatch(/source\s+basis stays the matching durable file/);
+  });
+
+  it('smithy.ignite limits harmonize cold persona repair to uncovered gaps', () => {
+    const ignite = claudeComposed.commands.get('smithy.ignite.md')!;
+    const subphase3gIdx = ignite.indexOf('Sub-phase 3g: Harmonize');
+    const phase4Idx = ignite.indexOf('## Phase 4', subphase3gIdx);
+    expect(subphase3gIdx).toBeGreaterThan(-1);
+    expect(phase4Idx).toBeGreaterThan(subphase3gIdx);
+    const subphase3gBlock = ignite.slice(subphase3gIdx, phase4Idx);
+
+    expect(subphase3gBlock).toContain('uncovered-persona repair gaps list');
+    expect(subphase3gBlock).toContain('Covered personas MUST be');
+    expect(subphase3gBlock).toContain('excluded from any cold Personas repair dispatch');
+    expect(subphase3gBlock).toContain('re-dispatch **smithy-prose** for only those gaps');
+    expect(subphase3gBlock).toContain('narrowed to the uncovered persona names or roles');
+    expect(subphase3gBlock).toMatch(/Do not regenerate personas covered by\s+existing `\.persona\.md` files/);
+    expect(subphase3gBlock).toMatch(/If every persona is file-sourced[\s\S]+do not dispatch\s+smithy-prose for Personas repair/);
+    expect(subphase3gBlock).toContain('Combine the file-sourced re-projections and any cold-repaired uncovered gap');
+    expect(subphase3gBlock).toContain('exactly one valid `## Personas` section');
+    expect(subphase3gBlock).toContain('do not append a second Personas section');
+  });
+
   it('smithy.pr-review scripts start with bash shebang', () => {
     const skill = claudeComposed.skills.get('smithy.pr-review')!;
     for (const [, content] of skill.scripts) {

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -430,12 +430,15 @@ Before drafting orchestrator-inline RFC prose in this phase, load
 source for directly authored RFC sections such as Decisions and coherence
 repairs. Keep Summary, Motivation / Problem Statement, and Personas delegated
 to `smithy-prose` where those sub-phases already own the narrative drafting,
-and do not inline the helper's taxonomy here. Sub-phase 3b is the sole
-Personas exception to this delegation rule: covered personas are projected
-inline by the orchestrator from their `.persona.md` files, and only the
-uncovered-persona gaps are delegated to `smithy-prose` — so when every needed
-persona is covered, no `smithy-prose` Personas dispatch occurs at all. See
-Sub-phase 3b for the full projection-and-gap procedure.
+and do not inline the helper's taxonomy here. Two Personas paths are
+exceptions to this delegation rule, and both follow the same
+project-covered / delegate-uncovered split: Sub-phase 3b's initial draft, and
+the Sub-phase 3g harmonize Personas repair branch. In both, covered personas
+are projected inline by the orchestrator from their `.persona.md` files, and
+only the uncovered-persona gaps are delegated to `smithy-prose` — so when
+every needed persona is covered, no `smithy-prose` Personas dispatch occurs at
+all. See Sub-phase 3b for the full projection-and-gap procedure and Sub-phase
+3g for the repair-time variant.
 
 {{#ifAgent}}
 ### RFC File Creation
@@ -640,7 +643,9 @@ Append the returned content to the RFC file.
 This sub-phase is primarily orchestrator-inline. The only exception is the
 Personas repair branch in step 3 below, which may conditionally re-dispatch
 **smithy-prose** for uncovered persona gaps when the coherence pass detects
-that the `## Personas` section is missing, empty, or placeholder-only. No other
+that the `## Personas` section is missing, empty, placeholder-only, or still
+misplaced after the reorder step. File-sourced personas are re-projected
+inline in that same branch and never go through that dispatch. No other
 sub-agents are dispatched in 3g.
 
 1. Read the complete `<slug>.rfc.md` from disk.

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -639,9 +639,9 @@ Append the returned content to the RFC file.
 
 This sub-phase is primarily orchestrator-inline. The only exception is the
 Personas repair branch in step 3 below, which may conditionally re-dispatch
-**smithy-prose** when the coherence pass detects that the `## Personas`
-section is missing, empty, or placeholder-only. No other sub-agents are
-dispatched in 3g.
+**smithy-prose** for uncovered persona gaps when the coherence pass detects
+that the `## Personas` section is missing, empty, or placeholder-only. No other
+sub-agents are dispatched in 3g.
 
 1. Read the complete `<slug>.rfc.md` from disk.
 2. Perform a coherence pass:
@@ -694,24 +694,49 @@ dispatched in 3g.
      it was projected from durable `.persona.md` files.
 3. **Personas repair.** If the Personas verification above fails for any
    reason (missing, empty, placeholder-only, or still misplaced after
-   reorder), re-dispatch **smithy-prose** with:
-   - `section_assignment` = "Personas"
-   - `idea_description` = the user's original idea description or PRD content
-     from intake (same value passed to sub-phase 3b; required by the
-     smithy-prose contract)
-   - `clarify_output` = the Phase 2 clarification Q&A and assumptions
-   - `rfc_file_path` = the path to the accumulating `<slug>.rfc.md`
-   - `tone_directives` = "Personas named or described during Phase 2
-     clarification are mandatory. Do not return placeholder or empty content."
+   reorder), repair by source class:
+   - For every persona recorded as file-sourced by the provenance pre-check,
+     read the matching `.persona.md` file again and rebuild that persona's RFC
+     entry from the durable file as source context. Preserve the durable
+     persona's role, context, and friction, while re-projecting the
+     RFC-specific benefit language for the current idea. This repaired entry
+     must remain a tailored RFC projection, not a byte-for-byte copy of the
+     durable persona file, and it must not be regenerated from clarify output
+     alone. Position or formatting normalization is allowed, but the source
+     basis stays the matching durable file.
+   - Build an uncovered-persona repair gaps list containing only personas from
+     Phase 2 clarification or the current on-disk `## Personas` section that
+     are not covered by matching durable files. Covered personas MUST be
+     excluded from any cold Personas repair dispatch.
+   - If the uncovered-persona repair gaps list is non-empty, re-dispatch **smithy-prose** for only those gaps with:
+     - `section_assignment` = "Personas"
+     - `idea_description` = the user's original idea description or PRD
+       content from intake (same value passed to sub-phase 3b; required by the
+       smithy-prose contract)
+     - `clarify_output` = the Phase 2 clarification Q&A and assumptions,
+       narrowed to the uncovered persona names or roles so file-sourced
+       personas are not regenerated cold
+     - `rfc_file_path` = the path to the accumulating `<slug>.rfc.md`
+     - `tone_directives` = "Draft only the uncovered Personas repair gaps
+       listed in clarify_output. Do not regenerate personas covered by
+       existing `.persona.md` files. Every uncovered persona is mandatory and
+       MUST appear with a role and a description of how this RFC benefits
+       them. Do not return placeholder or empty content."
+   - If every persona is file-sourced and the existing section is otherwise
+     well-formed apart from position or formatting, do not dispatch
+     smithy-prose for Personas repair. Re-project from the matching durable
+     files and normalize only what the coherence pass requires.
 
-   When smithy-prose returns, **replace** any existing `## Personas` section
-   in the RFC file with the returned content in place — do not append a
-   second Personas section. If no `## Personas` heading exists, splice the
-   returned section in at the canonical position (after `## Out of Scope`
-   and before `## Proposal`). Re-run the mandatory-section verification from
-   step 2 after repair; if Personas is still missing, empty, or misplaced,
-   halt the pipeline with a diagnostic pointing at the Phase 2 clarification
-   record.
+   Combine the file-sourced re-projections and any cold-repaired uncovered gap
+   content into exactly one valid `## Personas` section. **Replace** any
+   existing `## Personas` section in the RFC file with that combined section
+   in place — do not append a second Personas section. If no `## Personas`
+   heading exists, splice the combined section in at the canonical position
+   (after `## Out of Scope` and before `## Proposal`). Re-run the
+   mandatory-section verification from step 2 after repair; if Personas is
+   still missing, empty, or misplaced, halt the pipeline with a diagnostic
+   pointing at the Phase 2 clarification record and the durable persona
+   coverage record.
 4. Rewrite the file in place with the harmonized content.
 
 Confirm the harmonize step completed before proceeding to Phase 4.


### PR DESCRIPTION
## Summary

smithy.persona Command and Ignite Persona Reuse (spec `2026-06-05-011-smithy-persona-command`) → User Story 5: Harmonize Preserves File-Sourced Persona Content → Slice 2: Re-Project File-Sourced Personas Instead of Re-Drafting

*(This spec's `**Input**` is a direct feature description, not an RFC — there is no RFC → Milestone → Feature ancestry to cite.)*

Slice 1 taught ignite Sub-phase 3g to *recognize* file-sourced personas by re-running durable `.persona.md` discovery from disk. This slice acts on that record: the Personas repair branch now repairs **by source class** rather than uniformly re-drafting cold. File-sourced personas are rebuilt from their matching durable file as source context — role, context, and friction preserved, RFC-specific benefit language re-projected — while the `smithy-prose` dispatch is narrowed to an uncovered-persona gaps list. When every persona is file-sourced and otherwise well-formed, harmonize performs no cold repair dispatch at all. This is the user-visible non-clobber guarantee US5 exists to deliver.

## Spec debt & uncertainty

All four rows on this tasks file carry `Status: inherited` (each is bound by a downstream decision recorded in the tasks file's `Resolution` column); the parent spec still lists them as `open`:

- SD-001 (inherited): Rule by which Sub-phase 3b decides a pre-existing `.persona.md` "covers" a needed RFC persona — exact match vs. fuzzy/semantic vs. user-confirmed. Bound here by US4's deterministic filename-slug comparison.
- SD-002 (inherited): Whether `.persona.md` should carry a machine-readable identity field vs. relying on filename-slug comparison. Bound by US1's README convention (filename slug only, no identity key).
- SD-003 (inherited): How ignite feeds an existing `.persona.md`'s content to smithy-prose, given smithy-prose has no existing-persona-file parameter. Bound by US4's projection task — ignite reads covered files inline and supplies them as source context rather than amending smithy-prose's contract. **This slice depends on that binding**: the file-sourced repair path reads the durable file directly and never routes it through `clarify_output`.
- SD-004 (inherited): How Sub-phase 3g detects that on-disk `## Personas` content is file-sourced on resume. Bound by Slice 1's deterministic re-discovery (no markers, sidecars, or in-memory state).

Assumptions and uncertainty:

- Assumption (spec, Critical): ignite reuse attaches at Sub-phase 3b and non-clobber at Sub-phase 3g — this slice is the 3g half.
- Assumption (spec, Critical): storage is flat `{{artifactsRoot}}docs/personas/<slug>.persona.md`, authored once in the README; the repair path resolves the persona directory from the active `{{artifactsRoot}}` so in-repo and external-artifacts modes cannot cross-contaminate.
- Verification gap: this is prompt-text behavior, so it is verified by template-composition assertions on the rendered Claude output — not by executing a harmonize run. Whether an agent actually honors the "not a byte-for-byte copy" and "narrowed clarify_output" directives at runtime is only observable through an eval, and no persona eval case exists yet.
- Task 3's first two acceptance criteria (repair-time discovery, slug-based classification) were already satisfied by the two tests Slice 1 landed; this slice adds the two remaining tests (re-projection, gap-only cold repair). No deployed `.claude/`, `.gemini/`, `.agents/`, `.codex/`, or manifest snapshots were regenerated, per the project's source-vs-deployed rule.

## Validation

typecheck ✅ · build ✅ · test ✅ (1155 passed) — one pre-existing, environment-dependent failure in `src/artifact-store.test.ts` ("commits with a fallback identity when the machine has none"), confirmed failing identically on clean `HEAD` because this machine has a global git identity configured. Unrelated to this change.
