### PR TITLE
forge: build all design modes without a pipeline stall

### DIFF
--- a/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/04-a-non-blocking-visual-design-gate-with-import-brief-none-modes.tasks.md
+++ b/specs/2026-06-06-012-screens-and-flows-as-ui-feature-kinds/04-a-non-blocking-visual-design-gate-with-import-brief-none-modes.tasks.md
@@ -111,7 +111,7 @@
 
 ### Tasks
 
-- [ ] **Route screen builds by design mode**
+- [x] **Route screen builds by design mode**
 
   Update `src/templates/agent-skills/commands/smithy.forge.prompt` so `SC` task plans read the screen node's design mode and select the correct non-blocking build behavior. `none` and bundle-less `brief` should build from the committed design skill; `import` should expect a bundle when one was supplied upstream.
 
@@ -122,7 +122,7 @@
   - Missing bundle context never creates a hard stop for brief mode
   - Existing backend forge routing remains unchanged
 
-- [ ] **Honor bundles whenever present**
+- [x] **Honor bundles whenever present**
 
   Strengthen forge bundle handling so any attached bundle is honored at build time regardless of whether it entered through import mode or post-mark brief mode. Keep the design skill loaded as implementation-dialect context, and do not modify mark-owned `.design.md` or `.flow.md` files.
 
@@ -133,7 +133,7 @@
   - Bundle handling does not author or rewrite `.design.md` or `.flow.md`
   - Bundle absence falls back to the design skill rather than stopping the slice
 
-- [ ] **Surface unrealized prototypes in forge output**
+- [x] **Surface unrealized prototypes in forge output**
 
   Add forge guidance so a `brief` node with no bundle records the missing prototype as surfaced context, not as an implementation failure. This resolves the visual-intent honesty gap without introducing a visual-diff or pixel-fidelity review requirement.
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -2508,15 +2508,23 @@ describe('getComposedTemplates', () => {
     expect(forge).toContain('### Typed UI Node Build Profiles');
     expect(forge).toContain('**`SC<N>` / `screen-build` tasks** select the screen-build profile');
     expect(forge).toContain('Read the referenced `design/screens/<ScreenId>.design.md` before editing');
+    expect(forge).toContain('Read the task plan\'s `**Design Mode**` and `**Design Metadata**` lines');
+    expect(forge).toMatch(/`Design Mode` must be one of `none`,\s+`import`, or `brief`/);
     expect(forge).toContain('the committed design skill named by the screen artifact');
     expect(forge).toContain('behind the resolved feature `flag`');
     expect(forge).toContain('Use mock data for screen-build work');
     expect(forge).toContain('Represent every brief state named by the screen intent');
     expect(forge).toContain('design-system');
     expect(forge).toContain('tokens and reusable project components');
-    expect(forge).toContain('Honor an attached `bundle` for layout and visual intent');
-    expect(forge).toContain('`brief`');
-    expect(forge).toContain('mode without a bundle and `none` mode are non-blocking');
+    expect(forge).toContain('Route by design mode without creating a visual-gate stall');
+    expect(forge).toContain('`Design: none` builds from the committed design skill');
+    expect(forge).toContain('`Design: import` carries any supplied bundle context into the build');
+    expect(forge).toContain('Bundle-less `Design: brief` builds from the committed design skill');
+    expect(forge).toMatch(/no\s+prototype bundle was attached/);
+    expect(forge).toContain('Honor any attached `bundle` for layout and visual intent regardless');
+    expect(forge).toContain('was attached after `mark` for');
+    expect(forge).toContain('fall back to the design skill and `.design.md` intent instead of stopping');
+    expect(forge).toContain('Do not ask reviewers to judge visual fidelity');
     expect(forge).toContain('Refuse to author a new `.design.md` from scratch');
   });
 

--- a/src/templates/agent-skills/commands/smithy.forge.prompt
+++ b/src/templates/agent-skills/commands/smithy.forge.prompt
@@ -176,6 +176,10 @@ Store this value for later.
 
 ### Typed UI Node Build Profiles
 
+The shared profile below is forge's build contract for typed UI work: `SC`
+tasks read `Design Mode` and `Design Metadata`, route `none`/`import`/`brief`
+without stalling, and honor any attached bundle under the conflict rule.
+
 {{>typed-ui-build-profiles}}
 
 Execute each task from the slice's checklist **in order**:

--- a/src/templates/agent-skills/snippets/typed-ui-build-profiles.md
+++ b/src/templates/agent-skills/snippets/typed-ui-build-profiles.md
@@ -7,6 +7,9 @@ documentation, validation, and PR creation stay the same as ordinary work.
   below is scoped to that profile:
   - Read the referenced `design/screens/<ScreenId>.design.md` before editing any
     implementation files, and treat it as mark-owned durable screen intent.
+  - Read the task plan's `**Design Mode**` and `**Design Metadata**` lines
+    before choosing the build path. `Design Mode` must be one of `none`,
+    `import`, or `brief`; do not infer it from the screen title.
   - Preload the committed design skill named by the screen artifact's
     `design_system` metadata as implementation dialect context. If the screen
     artifact is missing or does not name a design skill, stop instead of
@@ -29,11 +32,26 @@ documentation, validation, and PR creation stay the same as ordinary work.
     tokens and reusable project components for styling; do not introduce
     hardcoded colors or one-off style constants when a project token or
     component convention exists.
-  - Honor an attached `bundle` for layout and visual intent under the conflict
-    rule: bundle wins layout/visual intent, while the design skill remains
-    authoritative for implementation dialect and project conventions. `brief`
-    mode without a bundle and `none` mode are non-blocking; build from the
-    design skill and the `.design.md` intent without waiting for a prototype.
+  - Route by design mode without creating a visual-gate stall:
+    - `Design: none` builds from the committed design skill and the
+      `.design.md` intent; no bundle or prototype ceremony is required.
+    - `Design: import` carries any supplied bundle context into the build. When
+      the metadata or screen artifact names a bundle, read and honor it as the
+      visual source context.
+    - Bundle-less `Design: brief` builds from the committed design skill and
+      the `.design.md` intent. Record in the task/terminal notes that no
+      prototype bundle was attached; this is informational context, not an
+      implementation failure.
+  - Honor any attached `bundle` for layout and visual intent regardless of
+    whether it entered through `import` mode or was attached after `mark` for
+    `brief` mode. Apply the conflict rule consistently: bundle wins
+    layout/visual intent, while the design skill remains authoritative for
+    implementation dialect and project conventions. When no bundle is attached,
+    fall back to the design skill and `.design.md` intent instead of stopping
+    the slice.
+  - Do not ask reviewers to judge visual fidelity. Review remains structural:
+    project conventions, design-system tokens/components, accessible structure,
+    gated behavior, mock-data coverage, and every named brief state.
   - Refuse to author a new `.design.md` from scratch, and do not modify
     `.design.md` or `.flow.md` files as part of screen-build work. Those durable
     artifacts originate at `mark`; `forge` consumes them.


### PR DESCRIPTION
## Summary

EPIC #404 → Screens and Flows as UI Feature Kinds (spec) → User Story 4:
A non-blocking visual-design gate with import / brief / none modes →
Slice 3: Build All Design Modes Without a Pipeline Stall

This slice closes the story's forge-side half. The shared
`typed-ui-build-profiles` snippet now tells an `SC` screen-build task to read
the node's `Design Mode` / `Design Metadata` explicitly and route on it:
`none` and bundle-less `brief` build from the committed design skill and the
`.design.md` intent, `import` carries any supplied bundle into the build, and
an attached bundle is honored under the existing conflict rule *regardless of
which mode delivered it* — so a prototype attached after `mark` is not
silently ignored. A bundle-less `brief` node records "no prototype bundle was
attached" as informational build context rather than a failure, and reviewers
are explicitly not asked to judge visual fidelity. Slices 1 and 2 established
the mode vocabulary and mark's honest brief-mode authoring; this is the first
slice where the *build* path differs per mode, completing AS 4.4 and AS 4.5.

Because the snippet is shared, `smithy.implement` picks up the same routing
contract as `smithy.forge` — the per-command lead-in added to
`smithy.forge.prompt` is framing only, with the behavior living in the one
snippet.

## Spec debt & uncertainty

- SD-005 (inherited): fidelity of `import`-mode structure derivation from a
  prototype/bundle, and how much human confirmation the derived structure
  needs — owned by User Story 5, untouched here.
- SD-006 (inherited): whether `SC`/`FL` nodes are always atomic or can be
  sub-sliced — owned by User Story 3; this slice consumes whatever task shape
  `cut` produces.
- SD-007 (inherited): build-phase coverage honesty — a build screen can be
  "done" with a missing brief state and no executable gate until its flows
  wire. This slice's build reporting is adjacent, but executable flow coverage
  stays owned by User Stories 3 and 6.
- SD-008 (inherited, owned by this story): visual-intent honesty for a
  `brief`-mode node that never received a bundle. This PR supplies the
  implementation path — bundle-less brief work is surfaced as informational
  build context — completing the build-side half that Slice 2 deferred.
- Assumption (from the spec): smithy never performs visual iteration inline;
  the `bundle` is the only object crossing the terminal↔visual boundary. All
  new guidance is prompt prose that keeps pixels out of the terminal.
- Assumption (from the spec): the reviewer never judges pixels — encoded here
  as an explicit "review remains structural" instruction.
- Assumption (from the spec): `.claude/` is NOT regenerated for
  source-template PRs. This PR edits `src/templates/` only, per CLAUDE.md.
- Uncertainty: this is agent-prompt text, so correctness is asserted by
  string-level template composition tests, not by behavior. Behavioral
  confirmation would need a Tier-3 eval run (`npm run eval`), which was not
  exercised here.

## Validation

typecheck ✅ · test ⚠️ 1172 passed / 1 failed — `src/templates.test.ts` passes
in full (294/294). The single failure is `src/artifact-store.test.ts >
commits with a fallback identity when the machine has none`, a pre-existing
environment failure (this machine supplies a git identity that overrides the
test's `GIT_CONFIG_GLOBAL` stub, so the fallback never engages). It touches no
file in this diff.
