### PR TITLE
forge: write one persona file per RFC candidate

### DIFF
--- a/specs/2026-06-05-011-smithy-persona-command/03-generate-persona-files-from-an-rfcs-personas-section.tasks.md
+++ b/specs/2026-06-05-011-smithy-persona-command/03-generate-persona-files-from-an-rfcs-personas-section.tasks.md
@@ -61,7 +61,7 @@
 
 ### Tasks
 
-- [ ] **Draft and write extracted personas**
+- [x] **Draft and write extracted personas**
 
   Extend RFC mode so each extracted persona candidate is drafted through `smithy-prose` and written as a separate `.persona.md` file that follows the README-defined persona convention. Reuse the slug and file-format rules established by the free-text path.
 
@@ -71,7 +71,7 @@
   - Each filename slug is kebab-case and derived from the persona name or role.
   - The free-text writer remains available and unchanged for non-RFC inputs.
 
-- [ ] **Skip and report slug collisions**
+- [x] **Skip and report slug collisions**
 
   Add RFC-mode collision handling so an extracted persona whose target slug already exists is skipped without mutating the existing file, while the command continues writing the remaining non-colliding personas.
 
@@ -81,7 +81,7 @@
   - Non-colliding personas from the same RFC are still written.
   - The final summary distinguishes written persona files from skipped collisions.
 
-- [ ] **Protect RFC-mode write behavior**
+- [x] **Protect RFC-mode write behavior**
 
   Update template coverage around `smithy.persona.prompt` for multi-persona writes and collision reporting. Keep the checks focused on deployable template behavior and avoid snapshot regeneration.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -886,7 +886,7 @@ describe('getComposedTemplates', () => {
     expect(persona).toContain('written and skipped persona paths as explicit result fields');
   });
 
-  it('smithy.persona renders RFC-mode routing and named persona extraction', () => {
+  it('smithy.persona renders RFC-mode routing, extraction, and persona writes', () => {
     const persona = claudeComposed.commands.get('smithy.persona.md')!;
     const routingIdx = persona.indexOf('If the input ends in `.rfc.md`, select **RFC mode**');
     const freeTextRoutingIdx = persona.indexOf(
@@ -915,14 +915,41 @@ describe('getComposedTemplates', () => {
     expect(rfcMode).toContain('explicit');
     expect(rfcMode).toContain('bullet/list item, bold lead-in, or subheading');
     expect(rfcMode).toContain('Keep the extracted candidate set as a structured list');
-    expect(rfcMode).toContain('as its source of truth');
-    expect(rfcMode).toContain('completes after reporting the candidate set');
-    expect(rfcMode).toContain('Do not draft with');
-    expect(rfcMode).toContain('smithy-prose');
-    expect(rfcMode).toContain('write files, or overwrite artifacts');
+    expect(rfcMode).toContain('its source of truth rather than rereading unrelated input');
+    expect(rfcMode).toContain('For each RFC persona candidate, derive the filename slug');
+    expect(rfcMode).toContain('Resolve each target path using the Persona Artifact Convention section');
+    expect(rfcMode).toContain('Before drafting a candidate, check whether its target path already exists');
+    expect(rfcMode).toContain('Continue processing the remaining candidates after any collision skip');
+    expect(rfcMode).toContain('For each non-colliding candidate, dispatch **smithy-prose** with:');
+    expect(rfcMode).toContain('`idea_description`: the candidate');
+    expect(rfcMode).toContain('`rfc_file_path`: the resolved input RFC path');
+    expect(rfcMode).toContain('Write one file per non-colliding candidate');
+    expect(rfcMode).toContain('Each final file must contain exactly one persona');
     expect(rfcMode).toContain('Do not infer personas from');
     expect(rfcMode).toContain('narrative-only prose');
     expect(rfcMode).toContain('emit empty-section diagnostics');
+  });
+
+  it('smithy.persona renders RFC-mode collision reporting and summary fields', () => {
+    const persona = claudeComposed.commands.get('smithy.persona.md')!;
+    const rfcModeIdx = persona.indexOf('## RFC Mode');
+    const summaryIdx = persona.indexOf('## One-Shot Summary');
+
+    expect(rfcModeIdx).toBeGreaterThan(-1);
+    expect(summaryIdx).toBeGreaterThan(rfcModeIdx);
+
+    const rfcMode = persona.slice(rfcModeIdx, summaryIdx);
+    const summary = persona.slice(summaryIdx);
+
+    expect(rfcMode).toContain('add the candidate name, slug, and path to the skipped-collisions list');
+    expect(rfcMode).toContain('leave the existing file untouched');
+    expect(rfcMode).toContain('Continue processing the remaining candidates after any collision skip');
+    expect(summary).toContain('For RFC mode, report:');
+    expect(summary).toContain('Written persona paths');
+    expect(summary).toContain('name/role and slug');
+    expect(summary).toContain('Skipped collisions');
+    expect(summary).toContain('target slug');
+    expect(summary).toContain('Totals');
   });
 
   it('smithy.persona renders shared persona convention and artifact policy snippets across agents', async () => {

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -883,7 +883,7 @@ describe('getComposedTemplates', () => {
     expect(persona).toContain('one durable persona file was');
     expect(persona).toContain('written from free text with no intermediate approval gates');
     expect(persona).toContain('target persona slug already exists');
-    expect(persona).toContain('written and skipped persona paths as explicit result fields');
+    expect(persona).toContain('written and skipped persona paths as explicit result');
   });
 
   it('smithy.persona renders RFC-mode routing, extraction, and persona writes', () => {
@@ -944,12 +944,34 @@ describe('getComposedTemplates', () => {
     expect(rfcMode).toContain('add the candidate name, slug, and path to the skipped-collisions list');
     expect(rfcMode).toContain('leave the existing file untouched');
     expect(rfcMode).toContain('Continue processing the remaining candidates after any collision skip');
-    expect(summary).toContain('For RFC mode, report:');
+    expect(summary).toContain('For **RFC mode**, report only this block');
     expect(summary).toContain('Written persona paths');
     expect(summary).toContain('name/role and slug');
     expect(summary).toContain('Skipped collisions');
     expect(summary).toContain('target slug');
     expect(summary).toContain('Totals');
+  });
+
+  it('smithy.persona scopes each One-Shot Summary block to a single mode', () => {
+    const persona = claudeComposed.commands.get('smithy.persona.md')!;
+    const summary = persona.slice(persona.indexOf('## One-Shot Summary'));
+
+    expect(summary).toContain('Report\nexactly one summary block');
+    expect(summary).toContain('the blocks are mutually exclusive');
+    expect(summary).toContain('For a successful **free-text mode** write, report:');
+    expect(summary).toContain('For a **free-text mode** slug collision skip, report:');
+    expect(summary).toContain(
+      'the two free-text blocks above never\napply to an RFC run',
+    );
+    expect(summary).toContain(
+      'In either mode, report the written and skipped persona paths',
+    );
+
+    // The RFC block must come last so its exclusivity clause can refer back to
+    // the free-text blocks it supersedes.
+    expect(summary.indexOf('For **RFC mode**, report only this block')).toBeGreaterThan(
+      summary.indexOf('For a **free-text mode** slug collision skip, report:'),
+    );
   });
 
   it('smithy.persona renders shared persona convention and artifact policy snippets across agents', async () => {

--- a/src/templates/agent-skills/commands/smithy.persona.prompt
+++ b/src/templates/agent-skills/commands/smithy.persona.prompt
@@ -37,8 +37,8 @@ persona input** for the rest of this run.
 
 ## RFC Mode
 
-Given a resolved input path ending in `.rfc.md`, identify the durable persona
-candidates that should seed `.persona.md` file creation.
+Given a resolved input path ending in `.rfc.md`, create durable persona files
+from the named personas in that RFC.
 
 1. Read the input RFC file before drafting, writing, or checking any persona
    artifact target paths.
@@ -55,11 +55,46 @@ candidates that should seed `.persona.md` file creation.
    - the source excerpt or bullet/paragraph that describes that persona;
    - the RFC path the candidate came from.
 5. Keep the extracted candidate set as a structured list named **RFC persona
-   candidates**. Any persona-file creation in this mode must consume this list
-   as its source of truth rather than rereading unrelated input.
-6. This RFC mode completes after reporting the candidate set. Do not draft with
-   smithy-prose, derive target paths, check collisions, create directories,
-   write files, or overwrite artifacts in RFC mode.
+   candidates**. Persona-file creation in this mode must consume this list as
+   its source of truth rather than rereading unrelated input.
+6. For each RFC persona candidate, derive the filename slug from the preserved
+   human-readable persona name or role:
+   - lower-case ASCII where possible;
+   - words separated by single hyphens;
+   - no spaces, underscores, date prefix, or sequence prefix.
+7. Resolve each target path using the Persona Artifact Convention section:
+   `{{artifactsRoot}}docs/personas/<slug>.persona.md`.
+8. Before drafting a candidate, check whether its target path already exists.
+   - If it exists, skip that candidate, leave the existing file untouched, and
+     add the candidate name, slug, and path to the skipped-collisions list.
+   - If it does not exist, continue with that candidate.
+   - Continue processing the remaining candidates after any collision skip.
+9. For each non-colliding candidate, dispatch **smithy-prose** with:
+   - `section_assignment`: "Personas"
+   - `idea_description`: the candidate's preserved source excerpt plus the RFC
+     path it came from
+   - `clarify_output`: the candidate's human-readable persona name or role,
+     source excerpt, derived slug, and source RFC path
+   - `rfc_file_path`: the resolved input RFC path
+   - `tone_directives`: "Draft exactly one reusable persona file body for the
+     named RFC persona. Cover role/context, friction today, and how their work
+     changes when relevant capabilities ship. Return narrative prose grounded
+     only in the candidate's RFC excerpt and source RFC context; do not add a
+     `## Personas` heading, bullets, dependency-order content, specification
+     debt, registry metadata, or a machine-readable identity field."
+10. Create the `{{artifactsRoot}}docs/personas/` directory if it does not
+    already exist. Write one file per non-colliding candidate at that
+    candidate's target path using the canonical file shape:
+    - `# Persona: <Name/Role>`
+    - blank line
+    - `**Created**: YYYY-MM-DD` using the current date
+    - blank line
+    - the smithy-prose narrative body
+
+If smithy-prose returns a `## Personas` heading for any candidate, remove that
+wrapper and keep only that single persona's narrative prose before writing the
+`.persona.md` file. Each final file must contain exactly one persona and must
+follow the Persona Artifact Convention section above.
 
 Keep this RFC-mode parser intentionally narrow. Do not infer personas from
 narrative-only prose, emit empty-section diagnostics, suppress placeholders
@@ -112,8 +147,8 @@ Persona Artifact Convention section above.
 
 ## One-Shot Summary
 
-After free-text mode completes, present a compact terminal summary. Do not dump
-the full persona file contents into the terminal.
+After the selected mode completes, present a compact terminal summary. Do not
+dump the full persona file contents into the terminal.
 
 For a successful write, report:
 
@@ -134,3 +169,15 @@ For a slug collision skip, report:
 
 Report the written and skipped persona paths as explicit result fields rather
 than a free-form diff, so the run's outcome is unambiguous.
+
+For RFC mode, report:
+
+1. **Phase summary** — one line stating that durable persona files were seeded
+   from the RFC with no intermediate approval gates.
+2. **Source RFC** — the resolved input RFC path.
+3. **Written persona paths** — every file written, including its candidate
+   name/role and slug. If no files were written, say `none`.
+4. **Skipped collisions** — every candidate skipped because the target slug
+   already existed, including its name/role, slug, and existing path. If no
+   collisions were skipped, say `none`.
+5. **Totals** — written count and skipped-collision count.

--- a/src/templates/agent-skills/commands/smithy.persona.prompt
+++ b/src/templates/agent-skills/commands/smithy.persona.prompt
@@ -147,10 +147,12 @@ Persona Artifact Convention section above.
 
 ## One-Shot Summary
 
-After the selected mode completes, present a compact terminal summary. Do not
-dump the full persona file contents into the terminal.
+After the selected mode completes, present a compact terminal summary. Report
+exactly one summary block — the mode that ran selects which block applies, and
+the blocks are mutually exclusive. Do not dump the full persona file contents
+into the terminal.
 
-For a successful write, report:
+For a successful **free-text mode** write, report:
 
 1. **Phase summary** — one line stating that one durable persona file was
    written from free text with no intermediate approval gates.
@@ -158,7 +160,7 @@ For a successful write, report:
    `{{artifactsRoot}}docs/personas/<slug>.persona.md`.
 3. **Slug** — the derived slug used for filename identity.
 
-For a slug collision skip, report:
+For a **free-text mode** slug collision skip, report:
 
 1. **Phase summary** — one line stating that no file was written because the
    target persona slug already exists.
@@ -167,10 +169,8 @@ For a slug collision skip, report:
 3. **Next step** — tell the user to choose a different persona name/role or
    edit the existing file directly.
 
-Report the written and skipped persona paths as explicit result fields rather
-than a free-form diff, so the run's outcome is unambiguous.
-
-For RFC mode, report:
+For **RFC mode**, report only this block — the two free-text blocks above never
+apply to an RFC run, no matter how many files were written or skipped:
 
 1. **Phase summary** — one line stating that durable persona files were seeded
    from the RFC with no intermediate approval gates.
@@ -181,3 +181,6 @@ For RFC mode, report:
    already existed, including its name/role, slug, and existing path. If no
    collisions were skipped, say `none`.
 5. **Totals** — written count and skipped-collision count.
+
+In either mode, report the written and skipped persona paths as explicit result
+fields rather than a free-form diff, so the run's outcome is unambiguous.


### PR DESCRIPTION
## Summary

smithy.persona Command and Ignite Persona Reuse (spec `2026-06-05-011-smithy-persona-command`) → User Story 3: Generate Persona Files from an RFC's `## Personas` Section → Slice 2: Write One Persona File per RFC Candidate

Slice 1 gave RFC mode its routing and extraction boundary but deliberately stopped at reporting the candidate set. This slice closes RFC mode end to end: each extracted candidate gets a kebab-case slug, a resolved target path under the persona artifact convention, a non-destructive collision check, a `smithy-prose` draft, and one written `.persona.md`. Collision handling is skip-and-report rather than overwrite, and the run continues through the remaining candidates so one pre-existing slug never blocks the rest of an RFC.

## Spec debt & uncertainty

- SD-001 (inherited): unresolved rule by which ignite Sub-phase 3b decides a pre-existing `.persona.md` "covers" a needed RFC persona (exact match vs. semantic similarity vs. user confirmation).
- SD-003 (inherited): unresolved mechanism for feeding an existing `.persona.md`'s content to `smithy-prose`, whose input contract has no existing-persona parameter.
- SD-004 (inherited): unresolved provenance signal for ignite Sub-phase 3g to detect file-sourced `## Personas` content on resume.
- SD-002 (inherited) is recorded resolved in the tasks file by US1's convention: persona identity is the filename slug, with no machine-readable identity key — this slice's writer relies on that.
- Assumption (spec Clarifications): RFC-mode filename collisions are handled by skip-and-report, never silent overwrite; the update-existing path is out of scope.
- Assumption (spec Clarifications): the command reuses `smithy-prose` as drafter via `section_assignment: "Personas"` rather than introducing a new drafting sub-agent.
- Verification gap: this is deployable template prose, so coverage is composed-template assertions, not an executed RFC-mode run. Narrative-prose extraction and empty-section diagnostics remain US6's scope and are intentionally untouched here.

## Validation

build ✅ · typecheck ✅ · test ✅ (290 passed, `src/templates.test.ts`) · no `.claude/`/`.gemini/`/`.agents/`/`.codex/`/manifest snapshots regenerated
