### PR TITLE
forge: calibrate fix-from-issue structural and helper-evidence checks

### DIFF
--- a/evals/cases/fix-from-issue.yaml
+++ b/evals/cases/fix-from-issue.yaml
@@ -5,10 +5,12 @@
 # Data model: specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md
 # Contracts:  specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.contracts.md
 # Tasks:      specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/02-run-smithy-fix-against-local-failure-evidence.tasks.md
+#             specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/03-validate-smithy-fix-output-structure-and-helper-evidence.tasks.md
 #
-# This case intentionally stops at local fixture declaration and invocation.
-# Stable output marker and helper-evidence calibration belongs to the later
-# structural-validation story.
+# Helper calibration: the committed offline prompt supplies an error
+# description with local evidence, so smithy.fix follows Path D. The current
+# Path D template contains no sub-agent dispatch instructions; helper evidence
+# is intentionally omitted rather than fabricating an agent-name check.
 
 name: fix-from-issue
 skill: /smithy.fix
@@ -35,14 +37,19 @@ structural_expectations:
     # deliberately not touched (spec Out of Scope).
     - '## Diagnosis'
   required_patterns:
-    # Template-guaranteed diagnosis labels (smithy.fix.prompt Step 1). These
-    # are bullet lines with trailing descriptions, so whole-line equality
-    # never matches -- they belong here rather than in `required_headings`.
+    # Template-stable diagnosis labels (smithy.fix.prompt Step 1).
     - '\*\*Error\*\*'
     - '\*\*Cause\*\*'
+    # Fix-action evidence: the template requires a Fix label, and the fixture
+    # points the smallest change at the missing /health route in src/index.ts.
     - '\*\*Fix\*\*'
-    - 'health'
-    - 'src/index\.ts|/health|verification'
+    - 'src/index\.ts'
+    - '/health'
+    # Verification-result evidence: require the output to name the local build
+    # or test verification and include a pass/success result, without snapshotting
+    # exact prose.
+    - '(npm run build|npm test|[Vv]erification)'
+    - '([Pp]ass|[Pp]assed|[Pp]asses|successful|succeeded)'
   forbidden_patterns:
     - "I'd be happy to help"
     - "Sure, here's"

--- a/evals/lib/fix-from-issue-scenario.test.ts
+++ b/evals/lib/fix-from-issue-scenario.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadScenarioFromFile } from './scenario-loader.js';
+import { validateStructure, verifySubAgents } from './structural.js';
+import { scenarioRunToResult } from './report.js';
+import type { RunOutput } from './types.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..');
+const scenarioPath = path.join(repoRoot, 'evals/cases/fix-from-issue.yaml');
+
+function makeOutput(text: string): RunOutput {
+  return {
+    extracted_text: text,
+    stream_events: [],
+    tokens: { input: 0, output: 0 },
+    duration_ms: 100,
+    exit_code: 0,
+    timed_out: false,
+  };
+}
+
+describe('fix-from-issue scenario validation', () => {
+  it('passes calibrated structural checks and the no-helper branch offline', () => {
+    const scenario = loadScenarioFromFile(scenarioPath);
+    const outputText = [
+      '## Diagnosis',
+      '',
+      '- **Error**: the smoke check receives 404 for GET /health.',
+      '- **Cause**: src/index.ts mounts /api/users but no health endpoint.',
+      '- **Fix**: add a minimal /health route in src/index.ts.',
+      '',
+      'Verification: npm run build passed.',
+    ].join('\n');
+
+    const structuralChecks = validateStructure(
+      outputText,
+      scenario.structural_expectations,
+    );
+    const helperChecks = verifySubAgents(
+      outputText,
+      [],
+      scenario.sub_agent_evidence ?? [],
+    );
+    const result = scenarioRunToResult(
+      scenario,
+      makeOutput(outputText),
+      structuralChecks,
+      helperChecks,
+    );
+
+    expect(scenario.name).toBe('fix-from-issue');
+    expect(scenario.sub_agent_evidence).toBeUndefined();
+    expect(structuralChecks.every((check) => check.passed)).toBe(true);
+    expect(helperChecks).toEqual([]);
+    expect(result.status).toBe('pass');
+    expect(result.sub_agent_checks).toBeUndefined();
+  });
+
+  it('fails when verification result evidence is absent', () => {
+    const scenario = loadScenarioFromFile(scenarioPath);
+    const outputText = [
+      '## Diagnosis',
+      '',
+      '- **Error**: the smoke check receives 404 for GET /health.',
+      '- **Cause**: src/index.ts mounts /api/users but no health endpoint.',
+      '- **Fix**: add a minimal /health route in src/index.ts.',
+    ].join('\n');
+
+    const structuralChecks = validateStructure(
+      outputText,
+      scenario.structural_expectations,
+    );
+    const result = scenarioRunToResult(
+      scenario,
+      makeOutput(outputText),
+      structuralChecks,
+      [],
+    );
+
+    expect(
+      structuralChecks.filter((check) => !check.passed).map((check) => check.expected),
+    ).toEqual([
+      '(npm run build|npm test|[Vv]erification)',
+      '([Pp]ass|[Pp]assed|[Pp]asses|successful|succeeded)',
+    ]);
+    expect(result.status).toBe('fail');
+  });
+});

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/03-validate-smithy-fix-output-structure-and-helper-evidence.tasks.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/03-validate-smithy-fix-output-structure-and-helper-evidence.tasks.md
@@ -18,7 +18,7 @@
 
 ### Tasks
 
-- [ ] **Calibrate structural workflow markers**
+- [x] **Calibrate structural workflow markers**
 
   Update the `fix-from-issue` scenario expectations so validation checks stable diagnosis, fix-action, and verification evidence produced by the offline run. Keep markers tied to workflow sections, labels, or fixture-specific evidence instead of a complete response snapshot.
 
@@ -28,7 +28,7 @@
   - The checks remain resilient to wording changes that preserve the workflow for AS 3.3.
   - Existing local fixture declaration and invocation behavior remains unchanged.
 
-- [ ] **Calibrate helper evidence from observed dispatches**
+- [x] **Calibrate helper evidence from observed dispatches**
 
   Run or inspect the offline `fix-from-issue` path and record helper evidence only for helpers that actually dispatch. If the current error-description path dispatches no helpers, leave helper evidence empty or omitted and document that choice on the scenario surface.
 
@@ -38,7 +38,7 @@
   - Helper patterns use stable dispatch or result evidence rather than agent-name-only matches.
   - The inherited helper-set uncertainty from spec SD-001 is resolved by observed behavior.
 
-- [ ] **Lock scenario validation coverage**
+- [x] **Lock scenario validation coverage**
 
   Add focused coverage that exercises the `fix-from-issue` structural expectations and the helper-evidence branch selected during calibration. The coverage should prove the report path emits the expected pass/fail checks without requiring live GitHub credentials.
 


### PR DESCRIPTION
## Summary
RFC 2026-001 Token Savings → M1 Measurement Foundation → F3 (Feature 1.4) smithy.fix End-to-End Eval Scenario → smithy.fix End-to-End Eval Scenario spec → Slice 1: Calibrated smithy.fix Validation Checks

US2 made the `fix-from-issue` eval runnable from committed fixtures; this slice turns that run into a durable quality signal. Structural expectations now assert diagnosis labels, the fixture-specific fix action (`src/index.ts`, `/health`), and a verification-result marker via alternations that survive wording changes, and a new focused test locks both the passing and failing branches without any GitHub credentials.

Helper evidence stays omitted, and the scenario file now documents why: the offline prompt supplies an error description, so `smithy.fix` takes **Path D**, which carries no sub-agent dispatch instructions. That is an empirical answer to IQ-001 rather than a fabricated agent-name check.

## Spec debt & uncertainty
- SD-001 (open, spec-level): the helper-agent evidence set for the offline smithy.fix path. Answered for this path by inspection — Path D of `smithy.fix.prompt` dispatches no sub-agents, so `sub_agent_evidence` is left absent. The spec row is left `open` because it is the parent artifact's to close; the tasks-level IQ-001 is settled by this slice.
- SD-002 (open): the token envelope for the `fix-from-issue` baseline — out of scope here, owned by US4.
- Assumption (spec): prompt-level local fixture references are enough to exercise the error-description path without editing `smithy.fix.prompt`. This PR does not touch that prompt (spec Out of Scope).
- Verification gap: helper behavior was established by **reading** Path D of `smithy.fix.prompt`, not by capturing a live agent run — a future prompt change that adds a dispatch to Path D would not be caught by these checks.
- Verification gap: the calibrated regexes were exercised against a representative synthetic output in the new test, not against a captured live `/smithy.fix` run; a live run remains the real proof and lands with US4's baseline capture.
- Note: this worktree had no installed dependencies, so `npm ci` was run under Node 22 to validate. No lockfile or dependency changes are in the diff.

## Validation
typecheck ✅ · eval unit tests ✅ (`npm run test:evals` — 272 passed, 13 files, including the 2 new `fix-from-issue-scenario` cases)
