### PR TITLE
refactor(templates): re-canonicalize the kind gate into composed snippets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,15 @@ The canonical schema and rules live in `src/templates/agent-skills/README.md`. W
 `## Specification Debt` is a **decision queue for a human**: a row belongs there
 only when a person must pick between named alternatives and the pick changes
 what gets built. Everything else the planning pass does not know has a
-different home, decided by the kind gate that `smithy-clarify` (Step 3b) and
-`smithy-plan-review` (Kind Gate) apply before any severity × confidence triage:
+different home, decided by the kind gate before any severity × confidence
+triage. The gate has one definition — `snippets/kind-gate.md` — composed by
+`smithy-clarify` (Step 3b), `smithy-refine`, and both review agents via
+`snippets/review-protocol.md`; the parent commands compose the consequence
+table from `snippets/plan-review-triage.md`. Only the reroute for a rejected
+candidate differs by consumer: the review agents name a different `kind` and
+let the parent file it, while clarify (which emits no `kind`) routes to its
+assumption stream with a `[Critical Assumption]` annotation and refine routes
+to `refinements`, both pointed at the home the gate's routing table names.
 
 | Kind | Home |
 |------|------|

--- a/docs/invariants/protocol-canonical-home.invariant.md
+++ b/docs/invariants/protocol-canonical-home.invariant.md
@@ -34,8 +34,7 @@ records the evidence from the 2026-08 audit.
 
 | Where | What diverges | Disposition + Why | Tracking Issue | Severity |
 |-------|---------------|-------------------|----------------|----------|
-| `commands/smithy.{mark,cut,render,ignite}.prompt` (two copies each), `commands/smithy.{strike,forge}.prompt` (one each) | Parent-side triage tables are hand-copied rather than composed from `snippets/review-protocol.md`, and the copies have diverged (ignite self-contradicts on the debt-row shape) | Temporary: predates this invariant; awaiting re-canonicalization | #553 | high |
-| `agents/smithy.clarify.prompt` Step 3b | A sibling kind-gate definition (third condition "no-prescription", no implementation/hygiene kinds) coexists with review-protocol's ("human-only") | Temporary: reconcile the two gates, or convert this row to Accepted with the deliberate difference stated | #553 | medium |
+| `agents/smithy.clarify.prompt` Step 3b, `agents/smithy.refine.prompt` | Both compose the one `kind-gate` definition but reroute a rejected candidate differently — clarify into its assumption stream with `[Critical Assumption]`, refine into `refinements` — because neither emits a `kind` field for a parent to route on | Accepted: the gate itself is shared and identical; only the return channel differs, and each consumer states its own in two sentences beside the composed gate | — | low |
 | Voice-tag grammar in `skills/smithy.helper-voice` §8, `agent-skills/README.md`, `snippets/audit-checklist-voice.md` | The same tag grammar and keys table is maintained in three places | Temporary: pick one canonical home and point the other two at it | #551 | low |
 
 ## Citations

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -105,7 +105,7 @@ describe('resolveSnippets', () => {
 describe('loadSnippets', () => {
   it('loads all snippet files', () => {
     const snippets = loadSnippets();
-    expect(snippets.size).toBe(29);
+    expect(snippets.size).toBe(33);
 
     const expectedFiles = [
       'audit-checklist-rfc.md',
@@ -137,6 +137,10 @@ describe('loadSnippets', () => {
       'spec-debt-section.md',
       'open-implementation-questions.md',
       'typed-ui-build-profiles.md',
+      'kind-gate.md',
+      'debt-row-shape.md',
+      'debt-grading.md',
+      'plan-review-triage.md',
     ];
     for (const file of expectedFiles) {
       expect(snippets.has(file)).toBe(true);
@@ -165,6 +169,9 @@ describe('loadSnippets', () => {
     expect(snippets.get('open-implementation-questions.md')).toContain(
       '## Open Implementation Questions',
     );
+    expect(snippets.get('kind-gate.md')).toContain('#### The steering test');
+    expect(snippets.get('debt-row-shape.md')).toContain('**Debt row fields.**');
+    expect(snippets.get('plan-review-triage.md')).toContain('the review note surface');
   });
 });
 
@@ -329,13 +336,181 @@ describe('engraved-recall consultation snippets', () => {
   });
 });
 
+/**
+ * Render a snippet through the same partial machinery the deploy path uses,
+ * so an assertion sees what a consumer actually receives — nested partials
+ * included. `loadSnippets()` returns raw files, which is the wrong surface
+ * for any rule that now lives one composition level down.
+ */
+async function composeSnippet(partialName: string): Promise<string> {
+  const partials: Record<string, string> = {};
+  for (const [filename, content] of loadSnippets()) {
+    partials[filename.replace(/\.md$/, '')] = content.trimEnd();
+  }
+  const renderer = new Dotprompt({ partials });
+  return resolveSnippets(`{{>${partialName}}}\n`, renderer);
+}
+
+describe('kind-gate snippet', () => {
+  // Issue #553: the kind gate had two non-identical "canonical" homes —
+  // `review-protocol` (third condition: human-only) and `smithy-clarify`
+  // Step 3b (third condition: no-prescription, and no implementation/hygiene
+  // kinds at all). This snippet is now the only definition; every consumer
+  // composes it, so the two can no longer disagree.
+
+  it('defines the three kinds and the three-part steering test', () => {
+    const content = loadSnippets().get('kind-gate.md')!;
+    expect(content).toContain('`steering`');
+    expect(content).toContain('`implementation`');
+    expect(content).toContain('`hygiene`');
+    expect(content).toContain('**Open question**');
+    expect(content).toContain('**Named alternatives**');
+    expect(content).toContain('**Human-only**');
+    expect(content).toContain('**Positive test:**');
+    expect(content).toContain('#### Calibration');
+    expect(content).toContain('Only `steering` findings may become specification debt.');
+  });
+
+  it('folds the no-prescription rule into the positive test rather than a fourth condition', () => {
+    // Clarify used to carry "no prescription" as a third gate condition, which
+    // made its gate structurally different from the review agents'. It is a
+    // test of how the finding is *phrased*, not of who resolves it, so it
+    // belongs with the positive test — one gate, same three conditions.
+    const content = loadSnippets().get('kind-gate.md')!;
+    const testIdx = content.indexOf('**Positive test:**');
+    const conditionsIdx = content.indexOf('**Human-only**');
+    expect(conditionsIdx).toBeGreaterThan(-1);
+    expect(content).not.toMatch(/\*\*No prescription\*\*/);
+    expect(content.slice(testIdx)).toMatch(/directive/);
+    // Exactly three numbered conditions, so no consumer can add a fourth.
+    const conditions = content.match(/^\d\. \*\*/gm) ?? [];
+    expect(conditions.length).toBe(3);
+    expect(testIdx).toBeGreaterThan(conditionsIdx);
+  });
+
+  it('routes every rejected kind to a named home, including the clarify leak kinds', () => {
+    // The routing table used to be split: review-protocol held four rows and
+    // pointed at clarify's six for the rest — a dead reference for Gemini,
+    // which deploys no sub-agent files at all. All of them live here now.
+    const content = loadSnippets().get('kind-gate.md')!;
+    expect(content).toContain('## Open Implementation Questions');
+    expect(content).toContain('### Functional Requirements');
+    expect(content).toContain('### Acceptance Scenarios');
+    expect(content).toContain('## Out of Scope');
+    expect(content).toContain('## Assumptions');
+    expect(content).toContain('Cross-Cutting Governance');
+    expect(content).toContain('A wrong table is a fix, not a question');
+    // No cross-file pointer to a prompt a consumer may never load.
+    expect(content).not.toMatch(/smithy-clarify Step 3b's routing table/);
+  });
+});
+
+describe('debt-row-shape snippet', () => {
+  // Issue #553: Confidence was High|Low in review-protocol, High|Medium|Low
+  // in clarify and in the debt section's own example rows, and "Medium/Low"
+  // in refine's prose; Impact's enum was never positively stated anywhere in
+  // the four authoring commands. One home now states both.
+
+  it('states the Impact and Confidence enums positively', () => {
+    const content = loadSnippets().get('debt-row-shape.md')!;
+    expect(content).toContain('`Critical` / `High` / `Medium` / `Low`');
+    expect(content).toContain('`High` / `Medium` / `Low`');
+  });
+
+  it('keeps the grading rubric out of the row shape the parents compose', async () => {
+    // P-1: the row shape ships to every plan-review site (eleven of them),
+    // but only clarify and refine ever pick a level from nothing — a parent
+    // maps severity and copies confidence. The rubric lives one level up, in
+    // `debt-grading`, which nests the shape so the enums are still stated once.
+    const shape = loadSnippets().get('debt-row-shape.md')!;
+    expect(shape).not.toMatch(/You would be surprised if the user disagreed/);
+    const grading = await composeSnippet('debt-grading');
+    expect(grading).toContain('You would be surprised if the user disagreed');
+    // Nesting, not restating: the shape's rules arrive with the rubric.
+    expect(grading.replace(/\s+/g, ' ')).toContain('`Important` becomes `High`');
+    expect(loadSnippets().get('debt-grading.md')!).toContain('{{>debt-row-shape}}');
+  });
+
+  it('maps review severity into Impact instead of copying it', () => {
+    const content = loadSnippets().get('debt-row-shape.md')!.replace(/\s+/g, ' ');
+    expect(content).toContain('`Important` is **not** a valid `Impact` value.');
+    expect(content).toContain('`Important` becomes `High`');
+  });
+
+  it('reconciles the binary review confidence with the three-level scale', () => {
+    // A review finding's High/Low is the same scale's endpoints, not a rival
+    // enum — which is what makes copying it into the Confidence column lossless.
+    const content = loadSnippets().get('debt-row-shape.md')!;
+    expect(content).toMatch(/endpoints of the same scale/);
+    expect(content.replace(/\s+/g, ' ')).toContain(
+      '`Medium` is produced only by clarification and refinement',
+    );
+  });
+});
+
+describe('plan-review-triage snippet', () => {
+  // Issue #553: the parent-side consequence table was hand-copied twice each
+  // into mark, cut, ignite and render and once each into strike and forge —
+  // about 500 source lines — while the canonical copy sat in a snippet only
+  // the child review agents composed. This is the parents' canonical home.
+
+  it('contains the kind × severity × confidence triage table', async () => {
+    const content = await composeSnippet('plan-review-triage');
+    expect(content).toContain('kind × severity ×');
+    expect(content).toMatch(/`steering`\s*\|\s*Critical or Important\s*\|\s*Any/);
+    expect(content).toMatch(/`implementation`\s*\|/);
+    expect(content).toMatch(/`hygiene`\s*\|/);
+    expect(content).toMatch(/Minor\s*\|\s*Any/);
+    expect(content).toContain('## Specification Debt');
+    expect(content).toContain('Apply the `proposed_fix`');
+  });
+
+  it('never lets a steering finding be auto-applied', () => {
+    const content = loadSnippets().get('plan-review-triage.md')!;
+    expect(content).toContain(
+      '**A `steering` finding is never auto-applied, at any confidence.**',
+    );
+    expect(content).not.toMatch(/`steering`\s*\|[^|]*\|\s*High\s*\|/);
+    // The escape hatch is reclassification, not an override.
+    expect(content).toMatch(/finding is `hygiene`/);
+    expect(content).toMatch(/confidence is Low by\s+construction/);
+  });
+
+  it('names its two per-command destinations instead of hard-coding one', () => {
+    // strike and forge route unapplied findings to terminal output, not the
+    // PR body (issue #385), so a canonical table cannot name a surface. Each
+    // command binds "the target artifact" and "the review note surface" just
+    // above the composition point.
+    const content = loadSnippets().get('plan-review-triage.md')!;
+    expect(content).toMatch(/\*\*[Tt]he target artifact\*\*/);
+    expect(content).toMatch(/\*\*[Tt]he review note surface\*\*/);
+    expect(content).not.toMatch(/PR body/);
+  });
+
+  it('carries one IQ row rule that covers tasks files and everything else', () => {
+    const content = loadSnippets().get('plan-review-triage.md')!;
+    expect(content).toContain('`## Open Implementation Questions`');
+    expect(content).toContain('.tasks.md');
+    expect(content).toContain('`IQ-NNN`');
+    expect(content).toContain('120 characters or fewer');
+  });
+
+  it('composes the debt row shape rather than restating the enums', async () => {
+    const raw = loadSnippets().get('plan-review-triage.md')!;
+    expect(raw).toContain('{{>debt-row-shape}}');
+    const content = await composeSnippet('plan-review-triage');
+    expect(content).not.toContain('{{>debt-row-shape}}');
+    expect(content.replace(/\s+/g, ' ')).toContain('`Important` becomes `High`');
+  });
+});
+
 describe('review-protocol snippet', () => {
   // Story 4 Slice 1: the shared review-protocol snippet is the single source
   // of truth for the read-only, findings-based review protocol that both
   // `smithy-plan-review` and `smithy-implementation-review` compose. These
   // assertions lock down the snippet's contract so any regression (deleted
-  // file, renamed file, dropped Finding structure section, dropped triage
-  // table, reintroduced auto-fix language) fails the test suite immediately.
+  // file, renamed file, dropped Finding structure section, dropped kind
+  // gate, reintroduced auto-fix language) fails the test suite immediately.
 
   it('snippet file is loadable as a partial via loadSnippets', () => {
     const snippets = loadSnippets();
@@ -358,48 +533,32 @@ describe('review-protocol snippet', () => {
     expect(content).toContain('`proposed_fix`');
   });
 
-  it('snippet contains the kind × severity × confidence triage table', () => {
-    const snippets = loadSnippets();
-    const content = snippets.get('review-protocol.md')!;
-    // Every row of the contracts triage table must be present so the parent
-    // command has an unambiguous rulebook for processing returned findings.
-    expect(content).toMatch(/`steering`\s*\|\s*Critical\s*\|\s*Any/);
-    expect(content).toMatch(/`steering`\s*\|\s*Important\s*\|\s*Any/);
-    expect(content).toMatch(/`implementation`\s*\|/);
-    expect(content).toMatch(/`hygiene`\s*\|/);
-    expect(content).toMatch(/Minor\s*\|\s*Any/);
-    // Parent-action column content is what makes this a triage table rather
-    // than just a grid of severities.
-    expect(content).toContain('specification debt');
-    expect(content).toContain('Apply proposed fix');
-  });
-
-  it('snippet never lets a steering finding be auto-applied', () => {
-    // `steering` means a human has to pick. Applying a proposed fix makes the
-    // pick for them and buries a product decision in a planning commit, so
-    // confidence cannot unlock it — the steering rows carry `Any` confidence
-    // and route to debt. A High-confidence steering finding is a
-    // contradiction, and the snippet says so rather than defining a cell for it.
-    const snippets = loadSnippets();
-    const content = snippets.get('review-protocol.md')!;
+  it('leaves the parent-side triage table to the parent, without dangling it', async () => {
+    // Issue #553: this snippet's old section 5 was titled "applied by the
+    // parent command, not by the review agent" and loaded nowhere a parent
+    // could see it, while all six parents hand-copied their own. The review
+    // agent needs to know its consequences exist, not to carry the table.
+    const content = await composeSnippet('review-protocol');
+    expect(content).toContain('### 5. Report; do not act');
+    expect(content).not.toMatch(/^\|\s*`?steering`?\s*\|.*Parent Action/m);
+    expect(content).toContain('The parent command owns the consequences');
+    // Two rules bind the agent because they are properties of what it emits.
     expect(content).toContain(
       '**A `steering` finding is never auto-applied, at any confidence.**',
     );
-    expect(content).not.toMatch(/`steering`\s*\|\s*Critical\s*\|\s*High/);
-    expect(content).not.toMatch(/`steering`\s*\|\s*Important\s*\|\s*High/);
-    // The escape hatch is reclassification, not an override.
-    expect(content).toMatch(/finding is `hygiene`/);
-    expect(content).toMatch(/confidence is Low by\s+construction/);
+    expect(content).toContain('**A wrong table is a fix, not a question.**');
   });
 
-  it('snippet carries the whole kind gate, not a pointer to an agent prompt', () => {
+  it('snippet carries the whole kind gate, not a pointer to an agent prompt', async () => {
     // Gemini deploys no sub-agents and forge has a degraded inline review
     // branch; both compose this snippet and never see `smithy-plan-review`'s
     // body. `smithy-implementation-review` composes it without plan-review
-    // too. Per the snippets README, rules shared by a sub-agent and an
-    // inline/degraded path live in one snippet — so the full test must be here.
-    const snippets = loadSnippets();
-    const content = snippets.get('review-protocol.md')!;
+    // too. The gate reaches all of them through the nested `kind-gate`
+    // partial, so the full test must survive composition.
+    const raw = loadSnippets().get('review-protocol.md')!;
+    expect(raw).toContain('{{>kind-gate}}');
+    const content = await composeSnippet('review-protocol');
+    expect(content).not.toContain('{{>kind-gate}}');
     expect(content).toContain('**Open question**');
     expect(content).toContain('**Named alternatives**');
     expect(content).toContain('**Human-only**');
@@ -410,14 +569,13 @@ describe('review-protocol snippet', () => {
     expect(content).not.toMatch(/consult that section/);
   });
 
-  it('snippet gates the debt table on kind, not on confidence alone', () => {
+  it('snippet gates the debt table on kind, not on confidence alone', async () => {
     // The bug this closes: routing on severity × confidence alone sent every
     // Low-confidence finding to `## Specification Debt`, so implementation
     // unknowns and wrong-table corrections outnumbered the real decisions and
     // buried them. `kind` is the axis that says who resolves a finding, and
     // only a human-resolvable one belongs in a decision queue.
-    const snippets = loadSnippets();
-    const content = snippets.get('review-protocol.md')!;
+    const content = await composeSnippet('review-protocol');
     expect(content).toContain('Kind gate');
     // The three kinds and their resolvers.
     expect(content).toContain('`steering`');
@@ -427,17 +585,16 @@ describe('review-protocol snippet', () => {
     expect(content).toContain('Only `steering` findings may become specification debt.');
     // Non-steering findings must be routed, not dropped.
     expect(content).toContain('## Open Implementation Questions');
-    // The kind gate precedes severity × confidence triage in the document,
-    // matching the order the parent command applies them.
-    const gateIdx = content.indexOf('### 4. Kind gate');
-    const triageIdx = content.indexOf('### 5. Triage rules');
+    // The kind is set before severity × confidence are graded, matching the
+    // order the agent applies them.
+    const gateIdx = content.indexOf('### 4. Kind gate —');
+    const reportIdx = content.indexOf('### 5. Report; do not act');
     expect(gateIdx).toBeGreaterThan(-1);
-    expect(triageIdx).toBeGreaterThan(gateIdx);
+    expect(reportIdx).toBeGreaterThan(gateIdx);
   });
 
-  it('snippet no longer contains auto-fix language', () => {
-    const snippets = loadSnippets();
-    const content = snippets.get('review-protocol.md')!;
+  it('snippet no longer contains auto-fix language', async () => {
+    const content = await composeSnippet('review-protocol');
     // The rewritten protocol is read-only: review agents return findings,
     // they do not auto-fix, commit, or edit artifacts themselves. Guard
     // against a future edit that reintroduces the old auto-fix vocabulary.
@@ -2550,27 +2707,67 @@ describe('getComposedTemplates', () => {
   it('cut routes plan-review findings by kind, not by confidence alone', () => {
     const cut = composed.commands.get('smithy.cut.md')!;
     // Both plan-review dispatch sites (Phase 0c and Phase 5) triage by kind.
-    const kindTables = cut.match(/kind × severity × confidence/g) ?? [];
+    // Each composes the canonical table, so the count also proves neither
+    // site went back to hand-copying it.
+    const kindTables = cut.match(/kind × severity ×\s+confidence/g) ?? [];
     expect(kindTables.length).toBe(2);
-    expect(cut).toContain('| `implementation` | Critical or Important | Low');
-    expect(cut).toContain('| `hygiene`        | Critical or Important | Low');
+    expect(cut).toMatch(/\|\s*`implementation`\s*\|\s*Critical or Important\s*\|\s*Low/);
+    expect(cut).toMatch(/\|\s*`hygiene`\s*\|\s*Critical or Important\s*\|\s*Low/);
     // Steering rows take `Any` confidence and never auto-apply: a High
     // confidence score must not let the command pick for the human.
-    expect(cut).toContain('| `steering`       | Critical              | Any');
+    expect(cut).toMatch(/\|\s*`steering`\s*\|\s*Critical or Important\s*\|\s*Any/);
     expect(cut).toContain('a steering finding is never auto-applied');
-    expect(cut).not.toMatch(/`steering`\s*\|\s*Critical\s*\|\s*High/);
+    expect(cut).not.toMatch(/`steering`\s*\|[^|]*\|\s*High\s*\|/);
     // Debt rows come only from steering findings now.
     const debtRoutes = cut.match(/For each `steering` finding routed to debt/g) ?? [];
     expect(debtRoutes.length).toBe(2);
   });
 
+  it('every review-dispatching command composes the canonical triage table', () => {
+    // Issue #553: the parent-side table was hand-copied twice each into mark,
+    // cut, ignite and render and once each into strike and forge, and had
+    // already diverged — ignite's Phase 0c mandated a debt "Description
+    // column" the index has never had while its own second copy mandated the
+    // detail-section shape. Composition is what makes that unrepresentable,
+    // so assert on the source templates, not just the rendered output.
+    const sources: Array<[string, string]> = [
+      ['commands/smithy.mark.prompt', '2'],
+      ['commands/smithy.cut.prompt', '2'],
+      ['commands/smithy.ignite.prompt', '2'],
+      ['commands/smithy.render.prompt', '2'],
+      ['commands/smithy.strike.prompt', '1'],
+      // forge composes twice: the sub-agent branch and the degraded inline one.
+      ['commands/smithy.forge.prompt', '2'],
+    ];
+    for (const [file, expected] of sources) {
+      const src = fs.readFileSync(
+        path.join(__dirname, 'templates/agent-skills', file),
+        'utf8',
+      );
+      const uses = src.match(/\{\{>plan-review-triage\}\}/g) ?? [];
+      expect(uses.length, `${file} composition count`).toBe(Number(expected));
+      // Each composition site binds the two terms the snippet leaves open.
+      // These bindings wrap across lines, so collapse whitespace first.
+      const flat = src.replace(/\s+/g, ' ');
+      expect(flat, `${file} must bind the target artifact`).toMatch(
+        /\*\*[Tt]he target artifact\*\*/,
+      );
+      expect(flat, `${file} must bind the review note surface`).toMatch(
+        /\*\*[Tt]he review note surface\*\*/,
+      );
+      // No hand-written consequence table may survive beside the composed one.
+      expect(src, `${file} still hand-copies a triage row`).not.toMatch(
+        /^\|\s*`?(steering|implementation|hygiene)`?\s*\|/m,
+      );
+    }
+  });
+
   it('no command triage table lets a steering finding be auto-applied', () => {
-    // Every command that dispatches a review agent restates the triage table
-    // with its own destinations, so the "steering is never auto-applied" rule
-    // has to hold at each site independently. It did not: forge's table wrote
-    // its columns at a different width and kept an `Any` kind + High row,
-    // which auto-applied exactly the findings the shared protocol reserves
-    // for a human. This sweeps all six rather than trusting one edit.
+    // The "steering is never auto-applied" rule has to hold at every rendered
+    // site. It did not: forge's hand-copied table wrote its columns at a
+    // different width and kept an `Any` kind + High row, which auto-applied
+    // exactly the findings the shared protocol reserves for a human. The
+    // table is composed now, and this sweeps all six rather than trusting it.
     for (const name of [
       'smithy.cut.md',
       'smithy.ignite.md',
@@ -3878,9 +4075,13 @@ describe('getComposedTemplates', () => {
     // Review severities are Critical/Important/Minor (review-protocol), but
     // Impact admits only Critical/High/Medium/Low. Copying verbatim is how
     // `Important` ended up in 12 Impact cells across this repo's artifacts —
-    // values plan-review's own debt lint now treats as malformed.
-    expect(cmd).not.toContain('copy severity into Impact');
-    expect(cmd).toContain('`Important` becomes `High`');
+    // values plan-review's own debt lint now treats as malformed. Ignite's
+    // Phase 0c said "copy severity into Impact" for months without tripping
+    // this, because a line wrap fell between "copy" and "severity" — so
+    // collapse whitespace before matching.
+    const flat = cmd.replace(/\s+/g, ' ');
+    expect(flat).not.toContain('copy severity into Impact');
+    expect(flat).toContain('`Important` becomes `High`');
   });
 
   it.each([
@@ -3893,12 +4094,14 @@ describe('getComposedTemplates', () => {
     const cmd = composed.commands.get(file)!;
     expect(cmd).toBeDefined();
     // There is no Description column any more; a finding's prose belongs in
-    // the item's detail section, and the row needs a Title derived from it.
-    expect(cmd).not.toContain('Description column');
+    // the item's detail section, and the row carries a short Title slug.
     // Prose wraps across lines in these templates, so match on collapsed
-    // whitespace rather than a fixed line break.
-    expect(cmd.replace(/\s+/g, ' ')).toContain('`### SD-NNN — <Title>` detail section');
-    expect(cmd.replace(/\s+/g, ' ')).toContain('derive a `Title` slug of 40 characters or fewer');
+    // whitespace rather than a fixed line break — ignite's Phase 0c kept
+    // mandating a "Description column" behind exactly such a wrap.
+    const flat = cmd.replace(/\s+/g, ' ');
+    expect(flat).not.toContain('Description column');
+    expect(flat).toContain('`### SD-NNN — <Title>` detail section');
+    expect(flat).toContain('A slug of 40 characters or fewer naming the unresolved choice');
   });
 
   it('cut distinguishes a legitimately empty upstream debt section from a broken one', () => {

--- a/src/templates/agent-skills/README.md
+++ b/src/templates/agent-skills/README.md
@@ -299,11 +299,13 @@ implementer works from — carries a second section, positioned after
 ### The gate between the two sections
 
 A finding reaches `## Specification Debt` only if **a human must decide and the
-decision changes what gets built**. The canonical three-part steering test —
-open question, named alternatives, human-only — lives in the
-`review-protocol` snippet's Kind gate section, and `smithy-clarify` Step 3b holds the
-matching leak-kind routing table for clarification candidates. Everything the
-gate rejects has a home:
+decision changes what gets built**. The canonical gate — the three-part
+steering test (open question, named alternatives, human-only), the positive
+test that rejects directives, and the leak-kind routing table — lives in the
+`kind-gate` snippet, which every producer of a debt row composes:
+`smithy-clarify`, `smithy-refine`, and both review agents by way of
+`review-protocol`. The parent commands compose the consequence table from
+`plan-review-triage`. Everything the gate rejects has a home:
 
 | Kind | Home |
 |------|------|

--- a/src/templates/agent-skills/agents/smithy.clarify.prompt
+++ b/src/templates/agent-skills/agents/smithy.clarify.prompt
@@ -61,22 +61,13 @@ For each candidate, produce all four elements:
 4. **Confidence**: High / Medium / Low — how confident are you that the
    recommended answer is correct?
 
-### Impact guidelines
+Both scales are the pipeline's shared ones:
 
-| Level | Meaning |
-|-------|---------|
-| **Critical** | Getting this wrong would invalidate the artifact or cause significant rework. When confidence is High, proceed as a `[Critical Assumption]`. |
-| **High** | Materially affects scope, architecture, or user experience. Wrong answer leads to meaningful wasted effort. |
-| **Medium** | Affects quality or completeness but can be corrected later without major rework. |
-| **Low** | Minor preference or stylistic choice. Wrong answer has negligible downstream cost. |
+{{>debt-grading}}
 
-### Confidence guidelines
 
-| Level | Meaning |
-|-------|---------|
-| **High** | Strong evidence in codebase, docs, or conventions. You would be surprised if the user disagreed. |
-| **Medium** | Reasonable inference but multiple valid approaches exist. The user might reasonably choose differently. |
-| **Low** | Genuine uncertainty. You are guessing or the codebase provides no clear signal. |
+A Critical-impact candidate you are confident about is not debt — carry it
+forward as a `[Critical Assumption]` per Step 3a.
 
 ---
 
@@ -101,38 +92,23 @@ will proceed with the assumption stream as recorded assumptions.
 
 ### Step 3b: Kind gate (applied only to Medium/Low candidates)
 
-A Medium/Low candidate qualifies as a `debt_items` row only if **all
-three** are true:
+A Medium/Low candidate qualifies as a `debt_items` row only if it is
+`steering` under the shared gate below. This is the same gate the review
+sub-agents apply to their findings; read "finding" as "candidate"
+throughout.
 
-1. **Open question**: the description names an unresolved choice the
-   codebase, conventions, and prior art cannot settle.
-2. **Named alternatives**: two or more meaningfully different paths
-   exist, and picking between them changes what the artifact specifies.
-3. **No prescription**: the description does not also tell the
-   implementer what to do, nor what to verify, nor when to defer it.
+{{>kind-gate}}
 
-Candidates that **pass** the gate go to `debt_items`. Candidates that
-**fail** are not silently discarded — they still represent information
-the model wants to surface. Route them to `assumptions` with a
+
+**How you route a candidate the gate rejects.** A review agent records
+the answer by setting a different `kind` on the finding and letting its
+parent file it. You emit no `kind` field, so you route by stream
+instead: send the candidate to `assumptions` with a
 `[Critical Assumption]` annotation regardless of Impact, so the parent
-command can lift them into the artifact's proper section
-(`### Functional Requirements`, `### Acceptance Scenarios`,
-`## Out of Scope`, the RFC's Cross-Cutting Governance matrix, the PR
-body, etc.) when populating the artifact. The annotation flags the
-finding for human attention because the model's confidence is
-non-High.
-
-The table below names the leak kinds and where they ultimately belong
-in the artifact:
-
-| If the candidate is really… | Tell the model | Proper home |
-|-----------------------------|----------------|-------------|
-| **A requirement** ("X must Y", "Implementers verify Z", "Mitigation: pin both files", "Resolution: X owns A and Y owns B") | the answer is known; the model is just writing the requirement | the artifact's `### Functional Requirements` (specs) or RFC body |
-| **A load-bearing assumption** ("Assumption: a retry count of 5 is sufficient", "Assumption: X is acceptable for now") | the model already chose; this is an assumption stated as if it were a question | the artifact's `## Assumptions` section, with `[Critical Assumption]` if the impact is Critical |
-| **An acceptance test** ("acceptance criteria require empirically capturing X", "Verification needed against actual Y at render/cut time") | this is verification work, not a steering choice | the user story's `### Acceptance Scenarios` |
-| **A dependency / coordination note** ("F1.5 and F1.6 both touch file Z; second-to-land rebases", "Tracked separately so SD-N's resolution explicitly closes both") | the RFC's Cross-Cutting Governance / touched-files matrix and `## Dependency Order` table already track this | the RFC's governance section, never debt |
-| **Future work / deferral** ("deferred to follow-up", "out of scope this round", "intentionally not authored in this round") | the decision to defer is already made; debt is forward-looking, not a deferral record | the artifact's `## Out of Scope` plus a follow-up GitHub issue |
-| **A resolution record** ("this was fixed in the same PR", "Resolution: resolved YYYY-MM-DD — verified that…", "Recorded here so a future maintainer can re-evaluate; no action expected", "reviewer's concern investigated and dismissed") | debt is forward-looking; backward-looking notes belong in the PR description or, at most, in a row whose `status` is already `resolved` | the PR body, never an `open` debt row |
+command lifts it into the home the routing table names when it
+populates the artifact. Nothing is discarded either way — the
+annotation flags the item for human attention precisely because your
+confidence is non-High.
 
 **Positive test for `debt_items`:** before recording any item as debt,
 you must be able to phrase its description as a question or as
@@ -189,8 +165,8 @@ Assumptions block contains one item. Debt list contains two items.
 | Candidate | Confidence | Kind gate | Triage result |
 |-----------|-----------|----------|--------------|
 | "Auth provider" — inferred from existing OAuth setup | High | not applied (Step 3a) | Assumption |
-| "Mitigation: pin the stub string in both the survey template and the eval scenario" | Medium | **fails** (prescription, no named alternatives) | Assumption with `[Critical Assumption]` — the parent will lift it into `### Functional Requirements` |
-| "Whether scenarios that create a PR need `gh` stub credentials, regex alternation, or assertion against the failure branch" | Medium | **passes** (open question + 3 named paths + no prescription) | Debt item |
+| "Mitigation: pin the stub string in both the survey template and the eval scenario" | Medium | **fails** — phrasable only as a directive, and it names no alternatives | Assumption with `[Critical Assumption]` — the parent will lift it into `### Functional Requirements` |
+| "Whether scenarios that create a PR need `gh` stub credentials, regex alternation, or assertion against the failure branch" | Medium | **passes** — open question, three named paths, human-only | Debt item |
 
 The assumptions block contains two items; one is a true high-confidence
 inference and one is a Critical-flagged leak that the parent must route
@@ -227,8 +203,8 @@ re-run." The debt table is already in `debt_items` — do not duplicate it in
      sequential), Title (a slug of 40 characters or fewer naming the
      unresolved choice), Description (the full statement, 1–3 sentences —
      this becomes the item's detail section, not a table cell), Source
-     Category, Impact (`Critical`/`High`/`Medium`/`Low`), Confidence
-     (`High`/`Medium`/`Low`), Origin (`local` — everything you produce is
+     Category, Impact, Confidence, and Origin, each on the scale defined
+     under Step 2 (`Origin` is always `local` — everything you produce is
      discovered in the artifact being authored). There is no Status or
      Resolution field: an item's lifecycle is carried structurally by the
      parent artifact's `## Specification Debt` section, not by a column.

--- a/src/templates/agent-skills/agents/smithy.plan-review.prompt
+++ b/src/templates/agent-skills/agents/smithy.plan-review.prompt
@@ -75,13 +75,12 @@ gate to **every** finding, not just the ones you expect to be Low
 confidence. Severity and confidence are graded after the kind is set,
 never before.
 
-**How it relates to clarify.** This gate is the plan-review sibling of
-`smithy-clarify` Step 3b: the same question ("must a human decide, and
-does the decision change what gets built?"), applied to review findings
-instead of clarification candidates. Where clarify reroutes a failing
-candidate into its assumption stream, you have no assumption stream — you
-reroute by naming a different `kind`, and the parent command sends it
-somewhere other than the debt table.
+**How it relates to clarify.** `smithy-clarify` Step 3b applies this same
+gate to clarification candidates — it is one definition, not a sibling
+rubric. Only the reroute differs: clarify sends a failing candidate into
+its assumption stream, and you have no assumption stream, so you reroute
+by naming a different `kind` and the parent command sends it somewhere
+other than the debt table.
 
 ### Kind-gate examples
 
@@ -90,7 +89,7 @@ somewhere other than the debt table.
 | "Whether scenarios that create a PR assert against the failure branch, stub credentials, or accept either outcome by regex alternation" | passes all three — no prior art, three named paths, and the pick changes what the scenario asserts | `steering` |
 | "Whether the runner's temp fixture copy carries a `.git` directory or initializes one" | fails **human-only** — reading the runner and running it once answers it | `implementation` |
 | "The `## Dependency Order` table lists S3 before S2, though S3's tasks consume S2's output" | fails **open question** — the correct order is knowable and the table is simply wrong | `hygiene` |
-| "Slices 2 and 4 both edit the same module; the second to land rebases" | fails **open question** — a dependency/coordination note per `smithy-clarify` Step 3b | `hygiene` |
+| "Slices 2 and 4 both edit the same module; the second to land rebases" | fails **open question** — a dependency/coordination note, which the routing table already homes | `hygiene` |
 | "Is the parent spec corrected too, or only this tasks file?" | fails **human-only** — reading the spec answers it | `hygiene` |
 
 ---

--- a/src/templates/agent-skills/agents/smithy.refine.prompt
+++ b/src/templates/agent-skills/agents/smithy.refine.prompt
@@ -78,27 +78,15 @@ For each finding, produce all four elements:
    Include brief reasoning. For High-confidence findings, this must be
    concrete and ready for the parent agent to apply verbatim (e.g., exact
    text to insert, section to add, reference to correct).
-3. **Impact**: Critical / High / Medium / Low — how much does leaving this
-   unresolved affect the quality of the artifact?
-4. **Confidence**: High / Medium / Low — how confident are you that the
-   recommended resolution is correct?
+3. **Impact** — how much does leaving this unresolved affect the quality of
+   the artifact?
+4. **Confidence** — how confident are you that the recommended resolution is
+   correct?
 
-### Impact guidelines
+Both scales are the pipeline's shared ones:
 
-| Level | Meaning |
-|-------|---------|
-| **Critical** | Leaving this unresolved would invalidate the artifact or cause significant downstream rework. Must be addressed. |
-| **High** | Materially affects scope, architecture, or correctness. Unresolved leads to meaningful wasted effort. |
-| **Medium** | Affects quality or completeness but can be corrected later without major rework. |
-| **Low** | Minor improvement or stylistic concern. Negligible downstream cost if left as-is. |
+{{>debt-grading}}
 
-### Confidence guidelines
-
-| Level | Meaning |
-|-------|---------|
-| **High** | Strong evidence in the audited artifacts, codebase, or conventions. The recommended resolution is concrete and you would be surprised if the user disagreed. |
-| **Medium** | Reasonable inference but multiple valid fixes exist. The user might reasonably choose differently. |
-| **Low** | Genuine uncertainty. You are guessing, or the resolution depends on information not present in the audited artifacts. |
 
 ### Ordering
 
@@ -132,29 +120,25 @@ For each, record a structured `Refinement` entry containing:
   insert, section to add, reference to correct). Be specific enough that the
   parent agent can apply it without re-analysis.
 - **Rationale** — a one-line justification tied back to the finding statement
-- **Impact** — Critical / High / Medium / Low (from Step 2)
+- **Impact** — from Step 2
 
 These populate the `refinements` field of the returned `RefineResult`. The
 parent agent applies them to disk during its Phase 0 refinement step.
 
 ### Specification Debt (cannot confidently resolve)
 
-Apply the **same kind gate** as `smithy-clarify` Step 3b before
-routing a finding to debt: a finding qualifies as debt only if it
-names an unresolved choice between two or more meaningfully different
-paths and contains no prescription ("Implementers verify…",
-"Mitigation: pin both…", "Resolution: X owns A and Y owns B"). See
-`smithy-clarify` Step 3b for the full kind-gate rubric and routing
-table; do not duplicate it here.
+Apply the shared kind gate before routing a finding to debt. It is the
+same gate the clarification and review sub-agents apply:
 
-Findings that are really requirements, acceptance tests, dependency/
-coordination notes, deferral records, or post-hoc resolution notes
-are **not dropped** — they still carry information the artifact
-should reflect. Route them as `refinements` rather than `debt_items`,
-with the `Target` pointed at the proper home named in `smithy-clarify`
-Step 3b's routing table (`### Functional Requirements`, `### Acceptance
+{{>kind-gate}}
+
+
+**How you route a finding the gate rejects.** You emit no `kind` field,
+so nothing the gate rejects is dropped — it becomes a `refinement`
+rather than a `debt_item`, with the `Target` pointed at the home the
+routing table names (`### Functional Requirements`, `### Acceptance
 Scenarios`, `## Out of Scope`, the RFC's Cross-Cutting Governance
-matrix, etc.). The parent command applies the refinement to that
+matrix, and so on). The parent command applies the refinement to that
 section verbatim; the debt table stays clean.
 
 Everything that passes the kind gate where **Confidence is Medium or
@@ -169,10 +153,10 @@ For each, record a structured `DebtItem` entry containing:
   Never a directive. This becomes the item's detail section, not a
   table cell, so it is not width-constrained.
 - **Source Category** — the audit category that produced the finding
-- **Impact** — Critical / High / Medium / Low (from Step 2)
-- **Confidence** — Medium or Low (from Step 2). The column itself
-  admits `High` as well; refine never emits it, because a
-  High-confidence finding becomes a refinement rather than debt.
+- **Impact** — from Step 2
+- **Confidence** — `Medium` or `Low` (from Step 2). The column admits
+  `High` as well; refine never emits it, because a High-confidence
+  finding becomes a refinement rather than debt.
 - **Origin** — `local`. Everything refine produces is discovered in
   the artifact under review.
 

--- a/src/templates/agent-skills/commands/smithy.cut.prompt
+++ b/src/templates/agent-skills/commands/smithy.cut.prompt
@@ -92,51 +92,14 @@ sub-agent to perform a self-consistency review of the tasks file. Pass it:
   `{{artifactsRoot}}specs/<folder>/<node-id-lower>-<node-slug>.tasks.md`).
 - **artifact_type** — `tasks`.
 
-The agent is read-only and returns a `ReviewResult` containing `findings` and a
-`summary`. Process the findings using the shared kind × severity × confidence
-triage table. Read each finding's `kind` first — only a `steering` finding can
-reach the debt table:
+For the triage below, **the target artifact** is the refined tasks file, and
+**the review note surface** is the refinement PR body.
 
-| Kind             | Severity              | Confidence | Action                                                                                                 |
-|------------------|-----------------------|------------|--------------------------------------------------------------------------------------------------------|
-| `implementation` or `hygiene` | Critical or Important | High | Apply the `proposed_fix` to the tasks file on disk. Note Critical fixes in the PR body.                  |
-| `steering`       | Critical              | Any        | Do not apply — a steering finding is never auto-applied. Append to the tasks file's `## Specification Debt` section. Flag in PR for the reviewer.   |
-| `steering`       | Important             | Any        | Do not apply. Append to the tasks file's `## Specification Debt` section.                                |
-| `implementation` | Critical or Important | Low        | Do not apply. Append an `IQ-NNN` row to the tasks file's `## Open Implementation Questions` section.     |
-| `hygiene`        | Critical or Important | Low        | Do not apply. List in the PR body for the reviewer to correct — never as a debt row.                    |
-| Any              | Minor                 | Any        | Do not apply. Note in the PR body only.                                                                 |
+{{>plan-review-triage}}
 
-For each `steering` finding routed to debt — confidence does not matter, since
-steering is never auto-applied — append a new row to
-the tasks file's `## Specification Debt` index table with the next available
-`SD-NNN` identifier (continue numbering from whatever the tasks file already
-contains, including debt inherited from the spec — do not reset). Use the
-finding's `description` as the body of a new `### SD-NNN — <Title>`
-detail section, derive a `Title` slug of 40 characters or fewer from it, set
-`Source Category` to `plan-review:<finding category>` (e.g.,
-`plan-review:Internal contradiction`), map severity into Impact (`Critical`
-stays `Critical`; `Important` becomes `High` — `Important` is not a valid
-`Impact` value) and copy confidence into Confidence, and set `Origin` to
-`local`.
 
-For each Low-confidence `implementation` finding, append a row to the tasks
-file's `## Open Implementation Questions` table instead: next available
-`IQ-NNN`, the finding's `description` compressed into a single question of 120
-characters or fewer, the `S<N>` slice it lands in (`—` when it spans slices),
-the `Settled By` path (`building`, `testing`, or `reading code`), and `Origin`
-`local`.
-
-For each High-confidence `implementation` or `hygiene` finding, edit the tasks file in place using the
-`proposed_fix`. The Phase 0c commit below captures both the refine diff and
-the plan-review fixes in the same commit.
-
-If the agent returns drift findings (assumption-output drift category),
-surface them prominently in the refinement PR body so the reviewer can
-confirm the underlying assumption rather than silently accepting the applied
-fix.
-
-The review agent never modifies files itself — all on-disk changes are made
-here, by cut.
+The Phase 0c commit below captures both the refine diff and the plan-review
+fixes in the same commit.
 
 **No-op check** (runs after refine and plan-review): if refine returned an
 empty `refinements` list, plan-review returned no High-confidence fixes and
@@ -873,50 +836,16 @@ perform a self-consistency review. Pass it:
   dependency-order table.
 - **artifact_type** — `tasks`.
 
-The agent is read-only and returns a `ReviewResult` containing `findings` and a
-`summary`. Process the findings using the shared kind × severity × confidence
-triage table from the contracts. Read each finding's `kind` first — only a
-`steering` finding can reach the debt table:
+For the triage below, **the target artifact** is the tasks file just
+written — its `SD-NNN` numbering continues from whatever it already carries,
+including debt inherited from the spec in Phase 1 and new items from cut's
+own clarify run. **The review note surface** is the PR body.
 
-| Kind             | Severity              | Confidence | Action                                                                                                 |
-|------------------|-----------------------|------------|--------------------------------------------------------------------------------------------------------|
-| `implementation` or `hygiene` | Critical or Important | High | Apply the `proposed_fix` to the tasks file on disk. Note Critical fixes in the PR body.                  |
-| `steering`       | Critical              | Any        | Do not apply — a steering finding is never auto-applied. Append to the tasks file's `## Specification Debt` section. Flag in PR for the reviewer.   |
-| `steering`       | Important             | Any        | Do not apply. Append to the tasks file's `## Specification Debt` section.                                |
-| `implementation` | Critical or Important | Low        | Do not apply. Append an `IQ-NNN` row to the tasks file's `## Open Implementation Questions` section.     |
-| `hygiene`        | Critical or Important | Low        | Do not apply. List in the PR body for the reviewer to correct — never as a debt row.                    |
-| Any              | Minor                 | Any        | Do not apply. Note in the PR body only.                                                                 |
+{{>plan-review-triage}}
 
-For each `steering` finding routed to debt — confidence does not matter, since
-steering is never auto-applied — append a new row to
-the tasks file's `## Specification Debt` index table with the next available
-`SD-NNN` identifier (continue numbering from whatever the tasks file already
-contains, including debt inherited from the spec in Phase 1 and new items
-from cut's own clarify run — do not reset). Use the finding's `description` as the body of a new `### SD-NNN — <Title>`
-detail section, derive a `Title` slug of 40 characters or fewer from it, set
-`Source Category` to `plan-review:<finding category>` (e.g.,
-`plan-review:Internal contradiction`), map severity into Impact (`Critical`
-stays `Critical`; `Important` becomes `High` — `Important` is not a valid
-`Impact` value) and copy confidence into Confidence, and set `Origin` to
-`local`.
 
-For each Low-confidence `implementation` finding, append a row to the tasks
-file's `## Open Implementation Questions` table instead: next available
-`IQ-NNN`, the finding's `description` compressed into a single question of 120
-characters or fewer, the `S<N>` slice it lands in (`—` when it spans slices),
-the `Settled By` path (`building`, `testing`, or `reading code`), and `Origin`
-`local`.
-
-For each High-confidence `implementation` or `hygiene` finding, edit the tasks file in place using the
-`proposed_fix`. The commit below captures both the original tasks file and
-the applied fixes in the same diff.
-
-If the agent returns drift findings (assumption-output drift category),
-surface them prominently in the PR body so the reviewer can confirm the
-underlying assumption rather than silently accepting the applied fix.
-
-The review agent never modifies files itself — all on-disk changes are made
-here, by cut.
+The commit below captures both the original tasks file and the applied fixes
+in the same diff.
 
 ### Commit and create the PR
 
@@ -992,8 +921,10 @@ is the contract.
 - **DO NOT** emit a slice whose tasks span more than one repository — split it
   along the repo boundary and order the resulting slices in
   `## Dependency Order`. A cross-repo slice cannot be forged.
-- **DO** use zero-padded two-digit numbering for the filename (`01-`, `02-`,
-  ..., `99-`) for consistent sort order.
+- **DO** derive the filename by the rule in Phase 5, which depends on the
+  spec's ledger shape — a backend story table gives `<NN>-<story-slug>` and a
+  typed UI ledger gives `<node-id-lower>-<node-slug>`. Do not apply the
+  backend zero-padded form to a typed UI node.
 - **DO** invoke smithy-clarify for ambiguity scanning and triage.
 - **DO** read all three spec artifacts (spec, data model, contracts) before
   slicing — the data model and contracts inform implementation boundaries.

--- a/src/templates/agent-skills/commands/smithy.forge.prompt
+++ b/src/templates/agent-skills/commands/smithy.forge.prompt
@@ -252,29 +252,18 @@ containing a list of `Finding` entries (`category`, `kind`, `severity`,
 It does not modify files, run commands, or create commits — forge owns every
 on-disk change and commit resulting from a finding.
 
-Process each returned finding by the kind × severity × confidence policy of
-the shared review protocol, using the **forge-specific destinations** in the
-table below. The policy is the shared one — read `kind` first, and only a
-`steering` finding (a human must choose between named alternatives, and the
-choice changes what gets built) can become specification debt. The
-destinations differ: forge has a terminal-output **Review Summary** and puts
-notes there rather than in the PR body.
+For the triage below, **the target artifact** is the slice planning artifact
+— the `.tasks.md`, `.strike.md`, `.spec.md`, or equivalent planning file
+associated with the slice you were asked to implement, derived from the
+intake file path. This is intentionally independent of the finding's
+`artifact_path`: when `artifact_path` points to source code or another
+non-planning file, apply the fix there but do **not** create or edit a
+`## Specification Debt` or `## Open Implementation Questions` section in it —
+those records go to the planning artifact only. **The review note surface**
+is forge's terminal-output **Review Summary** deliverable, never the PR body.
 
-| Kind | Severity | Confidence | Forge action |
-|------|----------|------------|--------------|
-| `implementation` or `hygiene` | Critical or Important | High | Apply the `proposed_fix` on disk, run the test suite, commit as `review: <description>`. |
-| `steering` | Critical or Important | Any | Do not apply — a steering finding is never auto-applied, at any confidence. Append the finding to the slice planning artifact's `## Specification Debt` section. |
-| `implementation` | Critical or Important | Low | Do not apply and do not record as debt. Append an `IQ-NNN` row to the tasks file's `## Open Implementation Questions` section when the slice came from a `.tasks.md`; otherwise note it in the **Review Summary**. |
-| `hygiene` | Critical or Important | Low | Do not apply and do not record as debt. Note in the **Review Summary** so the user can settle the correction directly. |
-| Any | Minor | Any | Do not apply and do not record as debt. Note in forge's terminal-output **Review Summary** deliverable so the user sees it; do not add to the PR body. |
+{{>plan-review-triage}}
 
-"Slice planning artifact" above means the `.tasks.md`, `.strike.md`,
-`.spec.md`, or equivalent planning file associated with the slice you were
-asked to implement (derived from the intake file path). This is intentionally
-independent of the finding's `artifact_path`: when `artifact_path` points to
-source code or another non-planning file, do **not** create or edit a
-`## Specification Debt` section there — record the debt in the planning
-artifact only.
 
 When applying a High-confidence `implementation` or `hygiene` fix:
 
@@ -323,6 +312,13 @@ git diff <BASE_SHA> HEAD
 ```
 
 {{>review-protocol}}
+
+For the triage below, **the target artifact** is the slice planning artifact
+associated with the slice you were asked to implement, and **the review note
+surface** is forge's terminal-output **Review Summary** deliverable, never
+the PR body.
+
+{{>plan-review-triage}}
 {{/ifAgent}}
 
 ---

--- a/src/templates/agent-skills/commands/smithy.ignite.prompt
+++ b/src/templates/agent-skills/commands/smithy.ignite.prompt
@@ -223,40 +223,19 @@ review of the refined artifact. Pass it:
   (`{{artifactsRoot}}docs/rfcs/<YYYY>-<NNN>-<slug>/<slug>.rfc.md`).
 - **artifact_type** — `rfc`.
 
-The agent is read-only and returns a `ReviewResult` containing `findings` and a
-`summary`. Process the findings using the shared kind × severity × confidence triage
-table, reading each finding's `kind` first. Only a `steering` finding —
-where a human must pick between named alternatives and the pick changes what
-gets built — can reach the debt table.
+For the triage below, **the target artifact** is the refined RFC file — its
+`SD-NNN` numbering continues from whatever refine or prior clarify passes
+already wrote. **The review note surface** is the refinement PR body; a
+Low-confidence `implementation` finding goes there under an **Implementation
+questions** heading, since an RFC carries no `## Open Implementation
+Questions` section and `smithy.cut` re-derives the unknown from its own
+plan-review pass when the tasks file is authored.
 
-| Kind             | Severity              | Confidence | Action                                                                                              |
-|------------------|-----------------------|------------|-----------------------------------------------------------------------------------------------------|
-| `implementation` or `hygiene` | Critical or Important | High | Apply the `proposed_fix` to the RFC on disk. Note Critical fixes in the PR body.                     |
-| `steering`       | Critical              | Any        | Do not apply — a steering finding is never auto-applied. Append to the RFC's `## Specification Debt` section. Flag in PR for the reviewer.      |
-| `steering`       | Important             | Any        | Do not apply. Append to the RFC's `## Specification Debt` section.                                   |
-| `implementation` | Critical or Important | Low        | Do not apply and do not record as debt. Note it in the PR body under an **Implementation questions** heading. This artifact has no `## Open Implementation Questions` section — that section is a tasks-file structure, and nothing reads a PR body, so the note is for the human reviewer. The unknown itself is settled while building, and `smithy.cut` re-derives it from its own plan-review pass when the tasks file is authored. |
-| `hygiene`        | Critical or Important | Low        | Do not apply and do not record as debt. List in the PR body for the reviewer to correct.            |
-| Any              | Minor                 | Any        | Do not apply. Note in the PR body only.                                                             |
+{{>plan-review-triage}}
 
-For each `steering` finding routed to debt — confidence does not matter, since
-steering is never auto-applied — append a new row to the RFC's
-`## Specification Debt` index table with the next available `SD-NNN` identifier
-(continue numbering from whatever refine or prior clarify passes already
-wrote — do not reset). Use the finding's `description` for the Description
-column, set `Source Category` to `plan-review:<finding category>`, copy
-severity into Impact and confidence into Confidence, and set `Origin` to `local`.
 
-For each High-confidence `implementation` or `hygiene` finding, edit the RFC file in place using the
-`proposed_fix`. The Phase 0c commit below captures both the refine diff and
-the plan-review fixes in the same commit.
-
-If the agent returns drift findings (assumption-output drift category),
-surface them prominently in the refinement PR body so the reviewer can
-confirm the underlying assumption rather than silently accepting the applied
-fix.
-
-The review agent never modifies files itself — all on-disk changes are made
-here, by ignite.
+The Phase 0c commit below captures both the refine diff and the plan-review
+fixes in the same commit.
 
 ---
 
@@ -837,43 +816,18 @@ review. Pass it:
   (`{{artifactsRoot}}docs/rfcs/<YYYY>-<NNN>-<slug>/<slug>.rfc.md`).
 - **artifact_type** — `rfc`.
 
-The agent is read-only and returns a `ReviewResult` containing `findings` and a
-`summary`. Process the findings using the shared kind × severity × confidence triage
-table from the contracts, reading each finding's `kind` first. Only a `steering` finding —
-where a human must pick between named alternatives and the pick changes what
-gets built — can reach the debt table.
+For the triage below, **the target artifact** is the RFC file just written —
+its `SD-NNN` numbering continues from whatever clarify / Phase 3 already
+wrote. **The review note surface** is the PR body; a Low-confidence
+`implementation` finding goes there under an **Implementation questions**
+heading, since an RFC carries no `## Open Implementation Questions` section
+and `smithy.cut` re-derives the unknown from its own plan-review pass when
+the tasks file is authored.
 
-| Kind             | Severity              | Confidence | Action                                                                                              |
-|------------------|-----------------------|------------|-----------------------------------------------------------------------------------------------------|
-| `implementation` or `hygiene` | Critical or Important | High | Apply the `proposed_fix` to the RFC on disk. Note Critical fixes in the PR body.                     |
-| `steering`       | Critical              | Any        | Do not apply — a steering finding is never auto-applied. Append to the RFC's `## Specification Debt` section. Flag in PR for the reviewer.      |
-| `steering`       | Important             | Any        | Do not apply. Append to the RFC's `## Specification Debt` section.                                   |
-| `implementation` | Critical or Important | Low        | Do not apply and do not record as debt. Note it in the PR body under an **Implementation questions** heading. This artifact has no `## Open Implementation Questions` section — that section is a tasks-file structure, and nothing reads a PR body, so the note is for the human reviewer. The unknown itself is settled while building, and `smithy.cut` re-derives it from its own plan-review pass when the tasks file is authored. |
-| `hygiene`        | Critical or Important | Low        | Do not apply and do not record as debt. List in the PR body for the reviewer to correct.            |
-| Any              | Minor                 | Any        | Do not apply. Note in the PR body only.                                                             |
+{{>plan-review-triage}}
 
-For each `steering` finding routed to debt — confidence does not matter, since
-steering is never auto-applied — append a new row to the RFC's
-`## Specification Debt` index table with the next available `SD-NNN` identifier
-(continue numbering from whatever clarify / Phase 3 already wrote — do not
-reset). Use the finding's `description` as the body of a new `### SD-NNN — <Title>`
-detail section, derive a `Title` slug of 40 characters or fewer from it, set
-`Source Category` to `plan-review:<finding category>` (e.g.,
-`plan-review:Internal contradiction`), map severity into Impact (`Critical`
-stays `Critical`; `Important` becomes `High` — `Important` is not a valid
-`Impact` value) and copy confidence into Confidence, and set `Origin` to
-`local`.
 
-For each High-confidence `implementation` or `hygiene` finding, edit the RFC file in place using the
-`proposed_fix`. The commit below captures the RFC and the applied fixes in
-the same diff.
-
-If the agent returns drift findings (assumption-output drift category),
-surface them prominently in the PR body so the reviewer can confirm the
-underlying assumption rather than silently accepting the applied fix.
-
-The review agent never modifies files itself — all on-disk changes are made
-here, by ignite.
+The commit below captures the RFC and the applied fixes in the same diff.
 
 {{#ifAgent}}
 Phase 3 already created the RFC folder, wrote the file piecewise through

--- a/src/templates/agent-skills/commands/smithy.mark.prompt
+++ b/src/templates/agent-skills/commands/smithy.mark.prompt
@@ -714,8 +714,8 @@ no checkboxes are flipped and no prose is rewritten.
 Write-back procedure:
 
 1. **Locate the `## Dependency Order` table** in the `.features.md` file
-   (locate by heading name, not by position). The table has the columns
-   `ID | Title | Depends On | Artifact`, with one `F<N>` row per feature.
+   (locate by heading name, not by position). It is the same table Routing
+   parsed to decide which features already have specs.
 2. **Find the matching row** whose `ID` cell equals `F<N>` where `<N>` is the
    current feature number (the one this spec was just created for). Match by
    the `F<N>` identifier, not by title or row position.
@@ -766,43 +766,20 @@ it:
   map's dependency-order table.
 - **artifact_type** — `spec`.
 
-The agent is read-only and returns a `ReviewResult` containing `findings` and a
-`summary`. Process the findings using the shared kind × severity × confidence triage
-table from the contracts, reading each finding's `kind` first. Only a `steering` finding —
-where a human must pick between named alternatives and the pick changes what
-gets built — can reach the debt table.
+For the triage below, **the target artifact** is the spec artifact set just
+written — record every debt row in the `.spec.md` file, and apply fixes to
+whichever of the three files the finding's `artifact_path` names. **The
+review note surface** is the PR body; a Low-confidence `implementation`
+finding goes there under an **Implementation questions** heading, since a
+spec carries no `## Open Implementation Questions` section and `smithy.cut`
+re-derives the unknown from its own plan-review pass when the tasks file is
+authored.
 
-| Kind             | Severity              | Confidence | Action                                                                                              |
-|------------------|-----------------------|------------|-----------------------------------------------------------------------------------------------------|
-| `implementation` or `hygiene` | Critical or Important | High | Apply the `proposed_fix` to the relevant spec artifact on disk. Note Critical fixes in the PR body.  |
-| `steering`       | Critical              | Any        | Do not apply — a steering finding is never auto-applied. Append to the spec's `## Specification Debt` section. Flag in PR for the reviewer.     |
-| `steering`       | Important             | Any        | Do not apply. Append to the spec's `## Specification Debt` section.                                  |
-| `implementation` | Critical or Important | Low        | Do not apply and do not record as debt. Note it in the PR body under an **Implementation questions** heading. This artifact has no `## Open Implementation Questions` section — that section is a tasks-file structure, and nothing reads a PR body, so the note is for the human reviewer. The unknown itself is settled while building, and `smithy.cut` re-derives it from its own plan-review pass when the tasks file is authored. |
-| `hygiene`        | Critical or Important | Low        | Do not apply and do not record as debt. List in the PR body for the reviewer to correct.             |
-| Any              | Minor                 | Any        | Do not apply. Note in the PR body only.                                                              |
+{{>plan-review-triage}}
 
-For each `steering` finding routed to debt — confidence does not matter, since
-steering is never auto-applied — append a new row to the
-`.spec.md` file's `## Specification Debt` index table with the next available
-`SD-NNN` identifier (continue numbering from whatever clarify already wrote
-in Phase 2 — do not reset). Use the finding's `description` as the body of a new `### SD-NNN — <Title>`
-detail section, derive a `Title` slug of 40 characters or fewer from it, set
-`Source Category` to `plan-review:<finding category>` (e.g.,
-`plan-review:Internal contradiction`), map severity into Impact (`Critical`
-stays `Critical`; `Important` becomes `High` — `Important` is not a valid
-`Impact` value) and copy confidence into Confidence, and set `Origin` to
-`local`.
 
-For each High-confidence `implementation` or `hygiene` finding, edit the referenced spec artifact file in
-place using the `proposed_fix`. The commit below captures both the original
-artifacts and the applied fixes in the same diff.
-
-If the agent returns drift findings (assumption-output drift category),
-surface them prominently in the PR body so the reviewer can confirm the
-underlying assumption rather than silently accepting the applied fix.
-
-The review agent never modifies files itself — all on-disk changes are made
-here, by mark.
+The commit below captures both the original artifacts and the applied fixes
+in the same diff.
 
 ### Commit and create the PR
 
@@ -870,7 +847,7 @@ Use the **smithy-refine** sub-agent. Pass it:
   | **Ambiguity & Risk** | Are there vague terms, unstated assumptions, or scope boundaries that could be interpreted multiple ways? |
   | **Specification Debt** | Are there open debt items that can now be resolved based on new information or user answers? Are all debt items structured with required metadata columns? Are inherited items attributed to their source artifact? |
   | **Staleness** | Does the spec still reflect the current codebase reality? Have upstream changes invalidated any assumptions? |
-  | **Dependency Order** | For `kind: backend` (or absent-kind) specs: does the spec contain a `## Dependency Order` 4-column table (`ID \| Title \| Depends On \| Artifact`) listing every user story with a `US<N>` ID (no leading zeros)? For `kind: ui` specs: does it instead contain the typed UI Spec Ledger — a 6-column table (`ID \| Kind \| Title \| Depends On \| Design \| Artifact`) with `SC<N>`/`FL<N>`/`US<N>` rows whose `Kind` matches the ID prefix (`screen`/`flow`/`story`), `Design` (`none`/`import`/`brief`) set on screen rows and `—` elsewhere, and screen/flow titles naming their durable `.design.md`/`.flow.md` files? Do not flag a valid UI ledger as missing the backend shape, and do not rewrite it back to the 4-column US-only table. In both shapes: does each `Depends On` cell contain `—` or comma-separated same-table IDs (no prose)? Does each `Artifact` cell contain `—` or a repo-relative path to the corresponding `.tasks.md` file (always `—` in mark's own output)? Are any `- [ ]`/`- [x]` checkboxes present in the section (an error if so)? |
+  | **Dependency Order** | Does the spec carry the ordering table its authoring path calls for, in the exact shape Phase 3 scaffolds — the backend `## Dependency Order` for `kind: backend` and absent-kind specs, or the typed UI Spec Ledger for `kind: ui`? Check every row against that shape: IDs, `Depends On` cells, `Design` cells where the shape has them, and `Artifact` cells (always `—` in mark's own output). Do not flag a valid UI ledger as missing the backend shape, and never rewrite one into the other. Flag any checkbox markup as an error. |
 
 - **Target files**: the spec (`.spec.md`), data model (`.data-model.md`), and
   contracts (`.contracts.md`) in the spec folder.
@@ -904,43 +881,20 @@ the spec artifact set. Pass it:
   (`<slug>.spec.md`, `<slug>.data-model.md`, `<slug>.contracts.md`).
 - **artifact_type** — `spec`.
 
-The agent is read-only and returns a `ReviewResult` containing `findings` and a
-`summary`. Process the findings using the shared kind × severity × confidence triage
-table, reading each finding's `kind` first. Only a `steering` finding —
-where a human must pick between named alternatives and the pick changes what
-gets built — can reach the debt table.
+For the triage below, **the target artifact** is the refined spec artifact
+set — record every debt row in the `.spec.md` file, and apply fixes to
+whichever of the three files the finding's `artifact_path` names. **The
+review note surface** is the refinement PR body; a Low-confidence
+`implementation` finding goes there under an **Implementation questions**
+heading, since a spec carries no `## Open Implementation Questions` section
+and `smithy.cut` re-derives the unknown from its own plan-review pass when
+the tasks file is authored.
 
-| Kind             | Severity              | Confidence | Action                                                                                              |
-|------------------|-----------------------|------------|-----------------------------------------------------------------------------------------------------|
-| `implementation` or `hygiene` | Critical or Important | High | Apply the `proposed_fix` to the relevant spec artifact on disk. Note Critical fixes in the PR body.  |
-| `steering`       | Critical              | Any        | Do not apply — a steering finding is never auto-applied. Append to the spec's `## Specification Debt` section. Flag in PR for the reviewer.     |
-| `steering`       | Important             | Any        | Do not apply. Append to the spec's `## Specification Debt` section.                                  |
-| `implementation` | Critical or Important | Low        | Do not apply and do not record as debt. Note it in the PR body under an **Implementation questions** heading. This artifact has no `## Open Implementation Questions` section — that section is a tasks-file structure, and nothing reads a PR body, so the note is for the human reviewer. The unknown itself is settled while building, and `smithy.cut` re-derives it from its own plan-review pass when the tasks file is authored. |
-| `hygiene`        | Critical or Important | Low        | Do not apply and do not record as debt. List in the PR body for the reviewer to correct.             |
-| Any              | Minor                 | Any        | Do not apply. Note in the PR body only.                                                              |
+{{>plan-review-triage}}
 
-For each `steering` finding routed to debt — confidence does not matter, since
-steering is never auto-applied — append a new row to the
-`.spec.md` file's `## Specification Debt` index table with the next available
-`SD-NNN` identifier (continue numbering from whatever the spec already
-contains — do not reset). Use the finding's `description` as the body of a new `### SD-NNN — <Title>`
-detail section, derive a `Title` slug of 40 characters or fewer from it, set
-`Source Category` to `plan-review:<finding category>`, map severity into
-Impact (`Critical` stays `Critical`; `Important` becomes `High` —
-`Important` is not a valid `Impact` value) and copy confidence into
-Confidence, and set `Origin` to `local`.
 
-For each High-confidence `implementation` or `hygiene` finding, edit the referenced spec artifact file in
-place using the `proposed_fix`. The Phase 0c commit below captures both the
-refine diff and the plan-review fixes in the same diff.
-
-If the agent returns drift findings (assumption-output drift category),
-surface them prominently in the refinement PR body so the reviewer can
-confirm the underlying assumption rather than silently accepting the applied
-fix.
-
-The review agent never modifies files itself — all on-disk changes are made
-here, by mark.
+The Phase 0c commit below captures both the refine diff and the plan-review
+fixes in the same diff.
 
 **No-op check** (runs after refine and plan-review): if refine returned an
 empty `refinements` list, plan-review returned no High-confidence fixes and

--- a/src/templates/agent-skills/commands/smithy.render.prompt
+++ b/src/templates/agent-skills/commands/smithy.render.prompt
@@ -137,44 +137,19 @@ review of the refined artifact. Pass it:
   file (`{{artifactsRoot}}docs/rfcs/<YYYY>-<NNN>-<slug>/<NN>-<milestone-slug>.features.md`).
 - **artifact_type** — `feature-map`.
 
-The agent is read-only and returns a `ReviewResult` containing `findings` and a
-`summary`. Process the findings using the shared kind × severity × confidence triage
-table, reading each finding's `kind` first. Only a `steering` finding —
-where a human must pick between named alternatives and the pick changes what
-gets built — can reach the debt table.
+For the triage below, **the target artifact** is the refined feature map —
+its `SD-NNN` numbering continues from whatever refine or prior clarify passes
+already wrote. **The review note surface** is the refinement PR body; a
+Low-confidence `implementation` finding goes there under an **Implementation
+questions** heading, since a feature map carries no `## Open Implementation
+Questions` section and `smithy.cut` re-derives the unknown from its own
+plan-review pass when the tasks file is authored.
 
-| Kind             | Severity              | Confidence | Action                                                                                                       |
-|------------------|-----------------------|------------|--------------------------------------------------------------------------------------------------------------|
-| `implementation` or `hygiene` | Critical or Important | High | Apply the `proposed_fix` to the feature map on disk. Note Critical fixes in the PR body.                      |
-| `steering`       | Critical              | Any        | Do not apply — a steering finding is never auto-applied. Append to the feature map's `## Specification Debt` section. Flag in PR for the reviewer.       |
-| `steering`       | Important             | Any        | Do not apply. Append to the feature map's `## Specification Debt` section.                                    |
-| `implementation` | Critical or Important | Low        | Do not apply and do not record as debt. Note it in the PR body under an **Implementation questions** heading. This artifact has no `## Open Implementation Questions` section — that section is a tasks-file structure, and nothing reads a PR body, so the note is for the human reviewer. The unknown itself is settled while building, and `smithy.cut` re-derives it from its own plan-review pass when the tasks file is authored. |
-| `hygiene`        | Critical or Important | Low        | Do not apply and do not record as debt. List in the PR body for the reviewer to correct.                     |
-| Any              | Minor                 | Any        | Do not apply. Note in the PR body only.                                                                      |
+{{>plan-review-triage}}
 
-For each `steering` finding routed to debt — confidence does not matter, since
-steering is never auto-applied — append a new row to the
-feature map's `## Specification Debt` index table with the next available `SD-NNN`
-identifier (continue numbering from whatever refine or prior clarify passes
-already wrote — do not reset). Use the finding's `description` as the body of a new `### SD-NNN — <Title>`
-detail section, derive a `Title` slug of 40 characters or fewer from it, set
-`Source Category` to `plan-review:<finding category>` (e.g.,
-`plan-review:Internal contradiction`), map severity into Impact (`Critical`
-stays `Critical`; `Important` becomes `High` — `Important` is not a valid
-`Impact` value) and copy confidence into Confidence, and set `Origin` to
-`local`.
 
-For each High-confidence `implementation` or `hygiene` finding, edit the feature map file in place using
-the `proposed_fix`. The Phase 0c commit below captures both the refine diff
-and the plan-review fixes in the same commit.
-
-If the agent returns drift findings (assumption-output drift category),
-surface them prominently in the refinement PR body so the reviewer can
-confirm the underlying assumption rather than silently accepting the applied
-fix.
-
-The review agent never modifies files itself — all on-disk changes are made
-here, by render.
+The Phase 0c commit below captures both the refine diff and the plan-review
+fixes in the same commit.
 
 ---
 
@@ -452,43 +427,19 @@ Pass it:
   (`{{artifactsRoot}}docs/rfcs/<YYYY>-<NNN>-<slug>/<NN>-<milestone-slug>.features.md`).
 - **artifact_type** — `feature-map`.
 
-The agent is read-only and returns a `ReviewResult` containing `findings` and a
-`summary`. Process the findings using the shared kind × severity × confidence triage
-table from the contracts, reading each finding's `kind` first. Only a `steering` finding —
-where a human must pick between named alternatives and the pick changes what
-gets built — can reach the debt table.
+For the triage below, **the target artifact** is the feature map just
+written — its `SD-NNN` numbering continues from whatever clarify already
+wrote in Phase 2. **The review note surface** is the PR body; a
+Low-confidence `implementation` finding goes there under an **Implementation
+questions** heading, since a feature map carries no `## Open Implementation
+Questions` section and `smithy.cut` re-derives the unknown from its own
+plan-review pass when the tasks file is authored.
 
-| Kind             | Severity              | Confidence | Action                                                                                                       |
-|------------------|-----------------------|------------|--------------------------------------------------------------------------------------------------------------|
-| `implementation` or `hygiene` | Critical or Important | High | Apply the `proposed_fix` to the feature map on disk. Note Critical fixes in the PR body.                      |
-| `steering`       | Critical              | Any        | Do not apply — a steering finding is never auto-applied. Append to the feature map's `## Specification Debt` section. Flag in PR for the reviewer.       |
-| `steering`       | Important             | Any        | Do not apply. Append to the feature map's `## Specification Debt` section.                                    |
-| `implementation` | Critical or Important | Low        | Do not apply and do not record as debt. Note it in the PR body under an **Implementation questions** heading. This artifact has no `## Open Implementation Questions` section — that section is a tasks-file structure, and nothing reads a PR body, so the note is for the human reviewer. The unknown itself is settled while building, and `smithy.cut` re-derives it from its own plan-review pass when the tasks file is authored. |
-| `hygiene`        | Critical or Important | Low        | Do not apply and do not record as debt. List in the PR body for the reviewer to correct.                     |
-| Any              | Minor                 | Any        | Do not apply. Note in the PR body only.                                                                      |
+{{>plan-review-triage}}
 
-For each `steering` finding routed to debt — confidence does not matter, since
-steering is never auto-applied — append a new row to the
-feature map's `## Specification Debt` index table with the next available `SD-NNN`
-identifier (continue numbering from whatever clarify already wrote in Phase 2
-— do not reset). Use the finding's `description` as the body of a new `### SD-NNN — <Title>`
-detail section, derive a `Title` slug of 40 characters or fewer from it, set
-`Source Category` to `plan-review:<finding category>` (e.g.,
-`plan-review:Internal contradiction`), map severity into Impact (`Critical`
-stays `Critical`; `Important` becomes `High` — `Important` is not a valid
-`Impact` value) and copy confidence into Confidence, and set `Origin` to
-`local`.
 
-For each High-confidence `implementation` or `hygiene` finding, edit the feature map file in place using
-the `proposed_fix`. The commit below captures both the original feature map
-and the applied fixes in the same diff.
-
-If the agent returns drift findings (assumption-output drift category),
-surface them prominently in the PR body so the reviewer can confirm the
-underlying assumption rather than silently accepting the applied fix.
-
-The review agent never modifies files itself — all on-disk changes are made
-here, by render.
+The commit below captures both the original feature map and the applied fixes
+in the same diff.
 
 ### Commit and create the PR
 

--- a/src/templates/agent-skills/commands/smithy.strike.prompt
+++ b/src/templates/agent-skills/commands/smithy.strike.prompt
@@ -237,48 +237,23 @@ After writing the strike document to disk and before committing, dispatch the
   repo-relative one — pass it through verbatim; do not strip the prefix.
 - **artifact_type** — `strike`.
 
-The agent is read-only and returns a `ReviewResult` containing `findings` and a
-`summary`. Process the findings using the shared kind × severity × confidence
-triage table from the contracts, reading each finding's `kind` first. Only a
-`steering` finding — where a human must pick between named alternatives and the
-pick changes what gets built — can reach the debt table.
+For the triage below, **the target artifact** is the strike document just
+written — its `SD-NNN` numbering continues from whatever clarify already
+wrote during Phase 2. **The review note surface** is strike's terminal
+output: surface each unapplied finding there once, for the user, and never in
+the PR body.
 
-| Kind             | Severity              | Confidence | Action                                                                                                |
-|------------------|-----------------------|------------|-------------------------------------------------------------------------------------------------------|
-| `implementation` or `hygiene` | Critical or Important | High | Apply the `proposed_fix` to the strike document on disk.                                               |
-| `steering`       | Critical or Important | Any        | Do not apply — a steering finding is never auto-applied. Append to the strike's `## Specification Debt` section.                                   |
-| `implementation` | Critical or Important | Low        | Do not apply and do not record as debt. Surface once in the terminal output — the unknown is settled while building this slice, so it needs no decision queue. |
-| `hygiene`        | Critical or Important | Low        | Do not apply and do not record as debt. Surface once in the terminal output so the user can settle the correction.  |
-| Any              | Minor                 | Any        | Do not apply. Surface once in the terminal output for the user; do not add to the PR body.             |
+{{>plan-review-triage}}
 
-For each `steering` finding routed to debt — confidence does not matter, since
-steering is never auto-applied — append a new row to the
-`## Specification Debt` index table with the next available `SD-NNN` identifier
-(continue numbering from whatever clarify already wrote during Phase 2 — do
-not reset). Use the finding's `description` as the body of a new `### SD-NNN — <Title>`
-detail section, derive a `Title` slug of 40 characters or fewer from it, set
-`Source Category` to `plan-review:<finding category>` (e.g.,
-`plan-review:Internal contradiction`), map severity into Impact (`Critical`
-stays `Critical`; `Important` becomes `High` — `Important` is not a valid
-`Impact` value) and copy confidence into Confidence, and set `Origin` to
-`local`.
 
-For each High-confidence `implementation` or `hygiene` finding routed to auto-fix, edit the strike document
-in place using the `proposed_fix`. The commit immediately below will capture
-both the original artifact and the applied fixes in the same diff.
+The commit immediately below will capture both the original artifact and the
+applied fixes in the same diff.
 
-If the agent returns drift findings (assumption-output drift category),
-treat them as Critical for routing — auto-fix only when High confidence and
-the underlying assumption is unambiguous; otherwise, when the finding's
-`kind` is `steering`, append to `## Specification Debt` so the reviewer (and
-future readers of the strike artifact) see the assumption flagged without
-scanning the agent transcript. Do not stash steering drift findings in the PR
-body. Severity escalation does not override the kind gate: a drift finding
-whose `kind` is `implementation` or `hygiene` still routes by its `kind` row
-above and never becomes a debt item.
-
-The review agent never modifies files itself — all on-disk changes are made
-here, by strike.
+Treat drift findings as Critical for routing — apply the fix only when
+confidence is High and the underlying assumption is unambiguous; otherwise,
+when the finding's `kind` is `steering`, append it to `## Specification Debt`
+so the reviewer (and future readers of the strike artifact) see the
+assumption flagged without scanning the agent transcript.
 
 ### Commit and create the PR
 

--- a/src/templates/agent-skills/snippets/README.md
+++ b/src/templates/agent-skills/snippets/README.md
@@ -20,7 +20,11 @@ its contents. The snippet file itself is never deployed.
 | `audit-checklist-features.md` | Audit checklist for feature map artifacts | smithy.audit |
 | `audit-checklist-tasks.md` | Audit checklist for task plan artifacts | smithy.audit |
 | `feature-kinds.md` | Feature kind (`backend`/`ui`) + build/wire phase field schema and the two-feature seam; the single source of the kind/phase fields | smithy.render, smithy.audit |
-| `review-protocol.md` | Read-only findings protocol shared by review agents (Finding structure, the `kind` gate, kind × severity × confidence triage, no file edits) | smithy.plan-review, smithy.implementation-review |
+| `review-protocol.md` | Read-only findings protocol shared by review agents: the Finding structure, the nested `kind-gate`, and the report-don't-act rule. Deliberately does **not** carry the parent-side consequence table — that is `plan-review-triage`, composed by the commands that own the on-disk action | smithy.plan-review, smithy.implementation-review, smithy.forge (degraded branch) |
+| `kind-gate.md` | The single definition of the `kind` gate: the three kinds, the three-part steering test (open question + named alternatives + human-only), the positive test that rejects directives, the routing table naming a home for every non-steering kind, and the calibration rule. Before this snippet the gate had two non-identical homes — review-protocol's and `smithy-clarify` Step 3b's — and they disagreed on the third condition | review-protocol; smithy.clarify; smithy.refine |
+| `debt-row-shape.md` | The `## Specification Debt` row's field rules: the `Impact` and `Confidence` enums stated positively, the review-severity → `Impact` mapping (`Important` becomes `High`), and the `Title` / `Source Category` / `Origin` rules. Composed wherever a row is written, so the enums cannot drift between producers | plan-review-triage; debt-grading |
+| `debt-grading.md` | Nests `debt-row-shape`, then adds what it means to *choose* an `Impact` or `Confidence` level. Split out because only clarify and refine grade a candidate from nothing — a parent command transcribing a review finding maps severity and copies confidence mechanically, and shipping it the grading rubric at every plan-review site would cost far more than it informs (P-1) | smithy.clarify; smithy.refine |
+| `plan-review-triage.md` | The parent-side kind × severity × confidence consequence table and the debt / `IQ-NNN` row-append rules, plus the nested `debt-row-shape`. Written against two terms the composing command binds just above the composition point — **the target artifact** and **the review note surface** — because commands disagree on both (strike and forge note findings in terminal output, the rest in the PR body) | smithy.mark, smithy.cut, smithy.ignite, smithy.render, smithy.strike, smithy.forge |
 | `open-implementation-questions.md` | The whole `## Open Implementation Questions` artifact section for tasks files: the `IQ-NNN` table (`ID`, `Question`, `Slice`, `Settled By`, `Origin`) and its empty-state line. Holds unknowns the implementer settles by building, so they stay out of the `## Specification Debt` decision queue. Carries its own voice tag. Must never contain a fenced code block: the host embeds it inside a markdown fence, and an inner fence would close the host early | smithy.cut |
 | `guidance-shell.md` | Shell environment guidance | smithy.guidance |
 | `tdd-protocol.md` | TDD workflow protocol | smithy.implement |
@@ -61,6 +65,19 @@ its contents. The snippet file itself is never deployed.
   (shared by the `smithy.implement` agent and `smithy.forge`) and
   `review-protocol.md` (shared across `smithy.plan-review` /
   `smithy.implementation-review` and forge).
+- **Split a protocol by who acts on it, not by who reads it.** `review-protocol`
+  once carried a section titled "applied by the parent command, not by the
+  review agent", which meant every review agent paid for a table it must never
+  act on while no parent could see it — so all six parents hand-copied their
+  own and drifted. The agent-facing half (`kind-gate`) and the parent-facing
+  half (`plan-review-triage`) are separate snippets, and each side composes
+  only what it acts on.
+- **Leave per-consumer variation as a named term, not a parameter.** Partials
+  take no arguments here. When one protocol has genuinely different
+  destinations per command, name the varying thing in the snippet (**the
+  target artifact**, **the review note surface**) and require the composing
+  command to bind it in the sentence immediately above the `{{>partial}}`.
+  That keeps one table for every consumer without a templating mechanism.
 - **Snippets are content, not commentary.** A snippet is inlined verbatim into
   a deployed agent skill, so it must read as a direct instruction. Do not
   narrate future/out-of-scope work ("lands in a later story", "there is no

--- a/src/templates/agent-skills/snippets/debt-grading.md
+++ b/src/templates/agent-skills/snippets/debt-grading.md
@@ -1,0 +1,14 @@
+{{>debt-row-shape}}
+
+
+**Choosing a level.** Impact asks how much getting it wrong costs, and
+Confidence asks how sure you are of the recommended answer. A parent command
+transcribing a review finding never picks either from scratch — it maps and
+copies per the rules above — but you are grading from nothing, so use these:
+
+| Level | `Impact` — the cost of being wrong | `Confidence` — how sure you are |
+|-------|-----------------------------------|---------------------------------|
+| `Critical` | Invalidates the artifact or forces significant rework. | (not a Confidence value) |
+| `High` | Materially affects scope, architecture, or user experience; a wrong answer wastes meaningful effort. | Strong evidence in the codebase, docs, or conventions. You would be surprised if the user disagreed. |
+| `Medium` | Affects quality or completeness, but is correctable later without major rework. | A reasonable inference where several valid approaches exist. The user might reasonably choose differently. |
+| `Low` | A preference or stylistic choice with negligible downstream cost. | Genuine uncertainty. You are guessing, or nothing in scope gives a signal. |

--- a/src/templates/agent-skills/snippets/debt-row-shape.md
+++ b/src/templates/agent-skills/snippets/debt-row-shape.md
@@ -1,0 +1,22 @@
+**Debt row fields.** One shape for every producer of a
+`## Specification Debt` row — clarification candidates, refinement findings,
+and plan-review findings alike:
+
+| Field | Rule |
+|-------|------|
+| `Impact` | One of `Critical` / `High` / `Medium` / `Low`. |
+| `Confidence` | One of `High` / `Medium` / `Low`. |
+| `Title` | A slug of 40 characters or fewer naming the unresolved choice. Not a sentence — the statement goes in the item's detail section. |
+| `Source Category` | The scan or audit category that produced the item. Findings from a review agent use `plan-review:<finding category>` (e.g. `plan-review:Internal contradiction`). |
+| `Origin` | `local` for an item discovered in the artifact being authored, or `<parent-kind>:SD-NNN` for one carried down from a parent artifact. |
+
+`Important` is **not** a valid `Impact` value. A review finding's severity is
+`Critical` / `Important` / `Minor`, which is a different scale, so map it into
+`Impact` rather than copying it: `Critical` stays `Critical` and `Important`
+becomes `High`. `Minor` never reaches the debt table, so it never maps.
+
+A review finding's `confidence` is the `High` / `Low` decision of whether the
+parent may apply the fix — the two endpoints of the same scale, so it copies
+into the `Confidence` column unchanged. `Medium` is produced only by
+clarification and refinement, which grade a recommended answer rather than an
+auto-apply decision.

--- a/src/templates/agent-skills/snippets/kind-gate.md
+++ b/src/templates/agent-skills/snippets/kind-gate.md
@@ -1,0 +1,69 @@
+Severity and confidence say how much a finding matters and how sure you
+are. They say nothing about **who resolves it**, and that is the axis
+that decides whether a finding belongs in the artifact's decision queue.
+Every finding therefore carries a `kind`:
+
+| `kind` | The finding is… | Who resolves it |
+|--------|-----------------|-----------------|
+| `steering` | an open question naming two or more meaningfully different paths, where the choice changes what gets built | a human, by choosing |
+| `implementation` | an unknown the implementer settles by writing the code, running a test, or reading the source — there is a right answer and the work reveals it | the implementer, by building |
+| `hygiene` | a factual error, stale table, or artifact-consistency defect with a knowable correct answer, including any of the leak kinds in the routing table below | the parent command, by applying a fix |
+
+**Only `steering` findings may become specification debt.** The debt
+table is a decision queue for a human; an implementation unknown or a
+wrong table parked there buries the real decisions and inflates apparent
+readiness risk.
+
+#### The steering test
+
+A finding is `steering` only if **all three** are true:
+
+1. **Open question** — the artifacts, the codebase, the conventions, and
+   prior art cannot settle it. Reading more does not produce the answer.
+2. **Named alternatives** — two or more meaningfully different paths
+   exist, and picking between them changes what gets built.
+3. **Human-only** — a person must pick. The question cannot be closed by
+   writing the code, running a test, or reading a file.
+
+Condition 3 is the one that does the work. Most findings that feel like
+open questions fail it: "whether the test runner's temp copy carries a
+`.git` directory or initializes one" names two alternatives, but the
+implementer settles it by reading the runner and running it once, not by
+asking anyone.
+
+**Positive test:** you must be able to phrase a `steering` finding as a
+question a named human could answer in one sitting, without opening an
+editor. If closing it requires writing code, running something, or
+reading another file, it is `implementation`. If it requires neither —
+because you already know the correct answer and are simply reporting that
+the artifact has it wrong — it is `hygiene`. A finding you can only
+phrase as a directive ("we will…", "implementers must…", "mitigation:
+pin both files…", "resolution: X owns A and Y owns B") has already had
+its answer chosen, so it is never `steering`.
+
+#### Where the non-steering kinds go
+
+Nothing the gate rejects is discarded — every kind has a home, and the
+finding carries the same information there.
+
+| If the finding is really… | `kind` | Where it belongs |
+|---------------------------|--------|------------------|
+| An unknown the implementer settles by building, testing, or reading source — which field carries a value, which producer serves a surface, which of two equivalent call sites to extend | `implementation` | The tasks file's `## Open Implementation Questions` section, as an `IQ-NNN` row. Never the debt table |
+| A factual error — a wrong `## Dependency Order` table, a stale path, a contradiction with a source the artifact itself cites, ordinary sequencing stated as if ownership were in doubt | `hygiene` | Applied as a correction to the artifact. A wrong table is a fix, not a question |
+| Artifact housekeeping — "is the parent artifact corrected, or only this one?", "does this rename need to propagate upstream?" | `hygiene` | Same: applied. The answer is knowable now, so it is never open uncertainty |
+| A requirement — "X must Y", "implementers verify Z", "mitigation: pin both files" | `hygiene` | The artifact's `### Functional Requirements` (specs) or the RFC body |
+| A load-bearing assumption — "a retry count of 5 is sufficient", "X is acceptable for now" | `hygiene` | The artifact's `## Assumptions` section, annotated `[Critical Assumption]` when the impact is Critical |
+| An acceptance test — "acceptance criteria require empirically capturing X", "verification needed against actual Y" | `hygiene` | The user story's `### Acceptance Scenarios` |
+| A dependency or coordination note — "F1.5 and F1.6 both touch file Z; second-to-land rebases" | `hygiene` | The RFC's Cross-Cutting Governance / touched-files matrix and the `## Dependency Order` table, which already track this. Never debt |
+| Future work or a deferral — "deferred to follow-up", "out of scope this round" | `hygiene` | The artifact's `## Out of Scope`, plus a follow-up issue. The decision to defer is already made; debt is forward-looking |
+| A resolution record — "this was fixed in the same PR", "reviewer's concern investigated and dismissed" | `hygiene` | The pull request description, or at most a row already under `### Resolved`. Never an open debt row |
+
+#### Calibration
+
+The debt table is a decision queue, and it stops working as one long
+before it stops rendering. If your findings would add more than a handful
+of debt rows to a single artifact, re-run the gate on each of them:
+implementation unknowns are the usual cause of an inflated table, and
+several rows that all reduce to one root cause are the second. Collapse
+findings sharing a single root cause into one finding naming that cause,
+rather than emitting one per symptom.

--- a/src/templates/agent-skills/snippets/plan-review-triage.md
+++ b/src/templates/agent-skills/snippets/plan-review-triage.md
@@ -1,0 +1,54 @@
+The agent is read-only and returns a `ReviewResult` containing `findings`
+and a `summary`. Process each finding with the kind × severity ×
+confidence table below, reading its `kind` first. Only a `steering`
+finding — where a human must pick between named alternatives and the pick
+changes what gets built — can reach the debt table.
+
+**The target artifact** is the planning file findings are recorded against
+and **the review note surface** is where a finding this command did not
+apply gets reported; both are named just above, and they differ per command.
+
+| Kind | Severity | Confidence | Action |
+|------|----------|------------|--------|
+| `implementation` or `hygiene` | Critical or Important | High | Apply the `proposed_fix` on disk, following whatever apply protocol this command defines. Note Critical fixes on the review note surface. |
+| `steering` | Critical or Important | Any | Do not apply — a steering finding is never auto-applied. Append it to the target artifact's `## Specification Debt` section, and flag Critical ones on the review note surface for the reviewer. |
+| `implementation` | Critical or Important | Low | Do not apply and do not record as debt. When the target artifact is a `.tasks.md`, append an `IQ-NNN` row to its `## Open Implementation Questions` section; otherwise note it on the review note surface, since only a tasks file carries that section and the unknown is settled while building either way. |
+| `hygiene` | Critical or Important | Low | Do not apply and do not record as debt. Note it on the review note surface so the reader can settle the correction. |
+| Any | Minor | Any | Do not apply. Note it on the review note surface. |
+
+**A `steering` finding is never auto-applied, at any confidence.** The
+kind means a human has to pick; applying a fix would make that pick for
+them and bury a product decision inside a planning commit. Confidence
+does not license it — a High-confidence `steering` finding is a
+contradiction and means the classification is wrong. Re-examine it: if
+the `proposed_fix` can be applied verbatim without anyone choosing, the
+finding is `hygiene`; if a human must choose, confidence is Low by
+construction. This is the one cell where confidence loses to kind.
+
+For each `steering` finding routed to debt — confidence does not matter,
+since steering is never auto-applied — append a row to the target
+artifact's `## Specification Debt` index table with the next available
+`SD-NNN` identifier, continuing from whatever the artifact already
+carries (including any debt inherited from a parent) rather than
+resetting. Use the finding's `description` as the body of a new
+`### SD-NNN — <Title>` detail section, never as a table cell.
+
+{{>debt-row-shape}}
+
+
+For each Low-confidence `implementation` finding routed to
+`## Open Implementation Questions`, append a row instead: the next
+available `IQ-NNN`, the finding's `description` compressed into a single
+question of 120 characters or fewer, the `S<N>` slice it lands in (`—`
+when it spans slices), a `Settled By` value of `building`, `testing`, or
+`reading code`, and `Origin` `local`.
+
+Drift findings (the assumption-output drift category) are surfaced
+prominently on the review note surface so the reader can confirm the
+underlying assumption rather than silently accepting an applied fix.
+Severity escalation never overrides the kind gate: a drift finding whose
+`kind` is `implementation` or `hygiene` still routes by its own row above
+and never becomes a debt item.
+
+The review agent never modifies files itself — every on-disk change from
+a finding is made here, by this command.

--- a/src/templates/agent-skills/snippets/review-protocol.md
+++ b/src/templates/agent-skills/snippets/review-protocol.md
@@ -33,105 +33,39 @@ following shape. Emit one finding per distinct issue.
 | `category` | enum | What kind of issue (per-agent category list) |
 | `kind` | enum | `steering`, `implementation`, or `hygiene` — what kind of *resolution* the finding needs (see the kind gate below) |
 | `severity` | enum | Critical, Important, Minor |
-| `confidence` | enum | High or Low — whether the finding can be auto-resolved by the parent |
+| `confidence` | enum | High or Low — whether the parent may apply the `proposed_fix` without a human. These are the two endpoints of the pipeline's `High` / `Medium` / `Low` confidence scale; a review finding never takes the middle value, because "may the parent apply this" has no middle setting |
 | `description` | string | What the issue is and where it appears |
 | `artifact_path` | string | Path to the file containing the issue |
 | `proposed_fix` | string | Suggested resolution (for High-confidence findings) |
 
-### 4. Kind gate (set by the review agent, applied before triage)
+### 4. Kind gate — set the kind before grading severity and confidence
 
-Severity and confidence say how much a finding matters and how sure you
-are. They say nothing about **who resolves it**, and that is the axis
-that decides whether a finding belongs in the artifact's decision queue.
-Every finding therefore carries a `kind`:
+{{>kind-gate}}
 
-| `kind` | The finding is… | Who resolves it |
-|--------|-----------------|-----------------|
-| `steering` | an open question naming two or more meaningfully different paths, where the choice changes what gets built | a human, by choosing |
-| `implementation` | an unknown the implementer settles by writing the code, running a test, or reading the source — there is a right answer and the work reveals it | the implementer, by building |
-| `hygiene` | a factual error, stale table, or artifact-consistency defect with a knowable correct answer, including anything the `smithy-clarify` Step 3b routing table names as a leak (requirement, acceptance test, dependency/coordination note, deferral, resolution record) | the parent command, by applying a fix |
 
-**Only `steering` findings may become specification debt.** The debt
-table is a decision queue for a human; an implementation unknown or a
-wrong table parked there buries the real decisions and inflates apparent
-readiness risk.
+### 5. Report; do not act
 
-#### The steering test
+Set `kind`, `severity`, and `confidence` on every finding and return it.
+The parent command owns the consequences: it reads `kind` first, then
+severity × confidence, and decides whether to apply the `proposed_fix`,
+record a debt row, record an implementation question, or simply note the
+finding for its reader. You never take that action yourself, and you
+never assume which one the parent will pick.
 
-A finding is `steering` only if **all three** are true:
+Two consequences bind you rather than the parent, because they are
+properties of the finding you emit:
 
-1. **Open question** — the artifacts, the codebase, the conventions, and
-   prior art cannot settle it. Reading more does not produce the answer.
-2. **Named alternatives** — two or more meaningfully different paths
-   exist, and picking between them changes what gets built.
-3. **Human-only** — a person must pick. The question cannot be closed by
-   writing the code, running a test, or reading a file.
-
-Condition 3 is the one that does the work. Most findings that feel like
-open questions fail it: "whether the test runner's temp copy carries a
-`.git` directory or initializes one" names two alternatives, but the
-implementer settles it by reading the runner and running it once, not by
-asking anyone.
-
-**Positive test:** you must be able to phrase a `steering` finding as a
-question a named human could answer in one sitting, without opening an
-editor. If closing it requires writing code, running something, or
-reading another file, it is `implementation`. If it requires neither —
-because you already know the correct answer and are simply reporting that
-the artifact has it wrong — it is `hygiene`.
-
-#### Where the non-steering kinds go
-
-| If the finding is really… | `kind` | Where the parent puts it |
-|---------------------------|--------|--------------------------|
-| An unknown the implementer settles by building, testing, or reading source — which field carries a value, which producer serves a surface, which of two equivalent call sites to extend | `implementation` | The tasks file's `## Open Implementation Questions` section, as an `IQ-NNN` row. Never the debt table |
-| A factual error — a wrong `## Dependency Order` table, a stale path, a contradiction with a source the artifact itself cites, ordinary sequencing stated as if ownership were in doubt | `hygiene` | Applied as a write-back via your `proposed_fix`, or listed in the PR body when confidence is Low. A wrong table is a fix, not a question |
-| Artifact housekeeping — "is the parent artifact corrected, or only this one?", "does this rename need to propagate upstream?" | `hygiene` | Same: applied, or listed in the PR body. The answer is knowable now, so it is never open uncertainty |
-| A requirement, acceptance test, dependency/coordination note, deferral, or post-hoc resolution record — the leak kinds named in `smithy-clarify` Step 3b's routing table | `hygiene` | Point `proposed_fix` at the proper home from that table (`### Functional Requirements`, `### Acceptance Scenarios`, `## Out of Scope`, the RFC's Cross-Cutting Governance matrix, the PR body) so the parent writes it there |
-
-#### Calibration
-
-The debt table is a decision queue, and it stops working as one long
-before it stops rendering. If your findings would add more than a handful
-of debt rows to a single artifact, re-run the gate on each of them:
-implementation unknowns are the usual cause of an inflated table, and
-several rows that all reduce to one root cause are the second. Collapse
-findings sharing a single root cause into one finding naming that cause,
-rather than emitting one per symptom.
-
-### 5. Triage rules (applied by the parent command, not by the review agent)
-
-The parent command decides what to do with each finding by reading
-`kind` first, then severity × confidence. The review agent only reports;
-it never takes the action itself.
-
-| `kind` | Severity | Confidence | Parent Action |
-|--------|----------|------------|---------------|
-| `steering` | Critical | Any | Record as specification debt, flag in PR for reviewer. **Never** apply the fix |
-| `steering` | Important | Any | Record as specification debt. **Never** apply the fix |
-| `steering` | Minor | Any | Note in PR only |
-| `implementation` | Critical or Important | High | Apply proposed fix — the reviewer settled the unknown, so there is nothing left to discover |
-| `implementation` | Critical or Important | Low | Record in the tasks file's `## Open Implementation Questions` section. When the work is not tracked by a tasks file, note in the PR body instead — never in the debt table |
-| `implementation` | Minor | Any | Note in PR only |
-| `hygiene` | Critical or Important | High | Apply proposed fix, note in PR |
-| `hygiene` | Critical or Important | Low | Do not apply. List in the PR body for the reviewer to correct — never in the debt table |
-| `hygiene` | Minor | Any | Note in PR only |
-
-**A `steering` finding is never auto-applied, at any confidence.** The
-kind means a human has to pick; applying a fix would make that pick for
-them and bury a product decision inside a planning commit. Confidence
-does not license it — a High-confidence `steering` finding is a
-contradiction and means the classification is wrong. Re-examine it: if
-the `proposed_fix` can be applied verbatim without anyone choosing, the
-finding is `hygiene`; if a human must choose, confidence is Low by
-construction. This is the one cell where confidence loses to kind.
-
-A wrong table is a fix, not a question: a `hygiene` finding never
-becomes debt at any severity or confidence, and neither does an
-`implementation` finding. A Low-confidence `hygiene` finding means the
-correction is knowable but you could not pin it down — the PR body is
-where it goes, so a reviewer can settle it in one pass instead of
-carrying it as open uncertainty.
+- **A `steering` finding is never auto-applied, at any confidence.** A
+  High-confidence `steering` finding is a contradiction and means the
+  classification is wrong. Re-examine it: if the `proposed_fix` can be
+  applied verbatim without anyone choosing, the finding is `hygiene`; if
+  a human must choose, confidence is Low by construction.
+- **A wrong table is a fix, not a question.** A `hygiene` finding never
+  becomes debt at any severity or confidence, and neither does an
+  `implementation` finding. When a `hygiene` correction is knowable but
+  you cannot pin it down, say so and keep confidence Low — the parent
+  hands it to a human to settle in one pass rather than carrying it as
+  open uncertainty.
 
 ### Read-only invariant
 


### PR DESCRIPTION
## Summary
- Primary outcome: the kind × severity × confidence triage protocol has one canonical home per acting role, composed by every consumer instead of hand-copied into ~12 places with two rival "canonical" definitions.
- Notable behaviour changes: clarify's third steering condition changes from *no-prescription* to *human-only* (the phrasing test moves into the positive test, where it applies); ignite's Phase 0c stops mandating a debt "Description column" and stops copying severity into `Impact`; strike's merged steering row and terminal-output destinations become the canonical shape for every command; `Confidence` is one `High`/`Medium`/`Low` scale pipeline-wide and `Impact`'s enum is stated positively.
- Follow-up work deferred: the voice-tag grammar duplication (INV-1 ledger row, tracked by #551) is untouched.

## Context

Sub-issue of the 2026-08 template audit (#551), audit priority 2. The gate is the system's central review-safety mechanism, and it was maintained by hand in roughly twelve places with two non-identical canonical homes:

- `snippets/review-protocol.md` — steering test = open question + named alternatives + **human-only**.
- `agents/smithy.clarify.prompt` Step 3b — third condition was **no-prescription**, with no `implementation`/`hygiene` kinds at all.

The parent-side consequence table was copied twice each into mark, cut, ignite and render and once each into strike and forge — roughly 500 source lines — while the canonical copy lived in a snippet only the *child* review agents compose, under a section titled "applied by the parent command, not by the review agent". Drift had already landed: ignite's Phase 0c mandated a `Description` column the debt index has never had and "copy severity into Impact", while ignite's own second copy mandated the detail-section shape and the `Important`→`High` mapping.

This lands the target state D-1 recorded and clears both #553 rows from INV-1's Known-Exceptions ledger.

## Implementation Notes

**Four snippets now hold what was restated.** Partials take no arguments here, so per-command variation is handled by naming the varying thing and requiring the composing command to bind it — a convention now written into `snippets/README.md`.

| Snippet | Holds | Composed by |
|---|---|---|
| `kind-gate.md` | The one gate: three kinds, three-part steering test, positive test, routing table, calibration | `review-protocol`, `smithy.clarify`, `smithy.refine` |
| `plan-review-triage.md` | Parent-side consequence table + debt / `IQ-NNN` append rules | mark ×2, cut ×2, ignite ×2, render ×2, strike, forge ×2 |
| `debt-row-shape.md` | `Impact` / `Confidence` enums, severity→`Impact` mapping, `Title` / `Source Category` / `Origin` rules | `plan-review-triage`, `debt-grading` |
| `debt-grading.md` | Nests the shape, adds what *choosing* a level means | `smithy.clarify`, `smithy.refine` |

Key choices and trade-offs:

- **Reconciling the two gates.** Clarify's "no prescription" was a test of how a finding is *phrased*, not of who resolves it, so it folds into the positive test rather than surviving as a fourth condition. The genuine difference is only the return channel: review agents reroute by naming a different `kind`, clarify routes to its assumption stream with `[Critical Assumption]`, refine routes to `refinements`. Each states its own in two sentences beside the shared gate, and INV-1 now carries that as an `Accepted:` exception rather than a `Temporary:` one.
- **Splitting by who acts, not who reads.** `review-protocol` keeps the agent-facing half and loses the parent-facing table entirely — it now says "report; do not act" and names only the two consequences that are properties of what the agent emits. That is why the parents can compose the table without every review agent paying for it.
- **Two named terms instead of a templating mechanism.** The canonical table cannot hard-code a destination: strike and forge report unapplied findings in terminal output, not the PR body (#385). Each command binds **the target artifact** and **the review note surface** in the sentence above `{{>plan-review-triage}}`, and a test asserts every composition site does so.
- **`debt-grading` split (P-1).** The grading rubric would otherwise ship to eleven plan-review sites that never grade from nothing — a parent maps severity and copies confidence mechanically. Splitting it saved ~4.5KB of deployed text at no cost to the sites that do grade.
- **Deployed size.** The composed tree grows 5.1% (691KB → 726KB). refine (+54%) and clarify (+34%) take the largest relative share, because refine previously carried only a pointer to clarify's gate — a citation that resolves to nothing under Gemini, which deploys no sub-agent files. This is the trade D-1 named and accepted; the numbers are in the commit message.
- **Two negative assertions that should have caught ignite's drift are fixed.** They matched exact substrings, and a line wrap fell between `copy` and `severity`. They normalize whitespace now.

Also in passing, per the issue's scope:

- cut's `## Rules` no longer restates the filename derivation with the backend-only `01-`…`99-` form, which contradicted the typed-UI `sc1-`/`fl2-` rule stated in Phases 1 and 5.
- mark's `## Dependency Order` restatements drop from five to two canonical statements plus scaffolds; the ~1,400-character refine scan-criteria cell now checks against the Phase 3 scaffold instead of respelling both the backend and typed-UI shapes.

Impacted boundaries: `src/templates/agent-skills/` only — six commands, three sub-agents, four new snippets, one rewritten snippet. Per `CLAUDE.md`, the committed `.claude/` snapshot is **not** regenerated here.

## Risks & Mitigations

- Risk: a command's composed triage text no longer names its own artifact, so an agent could apply a finding to the wrong file. | Mitigation: every composition site binds **the target artifact** immediately above the partial, and a test asserts the binding exists at all eleven sites and that no hand-written triage row survives beside it.
- Risk: the merged `steering | Critical or Important` row loses ignite/mark/cut/render's separate "Flag in PR for the reviewer" on Critical. | Mitigation: the merged row keeps it, phrased against the review note surface so strike and forge stay compliant with #385; the existing #385 regression tests still pass.
- Risk: composition costs context on every invocation (P-1). | Mitigation: measured (+5.1%), the grading rubric was split out of the parents' path, and the trade is the one D-1 already weighed and accepted.
- Risk: prompt text changes are not covered by unit tests the way code is. | Mitigation: 12 new assertions lock the gate's contract, the composition count per command, and the surface-neutrality of the canonical table; a full three-agent `init` was run against a scratch repo.

## Rollback Plan

Revert the single commit. The change is confined to source templates and their tests — nothing reads deployed state, no migration is involved, and target repos pick up the previous text on their next `smithy update`.

## Testing

### Smithy CLI Core
- [x] Build succeeds (`npm run build`)
- [x] Type check succeeds (`npm run typecheck`)
- [x] CLI `init` smoke test — `node dist/cli.js init -a all --artifacts-location repo -y` against a scratch git repo

`npm test` 1294 passed / 35 files; `npm run test:evals` 272 passed / 13 files.

### Template Generation
- [x] Gemini Skills: `.gemini/skills/` folders and `SKILL.md` validity — the gate reaches the Gemini forge path, which composes no sub-agent files and previously could not resolve the citation refine relied on.
- [x] Codex Prompts: `tools/codex/prompts/` and `.agents/skills/` content.
- [x] Claude Prompts: `.claude/commands/` and `.claude/agents/` content.
- [ ] GitHub Issue Templates: `.github/ISSUE_TEMPLATE/` content — unchanged by this PR.

Verified across all three targets: zero unresolved `{{>…}}` references, and the note-surface binding present in every deployed command (strike 7, mark 14, cut 15, render 14, ignite 14, forge 7 mentions).

### Permissions & Configuration
- [ ] Gemini Config / Codex Config / Claude Config — unchanged by this PR; no permissions or settings surface is touched.

### Manual Test Cases
- [ ] Not applicable — no `init`/`uninit` flow changed.

## Issue
- Closes #553

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtkmhUETvzzYdCNwWrHSoB)_