### PR TITLE
Engrave audit commitments: P-1 context budget, D-1/INV-1 protocol canonical home, D-2/INV-2 template portability

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,3 +40,13 @@ When assigned via “Assign to Copilot,” the coding agent **must**:
 
 - Reference the relevant issue number in commits/PRs using `Fixes #<issue>` so GitHub auto-closes the ticket on merge.
 - Follow repository documentation (`README.md`, `package.json`) for project conventions.
+
+<!-- smithy:engraved:begin -->
+## Engraved Knowledge
+
+This repository maintains engraved durable knowledge: decisions, invariants,
+and principles. Before planning or making changes, read the applicable records
+under these locations and judge whether they apply to the work at hand.
+
+- docs/constitution/
+<!-- smithy:engraved:end -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,5 +48,7 @@ This repository maintains engraved durable knowledge: decisions, invariants,
 and principles. Before planning or making changes, read the applicable records
 under these locations and judge whether they apply to the work at hand.
 
+- docs/decisions/
+- docs/invariants/
 - docs/constitution/
 <!-- smithy:engraved:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,3 +103,13 @@ npm test             # Run all tests
 
 Always use the `npm run` / `npm test` scripts — not `npx tsx` / `npx vitest`
 direct invocations.
+
+<!-- smithy:engraved:begin -->
+## Engraved Knowledge
+
+This repository maintains engraved durable knowledge: decisions, invariants,
+and principles. Before planning or making changes, read the applicable records
+under these locations and judge whether they apply to the work at hand.
+
+- docs/constitution/
+<!-- smithy:engraved:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,5 +111,7 @@ This repository maintains engraved durable knowledge: decisions, invariants,
 and principles. Before planning or making changes, read the applicable records
 under these locations and judge whether they apply to the work at hand.
 
+- docs/decisions/
+- docs/invariants/
 - docs/constitution/
 <!-- smithy:engraved:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,5 +273,7 @@ This repository maintains engraved durable knowledge: decisions, invariants,
 and principles. Before planning or making changes, read the applicable records
 under these locations and judge whether they apply to the work at hand.
 
+- docs/decisions/
+- docs/invariants/
 - docs/constitution/
 <!-- smithy:engraved:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,3 +265,13 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for test file details. Agent and human te
 - To test slash commands in Claude Code: run `smithy init` targeting a test repo, then start a **new** Claude Code session in that repo. Claude Code must be restarted to pick up new/changed commands.
 - The `--permissions` / `--no-permissions` flags control whether permissions are deployed at the selected location (`repo` or `user`).
 - The `templatesBaseDir` path in the built CLI resolves to `../src/templates` relative to `dist/`, so `src/templates/` must exist at runtime (it's included in `package.json` `files`).
+
+<!-- smithy:engraved:begin -->
+## Engraved Knowledge
+
+This repository maintains engraved durable knowledge: decisions, invariants,
+and principles. Before planning or making changes, read the applicable records
+under these locations and judge whether they apply to the work at hand.
+
+- docs/constitution/
+<!-- smithy:engraved:end -->

--- a/docs/constitution/context-budget.md
+++ b/docs/constitution/context-budget.md
@@ -27,7 +27,7 @@ The rule is cross-domain — it governs command bodies, skill descriptions,
 agent frontmatter, snippet architecture, and deploy-time rendering alike —
 and no release-to-release change in Smithy's features unseats it: it follows
 from how LLM context works, not from any current template's shape. The
-2026-08 template audit (#551) found five separate surfaces drifting toward
+2026-08 template audit ([#551](https://github.com/Balexda/SmithyCLI/issues/551)) found five separate surfaces drifting toward
 documentation-shaped always-loaded text independently, which is the
 signature of a missing constitution-level commitment rather than five local
 mistakes.

--- a/docs/constitution/context-budget.md
+++ b/docs/constitution/context-budget.md
@@ -1,0 +1,43 @@
+---
+id: P-1
+kind: principle
+domain: system
+title: "Always-loaded context is a budget"
+status: active
+topics: [context-economy, skill-descriptions, agent-descriptions, progressive-disclosure]
+scope: [src/templates/agent-skills/**]
+applies_to: [skill registry, command invocations, sub-agent dispatch, deployed agent-skill trees]
+---
+# Always-loaded context is a budget
+
+## Statement
+
+Every byte an agent carries without asking for it — skill and command
+descriptions, sub-agent advertisements, snippet text multiplied across
+composed templates — is spent from a shared budget before any work begins.
+Content enters the always-loaded surface only when it changes what the agent
+does next: descriptions are dispatch triggers, not documentation; reference
+material, worked examples, and schemas load on demand; and a snippet's cost
+is its size times every deployment that composes it, not its size once in
+source.
+
+## Why this is apex
+
+The rule is cross-domain — it governs command bodies, skill descriptions,
+agent frontmatter, snippet architecture, and deploy-time rendering alike —
+and no release-to-release change in Smithy's features unseats it: it follows
+from how LLM context works, not from any current template's shape. The
+2026-08 template audit (#551) found five separate surfaces drifting toward
+documentation-shaped always-loaded text independently, which is the
+signature of a missing constitution-level commitment rather than five local
+mistakes.
+
+## How decisions cite this
+
+Cite P-1 when a decision trades context weight against convenience: adding
+an always-advertised description, inlining a schema into a composed
+template, or choosing inline content over body-on-demand loading. State
+which side of the trade the decision takes and what budget it spends. Do
+not cite P-1 to justify omitting content an agent needs at dispatch time —
+the principle bounds unrequested context; it does not argue for
+under-specification.

--- a/docs/decisions/deployable-template-portability.decision.md
+++ b/docs/decisions/deployable-template-portability.decision.md
@@ -16,8 +16,10 @@ establishes: [INV-2]
 
 ## Context
 
-Templates under `src/templates/agent-skills/` deploy verbatim into
-arbitrary target repositories, but they are authored inside SmithyCLI —
+Templates under `src/templates/agent-skills/` are rendered into arbitrary
+target repositories — Handlebars partials resolved, frontmatter stripped
+or kept per target — but their prose ships as written, and they are
+authored inside SmithyCLI —
 where references to `src/manifest.ts`, local issue numbers, spec
 data-models, and this repo's settings are natural to reach for. The
 2026-08 audit (#551) found such references shipped on five surfaces

--- a/docs/decisions/deployable-template-portability.decision.md
+++ b/docs/decisions/deployable-template-portability.decision.md
@@ -1,0 +1,61 @@
+---
+id: D-2
+kind: decision
+domain: system
+title: "Deployed templates carry only target-repo-meaningful content"
+status: proposed
+decided_at: 2026-08-15
+topics: [template-authoring, deployables, portability]
+scope: [src/templates/agent-skills/**]
+applies_to: [deployed commands, prompts, sub-agents, skills, snippets]
+supersedes: []
+superseded_by: []
+establishes: [INV-2]
+---
+# Deployed templates carry only target-repo-meaningful content
+
+## Context
+
+Templates under `src/templates/agent-skills/` deploy verbatim into
+arbitrary target repositories, but they are authored inside SmithyCLI —
+where references to `src/manifest.ts`, local issue numbers, spec
+data-models, and this repo's settings are natural to reach for. The
+2026-08 audit (#551) found such references shipped on five surfaces
+(orders, spark, engrave, the survey agent, branch-policy), where they
+resolve to nothing — or to an unrelated issue — in every customer repo,
+plus ~1.5KB of commentary addressed to future template editors deployed as
+runtime instruction. The alternatives were to keep pruning these
+case-by-case in review, or to commit to a portability rule the authoring
+and review passes can hold templates against.
+
+## Decision
+
+Deployable template content is written for the agent executing it in the
+target repository. SmithyCLI-internal references — source paths and line
+numbers, SmithyCLI issue or PR numbers, this repo's specs and PRDs, and
+this repo's permission or settings choices — do not ship in deployable
+text, and neither does prose addressed to the template's future editors.
+Maintainer-facing rationale lives in source-tree-only files (directory
+READMEs, engraved records) or in commit and PR messages. The acceptance
+test: rendered into a fresh repo by `smithy init`, every path, reference,
+and instruction in the deployed file resolves there.
+
+## Consequences
+
+Good: deployed prompts stop instructing agents to read files that do not
+exist, issue references stop pointing at strangers' issues, and pure-weight
+maintainer commentary leaves the runtime context (per P-1). Bad: authoring
+rationale loses its most convenient home next to the text it explains —
+maintainers must route it to READMEs or engraved records — and templates
+must cite deployable homes (snippets, skills, the deployed agent-skill
+tree) rather than SmithyCLI source, which is occasionally less precise.
+
+## Establishes
+
+INV-2 — Deployable templates read correctly outside SmithyCLI.
+
+## Citations
+
+P-1 (always-loaded context is a budget — internal commentary is spent
+weight with no runtime value). Evidence and remediation: audit #551,
+sub-issue #555.

--- a/docs/decisions/deployable-template-portability.decision.md
+++ b/docs/decisions/deployable-template-portability.decision.md
@@ -22,7 +22,7 @@ or kept per target — but their prose ships as written, and they are
 authored inside SmithyCLI —
 where references to `src/manifest.ts`, local issue numbers, spec
 data-models, and this repo's settings are natural to reach for. The
-2026-08 audit (#551) found such references shipped on five surfaces
+2026-08 audit ([#551](https://github.com/Balexda/SmithyCLI/issues/551)) found such references shipped on five surfaces
 (orders, spark, engrave, the survey agent, branch-policy), where they
 resolve to nothing — or to an unrelated issue — in every customer repo,
 plus ~1.5KB of commentary addressed to future template editors deployed as
@@ -39,8 +39,12 @@ this repo's permission or settings choices — do not ship in deployable
 text, and neither does prose addressed to the template's future editors.
 Maintainer-facing rationale lives in source-tree-only files (directory
 READMEs, engraved records) or in commit and PR messages. The acceptance
-test: rendered into a fresh repo by `smithy init`, every path, reference,
-and instruction in the deployed file resolves there.
+test: rendered into a fresh repo by `smithy init`, every **actionable**
+reference in the deployed file — a path the agent is told to read, write,
+or execute; an issue or document cited as evidence; an instruction's
+target — resolves there. Purely illustrative example paths inside prose
+are exempt, per the carve-out in `AGENTS.md`'s deployable-template
+authoring rules: an example is not an instruction.
 
 ## Consequences
 
@@ -59,5 +63,5 @@ INV-2 — Deployable templates read correctly outside SmithyCLI.
 ## Citations
 
 P-1 (always-loaded context is a budget — internal commentary is spent
-weight with no runtime value). Evidence and remediation: audit #551,
-sub-issue #555.
+weight with no runtime value). Evidence and remediation: audit [#551](https://github.com/Balexda/SmithyCLI/issues/551),
+sub-issue [#555](https://github.com/Balexda/SmithyCLI/issues/555).

--- a/docs/decisions/protocol-canonical-home.decision.md
+++ b/docs/decisions/protocol-canonical-home.decision.md
@@ -16,7 +16,7 @@ establishes: [INV-1]
 
 ## Context
 
-The 2026-08 template audit (#551) found the kind × severity × confidence
+The 2026-08 template audit ([#551](https://github.com/Balexda/SmithyCLI/issues/551)) found the kind × severity × confidence
 triage protocol — the system's central review-safety mechanism — maintained
 by hand in roughly twelve places, with two non-identical "canonical"
 definitions (`snippets/review-protocol.md` and `smithy-clarify` Step 3b)
@@ -30,9 +30,14 @@ only mechanism for sharing protocol text.
 ## Decision
 
 Every protocol shared by more than one template — a triage table, a gate
-definition, an output contract, a schema — has exactly one canonical home.
-Templates that need it compose it (`{{>snippet}}`) or cite it by name and
-location; they never restate it. A consumer that genuinely needs a variant
+definition, an output contract, a schema — has exactly one canonical home,
+and no template restates it. A deployable consumer that needs the protocol
+at runtime composes it (`{{>snippet}}`): snippets are inlined at render and
+never exist as standalone files in a target repo, so a bare citation there
+is a dead reference. Citation in place of composition is reserved for
+contexts where the cited home is readable from where the text runs —
+source-tree documentation citing a snippet, or deployed text citing another
+deployed file such as a skill or agent. A consumer that genuinely needs a variant
 declares the variance as a Known Exception on INV-1, with rationale, rather
 than diverging silently.
 
@@ -40,7 +45,7 @@ than diverging silently.
 
 Good: drift between copies becomes structurally impossible for composed
 content, and deliberate variance becomes visible and auditable in a single
-ledger; the re-canonicalization work (#553) gains a defined target state.
+ledger; the re-canonicalization work ([#553](https://github.com/Balexda/SmithyCLI/issues/553)) gains a defined target state.
 Bad: composition costs deploy size where a hand-tuned inline copy could be
 shorter (weigh against P-1), and per-command variations — such as different
 finding destinations per command — require the canonical home to be written
@@ -54,4 +59,4 @@ INV-1 — Shared protocols are composed or cited, never restated.
 ## Citations
 
 P-1 (always-loaded context is a budget — composition must not multiply
-weight thoughtlessly). Evidence and remediation: audit #551, sub-issue #553.
+weight thoughtlessly). Evidence and remediation: audit [#551](https://github.com/Balexda/SmithyCLI/issues/551), sub-issue [#553](https://github.com/Balexda/SmithyCLI/issues/553).

--- a/docs/decisions/protocol-canonical-home.decision.md
+++ b/docs/decisions/protocol-canonical-home.decision.md
@@ -1,0 +1,57 @@
+---
+id: D-1
+kind: decision
+domain: system
+title: "Shared protocols have one canonical home"
+status: proposed
+decided_at: 2026-08-15
+topics: [protocol-composition, snippets, drift, template-authoring]
+scope: [src/templates/agent-skills/**]
+applies_to: [agent-skill templates, deployed commands, sub-agents, snippets]
+supersedes: []
+superseded_by: []
+establishes: [INV-1]
+---
+# Shared protocols have one canonical home
+
+## Context
+
+The 2026-08 template audit (#551) found the kind × severity × confidence
+triage protocol — the system's central review-safety mechanism — maintained
+by hand in roughly twelve places, with two non-identical "canonical"
+definitions (`snippets/review-protocol.md` and `smithy-clarify` Step 3b)
+and drift already landed: one command contradicts itself about how to write
+a debt row. The repo's READMEs already stated a link-don't-restate rule in
+prose, and it did not hold; the one surface with deterministic enforcement
+(the orders parity test) largely did. The alternatives on the table were to
+keep the prose rule and fix the copies, or to commit to composition as the
+only mechanism for sharing protocol text.
+
+## Decision
+
+Every protocol shared by more than one template — a triage table, a gate
+definition, an output contract, a schema — has exactly one canonical home.
+Templates that need it compose it (`{{>snippet}}`) or cite it by name and
+location; they never restate it. A consumer that genuinely needs a variant
+declares the variance as a Known Exception on INV-1, with rationale, rather
+than diverging silently.
+
+## Consequences
+
+Good: drift between copies becomes structurally impossible for composed
+content, and deliberate variance becomes visible and auditable in a single
+ledger; the re-canonicalization work (#553) gains a defined target state.
+Bad: composition costs deploy size where a hand-tuned inline copy could be
+shorter (weigh against P-1), and per-command variations — such as different
+finding destinations per command — require the canonical home to be written
+parametrically or the variance to be declared, both more design effort than
+copying.
+
+## Establishes
+
+INV-1 — Shared protocols are composed or cited, never restated.
+
+## Citations
+
+P-1 (always-loaded context is a budget — composition must not multiply
+weight thoughtlessly). Evidence and remediation: audit #551, sub-issue #553.

--- a/docs/invariants/deployable-template-portability.invariant.md
+++ b/docs/invariants/deployable-template-portability.invariant.md
@@ -1,0 +1,41 @@
+---
+id: INV-2
+kind: invariant
+domain: system
+title: "Deployable templates read correctly outside SmithyCLI"
+status: drifting
+topics: [template-authoring, deployables, portability]
+scope: [src/templates/agent-skills/**]
+applies_to: [deployed commands, prompts, sub-agents, skills, snippets]
+established_by: [D-2]
+---
+# Deployable templates read correctly outside SmithyCLI
+
+## Rule
+
+Every deployable template — commands, prompts, agents, skills, snippets —
+must read correctly in a repository that is not SmithyCLI. No deployable
+content references SmithyCLI source files or line numbers, SmithyCLI issue
+or PR numbers, specs or PRDs in this repo, or this repo's permission and
+settings choices; no deployable prose addresses the template's future
+editors. The test: rendered into a fresh repo by `smithy init`, every
+path, reference, and instruction resolves there.
+
+## Rationale
+
+Deployed text is runtime instruction for an agent standing in someone
+else's repo; internal references either dead-end or mislead it, and
+maintainer commentary is pure context weight. The establishing decision
+(D-2) records the evidence from the 2026-08 audit.
+
+## Known Exceptions
+
+| Where | What diverges | Disposition + Why | Tracking Issue | Severity |
+|-------|---------------|-------------------|----------------|----------|
+| `commands/smithy.orders.prompt` | Cites `src/manifest.ts` / `src/commands/update.ts` line references and "the data-model row" from a SmithyCLI spec across ~8 sites | Temporary: strip or restate self-contained in the context-diet pass | #555 | medium |
+| `commands/smithy.spark.prompt` (lines ~455–476) | ~1.5KB of prose addressed to future template editors, with FR-006/FR-007 spec citations | Temporary: relocate to source-tree docs | #555 | low |
+| `commands/smithy.engrave.prompt`, `agents/smithy.survey.prompt`, `snippets/branch-policy.md` | SmithyCLI issue numbers (#415/#416/#418), an eval-case maintenance comment, and a repo-local allowlist note ship in deployable text | Temporary: strip or generalize | #555 | low |
+
+## Citations
+
+Established by D-2. Current-state evidence: audit #551; remediation #555.

--- a/docs/invariants/deployable-template-portability.invariant.md
+++ b/docs/invariants/deployable-template-portability.invariant.md
@@ -19,7 +19,11 @@ content references SmithyCLI source files or line numbers, SmithyCLI issue
 or PR numbers, specs or PRDs in this repo, or this repo's permission and
 settings choices; no deployable prose addresses the template's future
 editors. The test: rendered into a fresh repo by `smithy init`, every
-path, reference, and instruction resolves there.
+**actionable** reference — a path the agent is told to read, write, or
+execute; an issue or document cited as evidence; an instruction's target —
+resolves there. Purely illustrative example paths inside prose are exempt
+(per the carve-out in `AGENTS.md`'s deployable-template authoring rules):
+an example is not an instruction.
 
 ## Rationale
 
@@ -33,9 +37,9 @@ maintainer commentary is pure context weight. The establishing decision
 | Where | What diverges | Disposition + Why | Tracking Issue | Severity |
 |-------|---------------|-------------------|----------------|----------|
 | `commands/smithy.orders.prompt` | Cites `src/manifest.ts` / `src/commands/update.ts` line references and "the data-model row" from a SmithyCLI spec across ~8 sites | Temporary: strip or restate self-contained in the context-diet pass | #555 | medium |
-| `commands/smithy.spark.prompt` (lines ~455–476) | ~1.5KB of prose addressed to future template editors, with FR-006/FR-007 spec citations | Temporary: relocate to source-tree docs | #555 | low |
+| `commands/smithy.spark.prompt` (line ~290; lines ~455–476) | An FR-006 citation of the SmithyCLI-only reduce-interaction-friction spec embedded in the PRD-shape rules, plus ~1.5KB of prose addressed to future template editors with further FR-006/FR-007 citations | Temporary: strip the spec citation and relocate the editor commentary to source-tree docs | #555 | low |
 | `commands/smithy.engrave.prompt`, `agents/smithy.survey.prompt`, `snippets/branch-policy.md` | SmithyCLI issue numbers (#415/#416/#418), an eval-case maintenance comment, and a repo-local allowlist note ship in deployable text | Temporary: strip or generalize | #555 | low |
 
 ## Citations
 
-Established by D-2. Current-state evidence: audit #551; remediation #555.
+Established by D-2. Current-state evidence: audit [#551](https://github.com/Balexda/SmithyCLI/issues/551); remediation [#555](https://github.com/Balexda/SmithyCLI/issues/555).

--- a/docs/invariants/protocol-canonical-home.invariant.md
+++ b/docs/invariants/protocol-canonical-home.invariant.md
@@ -1,0 +1,40 @@
+---
+id: INV-1
+kind: invariant
+domain: system
+title: "Shared protocols are composed or cited, never restated"
+status: drifting
+topics: [protocol-composition, snippets, drift, template-authoring]
+scope: [src/templates/agent-skills/**]
+applies_to: [agent-skill templates, deployed commands, sub-agents, snippets]
+established_by: [D-1]
+---
+# Shared protocols are composed or cited, never restated
+
+## Rule
+
+A protocol consumed by more than one template lives in exactly one
+canonical file. Consumers pull it in by composition (`{{>snippet}}`) or
+reference it by name and location; no template carries its own hand-written
+copy of the tables, gates, enums, or contract shapes defined there. A
+consumer that needs a genuine variant records the divergence as a row in
+this ledger instead of restating the protocol with local edits.
+
+## Rationale
+
+Hand-maintained copies of invariant-dense text drift, and drift in a
+safety protocol silently changes behavior; the establishing decision (D-1)
+records the evidence from the 2026-08 audit.
+
+## Known Exceptions
+
+| Where | What diverges | Disposition + Why | Tracking Issue | Severity |
+|-------|---------------|-------------------|----------------|----------|
+| `commands/smithy.{mark,cut,render,ignite}.prompt` (two copies each), `commands/smithy.{strike,forge}.prompt` (one each) | Parent-side triage tables are hand-copied rather than composed from `snippets/review-protocol.md`, and the copies have diverged (ignite self-contradicts on the debt-row shape) | Temporary: predates this invariant; awaiting re-canonicalization | #553 | high |
+| `agents/smithy.clarify.prompt` Step 3b | A sibling kind-gate definition (third condition "no-prescription", no implementation/hygiene kinds) coexists with review-protocol's ("human-only") | Temporary: reconcile the two gates, or convert this row to Accepted with the deliberate difference stated | #553 | medium |
+| Voice-tag grammar in `skills/smithy.helper-voice` §8, `agent-skills/README.md`, `snippets/audit-checklist-voice.md` | The same tag grammar and keys table is maintained in three places | Temporary: pick one canonical home and point the other two at it | #551 | low |
+
+## Citations
+
+Established by D-1. Current-state evidence and the full duplication
+inventory: audit #551; remediation #553.

--- a/docs/invariants/protocol-canonical-home.invariant.md
+++ b/docs/invariants/protocol-canonical-home.invariant.md
@@ -14,11 +14,15 @@ established_by: [D-1]
 ## Rule
 
 A protocol consumed by more than one template lives in exactly one
-canonical file. Consumers pull it in by composition (`{{>snippet}}`) or
-reference it by name and location; no template carries its own hand-written
-copy of the tables, gates, enums, or contract shapes defined there. A
-consumer that needs a genuine variant records the divergence as a row in
-this ledger instead of restating the protocol with local edits.
+canonical file; no template carries its own hand-written copy of the
+tables, gates, enums, or contract shapes defined there. A deployable
+consumer that needs the protocol at runtime composes it (`{{>snippet}}`) —
+snippets are inlined at render and never deploy as standalone files, so a
+deployed citation to one resolves to nothing. Citation in place of
+composition is valid only where the cited home is readable from where the
+text runs (source-tree docs, or another deployed file). A consumer that
+needs a genuine variant records the divergence as a row in this ledger
+instead of restating the protocol with local edits.
 
 ## Rationale
 
@@ -37,4 +41,4 @@ records the evidence from the 2026-08 audit.
 ## Citations
 
 Established by D-1. Current-state evidence and the full duplication
-inventory: audit #551; remediation #553.
+inventory: audit [#551](https://github.com/Balexda/SmithyCLI/issues/551); remediation [#553](https://github.com/Balexda/SmithyCLI/issues/553).


### PR DESCRIPTION
## Summary
- Primary outcome: the first engraved durable-knowledge records, capturing three steering-level commitments from the skill-set audit (#551) — one principle (`P-1` always-loaded context is a budget), two decisions with the invariants they establish (`D-1`/`INV-1` shared protocols have one canonical home; `D-2`/`INV-2` deployable templates read correctly outside SmithyCLI).
- Notable behaviour changes: none at runtime — docs-only. The `smithy:engraved` pointer block is projected into `CLAUDE.md`, `AGENTS.md`, and `.github/copilot-instructions.md`, so future agent sessions are pointed at the records.
- Follow-up work deferred (if any): flipping `D-1`/`D-2` from `proposed` to `accepted` on merge; the deferred fourth engraving (frontmatter-deploy decision, blocked on #552) and the enforcement/lint layer are filed as separate sub-issues of #551.

## Context
- The audit in #551 found that prose rules against protocol duplication and internal-reference leakage already existed and failed, while the one deterministically enforced surface held. Engraved records are the one prose channel with an active delivery mechanism (`smithy-recall` is dispatched by the authoring commands), so the judgment-laden commitments are being engraved while mechanical checks are tracked separately.
- Unlocks: future planning passes in this repo recall these records at exactly the moments template-design decisions get made.

## Implementation Notes
- Records follow the schema in `src/templates/agent-skills/commands/smithy.engrave.prompt` exactly: frontmatter fields, body-section order, Known-Exceptions ledger column order, suffixes, and default locations (`docs/constitution/`, `docs/decisions/`, `docs/invariants/`).
- Both invariants start `status: drifting`, honestly: their Known-Exceptions ledgers seed `Temporary:` rows for the divergences the audit proved, with existing tracking issues (#553, #555, #551) in the Tracking Issue column rather than newly created duplicates. `Accepted:` vs `Temporary:` dispositions are per the ledger rules; alignment status is derived from the ledger.
- Decisions are `status: proposed` per the create scaffold; accepting them is a one-line lifecycle patch (Phase 4) once reviewed.
- One record-set per commit, per the engrave rules (decision + its established invariant share a commit; the principle stands alone). Projection block updated only in the commits where the discovered directory set changed.

## Risks & Mitigations
- Risk: engraved rules drift from what the team actually wants. | Mitigation: decisions land as `proposed`; review is the acceptance gate, and supersession (never rewrite) is the change mechanism.
- Risk: pointer blocks in three context files drift from the directory set. | Mitigation: the block is marker-delimited and regenerated deterministically by future engrave runs.

## Rollback Plan
- Revert the three commits (docs and pointer blocks only; no code, config, or template changes). No data migration involved.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build` via pretest)
- [x] Type check succeeds (`npm run typecheck`)
- [ ] CLI `init` smoke test (`node dist/cli.js init`) — not run; no CLI or template changes in this PR

### Template Generation
- [ ] Gemini Skills / Codex Prompts / Claude Prompts / Issue Templates — N/A, no template changes

### Permissions & Configuration
- [ ] Gemini / Codex / Claude config — N/A, no config changes

### Manual Test Cases
- [ ] N/A — no init/uninit flow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oKUSHVskAcZ8DTcjAQ5mT

---
_Generated by [Claude Code](https://claude.ai/code/session_017oKUSHVskAcZ8DTcjAQ5mT)_