### PR TITLE
cut: commit the smithy.fix token-aware baseline

### DIFF
--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/04-commit-the-smithy-fix-token-aware-baseline.tasks.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/04-commit-the-smithy-fix-token-aware-baseline.tasks.md
@@ -1,0 +1,86 @@
+# Tasks: Commit the smithy.fix Token-Aware Baseline
+
+**Source**: `specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md` — User Story 4
+**Data Model**: `specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.data-model.md`
+**Contracts**: `specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.contracts.md`
+**Story Number**: 04
+
+---
+
+## Slice 1: fix-from-issue Token-Aware Baseline
+<!-- audience: builder; mode: how-to; length: 5-15 steps; diagram: optional; examples: forbidden -->
+
+**Goal**: Commit the `fix-from-issue` baseline in the token-aware schema and pin it with coverage so the smithy.fix eval reports structural and token baseline checks on later runs.
+
+**Justification**: US1-US3 provide deterministic local evidence, offline invocation, and calibrated workflow checks. This slice captures the known-good output and token envelope as the final downstream comparison point for M3 token-reduction work.
+
+**Addresses**: FR-011, FR-012, FR-013; Acceptance Scenarios 4.1, 4.2, 4.3
+
+### Tasks
+
+- [ ] **Capture a clean smithy.fix baseline run**
+
+  Run the `fix-from-issue` scenario after US3's structural and helper checks are present, using the repository-local issue and CI-log fixtures. Record the structural baseline data and observed token totals from a clean run without relying on live GitHub credentials.
+
+  _Acceptance criteria:_
+  - The captured run satisfies the scenario's structural expectations for AS 4.1.
+  - Captured token totals include the input and output values required by the token-aware baseline schema.
+  - The run uses the local fixture evidence and remains compatible with machines that lack GitHub credentials.
+  - Any calibration note needed for the initial token envelope is captured in the implementation PR rather than in deployed prompt templates.
+
+- [ ] **Commit the fix-from-issue baseline file**
+
+  Add the `fix-from-issue` baseline under the existing eval baseline directory using the F1.3a token-aware schema. Preserve the scenario name, structural expectations, and a conservative token envelope that passes for the clean captured run while still exposing material token drift.
+
+  _Acceptance criteria:_
+  - The committed baseline loads for scenario name `fix-from-issue` for AS 4.1.
+  - The baseline includes structural expectations and token envelope bounds for FR-012.
+  - The token envelope is compatible with the existing baseline loader and comparator.
+  - Scenario name mismatches, malformed token envelopes, and missing baseline data continue to fail or skip according to the baseline contract.
+
+- [ ] **Pin baseline compatibility and report behavior**
+
+  Add focused coverage that proves the committed `fix-from-issue` baseline loads, compares successfully against the captured known-good output, and causes the eval report to show a passing baseline marker when the live run remains inside the envelope.
+
+  _Acceptance criteria:_
+  - Coverage exercises baseline loading for the committed `fix-from-issue` file for FR-013.
+  - Coverage proves the baseline comparison passes against the known-good smithy.fix output for AS 4.2.
+  - Coverage proves structural or token drift can produce failing baseline checks for AS 4.3.
+  - Existing scenarios without baselines keep the current `baseline: n/a` or no-marker behavior.
+
+**PR Outcome**: The `fix-from-issue` eval has a committed token-aware baseline, and subsequent eval reports can expose both structural and token drift from the known high-cost smithy.fix path.
+
+---
+
+## Specification Debt
+<!-- audience: reviewer; mode: reference; length: index table + 1-3 sentences per item; diagram: optional; examples: discouraged -->
+
+_None — no specification debt was recorded._
+
+---
+
+## Open Implementation Questions
+<!-- audience: builder; mode: reference; length: one table row per question; diagram: optional; examples: discouraged -->
+
+| ID | Question | Slice | Settled By | Origin |
+|----|----------|-------|------------|--------|
+| IQ-001 | What token envelope bounds does a clean offline `fix-from-issue` run support? | S1 | testing | spec:SD-002 |
+
+---
+
+## Dependency Order
+<!-- audience: builder+ai-input; mode: reference; length: tables only; diagram: recommended; examples: discouraged -->
+
+Recommended implementation sequence:
+
+| ID | Title | Depends On | Artifact |
+|----|-------|------------|----------|
+| S1 | fix-from-issue Token-Aware Baseline | — | — |
+
+### Cross-Story Dependencies
+
+| Dependency | Direction | Notes |
+|------------|-----------|-------|
+| User Story 1: Provide Offline smithy.fix Fixtures | depends on | US4 captures the baseline from the committed issue and CI-log evidence authored by US1. |
+| User Story 2: Run smithy.fix Against Local Failure Evidence | depends on | US4 depends on the offline `fix-from-issue` scenario and local fixture injection delivered by US2. |
+| User Story 3: Validate smithy.fix Output Structure and Helper Evidence | depends on | US4 preserves the structural and helper expectations calibrated by US3 in the committed baseline. |

--- a/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
+++ b/specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/smithy-fix-end-to-end-eval-scenario.spec.md
@@ -103,7 +103,7 @@ Recommended implementation sequence:
 | US1 | Provide Offline smithy.fix Fixtures | — | — |
 | US2 | Run smithy.fix Against Local Failure Evidence | US1 | specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/02-run-smithy-fix-against-local-failure-evidence.tasks.md |
 | US3 | Validate smithy.fix Output Structure and Helper Evidence | US2 | specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/03-validate-smithy-fix-output-structure-and-helper-evidence.tasks.md |
-| US4 | Commit the smithy.fix Token-Aware Baseline | US3 | — |
+| US4 | Commit the smithy.fix Token-Aware Baseline | US3 | specs/2026-06-03-009-smithy-fix-end-to-end-eval-scenario/04-commit-the-smithy-fix-token-aware-baseline.tasks.md |
 
 ## Requirements *(mandatory)*
 


### PR DESCRIPTION
## Summary

RFC 2026-001 Token Savings → M1 Measurement Foundation → F3 Feature 1.4: smithy.fix End-to-End Eval Scenario → smithy.fix End-to-End Eval Scenario spec → User Story 4: Commit the smithy.fix Token-Aware Baseline

Cuts US4 into `04-commit-the-smithy-fix-token-aware-baseline.tasks.md` — one PR-sized slice covering the clean baseline capture, the committed token-aware baseline file, and the coverage that pins its load / compare / report behavior — and links it from the spec's `## Dependency Order` table. One slice is the right increment: US1–US3 already made `fix-from-issue` runnable offline and turned it into a calibrated quality signal, so US4 only freezes that known-good run as a comparison point, and the capture, the committed file, and its coverage cannot land separately — the envelope in the file only means something alongside the run it came from.

## ⚠️ Manager corrections to the spawned draft

- **The worker used the pre-#528 `## Specification Debt` shape.** It emitted the old `ID | Description | … | Status | Resolution` table with an `inherited from spec:` text prefix. The current scaffold (`snippets/spec-debt-section.md`, restructured in #528) and `smithy.audit`'s tasks checklist (`snippets/audit-checklist-tasks.md`) both require the index shape `ID | Title | Source Category | Impact | Confidence | Origin`, with `Origin: spec:SD-NNN` and no detail section for carried-down rows.
- **The worker omitted `## Open Implementation Questions` entirely.** The cut scaffold emits it between `## Specification Debt` and `## Dependency Order` on every tasks file, and the audit checklist flags its absence. The sibling `03-…tasks.md` in the same spec folder carries it.
- **This PR reclassifies spec `SD-002` under the cut kind gate.** The worker carried it down as inherited debt; it is *implementation*-kind. Its blocking precondition is gone — F1.3a's `token_envelope` schema has landed (`evals/lib/baseline.ts` validates it) — and what remains ("choose a conservative initial envelope and document the captured totals") names no alternatives for a human to pick between; it is settled by capturing a clean run. It therefore ships as `IQ-001` (Question: what envelope bounds a clean offline `fix-from-issue` run supports; Slice `S1`; Settled By `testing`; Origin `spec:SD-002`), leaving the debt section at its empty-state line. Per the README's inheritance rule the spec's own `SD-002` row stays `open` — reclassification changes what the child carries, not what the parent records. This mirrors what #562 did with `SD-001` → `IQ-001` for US3.
- No slice prose, task, or acceptance-criteria content was changed.

## Spec debt & uncertainty

- The tasks file records **no** specification debt. Spec `SD-002` (open) is carried as `IQ-001` per the kind gate above — a reviewer who disagrees that the envelope width is implementer's discretion should push back on that call, since it is the one judgment in this patch that is genuinely arguable.
- Spec `SD-001` (open) — the helper-agent evidence set for the offline smithy.fix path — was US3's concern and is deliberately not inherited here.
- Assumption (from the spec): F1.3a lands before the baseline is committed, so US4 consumes the established token-envelope schema rather than defining one. Verified as true at cut time — `token_envelope` is live in `evals/lib/baseline.ts`.
- Assumption I made: for a `smithy.cut` step there is no implementation checkbox to flip — the tasks inside the new file are `smithy.forge`'s work and must stay `[ ]`. The durable "this step is done" signal is the spec's `## Dependency Order` **Artifact** column for US4, flipped from `—` to the tasks path in this patch.
- Pre-existing drift, left alone as out of scope: the spec's US1 row still shows `Artifact: —` although `01-provide-offline-smithy-fix-fixtures.tasks.md` was committed in #477. `smithy status` discovers tasks files by scan rather than by that column, so the drift is cosmetic — worth a separate hygiene fix.

## Validation

docs-only change (no source touched) · build ✅ · `smithy status --format json` ✅ — parses the new tasks file as a real `tasks` record under spec row US4 (S1, `not-started`) with zero warnings, and the spec now reports `in-progress` with all four stories linked · `npm test` 1219/1220 ✅ — the one failure is `src/artifact-store.test.ts > commits with a fallback identity when the machine has none`, which is environment-dependent (this machine has a global git identity configured) and pre-existing, unrelated to these two Markdown files.
