### PR TITLE
feat(claude): translate command frontmatter instead of stripping it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Note the two sub-agent filename schemes: the Claude file derives from the source
 - **CLI entry**: `src/cli.ts` — Commander setup and arg parsing.
 - **Commands**: `src/commands/init.ts`, `src/commands/uninit.ts`, `src/commands/update.ts` — action handlers.
 - **Agent deployers**: `src/agents/{claude,gemini,codex}.ts` — per-agent deploy/remove logic.
-- **Templates**: `src/templates/agent-skills/{commands,prompts,agents}/*.prompt` — categorized by deployment target. Uses [Dotprompt](https://firebase.google.com/docs/genkit/dotprompt)'s native `.prompt` extension with YAML frontmatter (`name`, `description`). Dotprompt handles Handlebars rendering at deploy time — resolving partials (`{{>snippet-name}}`), conditionals (`{{#ifAgent}}...{{/ifAgent}}`), and other expressions. Frontmatter is stripped when deploying to Claude (kept for Gemini skills). Deployed files are translated to `.md`. See `src/templates/agent-skills/README.md` for full conventions.
+- **Templates**: `src/templates/agent-skills/{commands,prompts,agents}/*.prompt` — categorized by deployment target. Uses [Dotprompt](https://firebase.google.com/docs/genkit/dotprompt)'s native `.prompt` extension with YAML frontmatter (`name`, `description`). Dotprompt handles Handlebars rendering at deploy time — resolving partials (`{{>snippet-name}}`), conditionals (`{{#ifAgent}}...{{/ifAgent}}`), and other expressions. Frontmatter is kept verbatim for Gemini/Codex skills; on the Claude path, command frontmatter is *translated* to Claude's vocabulary (`src/command-frontmatter.ts`) and prompt frontmatter is stripped. Deployed files are translated to `.md`. See `src/templates/agent-skills/README.md` for full conventions.
 - **Snippets**: `src/templates/agent-skills/snippets/*.md` — shared Markdown fragments injected via `{{>partial-name}}` Handlebars partials. Resolved by Dotprompt at deploy time; not deployed as standalone files.
 - **Orders body templates**: `src/orders-templates.ts` — exports the four canonical default body strings (`rfc` / `features` / `spec` / `tasks`) plus the `provisionOrdersTemplates` function that `smithy init` calls to write them under `<manifestDir>/templates/orders/<type>.md`. The same defaults double as the built-in fallback bodies in `smithy.orders` (parity asserted in `src/templates.test.ts`).
 - **Manifest**: `src/manifest.ts` — tracks deployed files in `.smithy/smithy-manifest.json` for reliable cleanup and upgrades.
@@ -110,7 +110,13 @@ Templates are organized by their deployment target:
 - **`snippets/`** — shared Markdown fragments injected into other templates via `{{>partial-name}}` Handlebars partials (resolved by Dotprompt at deploy time).
 
 ### Cross-Agent Compatibility
-The same template source serves all three agents. Gemini and Codex keep frontmatter for skill metadata; Claude strips it from commands/prompts while retaining it for sub-agents and skills. The prompt text uses `$ARGUMENTS` which Claude replaces but Gemini/Codex leave as literal — so prompts include a fallback: "If no feature description is clear, ask the user."
+The same template source serves all three agents. Gemini and Codex keep frontmatter verbatim for skill metadata; Claude retains it for sub-agents and skills, strips it from reference prompts, and **translates** it for commands. The prompt text uses `$ARGUMENTS` which Claude replaces but Gemini/Codex leave as literal — so prompts include a fallback: "If no feature description is clear, ask the user."
+
+### Claude Command Frontmatter
+
+Claude Code advertises `.claude/commands/*.md` through the same registry skills use and drives that entry from the file's frontmatter, so the block is the command's only trigger signal. `src/command-frontmatter.ts` reduces the source block to the keys Claude Code reads — `description`, `argument-hint`, `disable-model-invocation`, `allowed-tools`, `model`, `context`, `agent`, `hooks` — and drops everything else, notably `name` (the dashed Codex spelling used to pick the Gemini/Codex skill directory; a Claude command is named by its filename instead). Unknown keys are dropped rather than rejected: one source block is the union of what all three targets need.
+
+Every command template declares `description`, `argument-hint`, and `disable-model-invocation: true` — all 13 Smithy commands are explicit pipeline steps the operator drives, so none should auto-fire, and keeping them out of the model registry recovers that context. `smithy.status` remains model-invocable because it ships as a skill, not a command. `src/templates.test.ts` enforces the contract on the source templates and through the Claude translation.
 
 ### Artifact Hierarchy and Relationships
 

--- a/src/agent-models.ts
+++ b/src/agent-models.ts
@@ -1,4 +1,5 @@
 import { parse as parseYaml } from 'yaml';
+import { splitFrontmatter } from './frontmatter.js';
 
 /**
  * Smithy's provider-neutral model abstraction for sub-agents.
@@ -66,14 +67,8 @@ export interface AgentModel {
   effort: ModelEffort | undefined;
 }
 
-const FRONTMATTER_RE = /^(---\s*\n[\s\S]*?\n---\s*\n)([\s\S]*)$/;
-
 /** Split an agent template into its raw frontmatter block and body. */
-export function splitAgentFrontmatter(content: string): { frontmatter: string; body: string } {
-  const match = content.match(FRONTMATTER_RE);
-  if (!match) return { frontmatter: '', body: content };
-  return { frontmatter: match[1] ?? '', body: match[2] ?? '' };
-}
+export const splitAgentFrontmatter = splitFrontmatter;
 
 function normalizeTools(raw: unknown): string[] {
   if (Array.isArray(raw)) return raw.map(String).map(t => t.trim()).filter(Boolean);

--- a/src/agents/claude.test.ts
+++ b/src/agents/claude.test.ts
@@ -76,6 +76,39 @@ describe('deploy', () => {
     }
   });
 
+  it('deploys commands with translated frontmatter, not stripped', async () => {
+    // Claude Code advertises command files through the skill registry and
+    // reads this block; stripping it left every command showing as its
+    // filename plus a recycled H1, with no trigger signal (#552).
+    await deploy(tmpDir, 'none');
+
+    const commandsDir = path.join(tmpDir, '.claude', 'commands');
+    for (const file of fs.readdirSync(commandsDir)) {
+      const content = fs.readFileSync(path.join(commandsDir, file), 'utf8');
+      expect(content.startsWith('---\n'), `${file} lost its frontmatter`).toBe(true);
+      const block = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n/)![1]!;
+      expect(block, file).toMatch(/^description:\s*\S/m);
+      expect(block, file).toMatch(/^argument-hint:\s*\S/m);
+      expect(block, file).toMatch(/^disable-model-invocation:\s*true$/m);
+      // The source `name:` is the Codex spelling (smithy-forge); a Claude
+      // command is named by its filename, so emitting it would advertise a
+      // command that does not exist.
+      expect(block, file).not.toMatch(/^name:/m);
+    }
+  });
+
+  it('keeps stripping frontmatter from reference prompts', async () => {
+    // Prompts are read as files, not registered — there is nothing for a
+    // frontmatter block to drive.
+    await deploy(tmpDir, 'none');
+
+    const promptsDir = path.join(tmpDir, '.claude', 'prompts');
+    for (const file of fs.readdirSync(promptsDir)) {
+      const content = fs.readFileSync(path.join(promptsDir, file), 'utf8');
+      expect(content.startsWith('---'), `${file} kept frontmatter`).toBe(false);
+    }
+  });
+
   it('deploys prompts only to prompts/ and not to commands/', async () => {
     await deploy(tmpDir, 'none');
 
@@ -241,18 +274,6 @@ describe('deploy', () => {
 
     for (const file of files) {
       const content = fs.readFileSync(path.join(promptsDir, file), 'utf8');
-      expect(content).not.toMatch(/^---\s*\n/);
-    }
-  });
-
-  it('strips frontmatter from deployed command files', async () => {
-    await deploy(tmpDir, 'none');
-
-    const commandsDir = path.join(tmpDir, '.claude', 'commands');
-    const files = fs.readdirSync(commandsDir);
-
-    for (const file of files) {
-      const content = fs.readFileSync(path.join(commandsDir, file), 'utf8');
       expect(content).not.toMatch(/^---\s*\n/);
     }
   });

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import picocolors from 'picocolors';
 import { getComposedTemplates, getTemplateFilesByCategory, stripFrontmatter } from '../templates.js';
 import { toClaudeAgentContent } from '../agent-models.js';
+import { toClaudeCommandContent } from '../command-frontmatter.js';
 import { flattenPermissions, claudeToolPermissions, askPermissions, denyPermissions, extraPermissions, type LanguageToolchain, type PlatformPackageManager } from '../permissions.js';
 import { hooksTemplateDir, removeIfExists } from '../utils.js';
 import { computeDrift, type DriftReport, type PermissionTriple } from '../drift.js';
@@ -42,14 +43,16 @@ export async function deploy(
   const templates = await getComposedTemplates('claude', artifactsRoot);
   const deployedFiles: string[] = [];
 
-  // Deploy commands -> .claude/commands/
+  // Deploy commands -> .claude/commands/ (frontmatter translated, not stripped:
+  // Claude Code advertises command files through the skill registry and reads
+  // description/argument-hint/disable-model-invocation from this block).
   const commandsDir = path.join(baseDir, '.claude', 'commands');
   if (templates.commands.size > 0) {
     if (!fs.existsSync(commandsDir)) fs.mkdirSync(commandsDir, { recursive: true });
   }
   for (const [file, content] of templates.commands) {
     const dest = path.join(commandsDir, file);
-    fs.writeFileSync(dest, stripFrontmatter(content));
+    fs.writeFileSync(dest, toClaudeCommandContent(content));
     deployedFiles.push(path.relative(baseDir, dest));
   }
   console.log(picocolors.green(`\nDeployed Claude agent skills in ${path.join(baseDir, '.claude')}`));

--- a/src/agents/codex.test.ts
+++ b/src/agents/codex.test.ts
@@ -161,6 +161,21 @@ describe('deploy', () => {
     }
   });
 
+  it('deploys command skills with the source frontmatter intact, `name` included', async () => {
+    // Codex derives the skill directory from `name:`, so the Claude-side
+    // frontmatter translation (#552) must not reach this path.
+    await deploy(tmpDir, false);
+
+    const skillsDir = path.join(tmpDir, '.agents', 'skills');
+    const composed = await getComposedTemplates('codex');
+    for (const [, content] of composed.commands) {
+      const name = parseFrontmatterName(content)!;
+      const deployed = fs.readFileSync(path.join(skillsDir, name, 'SKILL.md'), 'utf8');
+      expect(deployed, name).toBe(content);
+      expect(deployed, name).toMatch(/^---\s*\nname:\s*smithy-/);
+    }
+  });
+
   it('deploys operational skill scripts for Codex', async () => {
     await deploy(tmpDir, false);
 

--- a/src/agents/gemini.test.ts
+++ b/src/agents/gemini.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { buildGeminiAllowList, deploy, removeLegacy } from './gemini.js';
+import { getComposedTemplates, parseFrontmatterName } from '../templates.js';
 
 describe('deploy', () => {
   let tmpDir: string;
@@ -29,6 +30,21 @@ describe('deploy', () => {
     for (const skill of skills) {
       const skillMd = path.join(skillsDir, skill, 'SKILL.md');
       expect(fs.existsSync(skillMd)).toBe(true);
+    }
+  });
+
+  it('deploys command skills with the source frontmatter intact, `name` included', async () => {
+    // Gemini derives the skill directory from `name:`, so the Claude-side
+    // frontmatter translation (#552) must not reach this path.
+    await deploy(tmpDir, false);
+
+    const skillsDir = path.join(tmpDir, '.gemini', 'skills');
+    const composed = await getComposedTemplates('gemini');
+    for (const [, content] of composed.commands) {
+      const name = parseFrontmatterName(content)!;
+      const deployed = fs.readFileSync(path.join(skillsDir, name, 'SKILL.md'), 'utf8');
+      expect(deployed, name).toBe(content);
+      expect(deployed, name).toMatch(/^---\s*\nname:\s*smithy-/);
     }
   });
 

--- a/src/command-frontmatter.test.ts
+++ b/src/command-frontmatter.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { CLAUDE_COMMAND_FRONTMATTER_KEYS, toClaudeCommandContent } from './command-frontmatter.js';
+
+describe('toClaudeCommandContent', () => {
+  it('keeps the description — the whole point of translating instead of stripping', () => {
+    const content = '---\nname: smithy-audit\ndescription: "Audits a Smithy artifact."\n---\n# smithy-audit\n';
+    expect(toClaudeCommandContent(content)).toBe(
+      '---\ndescription: "Audits a Smithy artifact."\n---\n# smithy-audit\n',
+    );
+  });
+
+  it('drops `name` so a command is never advertised under its Codex spelling', () => {
+    const content = '---\nname: smithy-audit\ndescription: "d"\n---\nbody\n';
+    expect(toClaudeCommandContent(content)).not.toContain('name:');
+  });
+
+  it('keeps every key Claude Code reads on a command file', () => {
+    const content = [
+      '---',
+      'name: smithy-forge',
+      'description: "d"',
+      'argument-hint: "<tasks-file> [<slice-number>]"',
+      'allowed-tools: Bash(git status)',
+      'disable-model-invocation: true',
+      'model: opus',
+      'context: fork',
+      'agent: smithy-plan',
+      'hooks:',
+      '  PreToolUse: []',
+      '---',
+      'body',
+      '',
+    ].join('\n');
+    const out = toClaudeCommandContent(content);
+    for (const key of CLAUDE_COMMAND_FRONTMATTER_KEYS) {
+      expect(out).toContain(`${key}:`);
+    }
+  });
+
+  it('drops keys that only Gemini or Codex consume', () => {
+    const content = '---\nname: smithy-cut\ndescription: "d"\ntier: deep\ntools: Read, Grep\n---\nbody\n';
+    const out = toClaudeCommandContent(content);
+    expect(out).not.toContain('tier:');
+    expect(out).not.toContain('tools:');
+    expect(out).toContain('description:');
+  });
+
+  it('falls back to the bare body when the block carries nothing Claude reads', () => {
+    expect(toClaudeCommandContent('---\nname: smithy-x\n---\n# Body\n')).toBe('# Body\n');
+  });
+
+  it('returns content with no frontmatter unchanged', () => {
+    expect(toClaudeCommandContent('# Body\n')).toBe('# Body\n');
+  });
+});

--- a/src/command-frontmatter.ts
+++ b/src/command-frontmatter.ts
@@ -1,0 +1,63 @@
+import { filterFrontmatterKeys } from './frontmatter.js';
+
+/**
+ * Translation of a command template's frontmatter for the Claude target.
+ *
+ * Claude Code unified slash commands with skills: a `.claude/commands/*.md`
+ * file is advertised to the model through the same registry skills use, and
+ * its frontmatter is what drives that registry entry. Deploying these files
+ * with the frontmatter stripped (Smithy's behavior through v0.x) cost the
+ * `description` every command template already carries — the model saw only
+ * the filename and the recycled H1 — and forfeited the whole control surface
+ * built on top of it.
+ *
+ * Gemini and Codex consume the source block verbatim as skill metadata, so
+ * the block cannot simply be rewritten to Claude's vocabulary at the source.
+ * The deployer translates instead.
+ */
+
+/**
+ * Frontmatter keys Claude Code reads on a command file. Everything else in the
+ * source block is dropped on the Claude path.
+ *
+ * The notable drop is `name`. Gemini and Codex derive the deployed skill
+ * directory from it (`parseFrontmatterName`), but a Claude command is named by
+ * its filename — `smithy.audit.md` is `/smithy.audit` — and the source `name`
+ * carries the dashed Codex spelling (`smithy-audit`), so emitting it would
+ * advertise a command that does not exist.
+ *
+ * | Key | Effect |
+ * |-----|--------|
+ * | `description` | Registry/menu text. The reason this translation exists. |
+ * | `argument-hint` | Completion hint shown after the command name. |
+ * | `allowed-tools` | Per-command tool grant, narrower than settings.json. |
+ * | `disable-model-invocation` | Removes the command from the model registry; it stays user-invocable. |
+ * | `model` | Pins the command to a model. |
+ * | `context` | `fork` runs the command in a separate context window. |
+ * | `agent` | Sub-agent to run a forked command in. |
+ * | `hooks` | Command-scoped hooks. |
+ */
+export const CLAUDE_COMMAND_FRONTMATTER_KEYS = [
+  'description',
+  'argument-hint',
+  'allowed-tools',
+  'disable-model-invocation',
+  'model',
+  'context',
+  'agent',
+  'hooks',
+] as const;
+
+const CLAUDE_COMMAND_KEY_SET: ReadonlySet<string> = new Set(CLAUDE_COMMAND_FRONTMATTER_KEYS);
+
+/**
+ * Produce the Claude-deployed content for a command template: the source
+ * frontmatter reduced to {@link CLAUDE_COMMAND_FRONTMATTER_KEYS}, with the
+ * body untouched.
+ *
+ * A template whose frontmatter holds none of those keys deploys as a bare
+ * body, which is what the previous unconditional strip produced.
+ */
+export function toClaudeCommandContent(content: string): string {
+  return filterFrontmatterKeys(content, CLAUDE_COMMAND_KEY_SET);
+}

--- a/src/frontmatter.test.ts
+++ b/src/frontmatter.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { splitFrontmatter, filterFrontmatterKeys } from './frontmatter.js';
+
+describe('splitFrontmatter', () => {
+  it('splits a block from its body, fences included', () => {
+    const { frontmatter, body } = splitFrontmatter('---\nname: x\n---\n# Body\n');
+    expect(frontmatter).toBe('---\nname: x\n---\n');
+    expect(body).toBe('# Body\n');
+  });
+
+  it('returns an empty block and the whole content when there is no frontmatter', () => {
+    const { frontmatter, body } = splitFrontmatter('# Body only');
+    expect(frontmatter).toBe('');
+    expect(body).toBe('# Body only');
+  });
+
+  it('does not treat a horizontal rule inside the body as a fence', () => {
+    const content = '# Title\n\n---\n\nmore prose\n';
+    expect(splitFrontmatter(content)).toEqual({ frontmatter: '', body: content });
+  });
+});
+
+describe('filterFrontmatterKeys', () => {
+  const allow = (...keys: string[]) => new Set(keys);
+
+  it('keeps allowed keys and drops the rest, preserving source order', () => {
+    const content = '---\nname: smithy-audit\ndescription: "Audits things."\ntier: deep\n---\n# Body\n';
+    expect(filterFrontmatterKeys(content, allow('description'))).toBe(
+      '---\ndescription: "Audits things."\n---\n# Body\n',
+    );
+  });
+
+  it('preserves the exact formatting of kept lines', () => {
+    const content = '---\ndescription:   "spaced   out"\nname: x\n---\nbody\n';
+    expect(filterFrontmatterKeys(content, allow('description'))).toContain('description:   "spaced   out"');
+  });
+
+  it('carries the indented continuation lines of a kept block value', () => {
+    const content = [
+      '---',
+      'name: x',
+      'hooks:',
+      '  PreToolUse:',
+      '    - matcher: Bash',
+      'description: "d"',
+      '---',
+      'body',
+      '',
+    ].join('\n');
+    const out = filterFrontmatterKeys(content, allow('hooks', 'description'));
+    expect(out).toBe(
+      ['---', 'hooks:', '  PreToolUse:', '    - matcher: Bash', 'description: "d"', '---', 'body', ''].join('\n'),
+    );
+  });
+
+  it('does not carry the continuation lines of a dropped block value', () => {
+    const content = ['---', 'tools:', '  - Read', '  - Grep', 'description: "d"', '---', 'body', ''].join('\n');
+    const out = filterFrontmatterKeys(content, allow('description'));
+    expect(out).toBe(['---', 'description: "d"', '---', 'body', ''].join('\n'));
+    expect(out).not.toContain('Read');
+  });
+
+  it('returns a bare body when no key survives the filter', () => {
+    const content = '---\nname: x\ntier: deep\n---\n# Body\n';
+    expect(filterFrontmatterKeys(content, allow('description'))).toBe('# Body\n');
+  });
+
+  it('returns content unchanged when there is no frontmatter', () => {
+    expect(filterFrontmatterKeys('# Body\n', allow('description'))).toBe('# Body\n');
+  });
+
+  it('leaves the body untouched, horizontal rules and all', () => {
+    const content = '---\nname: x\ndescription: "d"\n---\n# Body\n\n---\n\nSection two\n';
+    expect(filterFrontmatterKeys(content, allow('description'))).toBe(
+      '---\ndescription: "d"\n---\n# Body\n\n---\n\nSection two\n',
+    );
+  });
+});

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -1,0 +1,71 @@
+/**
+ * Generic YAML-frontmatter helpers shared by the per-agent deployers.
+ *
+ * Smithy templates carry one frontmatter block that has to serve three
+ * targets with different vocabularies. Rather than maintain a block per
+ * target, each deployer *translates* the single source block into the shape
+ * its agent understands — see `agent-models.ts` for the sub-agent translation
+ * and `command-frontmatter.ts` for the Claude command translation.
+ */
+
+/** Matches a frontmatter block plus the body that follows it. */
+const FRONTMATTER_RE = /^(---\s*\n[\s\S]*?\n---\s*\n)([\s\S]*)$/;
+
+/**
+ * A top-level YAML key line: unindented `key:` or `key: value`. Continuation
+ * lines of a block value (`hooks:` and friends) are indented and therefore do
+ * not match, which is what lets {@link filterFrontmatterKeys} carry a nested
+ * value along with the key that owns it.
+ */
+const TOP_LEVEL_KEY_RE = /^([A-Za-z0-9_.-]+)\s*:/;
+
+/**
+ * Split a template into its raw frontmatter block (fences included) and body.
+ * Returns an empty `frontmatter` when the content has no block.
+ */
+export function splitFrontmatter(content: string): { frontmatter: string; body: string } {
+  const match = content.match(FRONTMATTER_RE);
+  if (!match) return { frontmatter: '', body: content };
+  return { frontmatter: match[1] ?? '', body: match[2] ?? '' };
+}
+
+/**
+ * Rewrite `content`'s frontmatter to hold only the keys in `allowed`,
+ * preserving source order and the exact formatting of every kept line
+ * (including indented continuation lines of a block value).
+ *
+ * Keys are dropped rather than rejected: a template's frontmatter is a union
+ * of what all three targets need, so a key this target does not understand is
+ * expected, not an error.
+ *
+ * Content with no frontmatter is returned unchanged. Content whose
+ * frontmatter holds no allowed key comes back as a bare body — an empty
+ * `---\n---\n` block would be noise, and for a Claude command it is exactly
+ * the pre-existing stripped output.
+ */
+export function filterFrontmatterKeys(content: string, allowed: ReadonlySet<string>): string {
+  const { frontmatter, body } = splitFrontmatter(content);
+  if (!frontmatter) return content;
+
+  const inner = frontmatter.replace(/^---\s*\n/, '').replace(/\n---\s*\n$/, '');
+  const kept: string[] = [];
+  let keeping = false;
+
+  for (const line of inner.split('\n')) {
+    const isTopLevel = !/^\s/.test(line) && line.trim() !== '';
+    if (isTopLevel) {
+      const key = line.match(TOP_LEVEL_KEY_RE)?.[1];
+      // An unindented line that is not a `key:` line can only be a
+      // continuation of a multi-line scalar, so leave `keeping` alone.
+      if (key !== undefined) keeping = allowed.has(key);
+    }
+    if (keeping) kept.push(line);
+  }
+
+  // Trailing blank lines belong to whichever key was last kept; they add
+  // nothing to the emitted block.
+  while (kept.length > 0 && kept[kept.length - 1]!.trim() === '') kept.pop();
+
+  if (kept.length === 0) return body;
+  return `---\n${kept.join('\n')}\n---\n${body}`;
+}

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -12,6 +12,7 @@ import {
   type ComposedTemplates,
 } from './templates.js';
 import { ORDERS_DEFAULT_TEMPLATES, ORDERS_TEMPLATE_TYPES } from './orders-templates.js';
+import { toClaudeCommandContent } from './command-frontmatter.js';
 
 describe('stripFrontmatter', () => {
   it('removes YAML frontmatter from content', () => {
@@ -2056,6 +2057,8 @@ describe('getComposedTemplates', () => {
       '---\n' +
       'name: smithy-audit\n' +
       'description: "Context-aware artifact auditor. Reviews any Smithy artifact by extension, or reviews code on a forge branch against its upstream spec context."\n' +
+      'argument-hint: "[<artifact-path>]"\n' +
+      'disable-model-invocation: true\n' +
       '---\n';
     expect(audit.startsWith(expectedFrontmatter)).toBe(true);
   });
@@ -4697,5 +4700,81 @@ describe('getComposedTemplates artifactsRoot', () => {
     const c = await getComposedTemplates('claude', '~/.smithy/myrepo/');
     const strike = c.commands.get('smithy.strike.md')!;
     expect(strike).toContain('Do not `git push`');
+  });
+});
+
+describe('command template frontmatter contract', () => {
+  // Claude Code advertises `.claude/commands/*.md` through the same registry
+  // skills use, and drives that entry from this block. Every command therefore
+  // has to declare its registry metadata at the source, where all three
+  // deployers can see it.
+  const commandsDir = path.join(process.cwd(), 'src/templates/agent-skills/commands');
+  const commandFiles = fs.readdirSync(commandsDir).filter(f => f.endsWith('.prompt'));
+
+  const frontmatterOf = (file: string): string => {
+    const raw = fs.readFileSync(path.join(commandsDir, file), 'utf8');
+    const match = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n/);
+    expect(match, `${file} has no frontmatter block`).not.toBeNull();
+    return match![1]!;
+  };
+
+  it('finds every command template', () => {
+    expect(commandFiles.length).toBeGreaterThanOrEqual(13);
+  });
+
+  it.each(commandFiles)('%s declares a non-empty description', file => {
+    const description = frontmatterOf(file).match(/^description:\s*(.+)$/m)?.[1]?.trim();
+    expect(description, `${file} is missing description:`).toBeTruthy();
+    // The H1 recycled as a description ("smithy.audit: smithy-audit") is the
+    // failure mode this contract exists to prevent — a real description is a
+    // sentence, not a slug.
+    expect(description!.length).toBeGreaterThan(30);
+  });
+
+  it.each(commandFiles)('%s declares an argument-hint', file => {
+    const hint = frontmatterOf(file).match(/^argument-hint:\s*(.+)$/m)?.[1]?.trim();
+    expect(hint, `${file} is missing argument-hint:`).toBeTruthy();
+  });
+
+  it.each(commandFiles)('%s opts out of model invocation', file => {
+    // Every Smithy command is an explicit pipeline step the operator drives.
+    // Leaving them model-invocable spends registry context on 13 entries that
+    // should never auto-fire.
+    expect(frontmatterOf(file)).toMatch(/^disable-model-invocation:\s*true$/m);
+  });
+
+  it('keeps the source `name` for the Gemini and Codex skill-directory scheme', () => {
+    for (const file of commandFiles) {
+      expect(frontmatterOf(file), file).toMatch(/^name:\s*smithy-/m);
+    }
+  });
+});
+
+describe('command frontmatter reaches each agent', () => {
+  it('Claude commands carry description, argument-hint, and the invocation opt-out', async () => {
+    const claude = await getComposedTemplates('claude');
+    for (const [file, content] of claude.commands) {
+      const deployed = toClaudeCommandContent(content);
+      expect(deployed.startsWith('---\n'), `${file} lost its frontmatter`).toBe(true);
+      const block = deployed.match(/^---\s*\n([\s\S]*?)\n---\s*\n/)![1]!;
+      expect(block, file).toMatch(/^description:/m);
+      expect(block, file).toMatch(/^argument-hint:/m);
+      expect(block, file).toMatch(/^disable-model-invocation:\s*true$/m);
+      // `name:` is the Codex spelling (smithy-audit); the Claude command is
+      // named by its filename (smithy.audit.md → /smithy.audit).
+      expect(block, file).not.toMatch(/^name:/m);
+    }
+  });
+
+  it('Gemini and Codex still receive the source block verbatim, `name` included', async () => {
+    for (const variant of ['gemini', 'codex'] as const) {
+      const composed = await getComposedTemplates(variant);
+      for (const [file, content] of composed.commands) {
+        const block = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n/)?.[1];
+        expect(block, `${variant}/${file} has no frontmatter`).toBeTruthy();
+        expect(block!, `${variant}/${file}`).toMatch(/^name:\s*smithy-/m);
+        expect(block!, `${variant}/${file}`).toMatch(/^description:/m);
+      }
+    }
   });
 });

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -28,9 +28,14 @@ See the README in each subdirectory for details on its contents and conventions.
 - **Body**: Markdown with Handlebars expressions. Dotprompt resolves partials
   (`{{>snippet-name}}`) and conditionals (`{{#ifAgent}}...{{/ifAgent}}`) at
   deploy time.
-- **Deploy transform**: Frontmatter is stripped when deploying Claude
-  commands/prompts (kept for Gemini and Codex skills). Files are renamed from
-  `.prompt` to `.md`. Sub-agents deploy with frontmatter intact to
+- **Deploy transform**: Claude **command** frontmatter is *translated* — reduced
+  to the keys Claude Code reads on a command file (`description`,
+  `argument-hint`, `disable-model-invocation`, `allowed-tools`, `model`,
+  `context`, `agent`, `hooks`), with `name` and every other source key dropped;
+  see [`commands/README.md`](commands/README.md#frontmatter). Claude **prompt**
+  frontmatter is still stripped outright — prompts are read as files, not
+  registered. Gemini and Codex keep the source block verbatim for both. Files
+  are renamed from `.prompt` to `.md`. Sub-agents deploy with frontmatter intact to
   `.claude/agents/` (Claude) and are translated into Codex custom-agent TOML at
   `.codex/agents/` — note the two filename schemes: Claude keeps the source
   `.prompt` filename (`smithy.plan.prompt` → `smithy.plan.md`) while Codex uses

--- a/src/templates/agent-skills/commands/README.md
+++ b/src/templates/agent-skills/commands/README.md
@@ -3,9 +3,10 @@
 Slash commands invocable by users (e.g., `/smithy.strike "add verbose flag"`).
 
 Deployed to:
-- **Claude**: `.claude/commands/smithy.<name>.md` (frontmatter stripped)
-- **Gemini**: `.gemini/skills/smithy.<name>/SKILL.md` (frontmatter kept)
-- **Codex**: `.agents/skills/smithy-<name>/SKILL.md` (frontmatter kept)
+- **Claude**: `.claude/commands/smithy.<name>.md` (frontmatter *translated* — see
+  [Frontmatter](#frontmatter) below)
+- **Gemini**: `.gemini/skills/smithy.<name>/SKILL.md` (frontmatter kept verbatim)
+- **Codex**: `.agents/skills/smithy-<name>/SKILL.md` (frontmatter kept verbatim)
 
 ## Current Commands
 
@@ -27,10 +28,43 @@ Deployed to:
 slash command, so it can auto-activate on natural-language status questions.
 It is still invocable explicitly via `/smithy.status …`.
 
+## Frontmatter
+
+One source block serves all three targets. Gemini and Codex consume it
+verbatim as skill metadata; the Claude deployer **translates** it, keeping only
+the keys Claude Code reads on a command file and dropping everything else. The
+translation lives in [`src/command-frontmatter.ts`](../../../command-frontmatter.ts).
+
+Claude Code advertises `.claude/commands/*.md` through the same registry skills
+use and drives that registry entry from this block, so the block is not
+decoration — it is the command's only trigger signal.
+
+### Required on every command
+
+| Key | Purpose |
+|-----|---------|
+| `name` | Skill-directory name for Gemini and Codex (dashed form: `smithy-cut`). **Dropped on the Claude path** — a Claude command is named by its filename, and emitting the dashed form would advertise a `/smithy-cut` that does not exist. |
+| `description` | What the command does and when to reach for it. Reaches all three targets. Never a restatement of the H1 — that is the failure this contract exists to prevent. |
+| `argument-hint` | The command's argument shape, in the `<required> [optional]` convention (e.g. `<tasks-file\|strike-file> [<slice-number>]`). Shown after the command name in Claude Code's completion. |
+| `disable-model-invocation: true` | Every Smithy command is an explicit pipeline step the operator drives. The opt-out keeps all 13 out of the model's registry — recovering that context — while leaving them fully user-invocable. |
+
+### Optional, Claude-only
+
+`allowed-tools`, `model`, `context` (`fork`), `agent`, and `hooks` are passed
+through to Claude when present and ignored by the other two targets. No command
+sets `allowed-tools` yet: per-command tool grants are the structural
+replacement for the global `settings.json` allowlist, and that migration is
+owned by the permissions work rather than this plumbing.
+
+Any other key is dropped on the Claude path rather than rejected — a source
+block is the union of what all three targets need, so a key one target does not
+understand is expected.
+
+`src/templates.test.ts` asserts the four required keys on every command
+template and that they survive the Claude translation.
+
 ## Conventions
 
-- Frontmatter must include `name` and `description`.
-- Commands that should deploy as slash commands set `command: true` in frontmatter.
 - Use `$ARGUMENTS` for user input; include a fallback for agents that don't substitute it.
 - Use `{{>partial-name}}` to include shared snippets (resolved by Dotprompt at deploy time).
 - Use `{{#ifAgent}}...{{else}}...{{/ifAgent}}` for orchestrator vs standalone conditional blocks; named branches such as `{{#ifAgent 'codex'}}` handle agent-specific paths.

--- a/src/templates/agent-skills/commands/smithy.audit.prompt
+++ b/src/templates/agent-skills/commands/smithy.audit.prompt
@@ -1,6 +1,8 @@
 ---
 name: smithy-audit
 description: "Context-aware artifact auditor. Reviews any Smithy artifact by extension, or reviews code on a forge branch against its upstream spec context."
+argument-hint: "[<artifact-path>]"
+disable-model-invocation: true
 ---
 # smithy-audit
 

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -1,6 +1,8 @@
 ---
 name: smithy-cut
 description: "Decompose a spec work node into PR-sized slices with ordered tasks. Use when a spec exists and you need an implementation plan for one backend story or typed UI ledger node."
+argument-hint: "<spec-folder|spec-path> [<story-number|node-id>]"
+disable-model-invocation: true
 ---
 # smithy.cut
 

--- a/src/templates/agent-skills/commands/smithy.engrave.prompt
+++ b/src/templates/agent-skills/commands/smithy.engrave.prompt
@@ -1,6 +1,8 @@
 ---
 name: smithy-engrave
 description: "Author or update a durable-knowledge record (decision, invariant, principle). Use to capture pivot-level commitments, supersede an old decision, or update an invariant's Known-Exceptions ledger."
+argument-hint: "decision:|invariant:|principle: <topic> | <record-path> [supersede|exception] [--level <level>] [--project <slug>]"
+disable-model-invocation: true
 ---
 # smithy.engrave
 

--- a/src/templates/agent-skills/commands/smithy.fix.prompt
+++ b/src/templates/agent-skills/commands/smithy.fix.prompt
@@ -1,6 +1,8 @@
 ---
 name: smithy-fix
 description: "Fix errors from CI failures, local test failures, or bugs. When run with no arguments on a branch with an open PR, automatically addresses PR review comments."
+argument-hint: "[<error-description|ci-link>]"
+disable-model-invocation: true
 ---
 # smithy-fix
 

--- a/src/templates/agent-skills/commands/smithy.forge.prompt
+++ b/src/templates/agent-skills/commands/smithy.forge.prompt
@@ -1,6 +1,8 @@
 ---
 name: smithy-forge
 description: "Implement a slice from a .tasks.md or .strike.md file as a pull request. Takes a file path and optional slice number."
+argument-hint: "<tasks-file|strike-file> [<slice-number>]"
+disable-model-invocation: true
 ---
 # smithy-forge
 

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -1,6 +1,8 @@
 ---
 name: smithy-ignite
 description: "Ignite a broad idea into a structured RFC with milestones one-shot. Runs clarify, drafts the RFC, creates a PR, and renders a standardized terminal summary without intermediate approval gates."
+argument-hint: "<idea|prd-path|rfc-path>"
+disable-model-invocation: true
 ---
 # smithy-ignite
 

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -1,6 +1,8 @@
 ---
 name: smithy-mark
 description: "Transform an idea, RFC, or feature map into a feature specification with user stories, data model, and contracts. Use when you need structured planning before implementation."
+argument-hint: "<feature-description|rfc-path|features-path> [<feature-number>]"
+disable-model-invocation: true
 ---
 # smithy.mark
 

--- a/src/templates/agent-skills/commands/smithy.orders.prompt
+++ b/src/templates/agent-skills/commands/smithy.orders.prompt
@@ -1,6 +1,8 @@
 ---
 name: smithy-orders
 description: "Create GitHub tickets from any artifact file. Auto-detects artifact type by extension and creates the correct ticket structure."
+argument-hint: "<artifact-path>"
+disable-model-invocation: true
 ---
 # smithy.orders
 

--- a/src/templates/agent-skills/commands/smithy.persona.prompt
+++ b/src/templates/agent-skills/commands/smithy.persona.prompt
@@ -1,6 +1,8 @@
 ---
 name: smithy-persona
 description: "Author durable .persona.md reference artifacts. Personas are cross-RFC, narrative-prose persona files stored flat under docs/personas/, identified by their filename slug."
+argument-hint: "<persona-description|rfc-path>"
+disable-model-invocation: true
 ---
 # smithy-persona
 

--- a/src/templates/agent-skills/commands/smithy.render.prompt
+++ b/src/templates/agent-skills/commands/smithy.render.prompt
@@ -1,6 +1,8 @@
 ---
 name: smithy-render
 description: "Break an RFC milestone into a feature map one-shot. Runs clarify, drafts the map, creates a PR, and renders a standardized terminal summary without intermediate approval gates."
+argument-hint: "<rfc-path|features-path> [<milestone-number>] [--bundle <path>]"
+disable-model-invocation: true
 ---
 # smithy-render
 

--- a/src/templates/agent-skills/commands/smithy.resolve.prompt
+++ b/src/templates/agent-skills/commands/smithy.resolve.prompt
@@ -1,6 +1,8 @@
 ---
 name: smithy-resolve
 description: "Resolve a specification-debt item in a Smithy planning artifact through a guided, interactive exercise. Given an artifact (and optionally a specific SD-NNN id), select the debt item, gather context — walking up to the parent artifact when the item was inherited — pose the open choice to the operator, and record the resolution. Use when an operator wants to step in and settle open specification debt."
+argument-hint: "<artifact-path> [SD-NNN]"
+disable-model-invocation: true
 ---
 # smithy.resolve
 

--- a/src/templates/agent-skills/commands/smithy.spark.prompt
+++ b/src/templates/agent-skills/commands/smithy.spark.prompt
@@ -1,6 +1,8 @@
 ---
 name: smithy-spark
 description: "Spark a raw idea into a one-page PRD. Clarifies the problem, surveys off-the-shelf alternatives, and produces a docs/prds/<YYYY>-<NNN>-<slug>.prd.md (or ~/.smithy/repos/<repo>/docs/prds/... in external-artifacts mode) as an optional upstream input to smithy.ignite."
+argument-hint: "<idea|brief-path|prd-path>"
+disable-model-invocation: true
 ---
 # smithy-spark
 

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -1,6 +1,8 @@
 ---
 name: smithy-strike
 description: "Strike while the iron is hot. Explore, plan, and produce a strike document in one shot — creates a PR and suggests forge for implementation."
+argument-hint: "<feature-description>"
+disable-model-invocation: true
 ---
 # smithy-strike
 


### PR DESCRIPTION
## Summary
- **Primary outcome**: Claude command deploys now *translate* the source frontmatter into Claude Code's vocabulary instead of stripping it, so every `/smithy.*` command ships with a real `description` and `argument-hint`, and none of them can auto-fire.
- **Notable behaviour changes**:
  - `.claude/commands/*.md` files now carry a frontmatter block (`description`, `argument-hint`, `disable-model-invocation: true`). Previously they were bare bodies.
  - `name:` is **dropped** on the Claude path; it is kept verbatim for Gemini and Codex.
  - All 13 commands set `disable-model-invocation: true` — they leave the model's skill registry entirely while staying fully user-invocable.
  - Claude *reference prompts* (`.claude/prompts/`) still strip frontmatter outright — unchanged.
  - Gemini and Codex deploys are byte-identical to before, apart from the two new frontmatter lines now present in the shared source block.
- **Follow-up work deferred**: per-command `allowed-tools` lists. The key is plumbed through when present, but no command sets one — replacing the global `settings.json` allowlist with per-command grants belongs to the permissions sub-issue of #551, not to this plumbing. `context: fork` + `agent` are likewise plumbed but unused, unblocking the fork-evaluation sub-issue.

## Context
`src/agents/claude.ts:52` ran `stripFrontmatter` on every command deploy. Since Claude Code unified slash commands with skills, `.claude/commands/*.md` files are advertised in the model's skill registry and their frontmatter is what drives that entry. Claude was the only one of the three targets discarding the well-written `description` each template already carried, so in a live session commands surfaced as `smithy.audit: smithy-audit` / `smithy.cut: smithy.cut` — the H1 recycled as the description. That is 13 model-invocable registry entries with zero trigger signal: pure context cost plus mis-fire risk.

Stripping also forfeited the whole modern control surface (`disable-model-invocation`, `argument-hint`, per-command `allowed-tools`, `context: fork` + `agent`, command-scoped `hooks`).

Audit priority 1 from #551 — the highest-leverage item, and a prerequisite for the `context: fork` evaluation sub-issue.

## Implementation Notes

**Translate, don't keep.** One source block has to serve three targets with different vocabularies, so the block cannot simply be passed through: `name:` carries the dashed Codex spelling (`smithy-audit`) that Gemini and Codex use to pick the deployed skill directory, while a Claude command is named by its filename (`smithy.audit.md` → `/smithy.audit`). Emitting it would advertise a command that does not exist. The deployer therefore translates, mirroring how `src/agent-models.ts` already translates the provider-neutral `tier:`/`effort:` into Claude's `model:` and Codex's `model_reasoning_effort`.

**Policy for unknown/foreign keys: drop, don't reject.** `src/command-frontmatter.ts` holds an allowlist of the keys Claude Code reads on a command file — `description`, `argument-hint`, `allowed-tools`, `disable-model-invocation`, `model`, `context`, `agent`, `hooks` — and drops everything else. A source block is the union of what all three targets need, so a key one target does not understand is expected, not an error. A template whose block survives with no allowed key deploys as a bare body, exactly matching the old stripped output.

**Impacted modules:**
- `src/frontmatter.ts` *(new)* — generic `splitFrontmatter` (moved out of `agent-models.ts`, which now aliases it) plus `filterFrontmatterKeys`. The filter is line-based rather than parse-and-reserialize, so kept lines keep their exact source formatting, and indented continuation lines travel with the key that owns them (a nested `hooks:` block survives; a dropped `tools:` block takes its list items with it).
- `src/command-frontmatter.ts` *(new)* — the Claude key allowlist and `toClaudeCommandContent`.
- `src/agents/claude.ts` — commands use `toClaudeCommandContent`; prompts keep `stripFrontmatter`.
- `src/templates/agent-skills/commands/*.prompt` — all 13 gain `argument-hint` and `disable-model-invocation: true`.

**Template / Agentic CLI specifics.** Each `argument-hint` was derived from that command's own `## Input` section, using the usual angle-brackets-for-required, square-brackets-for-optional convention. GitHub strips angle-bracket tokens out of PR descriptions, so rather than mangle them here, read the literal values straight off the diff — they are the one-line `argument-hint:` addition at the top of each `src/templates/agent-skills/commands/*.prompt`. In shape:

| Command | Argument shape |
|---------|----------------|
| `smithy.forge` | tasks-file **or** strike-file (required), then an optional slice number |
| `smithy.render` | rfc-path **or** features-path (required), then an optional milestone number and an optional `--bundle` path |
| `smithy.resolve` | artifact-path (required), then an optional `SD-NNN` id |
| `smithy.audit` | artifact-path, wholly optional — audit also runs off the current forge branch |

The `disable-model-invocation` opt-out covers every command because every Smithy command is an explicit pipeline step the operator drives. `smithy.status` is unaffected and stays model-invocable — it ships as a skill, not a command, and auto-activation on "what's next?" is the point of it.

Per the source-vs-deployed rule in `CLAUDE.md`, the committed `.claude/` snapshot is **not** regenerated here; that belongs in a dedicated chore PR.

## Risks & Mitigations
- **Risk**: the two new keys also land in the Gemini/Codex `SKILL.md` blocks, which do not understand them. | **Mitigation**: both already tolerate target-specific frontmatter — `smithy.pr-review` ships Claude MCP tool names and Codex pseudo-tools to all three in one `allowed-tools` line. Both deploys verified end-to-end and covered by byte-equality tests.
- **Risk**: `disable-model-invocation` on all 13 removes a command a user relied on the model auto-invoking. | **Mitigation**: the commands stay fully user-invocable via `/`, now with better `/`-menu text than before. The one surface intended to auto-trigger, `smithy.status`, is a skill and is untouched.
- **Risk**: the line-based filter mangles an exotic YAML value. | **Mitigation**: dedicated unit tests for nested block values, dropped block values, multi-line scalars, and body content containing horizontal rules.

## Rollback Plan
Revert the commit. No data or on-disk state migration is involved: the next `smithy init` / `smithy update` rewrites `.claude/commands/*.md` from the templates, and the manifest tracks the same file paths either way, so a downgrade restores the stripped bodies in one run. No config or permissions files are touched by this change.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npm run typecheck`)
- [x] CLI `init` smoke test (`node dist/cli.js init`) — run against scratch repos for `--agent claude`, `--agent gemini`, and `--agent codex`; deployed frontmatter inspected on all three
- [x] `npm test` — 1282 passed / 35 files
- [x] `npm run test:evals` — 272 passed / 13 files

### Template Generation
- [x] Claude Commands: `.claude/commands/` — all 13 carry `description` + `argument-hint` + `disable-model-invocation: true`, none carry `name:`
- [x] Claude Prompts: `.claude/prompts/` — still frontmatter-free
- [x] Gemini Skills: `.gemini/skills/` — SKILL.md asserted byte-equal to the composed template, `name:` intact
- [x] Codex Skills: `.agents/skills/` — SKILL.md asserted byte-equal to the composed template, `name:` intact
- [ ] GitHub Issue Templates: `.github/ISSUE_TEMPLATE/` — not touched by this change

### Permissions & Configuration
- [ ] Not touched by this change — no settings/config writer is modified. (Per-command `allowed-tools` is plumbed but unused; see Follow-up work.)

### New automated coverage
- `src/frontmatter.test.ts` — split and key-filter behaviour, including nested/dropped block values and horizontal rules in the body
- `src/command-frontmatter.test.ts` — the Claude key allowlist, the `name` drop, the bare-body fallback
- `src/templates.test.ts` — per-template contract (`it.each` over all 13: non-trivial description, argument-hint present, invocation opt-out, `name` retained for Gemini/Codex) plus the same contract asserted through the Claude translation
- `src/agents/{claude,gemini,codex}.test.ts` — deploy-level assertions on each target
- Removed the now-inverted `strips frontmatter from deployed command files` assertion

### Manual Test Cases
- [ ] `tests/Agent.tests.md` / `tests/Manual.tests.md` — init/uninit flows are unchanged (same file paths, same manifest entries); only deployed file *content* differs. Worth an A-series spot check that `/smithy.*` completion shows the new hints in a live session.

## Issue
- Closes #552
