### PR TITLE
forge: compare live token totals against baseline envelopes

### DIFF
--- a/evals/lib/baseline.test.ts
+++ b/evals/lib/baseline.test.ts
@@ -737,6 +737,140 @@ describe('compareToBaseline', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Token envelope comparison
+  // -----------------------------------------------------------------------
+  describe('token envelope comparison', () => {
+    it('skips token checks when the baseline has no token envelope', () => {
+      const baseline = makeBaseline({
+        headings: ['## A'],
+        tables: [{ columns: ['Col1'] }],
+      });
+      const results = compareToBaseline('## A\n| Col1 |', baseline, {
+        input: 10,
+        output: 5,
+      });
+
+      expect(results.map((r) => r.check_name)).toEqual([
+        "has baseline heading '## A'",
+        'has baseline table with columns: Col1',
+        'baseline regression summary',
+      ]);
+    });
+
+    it('emits an additional passing token check when live totals are inside every defined range', () => {
+      const baseline = makeBaseline({
+        headings: ['## A'],
+        token_envelope: {
+          input: { min: 10, max: 20 },
+          output: { min: 4, max: 8 },
+        },
+      });
+
+      const results = compareToBaseline('## A', baseline, {
+        input: 15,
+        output: 6,
+      });
+      const tokenCheck = results[results.length - 1]!;
+
+      expect(results.map((r) => r.check_name)).toEqual([
+        "has baseline heading '## A'",
+        'baseline regression summary',
+        'token envelope',
+      ]);
+      expect(tokenCheck).toEqual({
+        check_name: 'token envelope',
+        passed: true,
+        expected: 'input 10-20, output 4-8',
+        actual: 'input 15, output 6',
+      });
+    });
+
+    it('passes with input-only and output-only envelopes when the defined range contains the live total', () => {
+      const inputOnly = compareToBaseline(
+        '',
+        makeBaseline({
+          token_envelope: { input: { min: 1, max: 3 } },
+        }),
+        { input: 2, output: 999 },
+      );
+      const outputOnly = compareToBaseline(
+        '',
+        makeBaseline({
+          token_envelope: { output: { min: 5, max: 7 } },
+        }),
+        { input: 999, output: 6 },
+      );
+
+      expect(inputOnly[inputOnly.length - 1]!.passed).toBe(true);
+      expect(inputOnly[inputOnly.length - 1]!.expected).toBe('input 1-3');
+      expect(outputOnly[outputOnly.length - 1]!.passed).toBe(true);
+      expect(outputOnly[outputOnly.length - 1]!.expected).toBe('output 5-7');
+    });
+
+    it('fails when a live input total is below min or above max', () => {
+      const baseline = makeBaseline({
+        token_envelope: { input: { min: 10, max: 20 } },
+      });
+
+      const below = compareToBaseline('', baseline, { input: 9, output: 0 });
+      const above = compareToBaseline('', baseline, { input: 21, output: 0 });
+
+      expect(below[below.length - 1]).toMatchObject({
+        check_name: 'token envelope',
+        passed: false,
+        expected: 'input 10-20',
+        actual: 'input 9, output 0',
+      });
+      expect(above[above.length - 1]).toMatchObject({
+        check_name: 'token envelope',
+        passed: false,
+        expected: 'input 10-20',
+        actual: 'input 21, output 0',
+      });
+    });
+
+    it('fails when a live output total is below min or above max', () => {
+      const baseline = makeBaseline({
+        token_envelope: { output: { min: 5, max: 7 } },
+      });
+
+      const below = compareToBaseline('', baseline, { input: 0, output: 4 });
+      const above = compareToBaseline('', baseline, { input: 0, output: 8 });
+
+      expect(below[below.length - 1]).toMatchObject({
+        check_name: 'token envelope',
+        passed: false,
+        expected: 'output 5-7',
+        actual: 'input 0, output 4',
+      });
+      expect(above[above.length - 1]).toMatchObject({
+        check_name: 'token envelope',
+        passed: false,
+        expected: 'output 5-7',
+        actual: 'input 0, output 8',
+      });
+    });
+
+    it('fails when a token-aware baseline has no live token totals', () => {
+      const baseline = makeBaseline({
+        token_envelope: {
+          input: { min: 10, max: 20 },
+          output: { min: 4, max: 8 },
+        },
+      });
+
+      const results = compareToBaseline('', baseline);
+
+      expect(results[results.length - 1]).toEqual({
+        check_name: 'token envelope',
+        passed: false,
+        expected: 'input 10-20, output 4-8',
+        actual: 'missing live token totals',
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Purity — function must not mutate its inputs
   // -----------------------------------------------------------------------
   describe('purity', () => {

--- a/evals/lib/baseline.ts
+++ b/evals/lib/baseline.ts
@@ -292,8 +292,9 @@ export function loadBaseline(
 
 /**
  * Compare a live skill output against a persisted baseline and emit one
- * `CheckResult` per baseline heading, one per baseline table, and a final
- * aggregate summary entry.
+ * `CheckResult` per baseline heading, one per baseline table, an aggregate
+ * summary entry, and — only when the baseline declares a token envelope — a
+ * trailing token check.
  *
  * The comparator is intentionally a regression signal, not a content lock —
  * additional headings or tables in `output` that are not recorded in
@@ -310,10 +311,14 @@ export function loadBaseline(
  *   1. one check per baseline heading, in baseline order
  *   2. one check per baseline table, in baseline order
  *   3. exactly one `'baseline regression summary'` aggregate check
+ *   4. one `'token envelope'` check, only when `baseline.token_envelope` is
+ *      present — omitted entirely for structural-only baselines
  *
  * The summary's `actual` field enumerates every missing item on a single line
  * so a reviewer can see "what changed" without correlating the per-item
- * checks. When nothing is missing, `actual` is `'no regressions'`.
+ * checks. When nothing is missing, `actual` is `'no regressions'`. The summary
+ * covers structural drift only; token drift is reported by the separate token
+ * check so an out-of-envelope run does not read as a missing heading or table.
  *
  * This function is pure: no I/O, no mutation of `baseline` or `output`.
  *
@@ -321,7 +326,9 @@ export function loadBaseline(
  * @param baseline  The persisted `Baseline` snapshot to compare against.
  * @param tokens    Optional live token totals. Required for token comparison
  *                  when the baseline includes a token envelope.
- * @returns A `CheckResult[]` with per-heading, per-table, and aggregate entries.
+ * @returns A `CheckResult[]` with per-heading, per-table, and aggregate
+ *          entries, plus a trailing token-envelope entry when the baseline
+ *          declares one.
  */
 export function compareToBaseline(
   output: string,

--- a/evals/lib/baseline.ts
+++ b/evals/lib/baseline.ts
@@ -15,7 +15,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import type { Baseline, CheckResult, TokenEnvelope } from './types.js';
+import type {
+  Baseline,
+  CheckResult,
+  TokenEnvelope,
+  TokenTotals,
+} from './types.js';
 
 /** Default directory (relative to cwd) where baselines are looked up. */
 const DEFAULT_BASELINES_DIR = 'evals/baselines';
@@ -91,6 +96,53 @@ function validateTokenEnvelope(
     return undefined;
   }
   return envelope;
+}
+
+function formatTokenBounds(envelope: TokenEnvelope): string {
+  const parts: string[] = [];
+  if (envelope.input !== undefined) {
+    parts.push(`input ${envelope.input.min}-${envelope.input.max}`);
+  }
+  if (envelope.output !== undefined) {
+    parts.push(`output ${envelope.output.min}-${envelope.output.max}`);
+  }
+  return parts.join(', ');
+}
+
+function formatTokenTotals(tokens: TokenTotals): string {
+  return `input ${tokens.input}, output ${tokens.output}`;
+}
+
+function tokenRangeContains(
+  range: { min: number; max: number } | undefined,
+  actual: number,
+): boolean {
+  return range === undefined || (actual >= range.min && actual <= range.max);
+}
+
+function compareTokenEnvelope(
+  envelope: TokenEnvelope,
+  tokens?: TokenTotals,
+): CheckResult {
+  const expected = formatTokenBounds(envelope);
+  if (tokens === undefined) {
+    return {
+      check_name: 'token envelope',
+      passed: false,
+      expected,
+      actual: 'missing live token totals',
+    };
+  }
+
+  const passed =
+    tokenRangeContains(envelope.input, tokens.input) &&
+    tokenRangeContains(envelope.output, tokens.output);
+  return {
+    check_name: 'token envelope',
+    passed,
+    expected,
+    actual: formatTokenTotals(tokens),
+  };
 }
 
 /**
@@ -267,11 +319,14 @@ export function loadBaseline(
  *
  * @param output    The live extracted skill-output string to evaluate.
  * @param baseline  The persisted `Baseline` snapshot to compare against.
+ * @param tokens    Optional live token totals. Required for token comparison
+ *                  when the baseline includes a token envelope.
  * @returns A `CheckResult[]` with per-heading, per-table, and aggregate entries.
  */
 export function compareToBaseline(
   output: string,
   baseline: Baseline,
+  tokens?: TokenTotals,
 ): CheckResult[] {
   const results: CheckResult[] = [];
 
@@ -334,6 +389,10 @@ export function compareToBaseline(
     expected: `${baseline.headings.length} headings, ${baseline.tables.length} tables`,
     actual: passed ? 'no regressions' : summaryParts.join('; '),
   });
+
+  if (baseline.token_envelope !== undefined) {
+    results.push(compareTokenEnvelope(baseline.token_envelope, tokens));
+  }
 
   return results;
 }

--- a/evals/lib/report.test.ts
+++ b/evals/lib/report.test.ts
@@ -970,6 +970,28 @@ describe('baseline checks wiring', () => {
       expect(result.error).toBeUndefined();
     });
 
+    it('returns fail when a token envelope baseline check fails', () => {
+      const scenario = makeScenario();
+      const output = makeOutput({ tokens: { input: 25, output: 6 } });
+      const tokenBaselineCheck: CheckResult = {
+        check_name: 'token envelope',
+        passed: false,
+        expected: 'input 10-20, output 4-8',
+        actual: 'input 25, output 6',
+      };
+
+      const result = scenarioRunToResult(
+        scenario,
+        output,
+        [passingCheck],
+        undefined,
+        [tokenBaselineCheck],
+      );
+
+      expect(result.status).toBe('fail');
+      expect(result.baseline_checks).toEqual([tokenBaselineCheck]);
+    });
+
     it('returns pass when all baseline checks pass and structural checks pass', () => {
       const scenario = makeScenario();
       const output = makeOutput();

--- a/evals/run-evals.ts
+++ b/evals/run-evals.ts
@@ -355,7 +355,11 @@ for (const scenario of finalScenarios) {
     // bug, not a runtime failure.
     const baseline = loadBaseline(scenario.name, baselinesDir);
     if (baseline !== null) {
-      baselineChecks = compareToBaseline(output.extracted_text, baseline);
+      baselineChecks = compareToBaseline(
+        output.extracted_text,
+        baseline,
+        output.tokens,
+      );
     }
   } catch (err) {
     console.error(`Validation error: ${err instanceof Error ? err.message : String(err)}`);

--- a/specs/2026-05-18-007-per-case-token-totals-in-evalreport/03-extend-baselines-with-token-envelopes.tasks.md
+++ b/specs/2026-05-18-007-per-case-token-totals-in-evalreport/03-extend-baselines-with-token-envelopes.tasks.md
@@ -54,7 +54,7 @@
 
 ### Tasks
 
-- [ ] **Emit token envelope check results**
+- [x] **Emit token envelope check results**
 
   Extend `compareToBaseline` so a baseline with a token envelope produces one baseline check for the live token totals. The check must pass only when every defined input and output range contains the corresponding live total, and it must include expected bounds and actual totals when it fails.
 
@@ -67,7 +67,7 @@
   - Existing structural heading, table, and summary checks keep their ordering and behavior.
   - Unit coverage verifies passing, failing, skipped, and missing-live-token paths.
 
-- [ ] **Pass scenario tokens into baseline comparison**
+- [x] **Pass scenario tokens into baseline comparison**
 
   Update the eval runner/report assembly boundary so `run-evals` passes each scenario output's token totals into `compareToBaseline`. Preserve existing baseline marker rendering and status precedence so token check failures flow through the current baseline-check failure path.
 


### PR DESCRIPTION
## Summary
RFC 2026-001 Token Savings → M1 Measurement Foundation → F1.3a Per-Case Token Totals in EvalReport → Per-Case Token Totals in EvalReport spec (US3) → Slice 2: Compare Live Tokens Against Baseline Envelopes

`compareToBaseline` now emits one additional `token envelope` check when the loaded baseline carries token bounds, and `run-evals` feeds each scenario's live token totals into that comparison. This is the right increment because Slice 1 already landed optional envelope loading — this slice consumes those typed bounds and routes token drift through the existing baseline-check failure path, without touching structural checks or the report renderer.

## Spec debt & uncertainty
- SD-001 (open): stream-json usage-metadata event placement varies by Claude CLI version; extraction precedence is owned upstream by US1 and unchanged here.
- SD-002 (open): token envelope tolerance is uncalibrated until the first token-aware strike baseline is captured (US4). This slice ships the comparison mechanism only — no committed baseline yet declares an envelope, so no live scenario changes status from this PR.
- SD-003 (open): the RFC touched-files matrix still omits some token-threading surfaces; the amendment is not part of this slice.
- Assumption: envelopes are intentionally broad enough to tolerate provider-side variance while catching material drift — the check is a plain inclusive `min <= actual <= max` with no added tolerance.
- Behavior note: a baseline whose `token_envelope` declares neither range collapses to "absent" during loading (Slice 1), so it cannot produce a vacuously passing token check.
- Verification gap: the token comparison is unit-tested only — no live `npm run eval` was run (it spawns real agent CLIs), and the "timeout / non-zero-exit still preserves live totals" criterion is satisfied by the runner's single return path rather than by a new test.

## Validation
build ✅ · typecheck ✅ · eval unit tests ✅ (277 passed) · full suite ✅ except 1 pre-existing unrelated failure (`src/artifact-store.test.ts > commits with a fallback identity when the machine has none`, which also fails on a clean tree in this environment)
