### PR TITLE
forge: wire flow nodes and keep backend stories on the existing path

### DIFF
--- a/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/03-render-mark-cut-forge-is-identical-for-ui-and-backend-nodes.tasks.md
+++ b/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/03-render-mark-cut-forge-is-identical-for-ui-and-backend-nodes.tasks.md
@@ -111,7 +111,7 @@
 
 ### Tasks
 
-- [ ] **Add the flow-wire forge profile**
+- [x] **Add the flow-wire forge profile**
 
   Update `src/templates/agent-skills/commands/smithy.forge.prompt` so tasks produced for an `FL` node preload the referenced `.flow.md`, paired `test-body`, and dependent screen/backend context. The profile should connect the real data path represented by the flow's dependencies and honor or flip the feature `flag` as required by the task plan.
 
@@ -122,7 +122,7 @@
   - Real-data dependencies from the ledger are respected
   - The feature `flag` is honored or flipped as part of the flow-wire work
 
-- [ ] **Emit executable flow behavior only in test bodies**
+- [x] **Emit executable flow behavior only in test bodies**
 
   Constrain flow-wire implementation so the executable user actions and assertions are emitted or updated in the paired test body, not in the `.flow.md`. The generated behavior must run as the slice validation gate and remain keyed to the driver-neutral selector contract from User Story 2.
 
@@ -133,7 +133,7 @@
   - `.flow.md` remains mark-owned and intent-only
   - The flow test body is run as a validation gate when supported by the repo
 
-- [ ] **Preserve backend-story forge behavior**
+- [x] **Preserve backend-story forge behavior**
 
   Ensure `US` nodes that appear inside a UI ledger enter the same backend-story forge path as ordinary backend tasks. UI ledger context may explain ordering, but it must not change backend implementation mechanics or make forge author screen/flow durable artifacts.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -2486,12 +2486,53 @@ describe('getComposedTemplates', () => {
     expect(forge).toContain('ship an ungated screen');
   });
 
+  it('forge template defines the flow-wire profile for typed UI nodes', () => {
+    const forge = composed.commands.get('smithy.forge.md')!;
+    expect(forge).toContain('**`FL<N>` / `flow-wire` tasks** select the flow-wire profile');
+    expect(forge).toContain('Read the referenced `design/flows/<FlowId>.flow.md` before editing');
+    expect(forge).toContain('`**Test Body**` line');
+    expect(forge).toContain("the flow artifact's `test-body` front-matter");
+    expect(forge).toContain('`**Ledger Dependencies**` and `**Flow Data Path**`');
+    expect(forge).toContain('real-data-dependent flow also depends on backend `US` nodes');
+    expect(forge).toContain('Resolve the feature `flag`');
+    expect(forge).toContain('Refuse to author a new `.flow.md` from scratch');
+  });
+
+  it('flow-wire profile keeps executable behavior in the paired test body', () => {
+    const forge = composed.commands.get('smithy.forge.md')!;
+    expect(forge).toContain('Put executable user actions and assertions in the paired test body only');
+    expect(forge).toContain('every guard and traversal assertion named by the `.flow.md`');
+    expect(forge).toContain('stable test IDs, accessibility IDs, or');
+    expect(forge).toContain('never rely on visible text, layout position');
+    expect(forge).toContain('Run the paired flow test body as a validation gate');
+    expect(forge).toContain(
+      'do not add executable\n    steps, actions, assertions, or driver syntax to `.flow.md`',
+    );
+  });
+
+  it('forge template keeps backend-story nodes on the existing forge path', () => {
+    const forge = composed.commands.get('smithy.forge.md')!;
+    expect(forge).toContain(
+      '**`US<N>` / `backend-story` tasks inside a typed UI ledger** select the',
+    );
+    expect(forge).toContain('existing backend-story forge path');
+    expect(forge).toContain('must not change backend implementation');
+    expect(forge).toContain('skip the ordinary spec/data-model/contracts intake');
+    expect(forge).toContain('Backend-story work must not author');
+  });
+
   it('smithy-implement carries the same typed UI build profile as forge', () => {
     const implement = composed.agents.get('smithy.implement.md')!;
     expect(implement).toBeDefined();
     expect(implement).toContain('**`SC<N>` / `screen-build` tasks** select the screen-build profile');
     expect(implement).toContain('Resolve the gating feature `flag` before writing code');
     expect(implement).toContain('Refuse to author a new `.design.md` from scratch');
+    expect(implement).toContain('**`FL<N>` / `flow-wire` tasks** select the flow-wire profile');
+    expect(implement).toContain('Put executable user actions and assertions in the paired test body only');
+    expect(implement).toContain('Refuse to author a new `.flow.md` from scratch');
+    expect(implement).toContain(
+      '**`US<N>` / `backend-story` tasks inside a typed UI ledger** select the',
+    );
   });
 
   it('strike template contains ## Specification Debt between ## Decisions and ## Single Slice', () => {

--- a/src/templates/agent-skills/snippets/typed-ui-build-profiles.md
+++ b/src/templates/agent-skills/snippets/typed-ui-build-profiles.md
@@ -38,6 +38,46 @@ documentation, validation, and PR creation stay the same as ordinary work.
     `.design.md` or `.flow.md` files as part of screen-build work. Those durable
     artifacts originate at `mark`; `forge` consumes them.
 
-For non-screen node kinds, follow the selected task plan and the existing
-implementation mechanics; do not apply screen-build rules to `FL<N>` or `US<N>`
-work.
+- **`FL<N>` / `flow-wire` tasks** select the flow-wire profile. Every rule
+  below is scoped to that profile:
+  - Read the referenced `design/flows/<FlowId>.flow.md` before editing any
+    implementation files, and treat it as mark-owned durable flow intent.
+  - Read the paired executable test body named by the task plan's
+    `**Test Body**` line, or by the flow artifact's `test-body` front-matter
+    when the task plan omits it. Create behavior in that existing paired body
+    when it is still a stub; if the body is missing despite the `.flow.md`
+    contract naming it, stop instead of inventing a different path.
+  - Use the task plan's `**Ledger Dependencies**` and `**Flow Data Path**`
+    context to decide what must already be real. A mock-satisfiable flow depends
+    only on its screen node(s) and can wire against the flagged screen/mock
+    state; a real-data-dependent flow also depends on backend `US` nodes and
+    must connect to the behavior those backend artifacts provide rather than
+    bypassing the dependency.
+  - Read the dependent screen context named by the flow's `screens:` metadata
+    and any populated upstream task artifacts cited by the ledger dependency
+    notes. For backend dependencies, consume the existing spec, data model,
+    contracts, and completed backend artifact context exactly as ordinary forge
+    work would.
+  - Resolve the feature `flag` from the task plan's design metadata, source
+    feature map, or upstream screen-build context before writing code. Honor an
+    already-enabled flag when the task plan requires it, or flip/remove the gate
+    only when the flow-wire task explicitly makes that part of definition of
+    done. Do not leave the wired flow unreachable behind the wrong flag state.
+  - Put executable user actions and assertions in the paired test body only.
+    Represent every guard and traversal assertion named by the `.flow.md` using
+    the project's existing UI driver and stable test IDs, accessibility IDs, or
+    semantic tags; never rely on visible text, layout position, or prose copied
+    into the `.flow.md`.
+  - Run the paired flow test body as a validation gate when the repository has a
+    supported command for that driver. If no targeted flow-test command exists,
+    run the closest project test gate and report the validation limitation.
+  - Refuse to author a new `.flow.md` from scratch, and do not add executable
+    steps, actions, assertions, or driver syntax to `.flow.md`. That durable
+    artifact originates at `mark`; `forge` consumes it.
+
+- **`US<N>` / `backend-story` tasks inside a typed UI ledger** select the
+  existing backend-story forge path. UI ledger context may explain ordering and
+  prerequisite artifacts, but it must not change backend implementation
+  mechanics, skip the ordinary spec/data-model/contracts intake, or introduce
+  screen-build or flow-wire requirements. Backend-story work must not author
+  `.design.md` or `.flow.md` files.


### PR DESCRIPTION
## Summary
EPIC #404 → Screens and Flows as UI Feature Kinds (spec) → User Story 3: `render → mark → cut → forge` is identical for UI and backend nodes → Slice 3: Build flow and backend nodes through forge

Adds the flow-wire forge profile so an `FL<N>` task plan turns mark-owned flow intent into executable behavior: forge reads the referenced `design/flows/<FlowId>.flow.md`, the paired test body named by the task plan's `**Test Body**` line (falling back to the artifact's `test-body` front-matter), the dependent screen context, and — for real-data flows — the backend spec/data-model/contracts its `**Ledger Dependencies**` imply, then resolves the feature `flag` before writing code. Executable user actions plus every guard and traversal assertion land only in the paired test body, keyed to User Story 2's driver-neutral selector contract, and that body runs as the slice validation gate when the repo supports it; `.flow.md` stays mark-owned and intent-only. `US<N>` nodes inside a typed UI ledger explicitly keep the existing backend-story mechanics, which is what makes the pipeline uniform rather than forked — this is the increment that closes the build half of User Story 3 after Slice 2 landed screens.

## ⚠️ Manager corrections to the spawned draft
- The worker's diff carried no test coverage, while the immediately preceding slice (#542) established that this template surface is covered by `getComposedTemplates` string assertions in `src/templates.test.ts` — a prompt-only change with no assertion is silently un-regressable.
- This PR additionally ships three Tier-2 tests: flow-wire profile intake rules, the "executable behavior only in the paired test body" constraint, and the backend-story passthrough — asserted against both the composed `smithy.forge` command and the `smithy-implement` agent (the snippet feeds both).
- The task text names `src/templates/agent-skills/commands/smithy.forge.prompt`; the rules went into the shared `snippets/typed-ui-build-profiles.md` it includes, matching how Slice 2 landed the screen-build profile and keeping forge and `smithy-implement` from drifting apart.

## Spec debt & uncertainty
- SD-005 (inherited): fidelity of `import`-mode structure derivation from a prototype/bundle — owned by User Story 5; untouched here.
- SD-007 (inherited): build-phase coverage honesty — a screen can be "done" with no executable gate until its flows wire. This slice is the mitigation on the flow side (the paired test body is the gate), but the honesty question itself stays with User Story 6.
- SD-008 (inherited): visual-intent honesty for a `brief`-mode node that never received a bundle — owned by User Story 4.
- Assumption: Smithy templates stay tool-agnostic — the profile names no UI framework or test driver and defers to whatever the target project uses.
- Assumption: the profile keys off the `**Node Kind**:`, `**Test Body**`, `**Ledger Dependencies**`, and `**Flow Data Path**` metadata that `smithy.cut` writes; all four were verified against `smithy.cut.prompt` in this checkout.
- Verification gap: this is prompt-template text, so coverage is string assertions only — there is no eval-level check that an agent actually follows the flow-wire profile. Per CLAUDE.md the `.claude/` snapshot was deliberately not regenerated.

## Validation
build ✅ · typecheck ✅ · test ✅ (1170 passed) — one pre-existing environmental failure in `src/artifact-store.test.ts` ("commits with a fallback identity when the machine has none"), which asserts the fallback git identity and fails on a machine that has a global one; untouched by this diff.
